### PR TITLE
refactor(compiler): make build-path validation IR-native (#145, phase 1)

### DIFF
--- a/.llm/plans/manifest-to-ir-migration.md
+++ b/.llm/plans/manifest-to-ir-migration.md
@@ -18,15 +18,28 @@ Done:
 - Swapped leaf-type references to `internal/source` across `appgen`, `compiler`,
   `parser`, `gwdkanalysis`, `lsp`.
 
+Issue #145 progress (compiler IR-native validation):
+
+- (done) Enriched the IR so it is no longer lossy for standalone Go endpoints:
+  `gwdkir.GoEndpoint` preserves the raw declaration (kind/method/spans), and
+  `ManifestFromIR` reconstructs `manifest.Endpoints` from it. This closes the
+  silent-skip gap — `validateStandaloneEndpoints` / `validateRouteMethodConflicts`
+  now run on the IR path.
+- (done) Differential proof: `ValidateProgram(BuildIR(app))` is byte-identical to
+  `ValidateManifest(app)` across a valid/invalid corpus (kept as a regression
+  guard in `validate_differential_test.go`).
+- (done) The CLI build path validates the IR directly via `ValidateProgram(ir)`,
+  no longer threading a manifest into validation.
+
 Pending (largest remaining work):
 
-- Make `internal/compiler` validation/binding IR-native (it still validates the
-  manifest model — ~980 references). Tracked in **issue #145**. This is a
-  redesign, not a mechanical swap: a naive flip to `ValidateProgram(ir)` would
-  silently drop `validateStandaloneEndpoints` / `validateRouteMethodConflicts`
-  because IR lowering is lossy for endpoint spans, route params, and the raw
-  kind/method those validators check. The IR must be enriched first and the flip
-  guarded by a zero-diagnostic-drift differential corpus.
+- The validator bodies still read manifest model types internally (via the
+  `ManifestFromIR` adapter), so `internal/compiler` still imports `manifest` for
+  the model (~980 references). Rewriting the ~30 validators to read `gwdkir`
+  types directly — and dropping the adapter — is the remaining bulk of #145.
+- Remove the residual double validation in the build path (CLI validates the IR,
+  buildgen re-validates defensively for its other callers).
+- Flip the `lang` report commands (`check`/`sitemap`/`manifest`) to IR validation.
 - Collapse the `AST → manifest → IR` path to `AST → IR` in `gwdkanalysis`.
 - Keep public manifest JSON until a release plan deprecates it.
 

--- a/cmd/gowdk/build.go
+++ b/cmd/gowdk/build.go
@@ -98,12 +98,12 @@ func buildOnce(options cliOptions, request buildRequest) error {
 		fmt.Fprintln(os.Stderr, err)
 		return fmt.Errorf("build failed")
 	}
-	if err := compiler.ValidateManifest(options.Config, app); err != nil {
+	app = compiler.BindBackendHandlers(app)
+	ir := gwdkanalysis.BuildIR(options.Config, app)
+	if err := compiler.ValidateProgram(options.Config, ir); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		return fmt.Errorf("build failed")
 	}
-	app = compiler.BindBackendHandlers(app)
-	ir := gwdkanalysis.BuildIR(options.Config, app)
 	if err := linkIRContractReferences(&ir, "."); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		return fmt.Errorf("build failed")

--- a/internal/compiler/manifest_from_ir.go
+++ b/internal/compiler/manifest_from_ir.go
@@ -122,7 +122,7 @@ func pageFromIR(page gwdkir.Page) manifest.Page {
 		Imports:     importsFromIR(page.Imports),
 		Uses:        usesFromIR(page.Uses),
 		Stores:      storesFromIR(page.Stores),
-		Paths:       page.Blocks.PathsBody != "",
+		Paths:       page.Blocks.Paths,
 		Blocks:      blocksFromIR(page.Blocks),
 		LoadBinding: loadBindingFromIR(page),
 		Spans: manifest.PageSpans{

--- a/internal/compiler/manifest_from_ir.go
+++ b/internal/compiler/manifest_from_ir.go
@@ -20,6 +20,7 @@ func ManifestFromIR(ir gwdkir.Program) manifest.Manifest {
 		Pages:           make([]manifest.Page, 0, len(ir.Pages)),
 		Components:      make([]manifest.Component, 0, len(ir.Components)),
 		Layouts:         make([]manifest.Layout, 0, len(ir.Layouts)),
+		Endpoints:       goEndpointsFromIR(ir.GoEndpoints),
 		BackendBindings: BackendBindingsFromIR(ir),
 	}
 	for _, page := range ir.Pages {
@@ -45,6 +46,34 @@ func BackendBindingsFromIR(ir gwdkir.Program) []manifest.BackendBinding {
 		if binding.Status != "" || binding.ImportPath != "" || binding.FunctionName != "" {
 			out = append(out, binding)
 		}
+	}
+	return out
+}
+
+// goEndpointsFromIR reconstructs the standalone Go endpoint declarations from
+// their lossless IR mirror. This is a one-to-one field copy, so validation that
+// reads manifest.Endpoints (route conflicts, standalone-endpoint shape) runs
+// identically whether it starts from a parsed manifest or from IR.
+func goEndpointsFromIR(endpoints []gwdkir.GoEndpoint) []manifest.EndpointDeclaration {
+	if len(endpoints) == 0 {
+		return nil
+	}
+	out := make([]manifest.EndpointDeclaration, 0, len(endpoints))
+	for _, endpoint := range endpoints {
+		out = append(out, manifest.EndpointDeclaration{
+			Kind:          endpoint.Kind,
+			SourceKind:    manifest.EndpointSource(endpoint.SourceKind),
+			Package:       endpoint.Package,
+			Source:        endpoint.Source,
+			Name:          endpoint.Name,
+			Method:        endpoint.Method,
+			Route:         endpoint.Route,
+			ErrorPage:     endpoint.ErrorPage,
+			Span:          endpoint.Span,
+			RouteSpan:     endpoint.RouteSpan,
+			RouteParams:   append([]source.NamedSpan(nil), endpoint.RouteParams...),
+			ErrorPageSpan: endpoint.ErrorPageSpan,
+		})
 	}
 	return out
 }

--- a/internal/compiler/manifest_from_ir_test.go
+++ b/internal/compiler/manifest_from_ir_test.go
@@ -1,6 +1,7 @@
 package compiler
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/cssbruno/gowdk"
@@ -152,4 +153,78 @@ func errString(err error) string {
 		return ""
 	}
 	return err.Error()
+}
+
+// TestValidateProgramRunsStandaloneEndpointChecks guards the regression that
+// motivated issue #145: standalone Go endpoints are lowered into IR losslessly
+// via Program.GoEndpoints, and ManifestFromIR reconstructs manifest.Endpoints
+// from them, so validateStandaloneEndpoints actually runs on the IR path. Before
+// GoEndpoints existed, ManifestFromIR left Endpoints nil and this check was
+// silently skipped.
+func TestValidateProgramRunsStandaloneEndpointChecks(t *testing.T) {
+	ir := gwdkir.Program{
+		Version: gwdkir.Version,
+		GoEndpoints: []gwdkir.GoEndpoint{{
+			Kind:       "action",
+			SourceKind: gwdkir.EndpointSourceGo,
+			Package:    "handlers",
+			Source:     "handlers/subscribe.go",
+			Name:       "subscribe", // not an exported Go identifier -> invalid
+			Method:     "POST",
+			Route:      "/subscribe",
+		}},
+	}
+
+	err := ValidateProgram(gowdk.Config{}, ir)
+	if err == nil {
+		t.Fatal("expected non-exported standalone endpoint handler to fail IR validation")
+	}
+	if !strings.Contains(err.Error(), "must be an exported Go identifier") {
+		t.Fatalf("unexpected diagnostic: %v", err)
+	}
+
+	// The same IR lowered to a manifest must produce the identical diagnostic —
+	// proving ValidateProgram and ValidateManifest agree on endpoint checks.
+	if got := errString(ValidateProgram(gowdk.Config{}, ir)); got != errString(ValidateManifest(gowdk.Config{}, ManifestFromIR(ir))) {
+		t.Fatalf("IR and manifest endpoint validation diverged: %q", got)
+	}
+}
+
+// TestGoEndpointsReconstructFaithfully checks that ManifestFromIR rebuilds the
+// standalone endpoint declarations field-for-field from the IR mirror.
+func TestGoEndpointsReconstructFaithfully(t *testing.T) {
+	ir := gwdkir.Program{
+		Version: gwdkir.Version,
+		GoEndpoints: []gwdkir.GoEndpoint{{
+			Kind:          "api",
+			SourceKind:    gwdkir.EndpointSourceGo,
+			Package:       "handlers",
+			Source:        "handlers/list.go",
+			Name:          "List",
+			Method:        "GET",
+			Route:         "/api/list/{id:int}",
+			ErrorPage:     "500.html",
+			RouteParams:   []source.NamedSpan{{Name: "id"}},
+			RouteSpan:     source.SourceSpan{Start: source.SourcePosition{Line: 3, Column: 1}},
+			ErrorPageSpan: source.SourceSpan{Start: source.SourcePosition{Line: 4, Column: 1}},
+		}},
+	}
+
+	app := ManifestFromIR(ir)
+	if len(app.Endpoints) != 1 {
+		t.Fatalf("expected 1 reconstructed endpoint, got %d", len(app.Endpoints))
+	}
+	got := app.Endpoints[0]
+	if got.Kind != "api" || got.Name != "List" || got.Method != "GET" || got.Route != "/api/list/{id:int}" {
+		t.Fatalf("endpoint core fields not preserved: %#v", got)
+	}
+	if got.ErrorPage != "500.html" || got.SourceKind != "go" || got.Source != "handlers/list.go" {
+		t.Fatalf("endpoint metadata not preserved: %#v", got)
+	}
+	if len(got.RouteParams) != 1 || got.RouteParams[0].Name != "id" {
+		t.Fatalf("route params not preserved: %#v", got.RouteParams)
+	}
+	if got.RouteSpan.Start.Line != 3 || got.ErrorPageSpan.Start.Line != 4 {
+		t.Fatalf("spans not preserved: %#v", got)
+	}
 }

--- a/internal/compiler/manifest_from_ir_test.go
+++ b/internal/compiler/manifest_from_ir_test.go
@@ -23,6 +23,7 @@ func sampleProgram() gwdkir.Program {
 			Layouts: []string{"root"},
 			Guards:  []string{"public"},
 			Blocks: gwdkir.Blocks{
+				Paths:     true,
 				Build:     true,
 				BuildBody: `=> { title: "Home" }`,
 				View:      true,
@@ -81,6 +82,9 @@ func TestManifestFromIRReconstructsCoreRecords(t *testing.T) {
 	}
 	if len(app.Pages[0].Blocks.Fragments) != 1 || app.Pages[0].Blocks.Fragments[0].Name != "List" {
 		t.Fatalf("fragment endpoints not preserved: %#v", app.Pages[0].Blocks.Fragments)
+	}
+	if !app.Pages[0].Paths {
+		t.Fatalf("paths block presence not preserved: %#v", app.Pages[0])
 	}
 	if len(app.Components) != 1 || app.Components[0].Name != "Counter" {
 		t.Fatalf("unexpected components: %#v", app.Components)

--- a/internal/compiler/validate_differential_test.go
+++ b/internal/compiler/validate_differential_test.go
@@ -1,0 +1,88 @@
+package compiler_test
+
+import (
+	"testing"
+
+	"github.com/cssbruno/gowdk"
+	"github.com/cssbruno/gowdk/internal/compiler"
+	"github.com/cssbruno/gowdk/internal/gwdkanalysis"
+	"github.com/cssbruno/gowdk/internal/manifest"
+)
+
+// TestValidateProgramMatchesValidateManifestDifferential is the safety proof for
+// flipping the CLI to validate IR instead of the parsed manifest: for a corpus of
+// valid and invalid programs, ValidateProgram(BuildIR(app)) must produce the exact
+// same diagnostics as ValidateManifest(app). If this ever diverges, the IR round
+// trip has lost or reordered something a validator depends on.
+func TestValidateProgramMatchesValidateManifestDifferential(t *testing.T) {
+	view := func(body string) manifest.Blocks { return manifest.Blocks{View: true, ViewBody: body} }
+	page := func(id, route string) manifest.Page {
+		return manifest.Page{ID: id, Route: route, Package: "pages", Source: id + ".page.gwdk", Blocks: view("<main/>")}
+	}
+
+	cases := []struct {
+		name string
+		app  manifest.Manifest
+	}{
+		{
+			name: "valid program",
+			app:  manifest.Manifest{Pages: []manifest.Page{page("home", "/"), page("about", "/about")}},
+		},
+		{
+			name: "duplicate page identity",
+			app:  manifest.Manifest{Pages: []manifest.Page{page("home", "/"), page("home", "/other")}},
+		},
+		{
+			name: "duplicate route pattern",
+			app:  manifest.Manifest{Pages: []manifest.Page{page("home", "/dup"), page("other", "/dup")}},
+		},
+		{
+			name: "invalid standalone endpoint handler",
+			app: manifest.Manifest{
+				Pages: []manifest.Page{page("home", "/")},
+				Endpoints: []manifest.EndpointDeclaration{{
+					Kind: "action", SourceKind: manifest.EndpointSourceGo, Package: "h",
+					Source: "h/x.go", Name: "lowercase", Method: "POST", Route: "/x",
+				}},
+			},
+		},
+		{
+			name: "route method conflict between page and standalone endpoint",
+			app: manifest.Manifest{
+				Pages: []manifest.Page{page("home", "/clash")},
+				Endpoints: []manifest.EndpointDeclaration{{
+					Kind: "api", SourceKind: manifest.EndpointSourceGo, Package: "h",
+					Source: "h/x.go", Name: "Clash", Method: "GET", Route: "/clash",
+				}},
+			},
+		},
+		{
+			name: "standalone action with unsupported method",
+			app: manifest.Manifest{
+				Endpoints: []manifest.EndpointDeclaration{{
+					Kind: "action", SourceKind: manifest.EndpointSourceGo, Package: "h",
+					Source: "h/x.go", Name: "Save", Method: "DELETE", Route: "/save",
+				}},
+			},
+		},
+	}
+
+	config := gowdk.Config{}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			viaManifest := errText(compiler.ValidateManifest(config, tc.app))
+			ir := gwdkanalysis.BuildIR(config, tc.app)
+			viaProgram := errText(compiler.ValidateProgram(config, ir))
+			if viaManifest != viaProgram {
+				t.Fatalf("diagnostic drift between manifest and IR validation:\nmanifest: %q\nIR:       %q", viaManifest, viaProgram)
+			}
+		})
+	}
+}
+
+func errText(err error) string {
+	if err == nil {
+		return ""
+	}
+	return err.Error()
+}

--- a/internal/compiler/validate_differential_test.go
+++ b/internal/compiler/validate_differential_test.go
@@ -57,6 +57,13 @@ func TestValidateProgramMatchesValidateManifestDifferential(t *testing.T) {
 			},
 		},
 		{
+			name: "dynamic spa page with empty paths block",
+			app: manifest.Manifest{Pages: []manifest.Page{{
+				ID: "blog.post", Route: "/blog/{slug}", Package: "pages",
+				Source: "blog.post.page.gwdk", Paths: true, Blocks: view("<main/>"),
+			}}},
+		},
+		{
 			name: "standalone action with unsupported method",
 			app: manifest.Manifest{
 				Endpoints: []manifest.EndpointDeclaration{{

--- a/internal/gwdkanalysis/analyzer_test.go
+++ b/internal/gwdkanalysis/analyzer_test.go
@@ -359,6 +359,14 @@ func TestBuildIRIncludesStandaloneGoEndpointSource(t *testing.T) {
 	if endpoint.Source != gwdkir.EndpointSourceGo || endpoint.PageID != "api.Session" || endpoint.Binding.Signature != source.BackendSignatureAPI {
 		t.Fatalf("unexpected endpoint IR: %#v", endpoint)
 	}
+	// The raw declaration must also be preserved losslessly for validation.
+	if len(ir.GoEndpoints) != 1 {
+		t.Fatalf("expected one raw Go endpoint, got %#v", ir.GoEndpoints)
+	}
+	raw := ir.GoEndpoints[0]
+	if raw.Kind != "api" || raw.Name != "Session" || raw.Method != "GET" || raw.Route != "/api/session" || raw.SourceKind != gwdkir.EndpointSourceGo {
+		t.Fatalf("raw Go endpoint not preserved: %#v", raw)
+	}
 }
 
 func TestBuildIRResolvesQualifiedCSSAssetUse(t *testing.T) {

--- a/internal/gwdkanalysis/ir_builder.go
+++ b/internal/gwdkanalysis/ir_builder.go
@@ -334,6 +334,22 @@ func (builder *irBuilder) addStandaloneEndpoint(endpoint manifest.EndpointDeclar
 		SourceFile:    endpoint.Source,
 		Span:          endpoint.Span,
 	})
+	// Preserve the raw declaration losslessly for validation, which needs the
+	// exact kind, method, and spans before normalization.
+	builder.program.GoEndpoints = append(builder.program.GoEndpoints, gwdkir.GoEndpoint{
+		Kind:          endpoint.Kind,
+		SourceKind:    endpointSource(endpoint.SourceKind),
+		Package:       endpoint.Package,
+		Source:        endpoint.Source,
+		Name:          endpoint.Name,
+		Method:        endpoint.Method,
+		Route:         endpoint.Route,
+		ErrorPage:     endpoint.ErrorPage,
+		Span:          endpoint.Span,
+		RouteSpan:     endpoint.RouteSpan,
+		RouteParams:   append([]source.NamedSpan(nil), endpoint.RouteParams...),
+		ErrorPageSpan: endpoint.ErrorPageSpan,
+	})
 }
 
 func (builder *irBuilder) addTemplate(template gwdkir.Template) {

--- a/internal/gwdkanalysis/ir_lowering.go
+++ b/internal/gwdkanalysis/ir_lowering.go
@@ -19,6 +19,8 @@ func routeKind(mode gowdk.RenderMode, page manifest.Page) gwdkir.RouteKind {
 }
 
 func lowerIRPage(page manifest.Page) gwdkir.Page {
+	blocks := lowerIRBlocks(page.Blocks)
+	blocks.Paths = page.Paths
 	return gwdkir.Page{
 		Source:      page.Source,
 		Package:     page.Package,
@@ -38,7 +40,7 @@ func lowerIRPage(page manifest.Page) gwdkir.Page {
 		Imports:     lowerIRImports(page.Imports),
 		Uses:        lowerIRUses(page.Uses),
 		Stores:      lowerIRStores(page.Stores),
-		Blocks:      lowerIRBlocks(page.Blocks),
+		Blocks:      blocks,
 		Spans: gwdkir.PageSpans{
 			Package:     page.Spans.Package,
 			Page:        page.Spans.Page,

--- a/internal/gwdkir/ir.go
+++ b/internal/gwdkir/ir.go
@@ -18,6 +18,7 @@ type Program struct {
 	Layouts         []Layout
 	Routes          []Route
 	Endpoints       []Endpoint
+	GoEndpoints     []GoEndpoint
 	Templates       []Template
 	ContractRefs    []ContractReference
 	ClientBehaviors []ClientBehavior
@@ -341,6 +342,28 @@ type Endpoint struct {
 	SourceFile    string
 	Span          source.SourceSpan
 	Binding       Binding
+}
+
+// GoEndpoint preserves a standalone Go endpoint declaration (discovered from
+// `//gowdk:` comments) in its raw source-level form. Program.Endpoints holds the
+// normalized, codegen-ready endpoints with bindings attached, which is lossy for
+// validation (it collapses the raw kind, normalizes the method, and drops the
+// route/error-page spans). Keeping the raw declaration here lets validation read
+// the exact kind, method, and spans the author wrote with no information loss.
+// Fields mirror the parser/discovery output one-to-one.
+type GoEndpoint struct {
+	Kind          string
+	SourceKind    EndpointSource
+	Package       string
+	Source        string
+	Name          string
+	Method        string
+	Route         string
+	ErrorPage     string
+	Span          source.SourceSpan
+	RouteSpan     source.SourceSpan
+	RouteParams   []source.NamedSpan
+	ErrorPageSpan source.SourceSpan
 }
 
 type EndpointKind string

--- a/internal/gwdkir/ir.go
+++ b/internal/gwdkir/ir.go
@@ -108,6 +108,7 @@ type PageMetadata struct {
 }
 
 type Blocks struct {
+	Paths      bool
 	PathsBody  string
 	Build      bool
 	BuildBody  string


### PR DESCRIPTION
First phase of **#145** (make `internal/compiler` validation IR-native). This does the part that was the actual *blocker* — making the IR lossless for endpoints — and flips the build path to validate IR, with a differential proof. It deliberately does **not** attempt the full validator-body rewrite (that's the remaining bulk, see below).

## The blocker it fixes

A naive flip to `ValidateProgram(ir)` would have **silently dropped two validations**. IR lowering was lossy for standalone Go endpoints: `addStandaloneEndpoint` collapsed the raw kind (`act`/`action`/`api` → one enum), normalized the method, and dropped `RouteSpan`/`RouteParams`/`ErrorPageSpan`. So `ManifestFromIR` couldn't reconstruct `manifest.Endpoints`, and `validateStandaloneEndpoints` / `validateRouteMethodConflicts` never ran on the IR path.

## Changes

1. **`gwdkir.GoEndpoint`** — a faithful raw mirror of the endpoint declaration (using `source.*` leaf types; gwdkir stays manifest-free), stored in `Program.GoEndpoints`. The IR now preserves the front-end artifact losslessly, exactly as an IR should.
2. **`gwdkanalysis`** records the raw declaration alongside the normalized codegen endpoint.
3. **`compiler.ManifestFromIR`** reconstructs `manifest.Endpoints` from `ir.GoEndpoints` (1:1 field copy), so `ValidateProgram` runs the endpoint checks.
4. **CLI build path** validates the IR directly via `ValidateProgram(ir)` — no more manifest threading into validation.

## Proof (this is the important part)

`validate_differential_test.go` asserts `ValidateProgram(BuildIR(app))` is **byte-identical** to `ValidateManifest(app)` across a corpus of valid and invalid programs — duplicate pages, duplicate routes, invalid standalone endpoint handler, **page-vs-endpoint route conflict**, unsupported action method. The endpoint cases are exactly the ones previously skipped. This test stays as a permanent regression guard.

Plus: round-trip order-preservation is verified, and `BuildIR` is shown to populate `GoEndpoints`.

## Explicitly NOT in this PR (remaining #145 work, tracked in the plan)

- The ~30 validator bodies still read manifest model types **internally** via the `ManifestFromIR` adapter, so `internal/compiler` still imports `manifest` for the model. Rewriting them to read `gwdkir` directly (and deleting the adapter) is the remaining bulk.
- The build path still has one redundant validation (CLI validates IR; buildgen re-validates defensively for its other callers). Collapsing that is a follow-up.
- `lang` report commands (`check`/`sitemap`/`manifest`) still validate the manifest.

## Verification

- ✅ Full module gate `scripts/test-go-modules.sh` green (incl. nested modules); 47 root packages, 0 failures; gofmt/vet clean.
- `gwdkir` remains manifest-free (`go list -deps` = 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)