### PR TITLE
feat: add accessibility diagnostics

### DIFF
--- a/docs/language/diagnostics.md
+++ b/docs/language/diagnostics.md
@@ -33,6 +33,9 @@ The optional `suggestion` field carries a short structured fix hint for common
 mistakes such as missing `paths {}` on dynamic spa routes, unknown client or
 view fields, missing `g:key`, and malformed `g:for` syntax.
 
+Warnings are non-fatal. The first accessibility warning is `missing_img_alt`,
+emitted for literal `<img>` elements without an explicit `alt` attribute.
+
 ## Current Code Registry
 
 The diagnostic-code registry, stability policy, naming rules, and

--- a/docs/reference/diagnostic-codes.md
+++ b/docs/reference/diagnostic-codes.md
@@ -65,8 +65,9 @@ registry.
   feature hardens.
 - `addon`: emitted by addon-owned validation or fallback addon diagnostics.
 
-All current diagnostics use severity `error`. Future warning/info diagnostics
-must extend the registry and JSON schema docs before shipping.
+Most diagnostics use severity `error`. Accessibility diagnostics can use
+severity `warning`; warnings are reported by `gowdk check` but do not make the
+command fail.
 
 ## Naming
 
@@ -109,6 +110,7 @@ gets more specific stable codes.
   `component_field_error`, `component_client_error`,
   `duplicate_component_emit`, `duplicate_page_store`, `page_store_error`,
   `unknown_component_store`, `view_parse_error`.
+- Accessibility: `missing_img_alt`.
 - Go blocks and generated app wiring: `invalid_go_block`,
   `go_client_requires_page`, `go_ssr_requires_request_render`,
   `unknown_go_block_target`, `unknown_addon_go_block_target`,

