### PR TITLE
ci: restrict workflow token permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   verify:
     name: Verify


### PR DESCRIPTION
## Summary

- Add workflow-level `permissions: contents: read` to `.github/workflows/ci.yml`.
- Keep CI functionality read-only while limiting the default `GITHUB_TOKEN` scope.

This addresses the CodeQL `actions/missing-workflow-permissions` alert for the CI workflow.

## Verification

- [x] I ran the relevant tests, lint, and build commands.
- [ ] I ran `scripts/test-go-modules.sh` when Go code or compiler behavior changed.
- [ ] I ran `go build ./cmd/gowdk` when CLI, compiler, runtime, addon, or release behavior changed.
- [ ] I ran `node --check editors/vscode/extension.js` when editor files changed.
- [ ] I updated docs for behavior, setup, or architecture changes.
- [ ] I added or updated tests for changed behavior.

Additional validation:

- `git diff --check`

## LLM Assistance

- LLM session summary: Codex applied the least-privilege GitHub Actions permissions fix suggested by CodeQL/Copilot Autofix.
- Human-reviewed assumptions: Pending maintainer review before merge.
- Follow-up work: Confirm the code scanning alert closes after GitHub re-runs workflow analysis.