### PR TITLE
fix: harden html attribute escaping

### DIFF
--- a/runtime/html/html.go
+++ b/runtime/html/html.go
@@ -16,11 +16,14 @@ func Attr(name, value string) string {
 	if value == "" || !validAttrName(name) {
 		return ""
 	}
-	return " " + name + `="` + escapeAttrValue(value) + `"`
-}
 
-func escapeAttrValue(value string) string {
-	return htmltemplate.HTMLEscapeString(value)
+	var out strings.Builder
+	out.WriteByte(' ')
+	out.WriteString(name)
+	out.WriteString(`="`)
+	htmltemplate.HTMLEscape(&out, []byte(value))
+	out.WriteByte('"')
+	return out.String()
 }
 
 func validAttrName(name string) bool {

--- a/runtime/html/html.go
+++ b/runtime/html/html.go
@@ -20,7 +20,7 @@ func Attr(name, value string) string {
 }
 
 func escapeAttrValue(value string) string {
-	return htmltemplate.HTMLEscaper(value)
+	return htmltemplate.HTMLEscapeString(value)
 }
 
 func validAttrName(name string) bool {

--- a/runtime/html/html.go
+++ b/runtime/html/html.go
@@ -2,6 +2,7 @@ package html
 
 import (
 	stdhtml "html"
+	htmltemplate "html/template"
 	"strings"
 )
 
@@ -12,10 +13,31 @@ func Escape(value string) string {
 
 // Attr renders an escaped HTML attribute when value is non-empty.
 func Attr(name, value string) string {
-	if value == "" {
+	if value == "" || !validAttrName(name) {
 		return ""
 	}
-	return " " + name + `="` + stdhtml.EscapeString(value) + `"`
+	return " " + name + `="` + escapeAttrValue(value) + `"`
+}
+
+func escapeAttrValue(value string) string {
+	return htmltemplate.HTMLEscaper(value)
+}
+
+func validAttrName(name string) bool {
+	if name == "" {
+		return false
+	}
+	for _, char := range name {
+		switch {
+		case char >= 'a' && char <= 'z':
+		case char >= 'A' && char <= 'Z':
+		case char >= '0' && char <= '9':
+		case char == '-' || char == '_' || char == ':' || char == '.':
+		default:
+			return false
+		}
+	}
+	return true
 }
 
 // Classes joins generated class tokens.

--- a/runtime/html/html_test.go
+++ b/runtime/html/html_test.go
@@ -1,6 +1,9 @@
 package html
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestEscapeEscapesHTMLText(t *testing.T) {
 	if got := Escape(`<script>alert("x")</script>`); got != `&lt;script&gt;alert(&#34;x&#34;)&lt;/script&gt;` {
@@ -14,6 +17,39 @@ func TestAttrOmitsEmptyValuesAndEscapesNonEmptyValues(t *testing.T) {
 	}
 	if got := Attr("href", `/search?q=go&sort="new"`); got != ` href="/search?q=go&amp;sort=&#34;new&#34;"` {
 		t.Fatalf("unexpected attr: %q", got)
+	}
+}
+
+func TestAttrEscapesJSONAttributeValues(t *testing.T) {
+	got := Attr("data-gowdk-state", `{"name":"hero","quote":"\"","html":"</gowdk-island>","amp":"&"}`)
+	const prefix = ` data-gowdk-state="`
+	if !strings.HasPrefix(got, prefix) || !strings.HasSuffix(got, `"`) {
+		t.Fatalf("unexpected attr shape: %q", got)
+	}
+	inner := strings.TrimSuffix(strings.TrimPrefix(got, prefix), `"`)
+	if strings.Contains(inner, `"`) {
+		t.Fatalf("attribute value contains an unescaped double quote: %q", got)
+	}
+	for _, escaped := range []string{`&#34;name&#34;`, `&lt;/gowdk-island&gt;`, `&amp;`} {
+		if !strings.Contains(inner, escaped) {
+			t.Fatalf("attribute value is missing escaped fragment %q: %q", escaped, got)
+		}
+	}
+}
+
+func TestAttrRejectsUnsafeAttributeNames(t *testing.T) {
+	for _, name := range []string{
+		``,
+		`href" onclick="alert(1)`,
+		`data-gowdk-state onmouseover`,
+		`data-gowdk-state=bad`,
+	} {
+		if got := Attr(name, "value"); got != "" {
+			t.Fatalf("expected unsafe attr name %q to be omitted, got %q", name, got)
+		}
+	}
+	if got := Attr("data-gowdk-parent-on-submit", "Save()"); got == "" {
+		t.Fatal("expected generated data attribute name to be accepted")
 	}
 }
 


### PR DESCRIPTION
## Summary

- Use the HTML-template escaper for generated HTML attribute values.
- Reject unsafe generated attribute names before rendering an attribute.
- Add regression coverage for JSON attribute values containing quotes, HTML markup, and ampersands.

This addresses the CodeQL alert on `runtime/html/html.go` for potentially unsafe quoting in generated HTML attributes.

## Verification

- [x] I ran the relevant tests, lint, and build commands.
- [x] I ran `scripts/test-go-modules.sh` when Go code or compiler behavior changed.
- [x] I ran `go build ./cmd/gowdk` when CLI, compiler, runtime, addon, or release behavior changed.
- [ ] I ran `node --check editors/vscode/extension.js` when editor files changed.
- [ ] I updated docs for behavior, setup, or architecture changes.
- [x] I added or updated tests for changed behavior.

Additional validation:

- `go test ./runtime/html`
- `git diff --check`
- `go test ./...`

## LLM Assistance

- LLM session summary: Codex fixed the CodeQL HTML attribute quoting finding with a scoped runtime helper change and regression tests.
- Human-reviewed assumptions: Pending maintainer review before merge.
- Follow-up work: Re-run GitHub CodeQL on the PR to confirm the alert closes in GitHub Security.