--- a/internal/diagnostics/registry.go
+++ b/internal/diagnostics/registry.go
@@ -71,6 +71,7 @@ var Registry = []Code{
 	{Code: "load_requires_request_render", Area: "rendering", Stability: StabilityStable, Summary: "load block requires request-time page rendering"},
 	{Code: "malformed_gowdk_use", Area: "source-imports", Stability: StabilityStable, Summary: "GOWDK use declaration is malformed"},
 	{Code: "malformed_route", Area: "routing", Stability: StabilityStable, Summary: "route path violates GOWDK route syntax"},
+	{Code: "missing_img_alt", Area: "accessibility", Stability: StabilityStable, Summary: "image element is missing explicit alt text"},
 	{Code: "missing_package_declaration", Area: "packages", Stability: StabilityStable, Summary: "GOWDK source is missing a package declaration"},
 	{Code: "missing_page_guard", Area: "pages", Stability: StabilityStable, Summary: "page source is missing explicit access guard metadata"},
 	{Code: "missing_required_env", Area: "config", Stability: StabilityStable, Summary: "required environment variable is not set"},

--- a/internal/lang/accessibility.go
+++ b/internal/lang/accessibility.go
@@ -1,0 +1,105 @@
+package lang
+
+import (
+	"strings"
+
+	"github.com/cssbruno/gowdk/internal/manifest"
+	"github.com/cssbruno/gowdk/internal/view"
+)
+
+func accessibilityDiagnostics(app manifest.Manifest) Diagnostics {
+	var diagnostics Diagnostics
+	for _, page := range app.Pages {
+		diagnostics = append(diagnostics, viewAccessibilityDiagnostics(page.Source, page.Blocks)...)
+	}
+	for _, component := range app.Components {
+		diagnostics = append(diagnostics, viewAccessibilityDiagnostics(component.Source, component.Blocks)...)
+	}
+	for _, layout := range app.Layouts {
+		diagnostics = append(diagnostics, viewAccessibilityDiagnostics(layout.Source, layout.Blocks)...)
+	}
+	return diagnostics
+}
+
+func viewAccessibilityDiagnostics(file string, blocks manifest.Blocks) Diagnostics {
+	if !blocks.View || blocks.ViewBody == "" || blocks.Spans.ViewBodyStart.Line <= 0 {
+		return nil
+	}
+	if !strings.Contains(blocks.ViewBody, "<img") {
+		return nil
+	}
+	nodes, err := view.Parse(blocks.ViewBody)
+	if err != nil {
+		return nil
+	}
+	return imageAltDiagnostics(file, blocks.ViewBody, blocks.Spans.ViewBodyStart, nodes)
+}
+
+func imageAltDiagnostics(file string, body string, bodyStart manifest.SourcePosition, nodes []view.Node) Diagnostics {
+	var diagnostics Diagnostics
+	walkViewNodes(nodes, func(element view.Element) {
+		if element.Name != "img" || imageHasAlt(element.Attrs) {
+			return
+		}
+		start := viewBodyOffsetPosition(body, bodyStart, element.Start)
+		end := viewBodyOffsetPosition(body, bodyStart, element.End)
+		diagnostics = append(diagnostics, Diagnostic{
+			File:       file,
+			Code:       "missing_img_alt",
+			Pos:        start,
+			Range:      sourceRange(start, end),
+			Severity:   "warning",
+			Message:    "<img> is missing explicit alt text",
+			Suggestion: `Add alt="..." for informative images or alt="" for decorative images.`,
+		})
+	})
+	return diagnostics
+}
+
+func walkViewNodes(nodes []view.Node, visit func(view.Element)) {
+	for _, node := range nodes {
+		switch typed := node.(type) {
+		case view.Element:
+			visit(typed)
+			walkViewNodes(typed.Children, visit)
+		case view.ComponentCall:
+			walkViewNodes(typed.Children, visit)
+		}
+	}
+}
+
+func imageHasAlt(attrs []view.Attr) bool {
+	for _, attr := range attrs {
+		if attr.Name == "alt" && !attr.Boolean {
+			return true
+		}
+	}
+	return false
+}
+
+func viewBodyOffsetPosition(body string, start manifest.SourcePosition, offset int) Position {
+	if start.Column <= 0 {
+		start.Column = 1
+	}
+	if start.Line <= 0 {
+		start.Line = 1
+	}
+	if offset < 0 {
+		offset = 0
+	}
+	runes := []rune(body)
+	if offset > len(runes) {
+		offset = len(runes)
+	}
+	line := start.Line
+	column := start.Column
+	for _, char := range runes[:offset] {
+		if char == '\n' {
+			line++
+			column = 1
+			continue
+		}
+		column++
+	}
+	return Position{Line: line, Column: column}
+}

--- a/internal/lang/tools.go
+++ b/internal/lang/tools.go
@@ -288,6 +288,7 @@ func CheckFiles(config gowdk.Config, paths []string) (manifest.Manifest, Diagnos
 	if err := compiler.ValidateManifest(config, app); err != nil {
 		diagnostics = append(diagnostics, compilerDiagnostics(err, app)...)
 	}
+	diagnostics = append(diagnostics, accessibilityDiagnostics(app)...)
 	if !diagnostics.HasErrors() {
 		app = compiler.BindBackendHandlers(app)
 		diagnostics = append(diagnostics, validateContractReferences(config, app)...)
@@ -338,9 +339,14 @@ func CheckSource(config gowdk.Config, path string, source []byte) (manifest.Page
 		if err := compiler.ValidateManifest(config, app); err != nil {
 			diagnostics = append(diagnostics, compilerDiagnostics(err, app)...)
 		}
+		diagnostics = append(diagnostics, accessibilityDiagnostics(app)...)
 		return manifest.Page{}, diagnostics
 	case FileKindLayout:
-		_, diagnostics := ParseLayoutSource(path, source)
+		layout, diagnostics := ParseLayoutSource(path, source)
+		if diagnostics.HasErrors() {
+			return manifest.Page{}, diagnostics
+		}
+		diagnostics = append(diagnostics, accessibilityDiagnostics(manifest.Manifest{Layouts: []manifest.Layout{layout}})...)
 		return manifest.Page{}, diagnostics
 	case FileKindAsset, FileKindPlugin:
 		_, diagnostics := Lex(string(source))
@@ -358,6 +364,7 @@ func CheckSource(config gowdk.Config, path string, source []byte) (manifest.Page
 	if err := compiler.ValidateManifest(config, app); err != nil {
 		diagnostics = append(diagnostics, compilerDiagnostics(err, app)...)
 	}
+	diagnostics = append(diagnostics, accessibilityDiagnostics(app)...)
 	return page, diagnostics
 }
 

--- a/internal/lang/tools_test.go
+++ b/internal/lang/tools_test.go
@@ -234,6 +234,140 @@ func TestCheckJSONGoldenDiagnosticsFixture(t *testing.T) {
 	}
 }
 
+func TestCheckFilesWarnsForImageWithoutAlt(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "gallery.page.gwdk")
+	writeGWDK(t, path, `package app
+
+@page gallery
+@route "/gallery"
+@guard public
+
+view {
+  <main>
+    <img src="/hero.png" />
+  </main>
+}
+`)
+
+	_, diagnostics := CheckFiles(gowdk.Config{}, []string{path})
+	if diagnostics.HasErrors() {
+		t.Fatalf("expected warning-only diagnostics, got %v", diagnostics)
+	}
+	if len(diagnostics) != 1 {
+		t.Fatalf("expected one diagnostic, got %#v", diagnostics)
+	}
+	diagnostic := diagnostics[0]
+	if diagnostic.Code != "missing_img_alt" || diagnostic.Severity != "warning" {
+		t.Fatalf("expected missing_img_alt warning, got %#v", diagnostic)
+	}
+	if diagnostic.File != path {
+		t.Fatalf("expected diagnostic file %q, got %#v", path, diagnostic)
+	}
+	if diagnostic.Pos.Line != 9 || diagnostic.Pos.Column != 5 {
+		t.Fatalf("expected diagnostic at img tag, got %#v", diagnostic.Pos)
+	}
+	if diagnostic.Range == nil ||
+		diagnostic.Range.Start.Line != 9 || diagnostic.Range.Start.Column != 5 ||
+		diagnostic.Range.End.Line != 9 || diagnostic.Range.End.Column <= diagnostic.Range.Start.Column {
+		t.Fatalf("expected diagnostic range on img tag, got %#v", diagnostic.Range)
+	}
+	if !strings.Contains(diagnostic.Suggestion, `alt=""`) {
+		t.Fatalf("expected alt suggestion, got %#v", diagnostic)
+	}
+}
+
+func TestCheckFilesAcceptsImagesWithAlt(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "gallery.page.gwdk")
+	writeGWDK(t, path, `package app
+
+@page gallery
+@route "/gallery"
+@guard public
+
+view {
+  <main>
+    <img src="/hero.png" alt="Hero" />
+    <img src="/decorative.png" alt="" />
+  </main>
+}
+`)
+
+	_, diagnostics := CheckFiles(gowdk.Config{}, []string{path})
+	if len(diagnostics) != 0 {
+		t.Fatalf("expected no diagnostics, got %#v", diagnostics)
+	}
+}
+
+func TestCheckJSONIncludesAccessibilityWarning(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "gallery.page.gwdk")
+	writeGWDK(t, path, `package app
+
+@page gallery
+@route "/gallery"
+@guard public
+
+view {
+  <img src="/hero.png" />
+}
+`)
+
+	payload, diagnostics := CheckJSON(gowdk.Config{}, []string{path})
+	if diagnostics.HasErrors() {
+		t.Fatalf("expected warning-only diagnostics, got %v", diagnostics)
+	}
+	output := string(payload)
+	if !strings.Contains(output, `"code": "missing_img_alt"`) ||
+		!strings.Contains(output, `"severity": "warning"`) {
+		t.Fatalf("expected accessibility warning in JSON: %s", output)
+	}
+}
+
+func TestCheckFilesWarnsForImageWithoutAltInComponentsAndLayouts(t *testing.T) {
+	root := t.TempDir()
+	componentPath := filepath.Join(root, "hero.cmp.gwdk")
+	layoutPath := filepath.Join(root, "root.layout.gwdk")
+	writeGWDK(t, componentPath, `package app
+
+@component Hero
+
+view {
+  <section>
+    <img src="/hero.png" />
+  </section>
+}
+`)
+	writeGWDK(t, layoutPath, `package app
+
+@layout root
+
+view {
+  <main>
+    <img src="/logo.png" />
+    <slot />
+  </main>
+}
+`)
+
+	_, diagnostics := CheckFiles(gowdk.Config{}, []string{componentPath, layoutPath})
+	if diagnostics.HasErrors() {
+		t.Fatalf("expected warning-only diagnostics, got %v", diagnostics)
+	}
+	if len(diagnostics) != 2 {
+		t.Fatalf("expected two accessibility warnings, got %#v", diagnostics)
+	}
+	for _, diagnostic := range diagnostics {
+		if diagnostic.Code != "missing_img_alt" || diagnostic.Severity != "warning" {
+			t.Fatalf("expected missing_img_alt warning, got %#v", diagnostic)
+		}
+		if diagnostic.Pos.Line != 7 || diagnostic.Pos.Column != 5 {
+			t.Fatalf("expected diagnostic at img tag, got %#v", diagnostic)
+		}
+	}
+}
+
 func TestClassifySourceUsesCurrentFileKindRules(t *testing.T) {
 	cases := []struct {
 		path   string

--- a/internal/parser/component.go
+++ b/internal/parser/component.go
@@ -125,6 +125,7 @@ func ParseComponent(source []byte) (manifest.Component, error) {
 			}
 			if line == "}" {
 				component.Blocks.ViewBody = strings.TrimSpace(strings.Join(viewBody, "\n"))
+				component.Blocks.Spans.ViewBodyStart = sourceBodyStart(viewBody, lineNumber-len(viewBody))
 				inView = false
 				viewBody = nil
 				continue

--- a/internal/parser/layout.go
+++ b/internal/parser/layout.go
@@ -77,6 +77,7 @@ func ParseLayout(source []byte) (manifest.Layout, error) {
 			if line == "}" {
 				layout.Blocks.View = true
 				layout.Blocks.ViewBody = strings.TrimSpace(strings.Join(viewBody, "\n"))
+				layout.Blocks.Spans.ViewBodyStart = sourceBodyStart(viewBody, lineNumber-len(viewBody))
 				inView = false
 				viewBody = nil
 				continue

--- a/internal/parser/route_helpers.go
+++ b/internal/parser/route_helpers.go
@@ -50,6 +50,18 @@ func sourceLineSpan(lineNumber int, rawLine string) manifest.SourceSpan {
 	}
 }
 
+func sourceBodyStart(lines []string, firstLineNumber int) manifest.SourcePosition {
+	for offset, rawLine := range lines {
+		for index, char := range []rune(rawLine) {
+			if strings.TrimSpace(string(char)) == "" {
+				continue
+			}
+			return manifest.SourcePosition{Line: firstLineNumber + offset, Column: index + 1}
+		}
+	}
+	return manifest.SourcePosition{}
+}
+
 func namedValueSpans(values []string, lineNumber int, rawLine string) []manifest.NamedSpan {
 	if len(values) == 0 {
 		return nil

--- a/internal/view/element.go
+++ b/internal/view/element.go
@@ -12,6 +12,8 @@ type Element struct {
 	Name     string
 	Attrs    []Attr
 	Children []Node
+	Start    int
+	End      int
 }
 
 func (node Element) render(ctx *renderContext, out *renderOutput) error {

--- a/internal/view/parser.go
+++ b/internal/view/parser.go
@@ -84,6 +84,7 @@ func unsupportedTemplateSyntax(text string) (int, string, bool) {
 }
 
 func (parser *parser) element() (Node, error) {
+	start := parser.index
 	if !parser.consume("<") {
 		return nil, parser.errorf("expected element")
 	}
@@ -107,7 +108,7 @@ func (parser *parser) element() (Node, error) {
 			if err != nil {
 				return nil, err
 			}
-			return Element{Name: name, Attrs: attrs}, nil
+			return Element{Name: name, Attrs: attrs, Start: start, End: parser.index}, nil
 		case parser.consume(">"):
 			attrs, err := normalizeHTMLAttrs(attrs)
 			if err != nil {
@@ -117,7 +118,7 @@ func (parser *parser) element() (Node, error) {
 			if err != nil {
 				return nil, err
 			}
-			return Element{Name: name, Attrs: attrs, Children: children}, nil
+			return Element{Name: name, Attrs: attrs, Children: children, Start: start, End: parser.index}, nil
 		case parser.done():
 			return nil, parser.errorf("unterminated <%s> tag", name)
 		default:


### PR DESCRIPTION
## Summary

- Add `missing_img_alt` as the first accessibility diagnostic warning for literal `<img>` elements without explicit `alt` text.
- Wire accessibility diagnostics into `CheckFiles` and `CheckSource` for pages, components, and layouts.
- Add source spans for parsed HTML elements and view-body starts so warning ranges point at the affected tag.
- Update diagnostic registry/docs for warning severity and the new accessibility code.

Closes #26

## Verification

- [x] I ran the relevant tests, lint, and build commands.
- [x] I ran `scripts/test-go-modules.sh` when Go code or compiler behavior changed.
- [x] I ran `go build ./cmd/gowdk` when CLI, compiler, runtime, addon, or release behavior changed.
- [ ] I ran `node --check editors/vscode/extension.js` when editor files changed.
- [x] I updated docs for behavior, setup, or architecture changes.
- [x] I added or updated tests for changed behavior.

## LLM Assistance

- LLM session summary: Codex implemented a scoped M2 accessibility diagnostic slice and ran the Go verification gates.
- Human-reviewed assumptions: Pending maintainer review before merge.
- Follow-up work: Broaden the accessibility diagnostic catalogue after this first warning is reviewed.