### PR TITLE
fix(compiler): formatter data loss, IR load bindings, span columns, single-file validation

### DIFF
--- a/internal/compiler/backend_binding_policy.go
+++ b/internal/compiler/backend_binding_policy.go
@@ -5,25 +5,30 @@ import (
 
 	"github.com/cssbruno/gowdk"
 	"github.com/cssbruno/gowdk/internal/gwdkir"
+	"github.com/cssbruno/gowdk/internal/manifest"
 	"github.com/cssbruno/gowdk/internal/source"
 )
 
-// ValidateBackendBindingPolicyIR enforces build-mode rules for declared backend
-// endpoints after same-package Go handler binding metadata has been produced.
-// When the program carries no binding metadata but declares backend endpoints
-// (callers that build straight from an unbound program), handlers are
-// re-discovered from disk before the policy check.
+// ValidateBackendBindingPolicyIR enforces the same build-mode rules as
+// ValidateBackendBindingPolicy against an IR-first build path. IR already
+// carries per-endpoint binding metadata, so the reconstructed manifest has its
+// BackendBindings populated and the on-disk rebinding branch does not refire.
 func ValidateBackendBindingPolicyIR(config gowdk.Config, ir gwdkir.Program) error {
+	return ValidateBackendBindingPolicy(config, ManifestFromIR(ir))
+}
+
+// ValidateBackendBindingPolicy enforces build-mode rules for declared backend
+// endpoints after same-package Go handler binding metadata has been produced.
+func ValidateBackendBindingPolicy(config gowdk.Config, app manifest.Manifest) error {
 	if config.Build.Mode != gowdk.Production || config.Build.AllowMissingBackend {
 		return nil
 	}
-	bindings := BackendBindingsFromIR(ir)
-	if len(bindings) == 0 && programDeclaresBackendEndpoints(ir) {
-		bindings = computeBackendBindings(ir)
+	if len(app.BackendBindings) == 0 && manifestDeclaresBackendEndpoints(app) {
+		app = BindBackendHandlers(app)
 	}
 
 	var diagnostics []ValidationError
-	for _, binding := range bindings {
+	for _, binding := range app.BackendBindings {
 		switch binding.Status {
 		case source.BackendBindingMissing, source.BackendBindingUnsupportedSignature:
 			diagnostics = append(diagnostics, backendBindingRequiredDiagnostic(binding))
@@ -35,8 +40,8 @@ func ValidateBackendBindingPolicyIR(config gowdk.Config, ir gwdkir.Program) erro
 	return ValidationErrors(diagnostics)
 }
 
-func programDeclaresBackendEndpoints(ir gwdkir.Program) bool {
-	for _, page := range ir.Pages {
+func manifestDeclaresBackendEndpoints(app manifest.Manifest) bool {
+	for _, page := range app.Pages {
 		if len(page.Blocks.Actions) > 0 || len(page.Blocks.APIs) > 0 || page.Blocks.Load {
 			return true
 		}
@@ -44,7 +49,7 @@ func programDeclaresBackendEndpoints(ir gwdkir.Program) bool {
 	return false
 }
 
-func backendBindingRequiredDiagnostic(binding source.BackendBinding) ValidationError {
+func backendBindingRequiredDiagnostic(binding manifest.BackendBinding) ValidationError {
 	kind := binding.Kind
 	if kind == "" {
 		kind = "backend"

--- a/internal/compiler/backend_bindings.go
+++ b/internal/compiler/backend_bindings.go
@@ -15,8 +15,7 @@ import (
 	"strings"
 
 	"github.com/cssbruno/gowdk/internal/goblockgen"
-	"github.com/cssbruno/gowdk/internal/gwdkanalysis"
-	"github.com/cssbruno/gowdk/internal/gwdkir"
+	"github.com/cssbruno/gowdk/internal/manifest"
 	"github.com/cssbruno/gowdk/internal/source"
 )
 
@@ -33,26 +32,14 @@ const (
 	ssrImportPath      = "github.com/cssbruno/gowdk/addons/ssr"
 )
 
-// BindBackendHandlers discovers same-package Go handlers for act and api blocks,
-// attaches the resulting binding metadata to the program's endpoints and page
-// load bindings, and returns the full binding record list (sorted by source,
-// kind, and block name) for reporting and public manifest JSON.
+// BindBackendHandlers discovers same-package Go handlers for act and api blocks.
 // Discovery is intentionally non-fatal: missing packages, missing functions, and
 // unsupported signatures are reported as binding metadata so generated apps can
 // emit clear 501 responses.
-func BindBackendHandlers(ir *gwdkir.Program) []source.BackendBinding {
-	bindings := computeBackendBindings(*ir)
-	gwdkanalysis.AttachBackendBindings(ir, bindings)
-	return bindings
-}
-
-// computeBackendBindings derives the binding records without mutating the
-// program, for callers that only need the records (e.g. the production binding
-// policy check on an unbound program).
-func computeBackendBindings(ir gwdkir.Program) []source.BackendBinding {
-	var bindings []source.BackendBinding
+func BindBackendHandlers(app manifest.Manifest) manifest.Manifest {
+	var bindings []manifest.BackendBinding
 	cache := map[string]featurePackage{}
-	for _, page := range ir.Pages {
+	for _, page := range app.Pages {
 		if len(page.Blocks.Actions) == 0 && len(page.Blocks.APIs) == 0 && len(page.Blocks.Fragments) == 0 && !page.Blocks.Load {
 			continue
 		}
@@ -102,7 +89,7 @@ func computeBackendBindings(ir gwdkir.Program) []source.BackendBinding {
 			}
 		}
 	}
-	for _, endpoint := range ir.GoEndpoints {
+	for _, endpoint := range app.Endpoints {
 		dir := sourceDir(endpoint.Source)
 		pkg, ok := cache[dir]
 		if !ok {
@@ -125,10 +112,22 @@ func computeBackendBindings(ir gwdkir.Program) []source.BackendBinding {
 		}
 		return bindings[i].Source < bindings[j].Source
 	})
-	return bindings
+	app.BackendBindings = bindings
+	loadBindings := map[string]manifest.BackendBinding{}
+	for _, binding := range bindings {
+		if binding.Kind == loadHandlerKind {
+			loadBindings[binding.PageID] = binding
+		}
+	}
+	for index := range app.Pages {
+		if binding, ok := loadBindings[app.Pages[index].ID]; ok {
+			app.Pages[index].LoadBinding = binding
+		}
+	}
+	return app
 }
 
-func bindLoad(page gwdkir.Page, pkg featurePackage) source.BackendBinding {
+func bindLoad(page manifest.Page, pkg featurePackage) manifest.BackendBinding {
 	functionName := loadFunctionName(page.ID)
 	if function, ok := pkg.Functions[functionName]; ok {
 		binding := baseBackendBinding(page, loadHandlerKind, functionName, "GET", page.Route, pkg)
@@ -159,7 +158,7 @@ func bindLoad(page gwdkir.Page, pkg featurePackage) source.BackendBinding {
 	return binding
 }
 
-func bindStandaloneAction(endpoint gwdkir.GoEndpoint, pkg featurePackage) source.BackendBinding {
+func bindStandaloneAction(endpoint manifest.EndpointDeclaration, pkg featurePackage) manifest.BackendBinding {
 	method := endpoint.Method
 	if method == "" {
 		method = "POST"
@@ -188,7 +187,7 @@ func bindStandaloneAction(endpoint gwdkir.GoEndpoint, pkg featurePackage) source
 	return binding
 }
 
-func bindStandaloneAPI(endpoint gwdkir.GoEndpoint, pkg featurePackage) source.BackendBinding {
+func bindStandaloneAPI(endpoint manifest.EndpointDeclaration, pkg featurePackage) manifest.BackendBinding {
 	method := endpoint.Method
 	if method == "" {
 		method = "GET"
@@ -210,7 +209,7 @@ func bindStandaloneAPI(endpoint gwdkir.GoEndpoint, pkg featurePackage) source.Ba
 	return binding
 }
 
-func bindAction(page gwdkir.Page, action gwdkir.Action, pkg featurePackage) source.BackendBinding {
+func bindAction(page manifest.Page, action manifest.Action, pkg featurePackage) manifest.BackendBinding {
 	method := action.Method
 	if method == "" {
 		method = "POST"
@@ -243,7 +242,7 @@ func bindAction(page gwdkir.Page, action gwdkir.Action, pkg featurePackage) sour
 	return binding
 }
 
-func bindAPI(page gwdkir.Page, api gwdkir.API, pkg featurePackage) source.BackendBinding {
+func bindAPI(page manifest.Page, api manifest.API, pkg featurePackage) manifest.BackendBinding {
 	method := strings.TrimSpace(api.Method)
 	if method == "" {
 		method = "GET"
@@ -269,7 +268,7 @@ func bindAPI(page gwdkir.Page, api gwdkir.API, pkg featurePackage) source.Backen
 	return binding
 }
 
-func bindFragment(page gwdkir.Page, fragment gwdkir.FragmentEndpoint, pkg featurePackage) (source.BackendBinding, bool) {
+func bindFragment(page manifest.Page, fragment manifest.FragmentEndpoint, pkg featurePackage) (manifest.BackendBinding, bool) {
 	method := strings.TrimSpace(fragment.Method)
 	if method == "" {
 		method = "GET"
@@ -277,7 +276,7 @@ func bindFragment(page gwdkir.Page, fragment gwdkir.FragmentEndpoint, pkg featur
 	binding := baseBackendBinding(page, fragmentHandlerKind, fragment.Name, method, strings.TrimSpace(fragment.Route), pkg)
 	function, ok := pkg.Functions[binding.FunctionName]
 	if !ok {
-		return source.BackendBinding{}, false
+		return manifest.BackendBinding{}, false
 	}
 	if !function.Fragment() {
 		binding.Status = source.BackendBindingUnsupportedSignature
@@ -289,8 +288,8 @@ func bindFragment(page gwdkir.Page, fragment gwdkir.FragmentEndpoint, pkg featur
 	return binding, true
 }
 
-func baseBackendBinding(page gwdkir.Page, kind, blockName, method, route string, pkg featurePackage) source.BackendBinding {
-	return source.BackendBinding{
+func baseBackendBinding(page manifest.Page, kind, blockName, method, route string, pkg featurePackage) manifest.BackendBinding {
+	return manifest.BackendBinding{
 		Kind:         kind,
 		PageID:       page.ID,
 		Source:       page.Source,
@@ -304,10 +303,10 @@ func baseBackendBinding(page gwdkir.Page, kind, blockName, method, route string,
 	}
 }
 
-func baseStandaloneBackendBinding(endpoint gwdkir.GoEndpoint, kind, method string, pkg featurePackage) source.BackendBinding {
-	return source.BackendBinding{
+func baseStandaloneBackendBinding(endpoint manifest.EndpointDeclaration, kind, method string, pkg featurePackage) manifest.BackendBinding {
+	return manifest.BackendBinding{
 		Kind:         kind,
-		PageID:       standaloneEndpointPageID(endpoint.Package, endpoint.Name),
+		PageID:       standaloneEndpointPageID(endpoint),
 		Source:       endpoint.Source,
 		BlockName:    endpoint.Name,
 		Method:       method,
@@ -445,7 +444,7 @@ func inspectFeaturePackage(dir string) featurePackage {
 	return pkg
 }
 
-func inspectInlineScriptFeaturePackage(page gwdkir.Page, target string) featurePackage {
+func inspectInlineScriptFeaturePackage(page manifest.Page, target string) featurePackage {
 	pkg := featurePackage{
 		ImportPath: goblockgen.GeneratedImportPath(page.Package),
 		Name:       goblockgen.SafePackageName(page.Package),
@@ -834,43 +833,4 @@ func isSelector(expression ast.Expr, imports map[string]string, importPath, name
 func isError(expression ast.Expr) bool {
 	ident, ok := expression.(*ast.Ident)
 	return ok && ident.Name == "error"
-}
-
-// BackendBindingsFromIR derives the backend binding records already attached to
-// the program's endpoints, without inspecting Go packages on disk. Callers that
-// only need binding metadata for reporting (e.g. build reports) should use this
-// instead of re-running handler discovery.
-func BackendBindingsFromIR(ir gwdkir.Program) []source.BackendBinding {
-	out := make([]source.BackendBinding, 0, len(ir.Endpoints))
-	for _, endpoint := range ir.Endpoints {
-		binding := backendBindingFromIR(endpoint)
-		if binding.Status != "" || binding.ImportPath != "" || binding.FunctionName != "" {
-			out = append(out, binding)
-		}
-	}
-	return out
-}
-
-func backendBindingFromIR(endpoint gwdkir.Endpoint) source.BackendBinding {
-	kind := "action"
-	if endpoint.Kind == gwdkir.EndpointAPI {
-		kind = "api"
-	}
-	return source.BackendBinding{
-		Kind:         kind,
-		PageID:       endpoint.PageID,
-		Source:       endpoint.SourceFile,
-		BlockName:    endpoint.Symbol,
-		Method:       endpoint.Method,
-		Route:        endpoint.Path,
-		ImportPath:   endpoint.Binding.ImportPath,
-		PackageName:  endpoint.Binding.PackageName,
-		FunctionName: endpoint.Binding.FunctionName,
-		Signature:    endpoint.Binding.Signature,
-		InputType:    endpoint.Binding.InputType,
-		InputPointer: endpoint.Binding.InputPointer,
-		InputFields:  append([]source.BackendInputField(nil), endpoint.Binding.InputFields...),
-		Status:       endpoint.Binding.Status,
-		Message:      endpoint.Binding.Message,
-	}
 }

--- a/internal/compiler/backend_bindings_test.go
+++ b/internal/compiler/backend_bindings_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/cssbruno/gowdk"
 	"github.com/cssbruno/gowdk/internal/goblockgen"
-	"github.com/cssbruno/gowdk/internal/gwdkanalysis"
 	"github.com/cssbruno/gowdk/internal/manifest"
 	"github.com/cssbruno/gowdk/internal/source"
 )
@@ -77,7 +76,7 @@ func BrokenFragment(context.Context, *http.Request) (response.Response, error) {
 }
 `)
 
-	app := bindBackendHandlers(manifest.Manifest{Pages: []manifest.Page{{
+	app := BindBackendHandlers(manifest.Manifest{Pages: []manifest.Page{{
 		ID:     "Login",
 		Source: filepath.Join(root, "Login.page.gwdk"),
 		Route:  "/Login",
@@ -152,7 +151,7 @@ func LoadBroken() map[string]any {
 }
 `)
 
-	app := bindBackendHandlers(manifest.Manifest{Pages: []manifest.Page{
+	app := BindBackendHandlers(manifest.Manifest{Pages: []manifest.Page{
 		{
 			ID:     "dashboard",
 			Source: filepath.Join(root, "dashboard.page.gwdk"),
@@ -228,7 +227,7 @@ func TestBindBackendHandlersBindsInlineSSRScriptLoad(t *testing.T) {
 		},
 	}
 
-	app := bindBackendHandlers(manifest.Manifest{Pages: []manifest.Page{page}})
+	app := BindBackendHandlers(manifest.Manifest{Pages: []manifest.Page{page}})
 	bindings := compilerBindingsByBlock(app.BackendBindings)
 	binding := bindings["LoadDashboard"]
 	if binding.Status != source.BackendBindingBound || binding.Signature != source.BackendSignatureLoadError {
@@ -289,7 +288,7 @@ func List(context.Context) (response.Response, error) {
 		},
 	}
 
-	app := bindBackendHandlers(manifest.Manifest{Pages: []manifest.Page{page}})
+	app := BindBackendHandlers(manifest.Manifest{Pages: []manifest.Page{page}})
 	bindings := compilerBindingsByBlock(app.BackendBindings)
 	for _, name := range []string{"Subscribe", "Session", "List"} {
 		if bindings[name].ImportPath != goblockgen.GeneratedImportPath("pages") || bindings[name].PackageName != "pages" {
@@ -331,17 +330,18 @@ func Session(context.Context, *http.Request) (response.Response, error) {
 		Blocks: manifest.Blocks{View: true, ViewBody: "<main>Home</main>"},
 	}}}
 
-	ir := gwdkanalysis.BuildIR(gowdk.Config{}, app)
-	if err := DiscoverGoEndpoints(&ir); err != nil {
+	app, err := DiscoverGoEndpointComments(app)
+	if err != nil {
 		t.Fatal(err)
 	}
-	if len(ir.GoEndpoints) != 2 {
-		t.Fatalf("expected two Go comment endpoints, got %#v", ir.GoEndpoints)
+	if len(app.Endpoints) != 2 {
+		t.Fatalf("expected two Go comment endpoints, got %#v", app.Endpoints)
 	}
-	if err := ValidateProgram(gowdk.Config{}, ir); err != nil {
+	if err := ValidateManifest(gowdk.Config{}, app); err != nil {
 		t.Fatal(err)
 	}
-	bindings := compilerBindingsByBlock(BindBackendHandlers(&ir))
+	app = BindBackendHandlers(app)
+	bindings := compilerBindingsByBlock(app.BackendBindings)
 	assertBinding(t, bindings["Login"], source.BackendBindingBound, source.BackendSignatureAction0, "", false)
 	assertBinding(t, bindings["Session"], source.BackendBindingBound, source.BackendSignatureAPI, "", false)
 }
@@ -371,7 +371,7 @@ func TestValidateManifestRejectsGoEndpointConflictWithGOWDKEndpoint(t *testing.T
 		}},
 	}
 
-	err := validateManifest(gowdk.Config{}, app)
+	err := ValidateManifest(gowdk.Config{}, app)
 	if err == nil {
 		t.Fatal("expected route conflict diagnostic")
 	}
@@ -390,7 +390,7 @@ func TestValidateBackendBindingPolicyFailsProductionMissingHandler(t *testing.T)
 		},
 	}}}
 
-	err := validateBackendBindingPolicy(gowdk.Config{Build: gowdk.BuildConfig{Mode: gowdk.Production}}, app)
+	err := ValidateBackendBindingPolicy(gowdk.Config{Build: gowdk.BuildConfig{Mode: gowdk.Production}}, app)
 	if err == nil {
 		t.Fatal("expected production missing handler diagnostic")
 	}
@@ -414,7 +414,7 @@ func TestValidateBackendBindingPolicyAllowsDevelopmentMissingHandler(t *testing.
 		Status:       source.BackendBindingMissing,
 	}}}
 
-	if err := validateBackendBindingPolicy(gowdk.Config{}, app); err != nil {
+	if err := ValidateBackendBindingPolicy(gowdk.Config{}, app); err != nil {
 		t.Fatalf("expected development missing handler to remain non-fatal, got %v", err)
 	}
 }
@@ -434,7 +434,7 @@ func TestValidateBackendBindingPolicyAllowsExplicitProductionStubMode(t *testing
 		Mode:                gowdk.Production,
 		AllowMissingBackend: true,
 	}}
-	if err := validateBackendBindingPolicy(config, app); err != nil {
+	if err := ValidateBackendBindingPolicy(config, app); err != nil {
 		t.Fatalf("expected explicit production stub mode to allow missing backend, got %v", err)
 	}
 }
@@ -473,29 +473,4 @@ func writeCompilerTestFile(t *testing.T, path string, content string) {
 	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
 		t.Fatal(err)
 	}
-}
-
-// bindBackendHandlers routes a manifest fixture through the production IR
-// binding path and mirrors the records back onto the manifest shape these
-// tests assert against.
-func bindBackendHandlers(app manifest.Manifest) manifest.Manifest {
-	ir := gwdkanalysis.BuildIR(gowdk.Config{}, app)
-	bindings := BindBackendHandlers(&ir)
-	app.BackendBindings = bindings
-	loadBindings := map[string]manifest.BackendBinding{}
-	for _, binding := range bindings {
-		if binding.Kind == loadHandlerKind {
-			loadBindings[binding.PageID] = binding
-		}
-	}
-	for index := range app.Pages {
-		if binding, ok := loadBindings[app.Pages[index].ID]; ok {
-			app.Pages[index].LoadBinding = binding
-		}
-	}
-	return app
-}
-
-func validateBackendBindingPolicy(config gowdk.Config, app manifest.Manifest) error {
-	return ValidateBackendBindingPolicyIR(config, gwdkanalysis.BuildIR(config, app))
 }

--- a/internal/compiler/go_endpoints.go
+++ b/internal/compiler/go_endpoints.go
@@ -10,20 +10,18 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/cssbruno/gowdk/internal/gwdkanalysis"
-	"github.com/cssbruno/gowdk/internal/gwdkir"
+	"github.com/cssbruno/gowdk/internal/manifest"
 	"github.com/cssbruno/gowdk/internal/source"
 )
 
-// DiscoverGoEndpoints merges optional //gowdk:act and //gowdk:api comments
-// from selected feature-package Go files into the program as standalone Go
-// endpoints.
-func DiscoverGoEndpoints(ir *gwdkir.Program) error {
-	dirs := endpointSourceDirs(*ir)
+// DiscoverGoEndpointComments merges optional //gowdk:act and //gowdk:api
+// comments from selected feature-package Go files into the manifest.
+func DiscoverGoEndpointComments(app manifest.Manifest) (manifest.Manifest, error) {
+	dirs := endpointSourceDirs(app)
 	if len(dirs) == 0 {
-		return nil
+		return app, nil
 	}
-	var endpoints []gwdkir.GoEndpoint
+	var endpoints []manifest.EndpointDeclaration
 	var diagnostics []ValidationError
 	for _, dir := range dirs {
 		discovered, found := discoverGoEndpointsInDir(dir)
@@ -31,7 +29,7 @@ func DiscoverGoEndpoints(ir *gwdkir.Program) error {
 		diagnostics = append(diagnostics, found...)
 	}
 	if len(diagnostics) > 0 {
-		return ValidationErrors(diagnostics)
+		return app, ValidationErrors(diagnostics)
 	}
 	sort.Slice(endpoints, func(i, j int) bool {
 		if endpoints[i].Source == endpoints[j].Source {
@@ -39,11 +37,11 @@ func DiscoverGoEndpoints(ir *gwdkir.Program) error {
 		}
 		return endpoints[i].Source < endpoints[j].Source
 	})
-	gwdkanalysis.AddStandaloneEndpoints(ir, endpoints)
-	return nil
+	app.Endpoints = append(app.Endpoints, endpoints...)
+	return app, nil
 }
 
-func endpointSourceDirs(ir gwdkir.Program) []string {
+func endpointSourceDirs(app manifest.Manifest) []string {
 	seen := map[string]bool{}
 	var dirs []string
 	add := func(sourcePath string) {
@@ -61,26 +59,26 @@ func endpointSourceDirs(ir gwdkir.Program) []string {
 		seen[dir] = true
 		dirs = append(dirs, dir)
 	}
-	for _, page := range ir.Pages {
+	for _, page := range app.Pages {
 		add(page.Source)
 	}
-	for _, component := range ir.Components {
+	for _, component := range app.Components {
 		add(component.Source)
 	}
-	for _, layout := range ir.Layouts {
+	for _, layout := range app.Layouts {
 		add(layout.Source)
 	}
 	sort.Strings(dirs)
 	return dirs
 }
 
-func discoverGoEndpointsInDir(dir string) ([]gwdkir.GoEndpoint, []ValidationError) {
+func discoverGoEndpointsInDir(dir string) ([]manifest.EndpointDeclaration, []ValidationError) {
 	entries, err := os.ReadDir(dir)
 	if err != nil {
 		return nil, nil
 	}
 	fileSet := token.NewFileSet()
-	var endpoints []gwdkir.GoEndpoint
+	var endpoints []manifest.EndpointDeclaration
 	var diagnostics []ValidationError
 	for _, entry := range entries {
 		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".go") || strings.HasSuffix(entry.Name(), "_test.go") {
@@ -121,8 +119,8 @@ func discoverGoEndpointsInDir(dir string) ([]gwdkir.GoEndpoint, []ValidationErro
 	return endpoints, diagnostics
 }
 
-func endpointCommentsForFunction(fileSet *token.FileSet, path string, packageName string, function *ast.FuncDecl) []gwdkir.GoEndpoint {
-	var endpoints []gwdkir.GoEndpoint
+func endpointCommentsForFunction(fileSet *token.FileSet, path string, packageName string, function *ast.FuncDecl) []manifest.EndpointDeclaration {
+	var endpoints []manifest.EndpointDeclaration
 	for _, comment := range function.Doc.List {
 		text := strings.TrimSpace(strings.TrimPrefix(comment.Text, "//"))
 		text = strings.TrimSpace(strings.TrimPrefix(text, "/*"))
@@ -134,9 +132,9 @@ func endpointCommentsForFunction(fileSet *token.FileSet, path string, packageNam
 		method := strings.ToUpper(methodText)
 		route := strings.Trim(routeText, `"`)
 		span := goTokenSpan(fileSet, comment.Pos(), comment.End())
-		endpoints = append(endpoints, gwdkir.GoEndpoint{
+		endpoints = append(endpoints, manifest.EndpointDeclaration{
 			Kind:        kind,
-			SourceKind:  gwdkir.EndpointSourceGo,
+			SourceKind:  manifest.EndpointSourceGo,
 			Package:     packageName,
 			Source:      path,
 			Name:        function.Name.Name,

--- a/internal/compiler/manifest_from_ir.go
+++ b/internal/compiler/manifest_from_ir.go
@@ -1,0 +1,417 @@
+package compiler
+
+import (
+	"github.com/cssbruno/gowdk/internal/gwdkir"
+	"github.com/cssbruno/gowdk/internal/manifest"
+	"github.com/cssbruno/gowdk/internal/source"
+)
+
+// ManifestFromIR reconstructs a manifest.Manifest from compiler IR so the
+// existing manifest-typed validators can run against an IR-first build path.
+//
+// This is the single IR->manifest conversion seam in the codebase. It lives in
+// compiler (the package that owns validation) rather than being duplicated in
+// each generated-output package. As individual validators move to read IR
+// directly, this converter shrinks and is eventually removed; until then it
+// keeps the build path validating identical data whether it starts from a
+// parsed manifest or from IR.
+func ManifestFromIR(ir gwdkir.Program) manifest.Manifest {
+	app := manifest.Manifest{
+		Pages:           make([]manifest.Page, 0, len(ir.Pages)),
+		Components:      make([]manifest.Component, 0, len(ir.Components)),
+		Layouts:         make([]manifest.Layout, 0, len(ir.Layouts)),
+		Endpoints:       goEndpointsFromIR(ir.GoEndpoints),
+		BackendBindings: BackendBindingsFromIR(ir),
+	}
+	for _, page := range ir.Pages {
+		app.Pages = append(app.Pages, pageFromIR(page))
+	}
+	for _, component := range ir.Components {
+		app.Components = append(app.Components, componentFromIR(component))
+	}
+	for _, layout := range ir.Layouts {
+		app.Layouts = append(app.Layouts, layoutFromIR(layout))
+	}
+	return app
+}
+
+// BackendBindingsFromIR derives just the backend binding records from IR
+// endpoints and page load bindings, without reconstructing the full
+// page/component/layout manifest. Callers that only need bindings (e.g. build
+// reporting) should use this instead of ManifestFromIR(ir).BackendBindings,
+// which would allocate the whole model.
+func BackendBindingsFromIR(ir gwdkir.Program) []manifest.BackendBinding {
+	out := make([]manifest.BackendBinding, 0, len(ir.Endpoints)+len(ir.Pages))
+	for _, endpoint := range ir.Endpoints {
+		binding := backendBindingFromIR(endpoint)
+		if binding.Status != "" || binding.ImportPath != "" || binding.FunctionName != "" {
+			out = append(out, binding)
+		}
+	}
+	for _, page := range ir.Pages {
+		binding := loadBindingFromIR(page)
+		if binding.Status != "" || binding.ImportPath != "" || binding.FunctionName != "" {
+			out = append(out, binding)
+		}
+	}
+	return out
+}
+
+// goEndpointsFromIR reconstructs the standalone Go endpoint declarations from
+// their lossless IR mirror. This is a one-to-one field copy, so validation that
+// reads manifest.Endpoints (route conflicts, standalone-endpoint shape) runs
+// identically whether it starts from a parsed manifest or from IR.
+func goEndpointsFromIR(endpoints []gwdkir.GoEndpoint) []manifest.EndpointDeclaration {
+	if len(endpoints) == 0 {
+		return nil
+	}
+	out := make([]manifest.EndpointDeclaration, 0, len(endpoints))
+	for _, endpoint := range endpoints {
+		out = append(out, manifest.EndpointDeclaration{
+			Kind:          endpoint.Kind,
+			SourceKind:    manifest.EndpointSource(endpoint.SourceKind),
+			Package:       endpoint.Package,
+			Source:        endpoint.Source,
+			Name:          endpoint.Name,
+			Method:        endpoint.Method,
+			Route:         endpoint.Route,
+			ErrorPage:     endpoint.ErrorPage,
+			Span:          endpoint.Span,
+			RouteSpan:     endpoint.RouteSpan,
+			RouteParams:   append([]source.NamedSpan(nil), endpoint.RouteParams...),
+			ErrorPageSpan: endpoint.ErrorPageSpan,
+		})
+	}
+	return out
+}
+
+func backendBindingFromIR(endpoint gwdkir.Endpoint) manifest.BackendBinding {
+	kind := actionHandlerKind
+	switch endpoint.Kind {
+	case gwdkir.EndpointAPI:
+		kind = apiHandlerKind
+	case gwdkir.EndpointFragment:
+		kind = fragmentHandlerKind
+	}
+	return manifest.BackendBinding{
+		Kind:         kind,
+		PageID:       endpoint.PageID,
+		Source:       endpoint.SourceFile,
+		BlockName:    endpoint.Symbol,
+		Method:       endpoint.Method,
+		Route:        endpoint.Path,
+		ImportPath:   endpoint.Binding.ImportPath,
+		PackageName:  endpoint.Binding.PackageName,
+		FunctionName: endpoint.Binding.FunctionName,
+		Signature:    endpoint.Binding.Signature,
+		InputType:    endpoint.Binding.InputType,
+		InputPointer: endpoint.Binding.InputPointer,
+		InputFields:  append([]source.BackendInputField(nil), endpoint.Binding.InputFields...),
+		Status:       endpoint.Binding.Status,
+		Message:      endpoint.Binding.Message,
+	}
+}
+
+func pageFromIR(page gwdkir.Page) manifest.Page {
+	return manifest.Page{
+		Source:      page.Source,
+		Package:     page.Package,
+		ID:          page.ID,
+		Route:       page.Route,
+		RouteParams: append([]source.RouteParam(nil), page.RouteParams...),
+		Render:      page.Render,
+		Cache:       page.Cache,
+		Revalidate:  page.Revalidate,
+		ErrorPage:   page.ErrorPage,
+		Metadata:    manifest.PageMetadata(page.Metadata),
+		Layouts:     append([]string(nil), page.Layouts...),
+		Guard:       append([]string(nil), page.Guards...),
+		CSS:         append([]string(nil), page.CSS...),
+		JS:          append([]string(nil), page.JS...),
+		InlineJS:    copyInlineScriptsFromIR(page.InlineJS),
+		Imports:     importsFromIR(page.Imports),
+		Uses:        usesFromIR(page.Uses),
+		Stores:      storesFromIR(page.Stores),
+		Paths:       page.Blocks.Paths,
+		Blocks:      blocksFromIR(page.Blocks),
+		LoadBinding: loadBindingFromIR(page),
+		Spans: manifest.PageSpans{
+			Package:     page.Spans.Package,
+			Page:        page.Spans.Page,
+			Route:       page.Spans.Route,
+			Render:      page.Spans.Render,
+			Cache:       page.Spans.Cache,
+			Revalidate:  page.Spans.Revalidate,
+			ErrorPage:   page.Spans.ErrorPage,
+			Title:       page.Spans.Title,
+			Description: page.Spans.Description,
+			Canonical:   page.Spans.Canonical,
+			Image:       page.Spans.Image,
+			Layouts:     append([]source.NamedSpan(nil), page.Spans.Layouts...),
+			Guard:       append([]source.NamedSpan(nil), page.Spans.Guard...),
+			CSS:         append([]source.NamedSpan(nil), page.Spans.CSS...),
+			JS:          append([]source.NamedSpan(nil), page.Spans.JS...),
+			InlineJS:    append([]source.NamedSpan(nil), page.Spans.InlineJS...),
+			RouteParams: append([]source.NamedSpan(nil), page.Spans.RouteParams...),
+		},
+	}
+}
+
+func loadBindingFromIR(page gwdkir.Page) manifest.BackendBinding {
+	binding := page.LoadBinding
+	if binding.Status == "" && binding.ImportPath == "" && binding.FunctionName == "" {
+		return manifest.BackendBinding{}
+	}
+	return manifest.BackendBinding{
+		Kind:         loadHandlerKind,
+		PageID:       page.ID,
+		Source:       page.Source,
+		BlockName:    binding.FunctionName,
+		Method:       "GET",
+		Route:        page.Route,
+		ImportPath:   binding.ImportPath,
+		PackageName:  binding.PackageName,
+		FunctionName: binding.FunctionName,
+		Signature:    binding.Signature,
+		Status:       binding.Status,
+		Message:      binding.Message,
+	}
+}
+
+func componentFromIR(component gwdkir.Component) manifest.Component {
+	return manifest.Component{
+		Source:      component.Source,
+		Package:     component.Package,
+		Name:        component.Name,
+		Imports:     importsFromIR(component.Imports),
+		Uses:        usesFromIR(component.Uses),
+		CSS:         append([]string(nil), component.CSS...),
+		JS:          append([]string(nil), component.JS...),
+		InlineJS:    copyInlineScriptsFromIR(component.InlineJS),
+		Assets:      append([]string(nil), component.Assets...),
+		Props:       propsFromIR(component.Props),
+		PropsType:   goTypeRefFromIR(component.PropsType),
+		State:       stateContractFromIR(component.State),
+		WASM:        manifest.WASMContract(component.WASM),
+		Exports:     exportsFromIR(component.Exports),
+		Emits:       emitsFromIR(component.Emits),
+		Blocks:      blocksFromIR(component.Blocks),
+		Span:        component.Span,
+		PackageSpan: component.PackageSpan,
+		Spans: manifest.ComponentSpans{
+			CSS:      append([]source.NamedSpan(nil), component.Spans.CSS...),
+			JS:       append([]source.NamedSpan(nil), component.Spans.JS...),
+			InlineJS: append([]source.NamedSpan(nil), component.Spans.InlineJS...),
+			Assets:   append([]source.NamedSpan(nil), component.Spans.Assets...),
+		},
+	}
+}
+
+func copyInlineScriptsFromIR(scripts []source.InlineScript) []source.InlineScript {
+	if len(scripts) == 0 {
+		return nil
+	}
+	out := make([]source.InlineScript, len(scripts))
+	copy(out, scripts)
+	return out
+}
+
+func layoutFromIR(layout gwdkir.Layout) manifest.Layout {
+	return manifest.Layout{
+		Source:      layout.Source,
+		Package:     layout.Package,
+		ID:          layout.ID,
+		Uses:        usesFromIR(layout.Uses),
+		Blocks:      blocksFromIR(layout.Blocks),
+		Span:        layout.Span,
+		PackageSpan: layout.PackageSpan,
+	}
+}
+
+func blocksFromIR(blocks gwdkir.Blocks) manifest.Blocks {
+	return manifest.Blocks{
+		PathsBody:  blocks.PathsBody,
+		Build:      blocks.Build,
+		BuildBody:  blocks.BuildBody,
+		Load:       blocks.Load,
+		LoadBody:   blocks.LoadBody,
+		Client:     blocks.Client,
+		ClientBody: blocks.ClientBody,
+		GoBlocks:   scriptsFromIR(blocks.GoBlocks),
+		View:       blocks.View,
+		ViewBody:   blocks.ViewBody,
+		Style:      blocks.Style,
+		StyleBody:  blocks.StyleBody,
+		Actions:    actionsFromIR(blocks.Actions),
+		APIs:       apisFromIR(blocks.APIs),
+		Fragments:  fragmentEndpointsFromIR(blocks.Fragments),
+		Spans: manifest.BlockSpans{
+			Paths:         blocks.Spans.Paths,
+			Build:         blocks.Spans.Build,
+			Load:          blocks.Spans.Load,
+			Client:        blocks.Spans.Client,
+			GoBlocks:      append([]source.NamedSpan(nil), blocks.Spans.GoBlocks...),
+			View:          blocks.Spans.View,
+			ViewBodyStart: blocks.Spans.ViewBodyStart,
+			Actions:       append([]source.NamedSpan(nil), blocks.Spans.Actions...),
+			APIs:          append([]source.NamedSpan(nil), blocks.Spans.APIs...),
+			Fragments:     append([]source.NamedSpan(nil), blocks.Spans.Fragments...),
+			Exports:       blocks.Spans.Exports,
+			Emits:         blocks.Spans.Emits,
+		},
+	}
+}
+
+func scriptsFromIR(scripts []gwdkir.GoBlock) []manifest.GoBlock {
+	out := make([]manifest.GoBlock, 0, len(scripts))
+	for _, script := range scripts {
+		out = append(out, manifest.GoBlock{
+			Target: script.Target,
+			Body:   script.Body,
+			Span:   script.Span,
+		})
+	}
+	return out
+}
+
+func actionsFromIR(actions []gwdkir.Action) []manifest.Action {
+	out := make([]manifest.Action, 0, len(actions))
+	for _, action := range actions {
+		out = append(out, manifest.Action{
+			Name:           action.Name,
+			Method:         action.Method,
+			Route:          action.Route,
+			Body:           action.Body,
+			InputName:      action.InputName,
+			InputType:      action.InputType,
+			ValidatesInput: action.ValidatesInput,
+			Redirect:       action.Redirect,
+			Fragments:      fragmentsFromIR(action.Fragments),
+			ErrorPage:      action.ErrorPage,
+			Span:           action.Span,
+			RouteSpan:      action.RouteSpan,
+			RouteParams:    append([]source.NamedSpan(nil), action.RouteParams...),
+			InputSpan:      action.InputSpan,
+			ValidationSpan: action.ValidationSpan,
+			RedirectSpan:   action.RedirectSpan,
+			ErrorPageSpan:  action.ErrorPageSpan,
+		})
+	}
+	return out
+}
+
+func apisFromIR(apis []gwdkir.API) []manifest.API {
+	out := make([]manifest.API, 0, len(apis))
+	for _, api := range apis {
+		out = append(out, manifest.API{
+			Name:          api.Name,
+			Method:        api.Method,
+			Route:         api.Route,
+			ErrorPage:     api.ErrorPage,
+			Span:          api.Span,
+			RouteSpan:     api.RouteSpan,
+			RouteParams:   append([]source.NamedSpan(nil), api.RouteParams...),
+			ErrorPageSpan: api.ErrorPageSpan,
+		})
+	}
+	return out
+}
+
+func fragmentsFromIR(fragments []gwdkir.Fragment) []manifest.Fragment {
+	out := make([]manifest.Fragment, 0, len(fragments))
+	for _, fragment := range fragments {
+		out = append(out, manifest.Fragment{Target: fragment.Target, Body: fragment.Body, Span: fragment.Span})
+	}
+	return out
+}
+
+func fragmentEndpointsFromIR(fragments []gwdkir.FragmentEndpoint) []manifest.FragmentEndpoint {
+	out := make([]manifest.FragmentEndpoint, 0, len(fragments))
+	for _, fragment := range fragments {
+		out = append(out, manifest.FragmentEndpoint{
+			Name:        fragment.Name,
+			Method:      fragment.Method,
+			Route:       fragment.Route,
+			Target:      fragment.Target,
+			Body:        fragment.Body,
+			Span:        fragment.Span,
+			RouteSpan:   fragment.RouteSpan,
+			TargetSpan:  fragment.TargetSpan,
+			RouteParams: append([]source.NamedSpan(nil), fragment.RouteParams...),
+		})
+	}
+	return out
+}
+
+func importsFromIR(imports []gwdkir.Import) []manifest.Import {
+	out := make([]manifest.Import, 0, len(imports))
+	for _, item := range imports {
+		out = append(out, manifest.Import{Alias: item.Alias, Path: item.Path, Span: item.Span})
+	}
+	return out
+}
+
+func usesFromIR(uses []gwdkir.Use) []manifest.Use {
+	out := make([]manifest.Use, 0, len(uses))
+	for _, item := range uses {
+		out = append(out, manifest.Use{Alias: item.Alias, Package: item.Package, Span: item.Span})
+	}
+	return out
+}
+
+func storesFromIR(stores []gwdkir.Store) []manifest.Store {
+	out := make([]manifest.Store, 0, len(stores))
+	for _, store := range stores {
+		out = append(out, manifest.Store{
+			Name: store.Name,
+			Type: goTypeRefFromIR(store.Type),
+			Init: goFuncRefFromIR(store.Init),
+			Span: store.Span,
+		})
+	}
+	return out
+}
+
+func propsFromIR(props []gwdkir.Prop) []manifest.Prop {
+	out := make([]manifest.Prop, 0, len(props))
+	for _, prop := range props {
+		out = append(out, manifest.Prop{Name: prop.Name, Type: prop.Type, Span: prop.Span})
+	}
+	return out
+}
+
+func exportsFromIR(exports []gwdkir.Export) []manifest.Export {
+	out := make([]manifest.Export, 0, len(exports))
+	for _, export := range exports {
+		out = append(out, manifest.Export{Name: export.Name, Type: export.Type, Span: export.Span})
+	}
+	return out
+}
+
+func emitsFromIR(emits []gwdkir.Emit) []manifest.Emit {
+	out := make([]manifest.Emit, 0, len(emits))
+	for _, emit := range emits {
+		params := make([]manifest.EmitParam, 0, len(emit.Params))
+		for _, param := range emit.Params {
+			params = append(params, manifest.EmitParam{Name: param.Name, Type: param.Type, Span: param.Span})
+		}
+		out = append(out, manifest.Emit{Name: emit.Name, Params: params, Span: emit.Span})
+	}
+	return out
+}
+
+func stateContractFromIR(state gwdkir.StateContract) manifest.StateContract {
+	return manifest.StateContract{
+		Type: goTypeRefFromIR(state.Type),
+		Init: goFuncRefFromIR(state.Init),
+		Span: state.Span,
+	}
+}
+
+func goTypeRefFromIR(ref gwdkir.GoRef) manifest.GoTypeRef {
+	return manifest.GoTypeRef{Alias: ref.Alias, Name: ref.Name, Span: ref.Span}
+}
+
+func goFuncRefFromIR(ref gwdkir.GoRef) manifest.GoFuncRef {
+	return manifest.GoFuncRef{Alias: ref.Alias, Name: ref.Name, Span: ref.Span}
+}

--- a/internal/compiler/manifest_from_ir_test.go
+++ b/internal/compiler/manifest_from_ir_test.go
@@ -1,0 +1,310 @@
+package compiler
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/cssbruno/gowdk"
+	"github.com/cssbruno/gowdk/internal/gwdkir"
+	"github.com/cssbruno/gowdk/internal/manifest"
+	"github.com/cssbruno/gowdk/internal/source"
+)
+
+// sampleProgram returns an IR program that exercises the converter across pages,
+// components, layouts, blocks, endpoints, and bindings.
+func sampleProgram() gwdkir.Program {
+	return gwdkir.Program{
+		Version: gwdkir.Version,
+		Pages: []gwdkir.Page{{
+			Source:  "pages/home.page.gwdk",
+			Package: "pages",
+			ID:      "home",
+			Route:   "/",
+			Render:  gowdk.SPA,
+			Layouts: []string{"root"},
+			Guards:  []string{"public"},
+			Blocks: gwdkir.Blocks{
+				Paths:     true,
+				Build:     true,
+				BuildBody: `=> { title: "Home" }`,
+				View:      true,
+				ViewBody:  `<main>{title}</main>`,
+				Fragments: []gwdkir.FragmentEndpoint{{
+					Name:   "List",
+					Method: "GET",
+					Route:  "/home/list",
+					Target: "#list",
+					Body:   "<section>List</section>",
+				}},
+				Spans: gwdkir.BlockSpans{
+					Fragments: []source.NamedSpan{{Name: "List"}},
+				},
+			},
+		}},
+		Components: []gwdkir.Component{{
+			Source:  "components/counter.cmp.gwdk",
+			Package: "components",
+			Name:    "Counter",
+			Props:   []gwdkir.Prop{{Name: "label", Type: "string"}},
+		}},
+		Layouts: []gwdkir.Layout{{
+			Source:  "pages/root.layout.gwdk",
+			Package: "pages",
+			ID:      "root",
+			Blocks: gwdkir.Blocks{
+				View:     true,
+				ViewBody: `<html><slot /></html>`,
+			},
+		}},
+		Endpoints: []gwdkir.Endpoint{{
+			Kind:       gwdkir.EndpointAction,
+			PageID:     "home",
+			SourceFile: "pages/home.page.gwdk",
+			Symbol:     "Subscribe",
+			Method:     "POST",
+			Path:       "/subscribe",
+			Binding: gwdkir.Binding{
+				ImportPath:   "example.com/app/handlers",
+				PackageName:  "handlers",
+				FunctionName: "Subscribe",
+				Status:       source.BackendBindingBound,
+			},
+		}},
+	}
+}
+
+// TestManifestFromIRReconstructsCoreRecords pins the converter's output shape so
+// later validator-migration steps can rely on it as the IR->manifest seam.
+func TestManifestFromIRReconstructsCoreRecords(t *testing.T) {
+	app := ManifestFromIR(sampleProgram())
+
+	if len(app.Pages) != 1 || app.Pages[0].ID != "home" || app.Pages[0].Route != "/" {
+		t.Fatalf("unexpected pages: %#v", app.Pages)
+	}
+	if len(app.Pages[0].Blocks.Fragments) != 1 || app.Pages[0].Blocks.Fragments[0].Name != "List" {
+		t.Fatalf("fragment endpoints not preserved: %#v", app.Pages[0].Blocks.Fragments)
+	}
+	if !app.Pages[0].Paths {
+		t.Fatalf("paths block presence not preserved: %#v", app.Pages[0])
+	}
+	if len(app.Components) != 1 || app.Components[0].Name != "Counter" {
+		t.Fatalf("unexpected components: %#v", app.Components)
+	}
+	if len(app.Layouts) != 1 || app.Layouts[0].ID != "root" {
+		t.Fatalf("unexpected layouts: %#v", app.Layouts)
+	}
+	if len(app.BackendBindings) != 1 || app.BackendBindings[0].FunctionName != "Subscribe" {
+		t.Fatalf("unexpected backend bindings: %#v", app.BackendBindings)
+	}
+	if app.BackendBindings[0].Kind != "action" || app.BackendBindings[0].Status != source.BackendBindingBound {
+		t.Fatalf("unexpected binding kind/status: %#v", app.BackendBindings[0])
+	}
+}
+
+// TestValidateProgramMatchesManifestValidation is the equivalence guard for the
+// IR-first validation path: ValidateProgram(ir) must produce the exact same
+// result as running the manifest validator on the reconstructed manifest. While
+// individual validators still read manifest, this is a tautology by
+// construction; the test exists to catch a future change that makes
+// ValidateProgram diverge from "validate the manifest produced from this IR".
+func TestValidateProgramMatchesManifestValidation(t *testing.T) {
+	config := gowdk.Config{}
+	ir := sampleProgram()
+
+	viaProgram := ValidateProgram(config, ir)
+	viaManifest := ValidateManifest(config, ManifestFromIR(ir))
+
+	if errString(viaProgram) != errString(viaManifest) {
+		t.Fatalf("ValidateProgram diverged from manifest validation:\nprogram: %v\nmanifest: %v", viaProgram, viaManifest)
+	}
+	if viaProgram != nil {
+		t.Fatalf("expected sample program to validate cleanly, got: %v", viaProgram)
+	}
+}
+
+// TestValidateProgramReportsInvalidRoutes confirms the IR-first path still
+// surfaces validation failures (here, a duplicate page identity).
+func TestValidateProgramReportsInvalidRoutes(t *testing.T) {
+	config := gowdk.Config{}
+	ir := sampleProgram()
+	ir.Pages = append(ir.Pages, ir.Pages[0]) // duplicate page id "home"
+
+	if err := ValidateProgram(config, ir); err == nil {
+		t.Fatal("expected duplicate page identity to fail IR-first validation")
+	}
+}
+
+// TestValidateBackendBindingPolicyIRMatchesManifest is the equivalence guard for
+// the production backend-binding policy on the IR-first path.
+func TestValidateBackendBindingPolicyIRMatchesManifest(t *testing.T) {
+	config := gowdk.Config{Build: gowdk.BuildConfig{Mode: gowdk.Production}}
+	ir := sampleProgram()
+	// Force an unbound endpoint so the production policy has something to reject.
+	ir.Endpoints[0].Binding.Status = source.BackendBindingMissing
+
+	viaIR := ValidateBackendBindingPolicyIR(config, ir)
+	viaManifest := ValidateBackendBindingPolicy(config, ManifestFromIR(ir))
+
+	if errString(viaIR) != errString(viaManifest) {
+		t.Fatalf("policy IR path diverged:\nir: %v\nmanifest: %v", viaIR, viaManifest)
+	}
+	if viaIR == nil {
+		t.Fatal("expected production policy to reject a missing backend binding")
+	}
+}
+
+// TestBackendBindingsFromIRIncludesPageLoadBindings guards the regression where
+// page SSR load bindings were dropped on the IR path: BackendBindingsFromIR
+// only read ir.Endpoints, so the production binding policy never saw missing
+// load handlers (and the rebind fallback did not fire because the binding list
+// was non-empty).
+func TestBackendBindingsFromIRIncludesPageLoadBindings(t *testing.T) {
+	ir := sampleProgram()
+	ir.Pages[0].LoadBinding = gwdkir.Binding{
+		ImportPath:   "example.com/app/pages",
+		PackageName:  "pages",
+		FunctionName: "LoadHome",
+		Status:       source.BackendBindingMissing,
+		Message:      "GOWDK SSR load handler example.com/app/pages.LoadHome is not implemented",
+	}
+
+	bindings := BackendBindingsFromIR(ir)
+	var load *manifest.BackendBinding
+	for index := range bindings {
+		if bindings[index].Kind == "load" {
+			load = &bindings[index]
+		}
+	}
+	if load == nil {
+		t.Fatalf("expected a load binding, got %#v", bindings)
+	}
+	if load.PageID != "home" || load.Source != "pages/home.page.gwdk" || load.Route != "/" {
+		t.Fatalf("load binding page fields not preserved: %#v", load)
+	}
+	if load.FunctionName != "LoadHome" || load.Status != source.BackendBindingMissing {
+		t.Fatalf("load binding handler fields not preserved: %#v", load)
+	}
+
+	// The production policy must reject the missing load handler on the IR path.
+	config := gowdk.Config{Build: gowdk.BuildConfig{Mode: gowdk.Production}}
+	err := ValidateBackendBindingPolicyIR(config, ir)
+	if err == nil {
+		t.Fatal("expected production policy to reject a missing SSR load binding")
+	}
+	if !strings.Contains(err.Error(), "load handler LoadHome") {
+		t.Fatalf("unexpected diagnostic: %v", err)
+	}
+}
+
+// TestBackendBindingFromIRPreservesFragmentKind guards the regression where
+// fragment endpoint bindings round-tripped through IR as Kind "action".
+func TestBackendBindingFromIRPreservesFragmentKind(t *testing.T) {
+	ir := sampleProgram()
+	ir.Endpoints = append(ir.Endpoints, gwdkir.Endpoint{
+		Kind:       gwdkir.EndpointFragment,
+		PageID:     "home",
+		SourceFile: "pages/home.page.gwdk",
+		Symbol:     "List",
+		Method:     "GET",
+		Path:       "/home/list",
+		Binding: gwdkir.Binding{
+			ImportPath:   "example.com/app/pages",
+			PackageName:  "pages",
+			FunctionName: "List",
+			Status:       source.BackendBindingBound,
+		},
+	})
+
+	bindings := BackendBindingsFromIR(ir)
+	kinds := map[string]string{}
+	for _, binding := range bindings {
+		kinds[binding.BlockName] = binding.Kind
+	}
+	if kinds["Subscribe"] != "action" {
+		t.Fatalf("action binding kind not preserved: %#v", bindings)
+	}
+	if kinds["List"] != "fragment" {
+		t.Fatalf("fragment binding kind not preserved: %#v", bindings)
+	}
+}
+
+func errString(err error) string {
+	if err == nil {
+		return ""
+	}
+	return err.Error()
+}
+
+// TestValidateProgramRunsStandaloneEndpointChecks guards the regression that
+// motivated issue #145: standalone Go endpoints are lowered into IR losslessly
+// via Program.GoEndpoints, and ManifestFromIR reconstructs manifest.Endpoints
+// from them, so validateStandaloneEndpoints actually runs on the IR path. Before
+// GoEndpoints existed, ManifestFromIR left Endpoints nil and this check was
+// silently skipped.
+func TestValidateProgramRunsStandaloneEndpointChecks(t *testing.T) {
+	ir := gwdkir.Program{
+		Version: gwdkir.Version,
+		GoEndpoints: []gwdkir.GoEndpoint{{
+			Kind:       "action",
+			SourceKind: gwdkir.EndpointSourceGo,
+			Package:    "handlers",
+			Source:     "handlers/subscribe.go",
+			Name:       "subscribe", // not an exported Go identifier -> invalid
+			Method:     "POST",
+			Route:      "/subscribe",
+		}},
+	}
+
+	err := ValidateProgram(gowdk.Config{}, ir)
+	if err == nil {
+		t.Fatal("expected non-exported standalone endpoint handler to fail IR validation")
+	}
+	if !strings.Contains(err.Error(), "must be an exported Go identifier") {
+		t.Fatalf("unexpected diagnostic: %v", err)
+	}
+
+	// The same IR lowered to a manifest must produce the identical diagnostic —
+	// proving ValidateProgram and ValidateManifest agree on endpoint checks.
+	if got := errString(ValidateProgram(gowdk.Config{}, ir)); got != errString(ValidateManifest(gowdk.Config{}, ManifestFromIR(ir))) {
+		t.Fatalf("IR and manifest endpoint validation diverged: %q", got)
+	}
+}
+
+// TestGoEndpointsReconstructFaithfully checks that ManifestFromIR rebuilds the
+// standalone endpoint declarations field-for-field from the IR mirror.
+func TestGoEndpointsReconstructFaithfully(t *testing.T) {
+	ir := gwdkir.Program{
+		Version: gwdkir.Version,
+		GoEndpoints: []gwdkir.GoEndpoint{{
+			Kind:          "api",
+			SourceKind:    gwdkir.EndpointSourceGo,
+			Package:       "handlers",
+			Source:        "handlers/list.go",
+			Name:          "List",
+			Method:        "GET",
+			Route:         "/api/list/{id:int}",
+			ErrorPage:     "500.html",
+			RouteParams:   []source.NamedSpan{{Name: "id"}},
+			RouteSpan:     source.SourceSpan{Start: source.SourcePosition{Line: 3, Column: 1}},
+			ErrorPageSpan: source.SourceSpan{Start: source.SourcePosition{Line: 4, Column: 1}},
+		}},
+	}
+
+	app := ManifestFromIR(ir)
+	if len(app.Endpoints) != 1 {
+		t.Fatalf("expected 1 reconstructed endpoint, got %d", len(app.Endpoints))
+	}
+	got := app.Endpoints[0]
+	if got.Kind != "api" || got.Name != "List" || got.Method != "GET" || got.Route != "/api/list/{id:int}" {
+		t.Fatalf("endpoint core fields not preserved: %#v", got)
+	}
+	if got.ErrorPage != "500.html" || got.SourceKind != "go" || got.Source != "handlers/list.go" {
+		t.Fatalf("endpoint metadata not preserved: %#v", got)
+	}
+	if len(got.RouteParams) != 1 || got.RouteParams[0].Name != "id" {
+		t.Fatalf("route params not preserved: %#v", got.RouteParams)
+	}
+	if got.RouteSpan.Start.Line != 3 || got.ErrorPageSpan.Start.Line != 4 {
+		t.Fatalf("spans not preserved: %#v", got)
+	}
+}

--- a/internal/compiler/route_bindings.go
+++ b/internal/compiler/route_bindings.go
@@ -6,7 +6,9 @@ import (
 	"unicode"
 
 	"github.com/cssbruno/gowdk"
+	"github.com/cssbruno/gowdk/internal/gwdkanalysis"
 	"github.com/cssbruno/gowdk/internal/gwdkir"
+	"github.com/cssbruno/gowdk/internal/manifest"
 	"github.com/cssbruno/gowdk/internal/source"
 )
 
@@ -97,6 +99,19 @@ type RouteInfo struct {
 	PageID  string
 	Route   string
 	Message string
+}
+
+// BuildRouteMetadata converts a validated manifest into route and endpoint
+// metadata for CLI reporting.
+func BuildRouteMetadata(config gowdk.Config, app manifest.Manifest) (RouteMetadata, error) {
+	if err := ValidateManifest(config, app); err != nil {
+		return RouteMetadata{}, err
+	}
+	if len(app.BackendBindings) == 0 {
+		app = BindBackendHandlers(app)
+	}
+	ir := gwdkanalysis.BuildIR(config, app)
+	return BuildRouteMetadataFromIR(config, ir), nil
 }
 
 // BuildRouteMetadataFromIR converts stable compiler IR into CLI route and

--- a/internal/compiler/route_bindings_test.go
+++ b/internal/compiler/route_bindings_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/cssbruno/gowdk"
 	"github.com/cssbruno/gowdk/addons/ssr"
-	"github.com/cssbruno/gowdk/internal/gwdkanalysis"
 	"github.com/cssbruno/gowdk/internal/gwdkir"
 	"github.com/cssbruno/gowdk/internal/manifest"
 	"github.com/cssbruno/gowdk/internal/source"
@@ -45,7 +44,7 @@ func TestBuildRouteMetadataSeparatesRoutesFromEndpoints(t *testing.T) {
 		},
 	}
 
-	metadata, err := buildRouteMetadata(gowdk.Config{Addons: []gowdk.Addon{ssr.Addon()}}, app)
+	metadata, err := BuildRouteMetadata(gowdk.Config{Addons: []gowdk.Addon{ssr.Addon()}}, app)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -71,7 +70,7 @@ func TestBuildRouteMetadataRejectsSSRWithoutAddon(t *testing.T) {
 		}},
 	}
 
-	_, err := buildRouteMetadata(gowdk.Config{}, app)
+	_, err := BuildRouteMetadata(gowdk.Config{}, app)
 	if err == nil {
 		t.Fatal("expected Missing SSR addon error")
 	}
@@ -87,7 +86,7 @@ func TestBuildRouteMetadataRejectsHybridWithoutAddon(t *testing.T) {
 		},
 	}}}
 
-	_, err := buildRouteMetadata(gowdk.Config{}, app)
+	_, err := BuildRouteMetadata(gowdk.Config{}, app)
 	if err == nil {
 		t.Fatal("expected missing SSR addon error")
 	}
@@ -103,7 +102,7 @@ func TestBuildRouteMetadataMapsHybridWithoutExplicitLoadToHybridRoute(t *testing
 		},
 	}}}
 
-	metadata, err := buildRouteMetadata(gowdk.Config{Addons: []gowdk.Addon{ssr.Addon()}}, app)
+	metadata, err := BuildRouteMetadata(gowdk.Config{Addons: []gowdk.Addon{ssr.Addon()}}, app)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -121,7 +120,7 @@ func TestBuildRouteMetadataMapsHybridWithLoadToHybridRoute(t *testing.T) {
 		},
 	}}}
 
-	metadata, err := buildRouteMetadata(gowdk.Config{Addons: []gowdk.Addon{ssr.Addon()}}, app)
+	metadata, err := BuildRouteMetadata(gowdk.Config{Addons: []gowdk.Addon{ssr.Addon()}}, app)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -237,17 +236,4 @@ func assertInfo(t *testing.T, infos []RouteInfo, code string, pageID string) {
 		}
 	}
 	t.Fatalf("Missing info code=%s page=%s in %#v", code, pageID, infos)
-}
-
-// buildRouteMetadata validates and binds a manifest fixture through the
-// production IR path before deriving route metadata, mirroring the deleted
-// manifest-typed BuildRouteMetadata entrypoint these tests were written
-// against.
-func buildRouteMetadata(config gowdk.Config, app manifest.Manifest) (RouteMetadata, error) {
-	ir := gwdkanalysis.BuildIR(config, app)
-	if err := ValidateProgram(config, ir); err != nil {
-		return RouteMetadata{}, err
-	}
-	BindBackendHandlers(&ir)
-	return BuildRouteMetadataFromIR(config, ir), nil
 }

--- a/internal/compiler/routes.go
+++ b/internal/compiler/routes.go
@@ -5,12 +5,12 @@ import (
 	"strings"
 	"unicode"
 
-	"github.com/cssbruno/gowdk/internal/gwdkir"
+	"github.com/cssbruno/gowdk/internal/manifest"
 	"github.com/cssbruno/gowdk/internal/source"
 )
 
-func validateUniquePageRoutes(pages []gwdkir.Page) []ValidationError {
-	seen := map[string]gwdkir.Page{}
+func validateUniquePageRoutes(pages []manifest.Page) []ValidationError {
+	seen := map[string]manifest.Page{}
 	var diagnostics []ValidationError
 	for _, page := range pages {
 		info, issues := parseRoute(page.Route)
@@ -50,7 +50,7 @@ func duplicateRouteMessage(route, firstID, firstSource, duplicateID, duplicateSo
 	return message
 }
 
-func validateAmbiguousDynamicPageRoutes(pages []gwdkir.Page) []ValidationError {
+func validateAmbiguousDynamicPageRoutes(pages []manifest.Page) []ValidationError {
 	var dynamicRoutes []routeRegistration
 	var diagnostics []ValidationError
 	for _, page := range pages {
@@ -125,7 +125,7 @@ func routePatternSegments(pattern string) []string {
 	return strings.Split(trimmed, "/")
 }
 
-func validateRouteMethodConflicts(pages []gwdkir.Page, endpoints []gwdkir.GoEndpoint) []ValidationError {
+func validateRouteMethodConflicts(pages []manifest.Page, endpoints []manifest.EndpointDeclaration) []ValidationError {
 	seen := map[string]routeRegistration{}
 	var diagnostics []ValidationError
 	for _, registration := range routeRegistrations(pages, endpoints) {
@@ -166,7 +166,7 @@ type routeRegistration struct {
 	Span    source.SourceSpan
 }
 
-func routeRegistrations(pages []gwdkir.Page, endpoints []gwdkir.GoEndpoint) []routeRegistration {
+func routeRegistrations(pages []manifest.Page, endpoints []manifest.EndpointDeclaration) []routeRegistration {
 	var registrations []routeRegistration
 	for _, page := range pages {
 		pageInfo, pageIssues := parseRoute(page.Route)
@@ -272,7 +272,7 @@ func routeRegistrations(pages []gwdkir.Page, endpoints []gwdkir.GoEndpoint) []ro
 			Method:  method,
 			Route:   endpoint.Route,
 			Pattern: info.Pattern,
-			PageID:  standaloneEndpointPageID(endpoint.Package, endpoint.Name),
+			PageID:  standaloneEndpointPageID(endpoint),
 			Source:  endpoint.Source,
 			Span:    firstSpan(endpoint.RouteSpan, endpoint.Span),
 		})
@@ -280,10 +280,10 @@ func routeRegistrations(pages []gwdkir.Page, endpoints []gwdkir.GoEndpoint) []ro
 	return registrations
 }
 
-func validateStandaloneEndpoints(endpoints []gwdkir.GoEndpoint) []ValidationError {
+func validateStandaloneEndpoints(endpoints []manifest.EndpointDeclaration) []ValidationError {
 	var diagnostics []ValidationError
 	for _, endpoint := range endpoints {
-		page := gwdkir.Page{ID: standaloneEndpointPageID(endpoint.Package, endpoint.Name), Source: endpoint.Source}
+		page := manifest.Page{ID: standaloneEndpointPageID(endpoint), Source: endpoint.Source}
 		if !isExportedHandlerName(endpoint.Name) {
 			diagnostics = append(diagnostics, ValidationError{
 				Code:    "invalid_backend_handler_name",
@@ -319,14 +319,14 @@ func validateStandaloneEndpoints(endpoints []gwdkir.GoEndpoint) []ValidationErro
 	return diagnostics
 }
 
-func standaloneEndpointPageID(packageName, name string) string {
-	if packageName == "" {
-		return name
+func standaloneEndpointPageID(endpoint manifest.EndpointDeclaration) string {
+	if endpoint.Package == "" {
+		return endpoint.Name
 	}
-	return packageName + "." + name
+	return endpoint.Package + "." + endpoint.Name
 }
 
-func routeDiagnostics(page gwdkir.Page, label string, issues []routeIssue, routeSpan source.SourceSpan, paramSpans []source.NamedSpan) []ValidationError {
+func routeDiagnostics(page manifest.Page, label string, issues []routeIssue, routeSpan source.SourceSpan, paramSpans []source.NamedSpan) []ValidationError {
 	if len(issues) == 0 {
 		return nil
 	}

--- a/internal/compiler/validate.go
+++ b/internal/compiler/validate.go
@@ -2,9 +2,9 @@ package compiler
 
 import (
 	"fmt"
-
 	"github.com/cssbruno/gowdk"
 	"github.com/cssbruno/gowdk/internal/gwdkir"
+	"github.com/cssbruno/gowdk/internal/manifest"
 	"github.com/cssbruno/gowdk/internal/source"
 )
 
@@ -27,32 +27,51 @@ func (err ValidationError) Error() string {
 	return fmt.Sprintf("%s: %s", err.PageID, err.Message)
 }
 
-// ValidateProgram checks render-mode invariants that must hold before codegen.
-// The validators read the compiler IR directly; there is no manifest
-// intermediary on this path.
-func ValidateProgram(config gowdk.Config, ir gwdkir.Program) error {
+// ValidateManifest checks render-mode invariants that must hold before codegen.
+func ValidateManifest(config gowdk.Config, app manifest.Manifest) error {
+	return validateManifestApp(config, app, true)
+}
+
+// ValidateSourceManifest checks a manifest built from a single in-memory
+// source buffer. Cross-file checks (use packages and component references
+// resolved against the discovered project) are skipped because sibling files
+// are not present in the manifest.
+func ValidateSourceManifest(config gowdk.Config, app manifest.Manifest) error {
+	return validateManifestApp(config, app, false)
+}
+
+func validateManifestApp(config gowdk.Config, app manifest.Manifest, crossFile bool) error {
 	var diagnostics []ValidationError
-	diagnostics = append(diagnostics, validatePackages(ir)...)
-	diagnostics = append(diagnostics, validateUniquePages(ir.Pages)...)
-	diagnostics = append(diagnostics, validateUniqueComponents(ir.Components)...)
-	diagnostics = append(diagnostics, validateComponentEmits(ir.Components)...)
-	diagnostics = append(diagnostics, validateComponentGoContracts(ir.Components)...)
-	diagnostics = append(diagnostics, validateComponentStoreUses(ir.Pages, ir.Components)...)
-	diagnostics = append(diagnostics, validateRedundantComponents(ir.Components)...)
-	diagnostics = append(diagnostics, validateGOWDKUses(ir)...)
-	diagnostics = append(diagnostics, validatePageAssetUses(ir)...)
-	diagnostics = append(diagnostics, validateUniqueLayouts(ir.Layouts)...)
-	diagnostics = append(diagnostics, validatePageLayoutReferences(ir.Pages, ir.Layouts)...)
-	diagnostics = append(diagnostics, validateGoBlocks(config, ir)...)
-	diagnostics = append(diagnostics, validateUniquePageRoutes(ir.Pages)...)
-	diagnostics = append(diagnostics, validateAmbiguousDynamicPageRoutes(ir.Pages)...)
-	diagnostics = append(diagnostics, validateRouteMethodConflicts(ir.Pages, ir.GoEndpoints)...)
-	diagnostics = append(diagnostics, validateStandaloneEndpoints(ir.GoEndpoints)...)
-	for _, page := range ir.Pages {
+	diagnostics = append(diagnostics, validatePackages(app)...)
+	diagnostics = append(diagnostics, validateUniquePages(app.Pages)...)
+	diagnostics = append(diagnostics, validateUniqueComponents(app.Components)...)
+	diagnostics = append(diagnostics, validateComponentEmits(app.Components)...)
+	diagnostics = append(diagnostics, validateComponentGoContracts(app.Components)...)
+	diagnostics = append(diagnostics, validateComponentStoreUses(app.Pages, app.Components)...)
+	diagnostics = append(diagnostics, validateRedundantComponents(app.Components)...)
+	diagnostics = append(diagnostics, validateGOWDKUses(app, crossFile)...)
+	diagnostics = append(diagnostics, validatePageAssetUses(app)...)
+	diagnostics = append(diagnostics, validateUniqueLayouts(app.Layouts)...)
+	diagnostics = append(diagnostics, validatePageLayoutReferences(app.Pages, app.Layouts)...)
+	diagnostics = append(diagnostics, validateGoBlocks(config, app)...)
+	diagnostics = append(diagnostics, validateUniquePageRoutes(app.Pages)...)
+	diagnostics = append(diagnostics, validateAmbiguousDynamicPageRoutes(app.Pages)...)
+	diagnostics = append(diagnostics, validateRouteMethodConflicts(app.Pages, app.Endpoints)...)
+	diagnostics = append(diagnostics, validateStandaloneEndpoints(app.Endpoints)...)
+	for _, page := range app.Pages {
 		diagnostics = append(diagnostics, ValidatePage(config, page)...)
 	}
 	if len(diagnostics) == 0 {
 		return nil
 	}
 	return ValidationErrors(diagnostics)
+}
+
+// ValidateProgram checks the same render-mode invariants as ValidateManifest
+// against an IR-first build path. It reconstructs the manifest from IR via
+// ManifestFromIR so generated-output packages no longer need to carry their own
+// IR->manifest converter. As validators move to read IR directly, the converter
+// shrinks until this entrypoint reads IR with no manifest intermediary.
+func ValidateProgram(config gowdk.Config, ir gwdkir.Program) error {
+	return ValidateManifest(config, ManifestFromIR(ir))
 }

--- a/internal/compiler/validate_assets.go
+++ b/internal/compiler/validate_assets.go
@@ -4,14 +4,14 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/cssbruno/gowdk/internal/gwdkir"
+	"github.com/cssbruno/gowdk/internal/manifest"
 )
 
-func validatePageAssetUses(app gwdkir.Program) []ValidationError {
+func validatePageAssetUses(app manifest.Manifest) []ValidationError {
 	sourcePackages := gowdkSourcePackages(app)
 	var diagnostics []ValidationError
 	for _, page := range app.Pages {
-		usesByAlias := map[string]gwdkir.Use{}
+		usesByAlias := map[string]manifest.Use{}
 		for _, use := range page.Uses {
 			if _, exists := usesByAlias[use.Alias]; !exists {
 				usesByAlias[use.Alias] = use
@@ -59,7 +59,7 @@ func validatePageAssetUses(app gwdkir.Program) []ValidationError {
 	return diagnostics
 }
 
-func gowdkSourcePackages(app gwdkir.Program) map[string]bool {
+func gowdkSourcePackages(app manifest.Manifest) map[string]bool {
 	sourcePackages := map[string]bool{}
 	for _, page := range app.Pages {
 		if page.Package != "" {

--- a/internal/compiler/validate_component_client.go
+++ b/internal/compiler/validate_component_client.go
@@ -4,13 +4,13 @@ import (
 	"errors"
 	"fmt"
 	"github.com/cssbruno/gowdk/internal/clientlang"
-	"github.com/cssbruno/gowdk/internal/gwdkir"
+	"github.com/cssbruno/gowdk/internal/manifest"
 	"github.com/cssbruno/gowdk/internal/source"
 	"github.com/cssbruno/gowdk/internal/view"
 	"strings"
 )
 
-func validateComponentClient(component gwdkir.Component, stateTypes map[string]clientlang.ValueType, symbolTypes map[string]clientlang.ValueType) (map[string]clientlang.Handler, map[string]clientlang.Helper, map[string]clientlang.Ref, map[string]bool, map[string]clientlang.ValueType, []ValidationError) {
+func validateComponentClient(component manifest.Component, stateTypes map[string]clientlang.ValueType, symbolTypes map[string]clientlang.ValueType) (map[string]clientlang.Handler, map[string]clientlang.Helper, map[string]clientlang.Ref, map[string]bool, map[string]clientlang.ValueType, []ValidationError) {
 	if !component.Blocks.Client && strings.TrimSpace(component.Blocks.ClientBody) == "" {
 		return nil, nil, nil, nil, nil, nil
 	}
@@ -230,7 +230,7 @@ func validateComponentClient(component gwdkir.Component, stateTypes map[string]c
 	return handlers, helpers, refs, usedRefs, computedTypes, diagnostics
 }
 
-func componentEmitMap(component gwdkir.Component) map[string]clientlang.Emit {
+func componentEmitMap(component manifest.Component) map[string]clientlang.Emit {
 	if len(component.Emits) == 0 {
 		return nil
 	}
@@ -247,7 +247,7 @@ func componentEmitMap(component gwdkir.Component) map[string]clientlang.Emit {
 	return out
 }
 
-func clientStatementErrorSpan(component gwdkir.Component, statements []string, spans []clientlang.Span, err error) source.SourceSpan {
+func clientStatementErrorSpan(component manifest.Component, statements []string, spans []clientlang.Span, err error) source.SourceSpan {
 	var statementErr view.StatementValidationError
 	if errors.As(err, &statementErr) && statementErr.Index >= 0 && statementErr.Index < len(spans) {
 		if statementErr.Index < len(statements) {
@@ -258,7 +258,7 @@ func clientStatementErrorSpan(component gwdkir.Component, statements []string, s
 	return firstSpan(component.Blocks.Spans.Client, component.Span)
 }
 
-func clientParseErrorSpan(component gwdkir.Component, err error) source.SourceSpan {
+func clientParseErrorSpan(component manifest.Component, err error) source.SourceSpan {
 	var parseErr *clientlang.ParseError
 	if errors.As(err, &parseErr) && parseErr.Line > 0 {
 		return clientSpan(component, clientlang.Span{StartLine: parseErr.Line, EndLine: parseErr.Line})
@@ -266,7 +266,7 @@ func clientParseErrorSpan(component gwdkir.Component, err error) source.SourceSp
 	return firstSpan(component.Blocks.Spans.Client, component.Span)
 }
 
-func clientExpressionErrorSpan(component gwdkir.Component, statement string, span clientlang.Span, err error) source.SourceSpan {
+func clientExpressionErrorSpan(component manifest.Component, statement string, span clientlang.Span, err error) source.SourceSpan {
 	var exprErr clientlang.ExprValidationError
 	if !errors.As(err, &exprErr) || exprErr.Span.StartColumn <= 0 {
 		return clientSpan(component, span)
@@ -300,11 +300,11 @@ func functionReturnSpan(function clientlang.Function) clientlang.Span {
 	return function.StatementSpans[len(function.StatementSpans)-1]
 }
 
-func clientSpan(component gwdkir.Component, span clientlang.Span) source.SourceSpan {
+func clientSpan(component manifest.Component, span clientlang.Span) source.SourceSpan {
 	return clientSpanColumns(component, span, 1, 2)
 }
 
-func clientSpanColumns(component gwdkir.Component, span clientlang.Span, startColumn, endColumn int) source.SourceSpan {
+func clientSpanColumns(component manifest.Component, span clientlang.Span, startColumn, endColumn int) source.SourceSpan {
 	if span.StartLine <= 0 {
 		return firstSpan(component.Blocks.Spans.Client, component.Span)
 	}

--- a/internal/compiler/validate_component_contracts.go
+++ b/internal/compiler/validate_component_contracts.go
@@ -5,12 +5,12 @@ import (
 
 	"github.com/cssbruno/gowdk/internal/clientlang"
 	"github.com/cssbruno/gowdk/internal/gotypes"
-	"github.com/cssbruno/gowdk/internal/gwdkir"
+	"github.com/cssbruno/gowdk/internal/manifest"
 	"github.com/cssbruno/gowdk/internal/source"
 	"strings"
 )
 
-func validateComponentGoContracts(components []gwdkir.Component) []ValidationError {
+func validateComponentGoContracts(components []manifest.Component) []ValidationError {
 	var diagnostics []ValidationError
 	for _, component := range components {
 		diagnostics = append(diagnostics, validateComponentGoContract(component)...)
@@ -37,7 +37,7 @@ type componentValidationContext struct {
 	UsedRefs      map[string]bool
 }
 
-func validateComponentGoContract(component gwdkir.Component) []ValidationError {
+func validateComponentGoContract(component manifest.Component) []ValidationError {
 	var diagnostics []ValidationError
 	diagnostics = append(diagnostics, validateComponentImports(component)...)
 	if component.PropsType.Name != "" && len(component.Props) > 0 {
@@ -73,7 +73,7 @@ func validateComponentGoContract(component gwdkir.Component) []ValidationError {
 	return diagnostics
 }
 
-func resolveComponentContracts(component gwdkir.Component) (componentContracts, []ValidationError) {
+func resolveComponentContracts(component manifest.Component) (componentContracts, []ValidationError) {
 	contracts := componentContracts{
 		Props:      map[string]bool{},
 		PropTypes:  map[string]clientlang.ValueType{},
@@ -122,7 +122,7 @@ func addResolvedFields(names map[string]bool, types map[string]clientlang.ValueT
 	}
 }
 
-func validateComponentContractOverlap(component gwdkir.Component, contracts componentContracts) []ValidationError {
+func validateComponentContractOverlap(component manifest.Component, contracts componentContracts) []ValidationError {
 	var diagnostics []ValidationError
 	for name := range contracts.Props {
 		if !contracts.State[name] {
@@ -139,9 +139,9 @@ func validateComponentContractOverlap(component gwdkir.Component, contracts comp
 	return diagnostics
 }
 
-func validateComponentImports(component gwdkir.Component) []ValidationError {
+func validateComponentImports(component manifest.Component) []ValidationError {
 	var diagnostics []ValidationError
-	seen := map[string]gwdkir.Import{}
+	seen := map[string]manifest.Import{}
 	for _, item := range component.Imports {
 		if err := gotypes.ValidateImportPath(item.Path); err != nil {
 			diagnostics = append(diagnostics, componentContractDiagnostic(component, "invalid_go_import", item.Span, err))
@@ -167,7 +167,7 @@ func validateComponentImports(component gwdkir.Component) []ValidationError {
 	return diagnostics
 }
 
-func componentContractDiagnostic(component gwdkir.Component, code string, span source.SourceSpan, err error) ValidationError {
+func componentContractDiagnostic(component manifest.Component, code string, span source.SourceSpan, err error) ValidationError {
 	return ValidationError{
 		Code:          code,
 		ComponentName: component.Name,
@@ -177,7 +177,7 @@ func componentContractDiagnostic(component gwdkir.Component, code string, span s
 	}
 }
 
-func importSource(sourcePath string, item gwdkir.Import) string {
+func importSource(sourcePath string, item manifest.Import) string {
 	if sourcePath == "" {
 		return ""
 	}

--- a/internal/compiler/validate_component_fingerprint.go
+++ b/internal/compiler/validate_component_fingerprint.go
@@ -4,15 +4,15 @@ import (
 	"fmt"
 	"github.com/cssbruno/gowdk/internal/clientlang"
 	"github.com/cssbruno/gowdk/internal/gotypes"
-	"github.com/cssbruno/gowdk/internal/gwdkir"
+	"github.com/cssbruno/gowdk/internal/manifest"
 	"github.com/cssbruno/gowdk/internal/view"
 	"sort"
 	"strings"
 )
 
-func validateRedundantComponents(components []gwdkir.Component) []ValidationError {
+func validateRedundantComponents(components []manifest.Component) []ValidationError {
 	seenNames := map[string]bool{}
-	seen := map[string]gwdkir.Component{}
+	seen := map[string]manifest.Component{}
 	var diagnostics []ValidationError
 	for _, component := range components {
 		if component.Name == "" || seenNames[component.Name] {
@@ -45,7 +45,7 @@ func validateRedundantComponents(components []gwdkir.Component) []ValidationErro
 	return diagnostics
 }
 
-func componentFingerprint(component gwdkir.Component) string {
+func componentFingerprint(component manifest.Component) string {
 	parts := []string{
 		"props=" + componentPropsFingerprint(component),
 		"state=" + componentStateFingerprint(component),
@@ -55,7 +55,7 @@ func componentFingerprint(component gwdkir.Component) string {
 	return strings.Join(parts, "\n")
 }
 
-func componentPropsFingerprint(component gwdkir.Component) string {
+func componentPropsFingerprint(component manifest.Component) string {
 	if component.PropsType.Name != "" {
 		return "type:" + canonicalGoType(component.Imports, component.PropsType)
 	}
@@ -70,14 +70,14 @@ func componentPropsFingerprint(component gwdkir.Component) string {
 	return "inline:" + strings.Join(props, ",")
 }
 
-func componentStateFingerprint(component gwdkir.Component) string {
+func componentStateFingerprint(component manifest.Component) string {
 	if component.State.Type.Name == "" {
 		return ""
 	}
 	return canonicalGoType(component.Imports, component.State.Type) + "=init:" + canonicalGoFunc(component.Imports, component.State.Init)
 }
 
-func componentViewFingerprint(component gwdkir.Component) string {
+func componentViewFingerprint(component manifest.Component) string {
 	canonical, err := view.Canonical(component.Blocks.ViewBody)
 	if err == nil {
 		return canonical
@@ -85,7 +85,7 @@ func componentViewFingerprint(component gwdkir.Component) string {
 	return strings.Join(strings.Fields(component.Blocks.ViewBody), " ")
 }
 
-func componentClientFingerprint(component gwdkir.Component) string {
+func componentClientFingerprint(component manifest.Component) string {
 	if !component.Blocks.Client && strings.TrimSpace(component.Blocks.ClientBody) == "" {
 		return ""
 	}
@@ -96,7 +96,7 @@ func componentClientFingerprint(component gwdkir.Component) string {
 	return strings.Join(strings.Fields(component.Blocks.ClientBody), " ")
 }
 
-func canonicalGoType(imports []gwdkir.Import, ref gwdkir.GoRef) string {
+func canonicalGoType(imports []manifest.Import, ref manifest.GoTypeRef) string {
 	path, err := gotypes.ImportPathForAlias(imports, ref.Alias)
 	if err != nil {
 		return ref.Alias + "." + ref.Name
@@ -104,7 +104,7 @@ func canonicalGoType(imports []gwdkir.Import, ref gwdkir.GoRef) string {
 	return path + "." + ref.Name
 }
 
-func canonicalGoFunc(imports []gwdkir.Import, ref gwdkir.GoRef) string {
+func canonicalGoFunc(imports []manifest.Import, ref manifest.GoFuncRef) string {
 	path, err := gotypes.ImportPathForAlias(imports, ref.Alias)
 	if err != nil {
 		return ref.Alias + "." + ref.Name

--- a/internal/compiler/validate_component_lists.go
+++ b/internal/compiler/validate_component_lists.go
@@ -5,12 +5,12 @@ import (
 	"strings"
 
 	"github.com/cssbruno/gowdk/internal/clientlang"
-	"github.com/cssbruno/gowdk/internal/gwdkir"
+	"github.com/cssbruno/gowdk/internal/manifest"
 	"github.com/cssbruno/gowdk/internal/source"
 	"github.com/cssbruno/gowdk/internal/view"
 )
 
-func validateComponentListDirectives(component gwdkir.Component, symbols map[string]clientlang.ValueType, stateTypes map[string]clientlang.ValueType, handlers map[string]clientlang.Handler, helpers map[string]clientlang.ExprFunction) []ValidationError {
+func validateComponentListDirectives(component manifest.Component, symbols map[string]clientlang.ValueType, stateTypes map[string]clientlang.ValueType, handlers map[string]clientlang.Handler, helpers map[string]clientlang.ExprFunction) []ValidationError {
 	nodes, err := view.Parse(component.Blocks.ViewBody)
 	if err != nil {
 		return nil
@@ -38,7 +38,7 @@ type spannedMessage struct {
 	Span    source.SourceSpan
 }
 
-func validateListNodes(nodes []view.Node, component gwdkir.Component, symbols map[string]clientlang.ValueType, stateTypes map[string]clientlang.ValueType, handlers map[string]clientlang.Handler, helpers map[string]clientlang.ExprFunction, messages *[]spannedMessage) {
+func validateListNodes(nodes []view.Node, component manifest.Component, symbols map[string]clientlang.ValueType, stateTypes map[string]clientlang.ValueType, handlers map[string]clientlang.Handler, helpers map[string]clientlang.ExprFunction, messages *[]spannedMessage) {
 	for _, node := range nodes {
 		switch typed := node.(type) {
 		case view.Element:
@@ -53,7 +53,7 @@ func validateListNodes(nodes []view.Node, component gwdkir.Component, symbols ma
 	}
 }
 
-func validateListElement(element view.Element, loopAttr view.Attr, component gwdkir.Component, symbols map[string]clientlang.ValueType, stateTypes map[string]clientlang.ValueType, handlers map[string]clientlang.Handler, helpers map[string]clientlang.ExprFunction, messages *[]spannedMessage) {
+func validateListElement(element view.Element, loopAttr view.Attr, component manifest.Component, symbols map[string]clientlang.ValueType, stateTypes map[string]clientlang.ValueType, handlers map[string]clientlang.Handler, helpers map[string]clientlang.ExprFunction, messages *[]spannedMessage) {
 	loopSpan := viewBodyNeedleSpan(component, loopAttr.Value)
 	loop, err := view.ParseForDirective(loopAttr.Value)
 	if err != nil {
@@ -93,7 +93,7 @@ func validateLoopSubtree(node view.Node, readSymbols map[string]clientlang.Value
 		validateInterpolations(typed.Value, readSymbols, messages)
 	case view.Element:
 		if loopAttr, hasLoop := elementForDirective(typed); hasLoop {
-			validateListElement(typed, loopAttr, gwdkir.Component{}, readSymbols, writeSymbols, handlers, helpers, messages)
+			validateListElement(typed, loopAttr, manifest.Component{}, readSymbols, writeSymbols, handlers, helpers, messages)
 			return
 		}
 		validateLoopElementBody(typed, readSymbols, writeSymbols, handlers, helpers, messages)

--- a/internal/compiler/validate_component_view_contract.go
+++ b/internal/compiler/validate_component_view_contract.go
@@ -5,11 +5,11 @@ import (
 	"strings"
 
 	"github.com/cssbruno/gowdk/internal/clientlang"
-	"github.com/cssbruno/gowdk/internal/gwdkir"
+	"github.com/cssbruno/gowdk/internal/manifest"
 	"github.com/cssbruno/gowdk/internal/view"
 )
 
-func validateComponentViewContract(component gwdkir.Component, ctx componentValidationContext) []ValidationError {
+func validateComponentViewContract(component manifest.Component, ctx componentValidationContext) []ValidationError {
 	viewRefs, err := componentViewReferences(component.Blocks.ViewBody)
 	if err != nil {
 		return []ValidationError{{
@@ -35,7 +35,7 @@ func validateComponentViewContract(component gwdkir.Component, ctx componentVali
 	return diagnostics
 }
 
-func validateUnknownViewFields(component gwdkir.Component, ctx componentValidationContext, viewRefs componentViewRefs) []ValidationError {
+func validateUnknownViewFields(component manifest.Component, ctx componentValidationContext, viewRefs componentViewRefs) []ValidationError {
 	var diagnostics []ValidationError
 	for field := range viewRefs.Fields {
 		if ctx.Props[field] || ctx.State[field] {
@@ -55,7 +55,7 @@ func validateUnknownViewFields(component gwdkir.Component, ctx componentValidati
 	return diagnostics
 }
 
-func validateViewEventExpressions(component gwdkir.Component, ctx componentValidationContext, viewRefs componentViewRefs, helperFuncs map[string]clientlang.ExprFunction, emits map[string]clientlang.Emit) []ValidationError {
+func validateViewEventExpressions(component manifest.Component, ctx componentValidationContext, viewRefs componentViewRefs, helperFuncs map[string]clientlang.ExprFunction, emits map[string]clientlang.Emit) []ValidationError {
 	var diagnostics []ValidationError
 	for _, eventExpr := range viewRefs.Events {
 		if _, err := view.ParseEventDirective(eventExpr.Name); err != nil {
@@ -93,7 +93,7 @@ func mergeClientSymbols(left, right map[string]clientlang.ValueType) map[string]
 	return out
 }
 
-func validateViewBooleanExpressions(component gwdkir.Component, ctx componentValidationContext, viewRefs componentViewRefs) []ValidationError {
+func validateViewBooleanExpressions(component manifest.Component, ctx componentValidationContext, viewRefs componentViewRefs) []ValidationError {
 	var diagnostics []ValidationError
 	for _, expr := range viewRefs.Bools {
 		if err := view.ValidateIslandBoolExpressionTyped(expr, ctx.SymbolTypes); err != nil {
@@ -109,7 +109,7 @@ func validateViewBooleanExpressions(component gwdkir.Component, ctx componentVal
 	return diagnostics
 }
 
-func validateViewAttributeExpressions(component gwdkir.Component, ctx componentValidationContext, viewRefs componentViewRefs) []ValidationError {
+func validateViewAttributeExpressions(component manifest.Component, ctx componentValidationContext, viewRefs componentViewRefs) []ValidationError {
 	var diagnostics []ValidationError
 	for _, attrExpr := range viewRefs.Attrs {
 		if err := view.ValidateReactiveAttrExpressionTyped(attrExpr.Name, attrExpr.Expression, ctx.SymbolTypes); err != nil {
@@ -147,7 +147,7 @@ func validateViewAttributeExpressions(component gwdkir.Component, ctx componentV
 	return diagnostics
 }
 
-func validateViewValueBinds(component gwdkir.Component, ctx componentValidationContext, viewRefs componentViewRefs) []ValidationError {
+func validateViewValueBinds(component manifest.Component, ctx componentValidationContext, viewRefs componentViewRefs) []ValidationError {
 	var diagnostics []ValidationError
 	for _, field := range viewRefs.ValueBinds {
 		diagnostics = append(diagnostics, validateViewValueBind(component, ctx, field)...)
@@ -155,7 +155,7 @@ func validateViewValueBinds(component gwdkir.Component, ctx componentValidationC
 	return diagnostics
 }
 
-func validateViewValueBind(component gwdkir.Component, ctx componentValidationContext, field valueBindExpr) []ValidationError {
+func validateViewValueBind(component manifest.Component, ctx componentValidationContext, field valueBindExpr) []ValidationError {
 	typ, ok := ctx.StateTypes[field.Field]
 	if !ok {
 		return []ValidationError{componentFieldError(component, fmt.Sprintf("component %s g:bind:value target %q must be a state field", component.Name, field.Field))}
@@ -178,7 +178,7 @@ func validateViewValueBind(component gwdkir.Component, ctx componentValidationCo
 	return []ValidationError{componentFieldError(component, fmt.Sprintf("component %s g:bind:value target %q must be string or numeric, got %s", component.Name, field.Field, typ))}
 }
 
-func validateViewCheckedBinds(component gwdkir.Component, ctx componentValidationContext, viewRefs componentViewRefs) []ValidationError {
+func validateViewCheckedBinds(component manifest.Component, ctx componentValidationContext, viewRefs componentViewRefs) []ValidationError {
 	var diagnostics []ValidationError
 	for _, field := range viewRefs.CheckedBinds {
 		typ, ok := ctx.StateTypes[field]
@@ -193,7 +193,7 @@ func validateViewCheckedBinds(component gwdkir.Component, ctx componentValidatio
 	return diagnostics
 }
 
-func validateViewRefBinds(component gwdkir.Component, ctx componentValidationContext, viewRefs componentViewRefs) []ValidationError {
+func validateViewRefBinds(component manifest.Component, ctx componentValidationContext, viewRefs componentViewRefs) []ValidationError {
 	boundRefs := map[string]bool{}
 	var diagnostics []ValidationError
 	for _, refName := range viewRefs.RefBinds {
@@ -225,7 +225,7 @@ func validateViewRefBinds(component gwdkir.Component, ctx componentValidationCon
 	return diagnostics
 }
 
-func componentFieldError(component gwdkir.Component, message string) ValidationError {
+func componentFieldError(component manifest.Component, message string) ValidationError {
 	return ValidationError{
 		Code:          "component_field_error",
 		ComponentName: component.Name,

--- a/internal/compiler/validate_differential_test.go
+++ b/internal/compiler/validate_differential_test.go
@@ -1,0 +1,95 @@
+package compiler_test
+
+import (
+	"testing"
+
+	"github.com/cssbruno/gowdk"
+	"github.com/cssbruno/gowdk/internal/compiler"
+	"github.com/cssbruno/gowdk/internal/gwdkanalysis"
+	"github.com/cssbruno/gowdk/internal/manifest"
+)
+
+// TestValidateProgramMatchesValidateManifestDifferential is the safety proof for
+// flipping the CLI to validate IR instead of the parsed manifest: for a corpus of
+// valid and invalid programs, ValidateProgram(BuildIR(app)) must produce the exact
+// same diagnostics as ValidateManifest(app). If this ever diverges, the IR round
+// trip has lost or reordered something a validator depends on.
+func TestValidateProgramMatchesValidateManifestDifferential(t *testing.T) {
+	view := func(body string) manifest.Blocks { return manifest.Blocks{View: true, ViewBody: body} }
+	page := func(id, route string) manifest.Page {
+		return manifest.Page{ID: id, Route: route, Package: "pages", Source: id + ".page.gwdk", Blocks: view("<main/>")}
+	}
+
+	cases := []struct {
+		name string
+		app  manifest.Manifest
+	}{
+		{
+			name: "valid program",
+			app:  manifest.Manifest{Pages: []manifest.Page{page("home", "/"), page("about", "/about")}},
+		},
+		{
+			name: "duplicate page identity",
+			app:  manifest.Manifest{Pages: []manifest.Page{page("home", "/"), page("home", "/other")}},
+		},
+		{
+			name: "duplicate route pattern",
+			app:  manifest.Manifest{Pages: []manifest.Page{page("home", "/dup"), page("other", "/dup")}},
+		},
+		{
+			name: "invalid standalone endpoint handler",
+			app: manifest.Manifest{
+				Pages: []manifest.Page{page("home", "/")},
+				Endpoints: []manifest.EndpointDeclaration{{
+					Kind: "action", SourceKind: manifest.EndpointSourceGo, Package: "h",
+					Source: "h/x.go", Name: "lowercase", Method: "POST", Route: "/x",
+				}},
+			},
+		},
+		{
+			name: "route method conflict between page and standalone endpoint",
+			app: manifest.Manifest{
+				Pages: []manifest.Page{page("home", "/clash")},
+				Endpoints: []manifest.EndpointDeclaration{{
+					Kind: "api", SourceKind: manifest.EndpointSourceGo, Package: "h",
+					Source: "h/x.go", Name: "Clash", Method: "GET", Route: "/clash",
+				}},
+			},
+		},
+		{
+			name: "dynamic spa page with empty paths block",
+			app: manifest.Manifest{Pages: []manifest.Page{{
+				ID: "blog.post", Route: "/blog/{slug}", Package: "pages",
+				Source: "blog.post.page.gwdk", Paths: true, Blocks: view("<main/>"),
+			}}},
+		},
+		{
+			name: "standalone action with unsupported method",
+			app: manifest.Manifest{
+				Endpoints: []manifest.EndpointDeclaration{{
+					Kind: "action", SourceKind: manifest.EndpointSourceGo, Package: "h",
+					Source: "h/x.go", Name: "Save", Method: "DELETE", Route: "/save",
+				}},
+			},
+		},
+	}
+
+	config := gowdk.Config{}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			viaManifest := errText(compiler.ValidateManifest(config, tc.app))
+			ir := gwdkanalysis.BuildIR(config, tc.app)
+			viaProgram := errText(compiler.ValidateProgram(config, ir))
+			if viaManifest != viaProgram {
+				t.Fatalf("diagnostic drift between manifest and IR validation:\nmanifest: %q\nIR:       %q", viaManifest, viaProgram)
+			}
+		})
+	}
+}
+
+func errText(err error) string {
+	if err == nil {
+		return ""
+	}
+	return err.Error()
+}

--- a/internal/compiler/validate_identity.go
+++ b/internal/compiler/validate_identity.go
@@ -4,11 +4,11 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/cssbruno/gowdk/internal/gwdkir"
+	"github.com/cssbruno/gowdk/internal/manifest"
 )
 
-func validateUniquePages(pages []gwdkir.Page) []ValidationError {
-	seen := map[string]gwdkir.Page{}
+func validateUniquePages(pages []manifest.Page) []ValidationError {
+	seen := map[string]manifest.Page{}
 	var diagnostics []ValidationError
 	for _, page := range pages {
 		if page.ID == "" {
@@ -35,8 +35,8 @@ func validateUniquePages(pages []gwdkir.Page) []ValidationError {
 	return diagnostics
 }
 
-func validateUniqueLayouts(layouts []gwdkir.Layout) []ValidationError {
-	seen := map[string]gwdkir.Layout{}
+func validateUniqueLayouts(layouts []manifest.Layout) []ValidationError {
+	seen := map[string]manifest.Layout{}
 	var diagnostics []ValidationError
 	for _, layout := range layouts {
 		if layout.ID == "" {
@@ -63,11 +63,11 @@ func validateUniqueLayouts(layouts []gwdkir.Layout) []ValidationError {
 	return diagnostics
 }
 
-func validatePageLayoutReferences(pages []gwdkir.Page, layouts []gwdkir.Layout) []ValidationError {
+func validatePageLayoutReferences(pages []manifest.Page, layouts []manifest.Layout) []ValidationError {
 	if len(layouts) == 0 {
 		return nil
 	}
-	declared := map[string]gwdkir.Layout{}
+	declared := map[string]manifest.Layout{}
 	for _, layout := range layouts {
 		if layout.ID != "" {
 			declared[layoutIdentityKey(layout.Package, layout.ID)] = layout
@@ -140,8 +140,8 @@ func validatePageLayoutReferences(pages []gwdkir.Page, layouts []gwdkir.Layout) 
 	return diagnostics
 }
 
-func pageUsesByAlias(page gwdkir.Page) map[string]gwdkir.Use {
-	usesByAlias := map[string]gwdkir.Use{}
+func pageUsesByAlias(page manifest.Page) map[string]manifest.Use {
+	usesByAlias := map[string]manifest.Use{}
 	for _, use := range page.Uses {
 		if _, exists := usesByAlias[use.Alias]; !exists {
 			usesByAlias[use.Alias] = use
@@ -164,8 +164,8 @@ func layoutDisplayName(packageName, layoutID string) string {
 	return packageName + "." + layoutID
 }
 
-func validateUniqueComponents(components []gwdkir.Component) []ValidationError {
-	seen := map[string]gwdkir.Component{}
+func validateUniqueComponents(components []manifest.Component) []ValidationError {
+	seen := map[string]manifest.Component{}
 	var diagnostics []ValidationError
 	for _, component := range components {
 		if component.Name == "" {
@@ -192,10 +192,10 @@ func validateUniqueComponents(components []gwdkir.Component) []ValidationError {
 	return diagnostics
 }
 
-func validateComponentEmits(components []gwdkir.Component) []ValidationError {
+func validateComponentEmits(components []manifest.Component) []ValidationError {
 	var diagnostics []ValidationError
 	for _, component := range components {
-		seen := map[string]gwdkir.Emit{}
+		seen := map[string]manifest.Emit{}
 		for _, event := range component.Emits {
 			if event.Name == "" {
 				continue

--- a/internal/compiler/validate_packages.go
+++ b/internal/compiler/validate_packages.go
@@ -18,7 +18,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/cssbruno/gowdk/internal/gwdkir"
+	"github.com/cssbruno/gowdk/internal/manifest"
 	"github.com/cssbruno/gowdk/internal/source"
 )
 
@@ -28,8 +28,8 @@ type packageDeclaration struct {
 	PageID        string
 	ComponentName string
 	Package       string
-	Imports       []gwdkir.Import
-	GoBlocks      []gwdkir.GoBlock
+	Imports       []manifest.Import
+	GoBlocks      []manifest.GoBlock
 	Span          source.SourceSpan
 }
 
@@ -39,7 +39,7 @@ type goPackageInfo struct {
 	Diagnostics []ValidationError
 }
 
-func validatePackages(app gwdkir.Program) []ValidationError {
+func validatePackages(app manifest.Manifest) []ValidationError {
 	declarations := packageDeclarations(app)
 	var diagnostics []ValidationError
 	byDir := map[string][]packageDeclaration{}
@@ -103,7 +103,7 @@ func shouldValidatePackageSource(sourcePath string) bool {
 	return false
 }
 
-func packageDeclarations(app gwdkir.Program) []packageDeclaration {
+func packageDeclarations(app manifest.Manifest) []packageDeclaration {
 	var declarations []packageDeclaration
 	for _, page := range app.Pages {
 		declarations = append(declarations, packageDeclaration{
@@ -256,7 +256,7 @@ func inspectGoPackageForValidation(dir string, group []packageDeclaration) goPac
 	return info
 }
 
-func parseGoBlockPackageFileForValidation(fileSet *token.FileSet, declaration packageDeclaration, block gwdkir.GoBlock) (*ast.File, *ValidationError) {
+func parseGoBlockPackageFileForValidation(fileSet *token.FileSet, declaration packageDeclaration, block manifest.GoBlock) (*ast.File, *ValidationError) {
 	src, err := goBlockPackageSourceForValidation(declaration, block)
 	if err != nil {
 		return nil, nil
@@ -276,7 +276,7 @@ func parseGoBlockPackageFileForValidation(fileSet *token.FileSet, declaration pa
 	return file, nil
 }
 
-func goBlockPackageSourceForValidation(declaration packageDeclaration, block gwdkir.GoBlock) (string, error) {
+func goBlockPackageSourceForValidation(declaration packageDeclaration, block manifest.GoBlock) (string, error) {
 	packageName := strings.TrimSpace(declaration.Package)
 	if packageName == "" {
 		return "", fmt.Errorf("go block package is missing")
@@ -315,7 +315,7 @@ func goBlockPackageSourceForValidation(declaration packageDeclaration, block gwd
 	return buffer.String(), nil
 }
 
-func goBlockGOWDKImportSpecsForValidation(imports []gwdkir.Import, bodyFile *ast.File) []ast.Spec {
+func goBlockGOWDKImportSpecsForValidation(imports []manifest.Import, bodyFile *ast.File) []ast.Spec {
 	used := usedScriptIdentifiersForValidation(bodyFile)
 	localImports := goBlockImportAliasesForValidation(bodyFile)
 	var specs []ast.Spec
@@ -431,7 +431,7 @@ func goBlockImportAliasesForValidation(file *ast.File) map[string]bool {
 	return aliases
 }
 
-func goBlockImportAliasForValidation(item gwdkir.Import) string {
+func goBlockImportAliasForValidation(item manifest.Import) string {
 	if strings.TrimSpace(item.Alias) != "" {
 		return item.Alias
 	}

--- a/internal/compiler/validate_page.go
+++ b/internal/compiler/validate_page.go
@@ -7,12 +7,12 @@ import (
 
 	"github.com/cssbruno/gowdk"
 	"github.com/cssbruno/gowdk/internal/gotypes"
-	"github.com/cssbruno/gowdk/internal/gwdkir"
+	"github.com/cssbruno/gowdk/internal/manifest"
 	"github.com/cssbruno/gowdk/internal/source"
 	"github.com/cssbruno/gowdk/runtime/auth"
 )
 
-func ValidatePage(config gowdk.Config, page gwdkir.Page) []ValidationError {
+func ValidatePage(config gowdk.Config, page manifest.Page) []ValidationError {
 	mode := page.RenderMode(config.Render.DefaultMode())
 	var diagnostics []ValidationError
 	pageRoute, pageRouteIssues := parseRoute(page.Route)
@@ -141,7 +141,7 @@ func ValidatePage(config gowdk.Config, page gwdkir.Page) []ValidationError {
 	if len(pageRouteIssues) == 0 {
 		params = pageRoute.Params
 	}
-	if isBuildTimeRoute(mode, page) && len(params) > 0 && !page.Blocks.Paths {
+	if isBuildTimeRoute(mode, page) && len(params) > 0 && !page.Paths {
 		diagnostics = append(diagnostics, ValidationError{
 			Code:   "spa_dynamic_route_missing_paths",
 			PageID: page.ID,
@@ -173,11 +173,11 @@ func ValidatePage(config gowdk.Config, page gwdkir.Page) []ValidationError {
 	return diagnostics
 }
 
-func validatePageGuards(page gwdkir.Page) []ValidationError {
+func validatePageGuards(page manifest.Page) []ValidationError {
 	if !validateSourceBackedPageGuards(page) {
 		return nil
 	}
-	if len(page.Guards) == 0 {
+	if len(page.Guard) == 0 {
 		return []ValidationError{{
 			Code:   "missing_page_guard",
 			PageID: page.ID,
@@ -191,13 +191,13 @@ func validatePageGuards(page gwdkir.Page) []ValidationError {
 	}
 
 	public := false
-	for _, guard := range page.Guards {
+	for _, guard := range page.Guard {
 		if auth.IsPublicGuard(guard) {
 			public = true
 			break
 		}
 	}
-	if public && len(page.Guards) > 1 {
+	if public && len(page.Guard) > 1 {
 		return []ValidationError{{
 			Code:    "public_guard_exclusive",
 			PageID:  page.ID,
@@ -209,7 +209,7 @@ func validatePageGuards(page gwdkir.Page) []ValidationError {
 	return nil
 }
 
-func validateProtectedPageGuardRender(page gwdkir.Page, mode gowdk.RenderMode) []ValidationError {
+func validateProtectedPageGuardRender(page manifest.Page, mode gowdk.RenderMode) []ValidationError {
 	if !validateSourceBackedPageGuards(page) || !isBuildTimeRoute(mode, page) || !hasProtectedPageGuard(page) {
 		return nil
 	}
@@ -222,7 +222,7 @@ func validateProtectedPageGuardRender(page gwdkir.Page, mode gowdk.RenderMode) [
 	}}
 }
 
-func validateSourceBackedPageGuards(page gwdkir.Page) bool {
+func validateSourceBackedPageGuards(page manifest.Page) bool {
 	if strings.TrimSpace(page.Source) == "" {
 		return false
 	}
@@ -232,8 +232,8 @@ func validateSourceBackedPageGuards(page gwdkir.Page) bool {
 	return true
 }
 
-func hasProtectedPageGuard(page gwdkir.Page) bool {
-	for _, guard := range page.Guards {
+func hasProtectedPageGuard(page manifest.Page) bool {
+	for _, guard := range page.Guard {
 		if !auth.IsPublicGuard(guard) {
 			return true
 		}
@@ -241,7 +241,7 @@ func hasProtectedPageGuard(page gwdkir.Page) bool {
 	return false
 }
 
-func firstGoBlockSpan(page gwdkir.Page, target string) source.SourceSpan {
+func firstGoBlockSpan(page manifest.Page, target string) source.SourceSpan {
 	for _, block := range page.Blocks.GoBlocks {
 		if block.Target == target {
 			return block.Span
@@ -250,11 +250,11 @@ func firstGoBlockSpan(page gwdkir.Page, target string) source.SourceSpan {
 	return source.SourceSpan{}
 }
 
-func requiresSSRFeature(mode gowdk.RenderMode, page gwdkir.Page) bool {
+func requiresSSRFeature(mode gowdk.RenderMode, page manifest.Page) bool {
 	return mode == gowdk.SSR || mode == gowdk.Hybrid
 }
 
-func isBuildTimeRoute(mode gowdk.RenderMode, page gwdkir.Page) bool {
+func isBuildTimeRoute(mode gowdk.RenderMode, page manifest.Page) bool {
 	switch mode {
 	case gowdk.SPA, gowdk.Action:
 		return true
@@ -263,7 +263,7 @@ func isBuildTimeRoute(mode gowdk.RenderMode, page gwdkir.Page) bool {
 	}
 }
 
-func validatePageCachePolicy(page gwdkir.Page) []ValidationError {
+func validatePageCachePolicy(page manifest.Page) []ValidationError {
 	if page.Revalidate == "" {
 		return nil
 	}
@@ -288,8 +288,8 @@ func validatePageCachePolicy(page gwdkir.Page) []ValidationError {
 	return nil
 }
 
-func validatePageStores(page gwdkir.Page) []ValidationError {
-	seen := map[string]gwdkir.Store{}
+func validatePageStores(page manifest.Page) []ValidationError {
+	seen := map[string]manifest.Store{}
 	var diagnostics []ValidationError
 	for _, store := range page.Stores {
 		if first, exists := seen[store.Name]; exists {
@@ -319,7 +319,7 @@ func validatePageStores(page gwdkir.Page) []ValidationError {
 			})
 			continue
 		}
-		if err := gotypes.ValidateStateInit(page.Imports, gwdkir.StateContract{Type: store.Type, Init: store.Init, Span: store.Span}); err != nil {
+		if err := gotypes.ValidateStateInit(page.Imports, manifest.StateContract{Type: store.Type, Init: store.Init, Span: store.Span}); err != nil {
 			diagnostics = append(diagnostics, ValidationError{
 				Code:    "page_store_error",
 				PageID:  page.ID,
@@ -332,7 +332,7 @@ func validatePageStores(page gwdkir.Page) []ValidationError {
 	return diagnostics
 }
 
-func validatePageCSS(page gwdkir.Page) []ValidationError {
+func validatePageCSS(page manifest.Page) []ValidationError {
 	if len(page.CSS) == 0 {
 		return nil
 	}

--- a/internal/compiler/validate_scripts.go
+++ b/internal/compiler/validate_scripts.go
@@ -7,11 +7,11 @@ import (
 	"strings"
 
 	"github.com/cssbruno/gowdk"
-	"github.com/cssbruno/gowdk/internal/gwdkir"
+	"github.com/cssbruno/gowdk/internal/manifest"
 	"github.com/cssbruno/gowdk/internal/source"
 )
 
-func validateGoBlocks(config gowdk.Config, app gwdkir.Program) []ValidationError {
+func validateGoBlocks(config gowdk.Config, app manifest.Manifest) []ValidationError {
 	var diagnostics []ValidationError
 	enabledAddons := addonsByName(config)
 	for _, page := range app.Pages {
@@ -36,7 +36,7 @@ func validateGoBlocks(config gowdk.Config, app gwdkir.Program) []ValidationError
 	return diagnostics
 }
 
-func validateGoBlockSyntax(packageName string, sourcePath string, pageID string, componentName string, block gwdkir.GoBlock) []ValidationError {
+func validateGoBlockSyntax(packageName string, sourcePath string, pageID string, componentName string, block manifest.GoBlock) []ValidationError {
 	if strings.TrimSpace(block.Body) == "" {
 		return nil
 	}
@@ -57,7 +57,7 @@ func validateGoBlockSyntax(packageName string, sourcePath string, pageID string,
 	}}
 }
 
-func validateGoBlockTarget(config gowdk.Config, enabledAddons map[string]gowdk.Addon, pageID string, componentName string, sourcePath string, packageName string, mode gowdk.RenderMode, hasLoad bool, block gwdkir.GoBlock) []ValidationError {
+func validateGoBlockTarget(config gowdk.Config, enabledAddons map[string]gowdk.Addon, pageID string, componentName string, sourcePath string, packageName string, mode gowdk.RenderMode, hasLoad bool, block manifest.GoBlock) []ValidationError {
 	target := strings.TrimSpace(block.Target)
 	switch {
 	case target == "" || target == "client":
@@ -88,7 +88,7 @@ func validateGoBlockTarget(config gowdk.Config, enabledAddons map[string]gowdk.A
 	}
 }
 
-func validateNonPageGoBlockTarget(config gowdk.Config, enabledAddons map[string]gowdk.Addon, pageID string, componentName string, sourcePath string, packageName string, block gwdkir.GoBlock) []ValidationError {
+func validateNonPageGoBlockTarget(config gowdk.Config, enabledAddons map[string]gowdk.Addon, pageID string, componentName string, sourcePath string, packageName string, block manifest.GoBlock) []ValidationError {
 	target := strings.TrimSpace(block.Target)
 	switch {
 	case target == "":
@@ -128,7 +128,7 @@ func validateNonPageGoBlockTarget(config gowdk.Config, enabledAddons map[string]
 	}
 }
 
-func validateAddonGoBlockTarget(enabledAddons map[string]gowdk.Addon, pageID string, componentName string, sourcePath string, packageName string, render gowdk.RenderMode, block gwdkir.GoBlock) []ValidationError {
+func validateAddonGoBlockTarget(enabledAddons map[string]gowdk.Addon, pageID string, componentName string, sourcePath string, packageName string, render gowdk.RenderMode, block manifest.GoBlock) []ValidationError {
 	name := strings.TrimPrefix(strings.TrimSpace(block.Target), "addon.")
 	addon, ok := enabledAddons[name]
 	if name != "" && ok {
@@ -167,7 +167,7 @@ func goBlockConsumerSupportsTarget(consumer gowdk.GoBlockConsumer, target string
 	return false
 }
 
-func addonGoBlockDiagnostics(consumer gowdk.GoBlockConsumer, pageID string, componentName string, sourcePath string, packageName string, render gowdk.RenderMode, block gwdkir.GoBlock) []ValidationError {
+func addonGoBlockDiagnostics(consumer gowdk.GoBlockConsumer, pageID string, componentName string, sourcePath string, packageName string, render gowdk.RenderMode, block manifest.GoBlock) []ValidationError {
 	target := gowdkGoBlockTarget(pageID, componentName, sourcePath, packageName, block)
 	context := gowdk.GoBlockContext{Render: render}
 	var diagnostics []ValidationError
@@ -200,7 +200,7 @@ func addonsByName(config gowdk.Config) map[string]gowdk.Addon {
 	return names
 }
 
-func gowdkGoBlockTarget(pageID string, componentName string, sourcePath string, packageName string, block gwdkir.GoBlock) gowdk.GoBlockTarget {
+func gowdkGoBlockTarget(pageID string, componentName string, sourcePath string, packageName string, block manifest.GoBlock) gowdk.GoBlockTarget {
 	ownerKind := "layout"
 	ownerID := ""
 	if pageID != "" {

--- a/internal/compiler/validate_source_uses.go
+++ b/internal/compiler/validate_source_uses.go
@@ -4,11 +4,11 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/cssbruno/gowdk/internal/gwdkir"
+	"github.com/cssbruno/gowdk/internal/manifest"
 	"github.com/cssbruno/gowdk/internal/view"
 )
 
-func validateGOWDKUses(app gwdkir.Program) []ValidationError {
+func validateGOWDKUses(app manifest.Manifest, crossFile bool) []ValidationError {
 	componentPackages := map[string]bool{}
 	componentByPackageName := map[string]bool{}
 	sourcePackages := map[string]bool{}
@@ -35,9 +35,9 @@ func validateGOWDKUses(app gwdkir.Program) []ValidationError {
 
 	var diagnostics []ValidationError
 	for _, component := range app.Components {
-		usesByAlias := map[string]gwdkir.Use{}
-		diagnostics = append(diagnostics, validateComponentUses(component, usesByAlias, sourcePackages)...)
-		diagnostics = append(diagnostics, validateComponentQualifiedComponentRefs(component, usesByAlias, componentPackages, componentByPackageName, sourcePackages)...)
+		usesByAlias := map[string]manifest.Use{}
+		diagnostics = append(diagnostics, validateComponentUses(component, usesByAlias, sourcePackages, crossFile)...)
+		diagnostics = append(diagnostics, validateComponentQualifiedComponentRefs(component, usesByAlias, componentPackages, componentByPackageName, sourcePackages, crossFile)...)
 	}
 	for _, layout := range app.Layouts {
 		for _, use := range layout.Uses {
@@ -54,7 +54,7 @@ func validateGOWDKUses(app gwdkir.Program) []ValidationError {
 		}
 	}
 	for _, page := range app.Pages {
-		usesByAlias := map[string]gwdkir.Use{}
+		usesByAlias := map[string]manifest.Use{}
 		for _, use := range page.Uses {
 			if first, exists := usesByAlias[use.Alias]; exists {
 				diagnostics = append(diagnostics, ValidationError{
@@ -72,7 +72,7 @@ func validateGOWDKUses(app gwdkir.Program) []ValidationError {
 				continue
 			}
 			usesByAlias[use.Alias] = use
-			if !sourcePackages[use.Package] {
+			if crossFile && !sourcePackages[use.Package] {
 				diagnostics = append(diagnostics, ValidationError{
 					Code:   "unknown_gowdk_use_package",
 					PageID: page.ID,
@@ -88,12 +88,12 @@ func validateGOWDKUses(app gwdkir.Program) []ValidationError {
 				})
 			}
 		}
-		diagnostics = append(diagnostics, validatePageQualifiedComponentRefs(page, usesByAlias, componentPackages, componentByPackageName, sourcePackages)...)
+		diagnostics = append(diagnostics, validatePageQualifiedComponentRefs(page, usesByAlias, componentPackages, componentByPackageName, sourcePackages, crossFile)...)
 	}
 	return diagnostics
 }
 
-func validateComponentUses(component gwdkir.Component, usesByAlias map[string]gwdkir.Use, sourcePackages map[string]bool) []ValidationError {
+func validateComponentUses(component manifest.Component, usesByAlias map[string]manifest.Use, sourcePackages map[string]bool, crossFile bool) []ValidationError {
 	var diagnostics []ValidationError
 	for _, use := range component.Uses {
 		if first, exists := usesByAlias[use.Alias]; exists {
@@ -112,7 +112,7 @@ func validateComponentUses(component gwdkir.Component, usesByAlias map[string]gw
 			continue
 		}
 		usesByAlias[use.Alias] = use
-		if !sourcePackages[use.Package] {
+		if crossFile && !sourcePackages[use.Package] {
 			diagnostics = append(diagnostics, ValidationError{
 				Code:          "unknown_gowdk_use_package",
 				ComponentName: component.Name,
@@ -131,7 +131,7 @@ func validateComponentUses(component gwdkir.Component, usesByAlias map[string]gw
 	return diagnostics
 }
 
-func validatePageQualifiedComponentRefs(page gwdkir.Page, usesByAlias map[string]gwdkir.Use, componentPackages map[string]bool, componentByPackageName map[string]bool, sourcePackages map[string]bool) []ValidationError {
+func validatePageQualifiedComponentRefs(page manifest.Page, usesByAlias map[string]manifest.Use, componentPackages map[string]bool, componentByPackageName map[string]bool, sourcePackages map[string]bool, crossFile bool) []ValidationError {
 	if !page.Blocks.View || strings.TrimSpace(page.Blocks.ViewBody) == "" {
 		return nil
 	}
@@ -166,6 +166,9 @@ func validatePageQualifiedComponentRefs(page gwdkir.Page, usesByAlias map[string
 					alias,
 				),
 			})
+			continue
+		}
+		if !crossFile {
 			continue
 		}
 		if !componentPackages[use.Package] {
@@ -205,7 +208,7 @@ func validatePageQualifiedComponentRefs(page gwdkir.Page, usesByAlias map[string
 	return diagnostics
 }
 
-func validateComponentQualifiedComponentRefs(component gwdkir.Component, usesByAlias map[string]gwdkir.Use, componentPackages map[string]bool, componentByPackageName map[string]bool, sourcePackages map[string]bool) []ValidationError {
+func validateComponentQualifiedComponentRefs(component manifest.Component, usesByAlias map[string]manifest.Use, componentPackages map[string]bool, componentByPackageName map[string]bool, sourcePackages map[string]bool, crossFile bool) []ValidationError {
 	if !component.Blocks.View || strings.TrimSpace(component.Blocks.ViewBody) == "" {
 		return nil
 	}
@@ -240,6 +243,9 @@ func validateComponentQualifiedComponentRefs(component gwdkir.Component, usesByA
 					alias,
 				),
 			})
+			continue
+		}
+		if !crossFile {
 			continue
 		}
 		if !componentPackages[use.Package] {

--- a/internal/compiler/validate_spans.go
+++ b/internal/compiler/validate_spans.go
@@ -1,7 +1,7 @@
 package compiler
 
 import (
-	"github.com/cssbruno/gowdk/internal/gwdkir"
+	"github.com/cssbruno/gowdk/internal/manifest"
 	"github.com/cssbruno/gowdk/internal/source"
 	"strings"
 )
@@ -15,7 +15,7 @@ func firstSpan(spans ...source.SourceSpan) source.SourceSpan {
 	return source.SourceSpan{}
 }
 
-func viewBodyNeedleSpan(component gwdkir.Component, needle string) source.SourceSpan {
+func viewBodyNeedleSpan(component manifest.Component, needle string) source.SourceSpan {
 	needle = strings.TrimSpace(needle)
 	if needle == "" || component.Blocks.ViewBody == "" || !hasSpan(component.Blocks.Spans.View) {
 		return firstSpan(component.Blocks.Spans.View, component.Span)

--- a/internal/compiler/validate_stores.go
+++ b/internal/compiler/validate_stores.go
@@ -5,10 +5,10 @@ import (
 	"strings"
 
 	"github.com/cssbruno/gowdk/internal/clientlang"
-	"github.com/cssbruno/gowdk/internal/gwdkir"
+	"github.com/cssbruno/gowdk/internal/manifest"
 )
 
-func validateComponentStoreUses(pages []gwdkir.Page, components []gwdkir.Component) []ValidationError {
+func validateComponentStoreUses(pages []manifest.Page, components []manifest.Component) []ValidationError {
 	declared := declaredStoreNamesByPackage(pages)
 	if len(declared) == 0 {
 		return validateStoreUsesAgainst(nil, components)
@@ -16,7 +16,7 @@ func validateComponentStoreUses(pages []gwdkir.Page, components []gwdkir.Compone
 	return validateStoreUsesAgainst(declared, components)
 }
 
-func declaredStoreNamesByPackage(pages []gwdkir.Page) map[string]map[string]bool {
+func declaredStoreNamesByPackage(pages []manifest.Page) map[string]map[string]bool {
 	declared := map[string]map[string]bool{}
 	for _, page := range pages {
 		for _, store := range page.Stores {
@@ -32,7 +32,7 @@ func declaredStoreNamesByPackage(pages []gwdkir.Page) map[string]map[string]bool
 	return declared
 }
 
-func validateStoreUsesAgainst(declared map[string]map[string]bool, components []gwdkir.Component) []ValidationError {
+func validateStoreUsesAgainst(declared map[string]map[string]bool, components []manifest.Component) []ValidationError {
 	var diagnostics []ValidationError
 	for _, component := range components {
 		if !component.Blocks.Client && strings.TrimSpace(component.Blocks.ClientBody) == "" {
@@ -102,8 +102,8 @@ func validateStoreUsesAgainst(declared map[string]map[string]bool, components []
 	return diagnostics
 }
 
-func componentUsesByAlias(component gwdkir.Component) map[string]gwdkir.Use {
-	usesByAlias := map[string]gwdkir.Use{}
+func componentUsesByAlias(component manifest.Component) map[string]manifest.Use {
+	usesByAlias := map[string]manifest.Use{}
 	for _, use := range component.Uses {
 		if _, exists := usesByAlias[use.Alias]; !exists {
 			usesByAlias[use.Alias] = use

--- a/internal/compiler/validate_test.go
+++ b/internal/compiler/validate_test.go
@@ -12,8 +12,6 @@ import (
 
 	"github.com/cssbruno/gowdk"
 	"github.com/cssbruno/gowdk/addons/ssr"
-	"github.com/cssbruno/gowdk/internal/gwdkanalysis"
-	"github.com/cssbruno/gowdk/internal/gwdkir"
 	"github.com/cssbruno/gowdk/internal/manifest"
 	"github.com/cssbruno/gowdk/internal/source"
 )
@@ -31,7 +29,7 @@ func TestValidateManifestRejectsMissingPackageDeclaration(t *testing.T) {
 		Blocks: manifest.Blocks{View: true},
 	}
 
-	err := validateManifest(gowdk.Config{}, manifest.Manifest{Pages: []manifest.Page{page}})
+	err := ValidateManifest(gowdk.Config{}, manifest.Manifest{Pages: []manifest.Page{page}})
 	if err == nil {
 		t.Fatal("expected missing package diagnostic")
 	}
@@ -59,7 +57,7 @@ func TestValidateManifestRejectsPackageMismatchWithSiblingGoFile(t *testing.T) {
 		Blocks:  manifest.Blocks{View: true},
 	}
 
-	err := validateManifest(gowdk.Config{}, manifest.Manifest{Pages: []manifest.Page{page}})
+	err := ValidateManifest(gowdk.Config{}, manifest.Manifest{Pages: []manifest.Page{page}})
 	if err == nil {
 		t.Fatal("expected package mismatch diagnostic")
 	}
@@ -88,7 +86,7 @@ func TestValidateManifestAcceptsPackageMatchingSiblingGoFile(t *testing.T) {
 		Blocks:  manifest.Blocks{View: true},
 	}
 
-	if err := validateManifest(gowdk.Config{}, manifest.Manifest{Pages: []manifest.Page{page}}); err != nil {
+	if err := ValidateManifest(gowdk.Config{}, manifest.Manifest{Pages: []manifest.Page{page}}); err != nil {
 		t.Fatalf("expected matching package to validate, got %v", err)
 	}
 }
@@ -112,7 +110,7 @@ func TestValidateManifestIgnoresProjectConfigGoPackage(t *testing.T) {
 		Blocks:  manifest.Blocks{View: true},
 	}
 
-	if err := validateManifest(gowdk.Config{}, manifest.Manifest{Pages: []manifest.Page{page}}); err != nil {
+	if err := ValidateManifest(gowdk.Config{}, manifest.Manifest{Pages: []manifest.Page{page}}); err != nil {
 		t.Fatalf("expected project config package to be ignored, got %v", err)
 	}
 }
@@ -135,7 +133,7 @@ func TestValidateManifestReportsGoPackageParseErrors(t *testing.T) {
 		Blocks:  manifest.Blocks{View: true},
 	}
 
-	err := validateManifest(gowdk.Config{}, manifest.Manifest{Pages: []manifest.Page{page}})
+	err := ValidateManifest(gowdk.Config{}, manifest.Manifest{Pages: []manifest.Page{page}})
 	if err == nil {
 		t.Fatal("expected Go package error diagnostic")
 	}
@@ -163,7 +161,7 @@ func TestValidateManifestReportsGoPackageTypeErrors(t *testing.T) {
 		Blocks:  manifest.Blocks{View: true},
 	}
 
-	err := validateManifest(gowdk.Config{}, manifest.Manifest{Pages: []manifest.Page{page}})
+	err := ValidateManifest(gowdk.Config{}, manifest.Manifest{Pages: []manifest.Page{page}})
 	if err == nil {
 		t.Fatal("expected Go package type-check diagnostic")
 	}
@@ -214,7 +212,7 @@ type PageCopy struct {
 		},
 	}
 
-	if err := validateManifest(gowdk.Config{}, manifest.Manifest{Pages: []manifest.Page{page}}); err != nil {
+	if err := ValidateManifest(gowdk.Config{}, manifest.Manifest{Pages: []manifest.Page{page}}); err != nil {
 		t.Fatalf("expected inline go block to type-check with sibling Go files, got %v", err)
 	}
 }
@@ -242,7 +240,7 @@ func TestValidateManifestTypeChecksDefaultScriptWithGOWDKImports(t *testing.T) {
 		},
 	}
 
-	if err := validateManifest(gowdk.Config{}, manifest.Manifest{Pages: []manifest.Page{page}}); err != nil {
+	if err := ValidateManifest(gowdk.Config{}, manifest.Manifest{Pages: []manifest.Page{page}}); err != nil {
 		t.Fatalf("expected inline go block to type-check with GOWDK imports, got %v", err)
 	}
 }
@@ -269,7 +267,7 @@ func TestValidateManifestReportsDefaultScriptTypeErrors(t *testing.T) {
 		},
 	}
 
-	err := validateManifest(gowdk.Config{}, manifest.Manifest{Pages: []manifest.Page{page}})
+	err := ValidateManifest(gowdk.Config{}, manifest.Manifest{Pages: []manifest.Page{page}})
 	if err == nil {
 		t.Fatal("expected inline go block type-check diagnostic")
 	}
@@ -294,7 +292,7 @@ func TestGoBlockPackageSourceForValidationPreservesLineDirective(t *testing.T) {
 	payload, err := goBlockPackageSourceForValidation(packageDeclaration{
 		Source:  sourcePath,
 		Package: "app",
-	}, gwdkir.GoBlock{
+	}, manifest.GoBlock{
 		Span: source.SourceSpan{Start: source.SourcePosition{Line: 8, Column: 1}},
 		Body: `func BrokenCopy() string {
 	return MissingTitle
@@ -339,7 +337,7 @@ func TestValidateManifestTypeChecksDefaultGoBlockAsStaticPackageGo(t *testing.T)
 		},
 	}
 
-	err := validateManifest(gowdk.Config{}, manifest.Manifest{Pages: []manifest.Page{page}})
+	err := ValidateManifest(gowdk.Config{}, manifest.Manifest{Pages: []manifest.Page{page}})
 	if err == nil {
 		t.Fatal("expected default go block type-check diagnostic")
 	}
@@ -365,7 +363,7 @@ func TestValidateManifestSkipsSiblingGoPackageForUnsavedAbsoluteSource(t *testin
 		Blocks:  manifest.Blocks{View: true},
 	}
 
-	if err := validateManifest(gowdk.Config{}, manifest.Manifest{Pages: []manifest.Page{page}}); err != nil {
+	if err := ValidateManifest(gowdk.Config{}, manifest.Manifest{Pages: []manifest.Page{page}}); err != nil {
 		t.Fatalf("expected unsaved absolute source to skip sibling Go package validation, got %v", err)
 	}
 }
@@ -409,7 +407,7 @@ func Email(values form.Values) string {
 		Blocks:  manifest.Blocks{View: true},
 	}
 
-	if err := validateManifest(gowdk.Config{}, manifest.Manifest{Pages: []manifest.Page{page}}); err != nil {
+	if err := ValidateManifest(gowdk.Config{}, manifest.Manifest{Pages: []manifest.Page{page}}); err != nil {
 		t.Fatalf("expected module imports to type-check, got %v", err)
 	}
 }
@@ -433,7 +431,7 @@ func TestValidateManifestAcceptsQualifiedComponentUse(t *testing.T) {
 		}},
 	}
 
-	if err := validateManifest(gowdk.Config{}, app); err != nil {
+	if err := ValidateManifest(gowdk.Config{}, app); err != nil {
 		t.Fatalf("expected qualified component use to validate, got %v", err)
 	}
 }
@@ -447,7 +445,7 @@ func TestValidateManifestRejectsUnknownGOWDKUsePackage(t *testing.T) {
 		Blocks:  manifest.Blocks{View: true, ViewBody: `<main><ui.Hero /></main>`},
 	}}}
 
-	err := validateManifest(gowdk.Config{}, app)
+	err := ValidateManifest(gowdk.Config{}, app)
 	if err == nil {
 		t.Fatal("expected unknown use package diagnostic")
 	}
@@ -468,7 +466,7 @@ func TestValidateManifestRejectsUnknownGOWDKUseAlias(t *testing.T) {
 		Components: []manifest.Component{{Package: "components", Name: "Hero"}},
 	}
 
-	err := validateManifest(gowdk.Config{}, app)
+	err := ValidateManifest(gowdk.Config{}, app)
 	if err == nil {
 		t.Fatal("expected unknown use alias diagnostic")
 	}
@@ -490,7 +488,7 @@ func TestValidateManifestRejectsUnknownQualifiedComponent(t *testing.T) {
 		Components: []manifest.Component{{Package: "components", Name: "Hero"}},
 	}
 
-	err := validateManifest(gowdk.Config{}, app)
+	err := ValidateManifest(gowdk.Config{}, app)
 	if err == nil {
 		t.Fatal("expected unknown component diagnostic")
 	}
@@ -512,7 +510,7 @@ func TestValidateManifestRejectsComponentRefToLayoutOnlyUsePackage(t *testing.T)
 		Layouts: []manifest.Layout{{Package: "layouts", ID: "root"}},
 	}
 
-	err := validateManifest(gowdk.Config{}, app)
+	err := ValidateManifest(gowdk.Config{}, app)
 	if err == nil {
 		t.Fatal("expected unknown component diagnostic")
 	}
@@ -547,7 +545,7 @@ func TestValidateManifestRejectsComponentScopedComponentRefToStoreOnlyUsePackage
 		}},
 	}
 
-	err := validateManifest(gowdk.Config{}, app)
+	err := ValidateManifest(gowdk.Config{}, app)
 	if err == nil {
 		t.Fatal("expected unknown component diagnostic")
 	}
@@ -572,7 +570,7 @@ func TestValidateManifestAcceptsComponentScopedGOWDKUse(t *testing.T) {
 		},
 	}}
 
-	if err := validateManifest(gowdk.Config{}, app); err != nil {
+	if err := ValidateManifest(gowdk.Config{}, app); err != nil {
 		t.Fatalf("expected component-scoped use to validate, got %v", err)
 	}
 }
@@ -584,7 +582,7 @@ func TestValidateManifestRejectsUnknownComponentScopedGOWDKUseAlias(t *testing.T
 		Blocks:  manifest.Blocks{View: true, ViewBody: `<section><icons.Badge /></section>`},
 	}}}
 
-	err := validateManifest(gowdk.Config{}, app)
+	err := ValidateManifest(gowdk.Config{}, app)
 	if err == nil {
 		t.Fatal("expected unknown component use alias diagnostic")
 	}
@@ -602,7 +600,7 @@ func TestValidateManifestRejectsUnknownComponentScopedGOWDKUsePackage(t *testing
 		Blocks:  manifest.Blocks{View: true, ViewBody: `<section><icons.Badge /></section>`},
 	}}}
 
-	err := validateManifest(gowdk.Config{}, app)
+	err := ValidateManifest(gowdk.Config{}, app)
 	if err == nil {
 		t.Fatal("expected unknown component use package diagnostic")
 	}
@@ -623,7 +621,7 @@ func TestValidatePageRejectsSSRWithoutAddon(t *testing.T) {
 		},
 	}
 
-	diagnostics := ValidatePage(gowdk.Config{}, irPage(page))
+	diagnostics := ValidatePage(gowdk.Config{}, page)
 	if len(diagnostics) != 1 {
 		t.Fatalf("expected 1 diagnostic, got %d", len(diagnostics))
 	}
@@ -647,7 +645,7 @@ func TestValidatePageRequiresExplicitGuard(t *testing.T) {
 		Blocks: manifest.Blocks{View: true},
 	}
 
-	diagnostics := ValidatePage(gowdk.Config{}, irPage(page))
+	diagnostics := ValidatePage(gowdk.Config{}, page)
 	if !hasDiagnosticCode(diagnostics, "missing_page_guard") {
 		t.Fatalf("missing missing_page_guard diagnostic: %#v", diagnostics)
 	}
@@ -666,7 +664,7 @@ func TestValidatePageRequiresPublicGuardToBeExclusive(t *testing.T) {
 		Blocks: manifest.Blocks{View: true},
 	}
 
-	diagnostics := ValidatePage(gowdk.Config{}, irPage(page))
+	diagnostics := ValidatePage(gowdk.Config{}, page)
 	if !hasDiagnosticCode(diagnostics, "public_guard_exclusive") {
 		t.Fatalf("missing public_guard_exclusive diagnostic: %#v", diagnostics)
 	}
@@ -686,7 +684,7 @@ func TestValidatePageRejectsProtectedGuardOnBuildTimePage(t *testing.T) {
 		Blocks: manifest.Blocks{View: true},
 	}
 
-	diagnostics := ValidatePage(gowdk.Config{}, irPage(page))
+	diagnostics := ValidatePage(gowdk.Config{}, page)
 	if !hasDiagnosticCode(diagnostics, "guard_requires_request_render") {
 		t.Fatalf("missing guard_requires_request_render diagnostic: %#v", diagnostics)
 	}
@@ -706,7 +704,7 @@ func TestValidatePageAllowsProtectedGuardOnRequestTimePage(t *testing.T) {
 		Blocks: manifest.Blocks{View: true},
 	}
 
-	diagnostics := ValidatePage(gowdk.Config{Addons: []gowdk.Addon{ssr.Addon()}}, irPage(page))
+	diagnostics := ValidatePage(gowdk.Config{Addons: []gowdk.Addon{ssr.Addon()}}, page)
 	if hasDiagnosticCode(diagnostics, "guard_requires_request_render") {
 		t.Fatalf("unexpected guard_requires_request_render diagnostic: %#v", diagnostics)
 	}
@@ -723,7 +721,7 @@ func TestValidatePageAllowsSSRWithAddon(t *testing.T) {
 		},
 	}
 
-	diagnostics := ValidatePage(gowdk.Config{Addons: []gowdk.Addon{ssr.Addon()}}, irPage(page))
+	diagnostics := ValidatePage(gowdk.Config{Addons: []gowdk.Addon{ssr.Addon()}}, page)
 	if len(diagnostics) != 0 {
 		t.Fatalf("expected no diagnostics, got %#v", diagnostics)
 	}
@@ -741,7 +739,7 @@ func TestValidateManifestRejectsDuplicatePageIDsAndComponentNames(t *testing.T) 
 		},
 	}
 
-	err := validateManifest(gowdk.Config{}, app)
+	err := ValidateManifest(gowdk.Config{}, app)
 	if err == nil {
 		t.Fatal("expected duplicate identity diagnostics")
 	}
@@ -783,7 +781,7 @@ func TestValidateManifestAllowsPageStoreDeclaration(t *testing.T) {
 		Blocks: manifest.Blocks{View: true, ViewBody: `<main>Cart</main>`},
 	}}}
 
-	if err := validateManifest(gowdk.Config{}, app); err != nil {
+	if err := ValidateManifest(gowdk.Config{}, app); err != nil {
 		t.Fatalf("expected valid store declaration, got %v", err)
 	}
 }
@@ -806,7 +804,7 @@ func TestValidateManifestRejectsDuplicatePageStore(t *testing.T) {
 		Blocks: manifest.Blocks{View: true, ViewBody: `<main>Cart</main>`},
 	}}}
 
-	err := validateManifest(gowdk.Config{}, app)
+	err := ValidateManifest(gowdk.Config{}, app)
 	if err == nil {
 		t.Fatal("expected duplicate store diagnostic")
 	}
@@ -839,7 +837,7 @@ func TestValidateManifestRejectsUnknownComponentStoreUse(t *testing.T) {
 		}},
 	}
 
-	err := validateManifest(gowdk.Config{}, app)
+	err := ValidateManifest(gowdk.Config{}, app)
 	if err == nil {
 		t.Fatal("expected unknown store diagnostic")
 	}
@@ -880,7 +878,7 @@ func TestValidateManifestAcceptsQualifiedComponentStoreUse(t *testing.T) {
 		}},
 	}
 
-	if err := validateManifest(gowdk.Config{}, app); err != nil {
+	if err := ValidateManifest(gowdk.Config{}, app); err != nil {
 		t.Fatalf("expected qualified store use to validate, got %v", err)
 	}
 }
@@ -906,7 +904,7 @@ func TestValidateManifestRejectsUnknownQualifiedComponentStoreUseAlias(t *testin
 		}},
 	}
 
-	err := validateManifest(gowdk.Config{}, app)
+	err := ValidateManifest(gowdk.Config{}, app)
 	if err == nil {
 		t.Fatal("expected unknown store alias diagnostic")
 	}
@@ -938,7 +936,7 @@ func TestValidateManifestRejectsUnknownQualifiedComponentStoreName(t *testing.T)
 		}},
 	}
 
-	err := validateManifest(gowdk.Config{}, app)
+	err := ValidateManifest(gowdk.Config{}, app)
 	if err == nil {
 		t.Fatal("expected unknown store diagnostic")
 	}
@@ -967,7 +965,7 @@ func TestValidateManifestRejectsRedundantComponentImplementations(t *testing.T) 
 		},
 	}}
 
-	err := validateManifest(gowdk.Config{}, app)
+	err := ValidateManifest(gowdk.Config{}, app)
 	if err == nil {
 		t.Fatal("expected redundant component diagnostic")
 	}
@@ -993,7 +991,7 @@ func TestValidateManifestRejectsRedundantComponentImplementationsWithNormalizedA
 		},
 	}}
 
-	err := validateManifest(gowdk.Config{}, app)
+	err := ValidateManifest(gowdk.Config{}, app)
 	if err == nil {
 		t.Fatal("expected redundant component diagnostic")
 	}
@@ -1035,7 +1033,7 @@ func TestValidateManifestRejectsRedundantTypedComponentsWithCanonicalImportsAndE
 		},
 	}}
 
-	err := validateManifest(gowdk.Config{}, app)
+	err := ValidateManifest(gowdk.Config{}, app)
 	if err == nil {
 		t.Fatal("expected redundant component diagnostic")
 	}
@@ -1064,7 +1062,7 @@ func TestValidateManifestAllowsSameViewWithDifferentContracts(t *testing.T) {
 		},
 	}}
 
-	if err := validateManifest(gowdk.Config{}, app); err != nil {
+	if err := ValidateManifest(gowdk.Config{}, app); err != nil {
 		t.Fatalf("expected different contracts to be allowed, got %v", err)
 	}
 }
@@ -1093,7 +1091,7 @@ func TestValidateManifestAllowsSameViewWithDifferentTypedContracts(t *testing.T)
 		},
 	}}
 
-	if err := validateManifest(gowdk.Config{}, app); err != nil {
+	if err := ValidateManifest(gowdk.Config{}, app); err != nil {
 		t.Fatalf("expected different typed contracts to be allowed, got %v", err)
 	}
 }
@@ -1117,7 +1115,7 @@ func TestValidateManifestResolvesGoTypedComponentContracts(t *testing.T) {
 		},
 	}}}
 
-	if err := validateManifest(gowdk.Config{}, app); err != nil {
+	if err := ValidateManifest(gowdk.Config{}, app); err != nil {
 		t.Fatalf("expected typed component contracts to validate, got %v", err)
 	}
 }
@@ -1137,7 +1135,7 @@ func TestValidateManifestAllowsEventModifiers(t *testing.T) {
 		},
 	}}}
 
-	if err := validateManifest(gowdk.Config{}, app); err != nil {
+	if err := ValidateManifest(gowdk.Config{}, app); err != nil {
 		t.Fatalf("expected event modifiers to validate, got %v", err)
 	}
 }
@@ -1157,7 +1155,7 @@ func TestValidateManifestRejectsBadEventModifier(t *testing.T) {
 		},
 	}}}
 
-	err := validateManifest(gowdk.Config{}, app)
+	err := ValidateManifest(gowdk.Config{}, app)
 	if err == nil {
 		t.Fatal("expected unsupported event modifier diagnostic")
 	}
@@ -1182,7 +1180,7 @@ func TestValidateManifestRejectsBadDebounceDuration(t *testing.T) {
 		},
 	}}}
 
-	err := validateManifest(gowdk.Config{}, app)
+	err := ValidateManifest(gowdk.Config{}, app)
 	if err == nil {
 		t.Fatal("expected invalid debounce duration diagnostic")
 	}
@@ -1207,7 +1205,7 @@ func TestValidateManifestRejectsDebounceThrottleCombination(t *testing.T) {
 		},
 	}}}
 
-	err := validateManifest(gowdk.Config{}, app)
+	err := ValidateManifest(gowdk.Config{}, app)
 	if err == nil {
 		t.Fatal("expected debounce/throttle compatibility diagnostic")
 	}
@@ -1236,7 +1234,7 @@ func TestValidateManifestResolvesUnaliasedGoTypedComponentImports(t *testing.T) 
 		},
 	}}}
 
-	if err := validateManifest(gowdk.Config{}, app); err != nil {
+	if err := ValidateManifest(gowdk.Config{}, app); err != nil {
 		t.Fatalf("expected unaliased Go imports to validate, got %v", err)
 	}
 }
@@ -1256,7 +1254,7 @@ func TestValidateManifestRejectsMissingGoTypedComponentField(t *testing.T) {
 		},
 	}}}
 
-	err := validateManifest(gowdk.Config{}, app)
+	err := ValidateManifest(gowdk.Config{}, app)
 	if err == nil {
 		t.Fatal("expected Missing field diagnostic")
 	}
@@ -1281,7 +1279,7 @@ func TestValidateManifestRejectsMissingGoTypedComponentPackage(t *testing.T) {
 		},
 	}}}
 
-	err := validateManifest(gowdk.Config{}, app)
+	err := ValidateManifest(gowdk.Config{}, app)
 	if err == nil {
 		t.Fatal("expected Missing package diagnostic")
 	}
@@ -1306,7 +1304,7 @@ func TestValidateManifestRejectsMissingGoTypedComponentType(t *testing.T) {
 		},
 	}}}
 
-	err := validateManifest(gowdk.Config{}, app)
+	err := ValidateManifest(gowdk.Config{}, app)
 	if err == nil {
 		t.Fatal("expected Missing type diagnostic")
 	}
@@ -1335,7 +1333,7 @@ func TestValidateManifestAllowsClientFunctionEventCall(t *testing.T) {
 		},
 	}}}
 
-	if err := validateManifest(gowdk.Config{}, app); err != nil {
+	if err := ValidateManifest(gowdk.Config{}, app); err != nil {
 		t.Fatalf("expected client function event call to validate, got %v", err)
 	}
 }
@@ -1363,7 +1361,7 @@ func TestValidateManifestAllowsDeclaredComponentEmit(t *testing.T) {
 		},
 	}}}
 
-	if err := validateManifest(gowdk.Config{}, app); err != nil {
+	if err := ValidateManifest(gowdk.Config{}, app); err != nil {
 		t.Fatalf("expected declared component emit to validate, got %v", err)
 	}
 }
@@ -1390,7 +1388,7 @@ func TestValidateManifestRejectsDuplicateComponentEmitNames(t *testing.T) {
 		},
 	}}}
 
-	err := validateManifest(gowdk.Config{}, app)
+	err := ValidateManifest(gowdk.Config{}, app)
 	if err == nil {
 		t.Fatal("expected duplicate component emit diagnostic")
 	}
@@ -1423,7 +1421,7 @@ func TestValidateManifestRejectsUnknownComponentEmit(t *testing.T) {
 		},
 	}}}
 
-	err := validateManifest(gowdk.Config{}, app)
+	err := ValidateManifest(gowdk.Config{}, app)
 	if err == nil {
 		t.Fatal("expected unknown component emit diagnostic")
 	}
@@ -1451,7 +1449,7 @@ func TestValidateManifestClientParseErrorPointsToClientLine(t *testing.T) {
 		},
 	}}}
 
-	err := validateManifest(gowdk.Config{}, app)
+	err := ValidateManifest(gowdk.Config{}, app)
 	if err == nil {
 		t.Fatal("expected client parse diagnostic")
 	}
@@ -1488,7 +1486,7 @@ func TestValidateManifestRejectsComponentEmitPayloadTypeMismatch(t *testing.T) {
 		},
 	}}}
 
-	err := validateManifest(gowdk.Config{}, app)
+	err := ValidateManifest(gowdk.Config{}, app)
 	if err == nil {
 		t.Fatal("expected component emit payload type diagnostic")
 	}
@@ -1517,7 +1515,7 @@ func TestValidateManifestAllowsClientFunctionParams(t *testing.T) {
 		},
 	}}}
 
-	if err := validateManifest(gowdk.Config{}, app); err != nil {
+	if err := ValidateManifest(gowdk.Config{}, app); err != nil {
 		t.Fatalf("expected client function params to validate, got %v", err)
 	}
 }
@@ -1545,7 +1543,7 @@ fn Add() {
 		},
 	}}}
 
-	if err := validateManifest(gowdk.Config{}, app); err != nil {
+	if err := ValidateManifest(gowdk.Config{}, app); err != nil {
 		t.Fatalf("expected client helper function to validate, got %v", err)
 	}
 }
@@ -1573,7 +1571,7 @@ fn SetCount() {
 		},
 	}}}
 
-	if err := validateManifest(gowdk.Config{}, app); err != nil {
+	if err := ValidateManifest(gowdk.Config{}, app); err != nil {
 		t.Fatalf("expected client built-ins to validate, got %v", err)
 	}
 }
@@ -1597,7 +1595,7 @@ func TestValidateManifestAllowsAsyncFetchJSONClientFunction(t *testing.T) {
 		},
 	}}}
 
-	if err := validateManifest(gowdk.Config{}, app); err != nil {
+	if err := ValidateManifest(gowdk.Config{}, app); err != nil {
 		t.Fatalf("expected async fetchJSON function to validate, got %v", err)
 	}
 }
@@ -1621,7 +1619,7 @@ func TestValidateManifestRejectsAwaitOutsideAsyncClientFunction(t *testing.T) {
 		},
 	}}}
 
-	err := validateManifest(gowdk.Config{}, app)
+	err := ValidateManifest(gowdk.Config{}, app)
 	if err == nil {
 		t.Fatal("expected await outside async diagnostic")
 	}
@@ -1650,7 +1648,7 @@ func TestValidateManifestRejectsAsyncFetchJSONNonStringURL(t *testing.T) {
 		},
 	}}}
 
-	err := validateManifest(gowdk.Config{}, app)
+	err := ValidateManifest(gowdk.Config{}, app)
 	if err == nil {
 		t.Fatal("expected fetchJSON URL diagnostic")
 	}
@@ -1679,7 +1677,7 @@ func TestValidateManifestRejectsBadClientBuiltinArg(t *testing.T) {
 		},
 	}}}
 
-	err := validateManifest(gowdk.Config{}, app)
+	err := ValidateManifest(gowdk.Config{}, app)
 	if err == nil {
 		t.Fatal("expected Bad built-in argument diagnostic")
 	}
@@ -1708,7 +1706,7 @@ func TestValidateManifestRejectsHelperAsEventHandler(t *testing.T) {
 		},
 	}}}
 
-	err := validateManifest(gowdk.Config{}, app)
+	err := ValidateManifest(gowdk.Config{}, app)
 	if err == nil {
 		t.Fatal("expected helper event handler diagnostic")
 	}
@@ -1741,7 +1739,7 @@ fn Add() {
 		},
 	}}}
 
-	err := validateManifest(gowdk.Config{}, app)
+	err := ValidateManifest(gowdk.Config{}, app)
 	if err == nil {
 		t.Fatal("expected helper return mismatch diagnostic")
 	}
@@ -1778,7 +1776,7 @@ fn Add() {
 		},
 	}}}
 
-	err := validateManifest(gowdk.Config{}, app)
+	err := ValidateManifest(gowdk.Config{}, app)
 	if err == nil {
 		t.Fatal("expected helper call cycle diagnostic")
 	}
@@ -1807,7 +1805,7 @@ func TestValidateManifestRejectsClientExpressionTypeMismatch(t *testing.T) {
 		},
 	}}}
 
-	err := validateManifest(gowdk.Config{}, app)
+	err := ValidateManifest(gowdk.Config{}, app)
 	if err == nil {
 		t.Fatal("expected expression type mismatch diagnostic")
 	}
@@ -1836,7 +1834,7 @@ func TestValidateManifestRejectsClientFunctionArgumentMismatch(t *testing.T) {
 		},
 	}}}
 
-	err := validateManifest(gowdk.Config{}, app)
+	err := ValidateManifest(gowdk.Config{}, app)
 	if err == nil {
 		t.Fatal("expected argument mismatch diagnostic")
 	}
@@ -1865,7 +1863,7 @@ func TestValidateManifestRejectsUnknownClientFunctionEventCall(t *testing.T) {
 		},
 	}}}
 
-	err := validateManifest(gowdk.Config{}, app)
+	err := ValidateManifest(gowdk.Config{}, app)
 	if err == nil {
 		t.Fatal("expected unknown client function diagnostic")
 	}
@@ -1894,7 +1892,7 @@ func TestValidateManifestRejectsClientFunctionUnknownStateField(t *testing.T) {
 		},
 	}}}
 
-	err := validateManifest(gowdk.Config{}, app)
+	err := ValidateManifest(gowdk.Config{}, app)
 	if err == nil {
 		t.Fatal("expected client function field diagnostic")
 	}
@@ -1927,7 +1925,7 @@ func TestValidateManifestRejectsClientFunctionMutatingProp(t *testing.T) {
 		},
 	}}}
 
-	err := validateManifest(gowdk.Config{}, app)
+	err := ValidateManifest(gowdk.Config{}, app)
 	if err == nil {
 		t.Fatal("expected prop mutation diagnostic")
 	}
@@ -1967,7 +1965,7 @@ on destroy {
 		},
 	}}}
 
-	if err := validateManifest(gowdk.Config{}, app); err != nil {
+	if err := ValidateManifest(gowdk.Config{}, app); err != nil {
 		t.Fatalf("expected lifecycle/effects to validate, got %v", err)
 	}
 }
@@ -1991,7 +1989,7 @@ func TestValidateManifestRejectsEffectUnknownDependency(t *testing.T) {
 		},
 	}}}
 
-	err := validateManifest(gowdk.Config{}, app)
+	err := ValidateManifest(gowdk.Config{}, app)
 	if err == nil {
 		t.Fatal("expected unknown effect dependency diagnostic")
 	}
@@ -2022,7 +2020,7 @@ fn FocusSearch() {
 		},
 	}}}
 
-	if err := validateManifest(gowdk.Config{}, app); err != nil {
+	if err := ValidateManifest(gowdk.Config{}, app); err != nil {
 		t.Fatalf("expected DOM ref focus call to validate, got %v", err)
 	}
 }
@@ -2044,7 +2042,7 @@ func TestValidateManifestRejectsUnknownDOMRefBinding(t *testing.T) {
 		},
 	}}}
 
-	err := validateManifest(gowdk.Config{}, app)
+	err := ValidateManifest(gowdk.Config{}, app)
 	if err == nil {
 		t.Fatal("expected unknown DOM ref binding diagnostic")
 	}
@@ -2071,7 +2069,7 @@ func TestValidateManifestRejectsDuplicateDOMRefBinding(t *testing.T) {
 		},
 	}}}
 
-	err := validateManifest(gowdk.Config{}, app)
+	err := ValidateManifest(gowdk.Config{}, app)
 	if err == nil {
 		t.Fatal("expected duplicate DOM ref binding diagnostic")
 	}
@@ -2102,7 +2100,7 @@ fn FocusSearch() {
 		},
 	}}}
 
-	err := validateManifest(gowdk.Config{}, app)
+	err := ValidateManifest(gowdk.Config{}, app)
 	if err == nil {
 		t.Fatal("expected unbound DOM ref diagnostic")
 	}
@@ -2127,7 +2125,7 @@ func TestValidateManifestAllowsGIfBoolExpression(t *testing.T) {
 		},
 	}}}
 
-	if err := validateManifest(gowdk.Config{}, app); err != nil {
+	if err := ValidateManifest(gowdk.Config{}, app); err != nil {
 		t.Fatalf("expected g:if bool expression to validate, got %v", err)
 	}
 }
@@ -2147,7 +2145,7 @@ func TestValidateManifestAllowsGElseIfExpression(t *testing.T) {
 		},
 	}}}
 
-	if err := validateManifest(gowdk.Config{}, app); err != nil {
+	if err := ValidateManifest(gowdk.Config{}, app); err != nil {
 		t.Fatalf("expected g:else-if expression to validate, got %v", err)
 	}
 }
@@ -2167,7 +2165,7 @@ func TestValidateManifestRejectsGElseIfNonBoolExpression(t *testing.T) {
 		},
 	}}}
 
-	err := validateManifest(gowdk.Config{}, app)
+	err := ValidateManifest(gowdk.Config{}, app)
 	if err == nil {
 		t.Fatal("expected g:else-if non-bool diagnostic")
 	}
@@ -2192,7 +2190,7 @@ func TestValidateManifestRejectsGIfNonBoolExpression(t *testing.T) {
 		},
 	}}}
 
-	err := validateManifest(gowdk.Config{}, app)
+	err := ValidateManifest(gowdk.Config{}, app)
 	if err == nil {
 		t.Fatal("expected g:if non-bool diagnostic")
 	}
@@ -2217,7 +2215,7 @@ func TestValidateManifestAllowsNestedAndIndexExpressions(t *testing.T) {
 		},
 	}}}
 
-	if err := validateManifest(gowdk.Config{}, app); err != nil {
+	if err := ValidateManifest(gowdk.Config{}, app); err != nil {
 		t.Fatalf("expected nested/index expressions to validate, got %v", err)
 	}
 }
@@ -2237,7 +2235,7 @@ func TestValidateManifestAllowsGForListRendering(t *testing.T) {
 		},
 	}}}
 
-	if err := validateManifest(gowdk.Config{}, app); err != nil {
+	if err := ValidateManifest(gowdk.Config{}, app); err != nil {
 		t.Fatalf("expected g:for list rendering to validate, got %v", err)
 	}
 }
@@ -2257,7 +2255,7 @@ func TestValidateManifestAllowsGForIndexVariable(t *testing.T) {
 		},
 	}}}
 
-	if err := validateManifest(gowdk.Config{}, app); err != nil {
+	if err := ValidateManifest(gowdk.Config{}, app); err != nil {
 		t.Fatalf("expected g:for index variable to validate, got %v", err)
 	}
 }
@@ -2289,7 +2287,7 @@ fn SwapFirstTwo() {
 		},
 	}}}
 
-	if err := validateManifest(gowdk.Config{}, app); err != nil {
+	if err := ValidateManifest(gowdk.Config{}, app); err != nil {
 		t.Fatalf("expected list mutation built-ins to validate, got %v", err)
 	}
 }
@@ -2313,7 +2311,7 @@ func TestValidateManifestRejectsBadAppendItemField(t *testing.T) {
 		},
 	}}}
 
-	err := validateManifest(gowdk.Config{}, app)
+	err := ValidateManifest(gowdk.Config{}, app)
 	if err == nil {
 		t.Fatal("expected Bad append item diagnostic")
 	}
@@ -2338,7 +2336,7 @@ func TestValidateManifestRejectsGForWithoutKey(t *testing.T) {
 		},
 	}}}
 
-	err := validateManifest(gowdk.Config{}, app)
+	err := ValidateManifest(gowdk.Config{}, app)
 	if err == nil {
 		t.Fatal("expected Missing g:key diagnostic")
 	}
@@ -2363,7 +2361,7 @@ func TestValidateManifestRejectsUnknownGForItemField(t *testing.T) {
 		},
 	}}}
 
-	err := validateManifest(gowdk.Config{}, app)
+	err := ValidateManifest(gowdk.Config{}, app)
 	if err == nil {
 		t.Fatal("expected unknown item field diagnostic")
 	}
@@ -2391,7 +2389,7 @@ func TestValidateManifestViewEventDiagnosticPointsToExpression(t *testing.T) {
 		},
 	}}}
 
-	err := validateManifest(gowdk.Config{}, app)
+	err := ValidateManifest(gowdk.Config{}, app)
 	if err == nil {
 		t.Fatal("expected invalid event expression diagnostic")
 	}
@@ -2415,7 +2413,7 @@ func TestValidateManifestUnknownViewFieldDiagnosticPointsToIdentifier(t *testing
 		},
 	}}}
 
-	err := validateManifest(gowdk.Config{}, app)
+	err := ValidateManifest(gowdk.Config{}, app)
 	if err == nil {
 		t.Fatal("expected unknown field diagnostic")
 	}
@@ -2439,7 +2437,7 @@ func TestValidateManifestBadGForDiagnosticPointsToDirectiveValue(t *testing.T) {
 		},
 	}}}
 
-	err := validateManifest(gowdk.Config{}, app)
+	err := ValidateManifest(gowdk.Config{}, app)
 	if err == nil {
 		t.Fatal("expected Bad g:for diagnostic")
 	}
@@ -2469,7 +2467,7 @@ func TestValidateManifestAllowsGoishConditionalExpressions(t *testing.T) {
 		},
 	}}}
 
-	if err := validateManifest(gowdk.Config{}, app); err != nil {
+	if err := ValidateManifest(gowdk.Config{}, app); err != nil {
 		t.Fatalf("expected Go-ish conditional expressions to validate, got %v", err)
 	}
 }
@@ -2494,7 +2492,7 @@ func TestValidateManifestAllowsClientLocalVariables(t *testing.T) {
 		},
 	}}}
 
-	if err := validateManifest(gowdk.Config{}, app); err != nil {
+	if err := ValidateManifest(gowdk.Config{}, app); err != nil {
 		t.Fatalf("expected local variables to validate, got %v", err)
 	}
 }
@@ -2519,7 +2517,7 @@ func TestValidateManifestRejectsLocalVariableBeforeDeclaration(t *testing.T) {
 		},
 	}}}
 
-	err := validateManifest(gowdk.Config{}, app)
+	err := ValidateManifest(gowdk.Config{}, app)
 	if err == nil {
 		t.Fatal("expected local-before-declaration diagnostic")
 	}
@@ -2548,7 +2546,7 @@ func TestValidateManifestRejectsGoishConditionalTypeMismatch(t *testing.T) {
 		},
 	}}}
 
-	err := validateManifest(gowdk.Config{}, app)
+	err := ValidateManifest(gowdk.Config{}, app)
 	if err == nil {
 		t.Fatal("expected conditional branch mismatch diagnostic")
 	}
@@ -2581,7 +2579,7 @@ computed Visible bool {
 		},
 	}}}
 
-	if err := validateManifest(gowdk.Config{}, app); err != nil {
+	if err := ValidateManifest(gowdk.Config{}, app); err != nil {
 		t.Fatalf("expected computed state to validate, got %v", err)
 	}
 }
@@ -2612,7 +2610,7 @@ func Increment() {
 		},
 	}}}
 
-	if err := validateManifest(gowdk.Config{}, app); err != nil {
+	if err := ValidateManifest(gowdk.Config{}, app); err != nil {
 		t.Fatalf("expected Go-style computed state to validate, got %v", err)
 	}
 }
@@ -2640,7 +2638,7 @@ computed Label string {
 		},
 	}}}
 
-	if err := validateManifest(gowdk.Config{}, app); err != nil {
+	if err := ValidateManifest(gowdk.Config{}, app); err != nil {
 		t.Fatalf("expected out-of-order computed state to validate, got %v", err)
 	}
 }
@@ -2668,7 +2666,7 @@ computed Second string {
 		},
 	}}}
 
-	err := validateManifest(gowdk.Config{}, app)
+	err := ValidateManifest(gowdk.Config{}, app)
 	if err == nil {
 		t.Fatal("expected computed cycle diagnostic")
 	}
@@ -2697,7 +2695,7 @@ func TestValidateManifestRejectsComputedMutation(t *testing.T) {
 		},
 	}}}
 
-	err := validateManifest(gowdk.Config{}, app)
+	err := ValidateManifest(gowdk.Config{}, app)
 	if err == nil {
 		t.Fatal("expected computed mutation diagnostic")
 	}
@@ -2722,7 +2720,7 @@ func TestValidateManifestRejectsUnknownNestedField(t *testing.T) {
 		},
 	}}}
 
-	err := validateManifest(gowdk.Config{}, app)
+	err := ValidateManifest(gowdk.Config{}, app)
 	if err == nil {
 		t.Fatal("expected unknown nested field diagnostic")
 	}
@@ -2747,7 +2745,7 @@ func TestValidateManifestAllowsValueBindingToStringState(t *testing.T) {
 		},
 	}}}
 
-	if err := validateManifest(gowdk.Config{}, app); err != nil {
+	if err := ValidateManifest(gowdk.Config{}, app); err != nil {
 		t.Fatalf("expected string state value binding to validate, got %v", err)
 	}
 }
@@ -2767,7 +2765,7 @@ func TestValidateManifestRejectsValueBindingToNonStringState(t *testing.T) {
 		},
 	}}}
 
-	err := validateManifest(gowdk.Config{}, app)
+	err := ValidateManifest(gowdk.Config{}, app)
 	if err == nil {
 		t.Fatal("expected non-string value binding diagnostic")
 	}
@@ -2792,7 +2790,7 @@ func TestValidateManifestAllowsNumberInputValueBindingToNumericState(t *testing.
 		},
 	}}}
 
-	if err := validateManifest(gowdk.Config{}, app); err != nil {
+	if err := ValidateManifest(gowdk.Config{}, app); err != nil {
 		t.Fatalf("expected numeric value binding to validate, got %v", err)
 	}
 }
@@ -2812,7 +2810,7 @@ func TestValidateManifestRejectsNumericValueBindingOutsideNumberInput(t *testing
 		},
 	}}}
 
-	err := validateManifest(gowdk.Config{}, app)
+	err := ValidateManifest(gowdk.Config{}, app)
 	if err == nil {
 		t.Fatal("expected numeric value binding target diagnostic")
 	}
@@ -2837,7 +2835,7 @@ func TestValidateManifestAllowsRadioValueBindingToStringState(t *testing.T) {
 		},
 	}}}
 
-	if err := validateManifest(gowdk.Config{}, app); err != nil {
+	if err := ValidateManifest(gowdk.Config{}, app); err != nil {
 		t.Fatalf("expected radio value binding to validate, got %v", err)
 	}
 }
@@ -2857,7 +2855,7 @@ func TestValidateManifestRejectsRadioValueBindingWithoutValue(t *testing.T) {
 		},
 	}}}
 
-	err := validateManifest(gowdk.Config{}, app)
+	err := ValidateManifest(gowdk.Config{}, app)
 	if err == nil {
 		t.Fatal("expected radio Missing value diagnostic")
 	}
@@ -2882,7 +2880,7 @@ func TestValidateManifestRejectsValueBindingToProp(t *testing.T) {
 		},
 	}}}
 
-	err := validateManifest(gowdk.Config{}, app)
+	err := ValidateManifest(gowdk.Config{}, app)
 	if err == nil {
 		t.Fatal("expected prop value binding diagnostic")
 	}
@@ -2907,7 +2905,7 @@ func TestValidateManifestAllowsCheckedBindingToBoolState(t *testing.T) {
 		},
 	}}}
 
-	if err := validateManifest(gowdk.Config{}, app); err != nil {
+	if err := ValidateManifest(gowdk.Config{}, app); err != nil {
 		t.Fatalf("expected bool state checked binding to validate, got %v", err)
 	}
 }
@@ -2927,7 +2925,7 @@ func TestValidateManifestRejectsCheckedBindingToNonBoolState(t *testing.T) {
 		},
 	}}}
 
-	err := validateManifest(gowdk.Config{}, app)
+	err := ValidateManifest(gowdk.Config{}, app)
 	if err == nil {
 		t.Fatal("expected non-bool checked binding diagnostic")
 	}
@@ -2952,7 +2950,7 @@ func TestValidateManifestAllowsReactiveAttributes(t *testing.T) {
 		},
 	}}}
 
-	if err := validateManifest(gowdk.Config{}, app); err != nil {
+	if err := ValidateManifest(gowdk.Config{}, app); err != nil {
 		t.Fatalf("expected reactive attributes to validate, got %v", err)
 	}
 }
@@ -2972,7 +2970,7 @@ func TestValidateManifestRejectsNonBoolReactiveBooleanAttribute(t *testing.T) {
 		},
 	}}}
 
-	err := validateManifest(gowdk.Config{}, app)
+	err := ValidateManifest(gowdk.Config{}, app)
 	if err == nil {
 		t.Fatal("expected non-bool boolean attr diagnostic")
 	}
@@ -2997,7 +2995,7 @@ func TestValidateManifestRejectsUnsafeReactiveURLAttribute(t *testing.T) {
 		},
 	}}}
 
-	err := validateManifest(gowdk.Config{}, app)
+	err := ValidateManifest(gowdk.Config{}, app)
 	if err == nil {
 		t.Fatal("expected unsafe reactive URL attr diagnostic")
 	}
@@ -3022,7 +3020,7 @@ func TestValidateManifestAllowsClassToggle(t *testing.T) {
 		},
 	}}}
 
-	if err := validateManifest(gowdk.Config{}, app); err != nil {
+	if err := ValidateManifest(gowdk.Config{}, app); err != nil {
 		t.Fatalf("expected class toggle to validate, got %v", err)
 	}
 }
@@ -3042,7 +3040,7 @@ func TestValidateManifestRejectsNonBoolClassToggle(t *testing.T) {
 		},
 	}}}
 
-	err := validateManifest(gowdk.Config{}, app)
+	err := ValidateManifest(gowdk.Config{}, app)
 	if err == nil {
 		t.Fatal("expected non-bool class toggle diagnostic")
 	}
@@ -3067,7 +3065,7 @@ func TestValidateManifestAllowsStyleBinding(t *testing.T) {
 		},
 	}}}
 
-	if err := validateManifest(gowdk.Config{}, app); err != nil {
+	if err := ValidateManifest(gowdk.Config{}, app); err != nil {
 		t.Fatalf("expected style binding to validate, got %v", err)
 	}
 }
@@ -3087,7 +3085,7 @@ func TestValidateManifestRejectsBoolStyleBinding(t *testing.T) {
 		},
 	}}}
 
-	err := validateManifest(gowdk.Config{}, app)
+	err := ValidateManifest(gowdk.Config{}, app)
 	if err == nil {
 		t.Fatal("expected bool style binding diagnostic")
 	}
@@ -3108,7 +3106,7 @@ func TestValidateManifestRejectsRelativeGoTypedImportPath(t *testing.T) {
 		},
 	}}}
 
-	err := validateManifest(gowdk.Config{}, app)
+	err := ValidateManifest(gowdk.Config{}, app)
 	if err == nil {
 		t.Fatal("expected invalid import diagnostic")
 	}
@@ -3133,7 +3131,7 @@ func TestValidateManifestRejectsStateInitReturnMismatch(t *testing.T) {
 		},
 	}}}
 
-	err := validateManifest(gowdk.Config{}, app)
+	err := ValidateManifest(gowdk.Config{}, app)
 	if err == nil {
 		t.Fatal("expected state init mismatch diagnostic")
 	}
@@ -3158,7 +3156,7 @@ func TestValidateManifestResolvesLayoutsByID(t *testing.T) {
 		}},
 	}
 
-	err := validateManifest(gowdk.Config{}, app)
+	err := ValidateManifest(gowdk.Config{}, app)
 	if err == nil {
 		t.Fatal("expected unknown layout diagnostic")
 	}
@@ -3185,7 +3183,7 @@ func TestValidateManifestAcceptsQualifiedLayoutUse(t *testing.T) {
 		}},
 	}
 
-	if err := validateManifest(gowdk.Config{}, app); err != nil {
+	if err := ValidateManifest(gowdk.Config{}, app); err != nil {
 		t.Fatalf("expected qualified layout reference to validate, got %v", err)
 	}
 }
@@ -3206,7 +3204,7 @@ func TestValidateManifestRejectsUnqualifiedCrossPackageLayout(t *testing.T) {
 		}},
 	}
 
-	err := validateManifest(gowdk.Config{}, app)
+	err := ValidateManifest(gowdk.Config{}, app)
 	if err == nil {
 		t.Fatal("expected unknown layout diagnostic")
 	}
@@ -3224,7 +3222,7 @@ func TestValidateManifestRejectsDuplicateLayoutIDs(t *testing.T) {
 		},
 	}
 
-	err := validateManifest(gowdk.Config{}, app)
+	err := ValidateManifest(gowdk.Config{}, app)
 	if err == nil {
 		t.Fatal("expected duplicate layout diagnostic")
 	}
@@ -3242,7 +3240,7 @@ func TestValidateManifestAllowsDuplicateLayoutIDsAcrossPackages(t *testing.T) {
 		},
 	}
 
-	if err := validateManifest(gowdk.Config{}, app); err != nil {
+	if err := ValidateManifest(gowdk.Config{}, app); err != nil {
 		t.Fatalf("expected package-qualified layout IDs to be unique, got %v", err)
 	}
 }
@@ -3255,7 +3253,7 @@ func TestValidateManifestRejectsDuplicateLayoutIDsInSamePackage(t *testing.T) {
 		},
 	}
 
-	err := validateManifest(gowdk.Config{}, app)
+	err := ValidateManifest(gowdk.Config{}, app)
 	if err == nil {
 		t.Fatal("expected duplicate layout diagnostic")
 	}
@@ -3273,7 +3271,7 @@ func TestValidateManifestRejectsDuplicatePageRoutes(t *testing.T) {
 		},
 	}
 
-	err := validateManifest(gowdk.Config{}, app)
+	err := ValidateManifest(gowdk.Config{}, app)
 	if err == nil {
 		t.Fatal("expected duplicate route diagnostic")
 	}
@@ -3310,7 +3308,7 @@ func TestValidateManifestRejectsAmbiguousDynamicPageRoutes(t *testing.T) {
 				},
 			}
 
-			err := validateManifest(gowdk.Config{}, app)
+			err := ValidateManifest(gowdk.Config{}, app)
 			if err == nil {
 				t.Fatal("expected ambiguous dynamic route diagnostic")
 			}
@@ -3330,7 +3328,7 @@ func TestValidateManifestAllowsConcreteRouteBesideDynamicPageRoute(t *testing.T)
 		},
 	}
 
-	if err := validateManifest(gowdk.Config{}, app); err != nil {
+	if err := ValidateManifest(gowdk.Config{}, app); err != nil {
 		t.Fatalf("expected concrete and dynamic routes to be valid, got %v", err)
 	}
 }
@@ -3348,7 +3346,7 @@ func TestValidateManifestRejectsRouteMethodConflicts(t *testing.T) {
 			}},
 		}
 
-		err := validateManifest(gowdk.Config{}, app)
+		err := ValidateManifest(gowdk.Config{}, app)
 		if err == nil {
 			t.Fatal("expected route method conflict")
 		}
@@ -3370,7 +3368,7 @@ func TestValidateManifestRejectsRouteMethodConflicts(t *testing.T) {
 			}},
 		}
 
-		err := validateManifest(gowdk.Config{}, app)
+		err := ValidateManifest(gowdk.Config{}, app)
 		if err == nil {
 			t.Fatal("expected route method conflict")
 		}
@@ -3393,7 +3391,7 @@ func TestValidateManifestAllowsSameRouteWithDifferentMethods(t *testing.T) {
 		}},
 	}
 
-	if err := validateManifest(gowdk.Config{}, app); err != nil {
+	if err := ValidateManifest(gowdk.Config{}, app); err != nil {
 		t.Fatalf("expected GET page plus POST action to be valid, got %v", err)
 	}
 }
@@ -3415,7 +3413,7 @@ func TestValidatePageRejectsMalformedRoutes(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			page := manifest.Page{ID: "patients", Route: test.route, Paths: true, Blocks: manifest.Blocks{View: true}}
 
-			diagnostics := ValidatePage(gowdk.Config{}, irPage(page))
+			diagnostics := ValidatePage(gowdk.Config{}, page)
 			if !hasDiagnosticCode(diagnostics, "malformed_route") {
 				t.Fatalf("Missing malformed_route diagnostic for %q: %#v", test.route, diagnostics)
 			}
@@ -3441,7 +3439,7 @@ func TestValidatePageRejectsDuplicateRouteParams(t *testing.T) {
 		},
 	}
 
-	diagnostics := ValidatePage(gowdk.Config{}, irPage(page))
+	diagnostics := ValidatePage(gowdk.Config{}, page)
 	diagnostic := firstDiagnostic(diagnostics, "duplicate_route_param")
 	if diagnostic == nil {
 		t.Fatalf("Missing duplicate_route_param diagnostic: %#v", diagnostics)
@@ -3467,7 +3465,7 @@ func TestValidatePageRouteDiagnosticsUseExactSpans(t *testing.T) {
 			RouteParams: []source.NamedSpan{{Name: "id", Span: testSourceSpan(6, 24, 6, 33)}},
 		}}
 
-		diagnostics := ValidatePage(gowdk.Config{}, irPage(page))
+		diagnostics := ValidatePage(gowdk.Config{}, page)
 		diagnostic := firstDiagnostic(diagnostics, "malformed_route")
 		if diagnostic == nil {
 			t.Fatalf("Missing malformed_route diagnostic: %#v", diagnostics)
@@ -3486,7 +3484,7 @@ func TestValidatePageRouteDiagnosticsUseExactSpans(t *testing.T) {
 			RouteParams: []source.NamedSpan{{Name: "id", Span: testSourceSpan(9, 21, 9, 30)}},
 		}}
 
-		diagnostics := ValidatePage(gowdk.Config{}, irPage(page))
+		diagnostics := ValidatePage(gowdk.Config{}, page)
 		diagnostic := firstDiagnostic(diagnostics, "malformed_route")
 		if diagnostic == nil {
 			t.Fatalf("Missing malformed_route diagnostic: %#v", diagnostics)
@@ -3505,7 +3503,7 @@ func TestValidatePageRouteDiagnosticsUseExactSpans(t *testing.T) {
 			RouteParams: []source.NamedSpan{{Name: "id", Span: testSourceSpan(12, 29, 12, 33)}},
 		}}
 
-		diagnostics := ValidatePage(gowdk.Config{}, irPage(page))
+		diagnostics := ValidatePage(gowdk.Config{}, page)
 		diagnostic := firstDiagnostic(diagnostics, "fragment_dynamic_route")
 		if diagnostic == nil {
 			t.Fatalf("Missing fragment_dynamic_route diagnostic: %#v", diagnostics)
@@ -3517,7 +3515,7 @@ func TestValidatePageRouteDiagnosticsUseExactSpans(t *testing.T) {
 func TestValidatePageRejectsRevalidateWithoutCache(t *testing.T) {
 	page := manifest.Page{ID: "home", Route: "/", Revalidate: "60", Blocks: manifest.Blocks{View: true}}
 
-	diagnostics := ValidatePage(gowdk.Config{}, irPage(page))
+	diagnostics := ValidatePage(gowdk.Config{}, page)
 	if !hasDiagnosticCode(diagnostics, "revalidate_requires_cache") {
 		t.Fatalf("Missing revalidate_requires_cache diagnostic: %#v", diagnostics)
 	}
@@ -3532,7 +3530,7 @@ func TestValidatePageRejectsDuplicateRevalidatePolicy(t *testing.T) {
 		Blocks:     manifest.Blocks{View: true},
 	}
 
-	diagnostics := ValidatePage(gowdk.Config{}, irPage(page))
+	diagnostics := ValidatePage(gowdk.Config{}, page)
 	if !hasDiagnosticCode(diagnostics, "duplicate_revalidate_policy") {
 		t.Fatalf("Missing duplicate_revalidate_policy diagnostic: %#v", diagnostics)
 	}
@@ -3541,7 +3539,7 @@ func TestValidatePageRejectsDuplicateRevalidatePolicy(t *testing.T) {
 func TestValidatePageAllowsTypedRouteParams(t *testing.T) {
 	page := manifest.Page{ID: "patients.show", Route: "/patients/{id:int}", Paths: true, Blocks: manifest.Blocks{View: true}}
 
-	diagnostics := ValidatePage(gowdk.Config{}, irPage(page))
+	diagnostics := ValidatePage(gowdk.Config{}, page)
 	if hasDiagnosticCode(diagnostics, "malformed_route") {
 		t.Fatalf("typed route params should be valid: %#v", diagnostics)
 	}
@@ -3550,7 +3548,7 @@ func TestValidatePageAllowsTypedRouteParams(t *testing.T) {
 func TestValidatePageRequiresPathsForSPADynamicRoutes(t *testing.T) {
 	page := manifest.Page{ID: "patients.show", Route: "/patients/{id}", Render: gowdk.SPA, Blocks: manifest.Blocks{View: true}}
 
-	diagnostics := ValidatePage(gowdk.Config{}, irPage(page))
+	diagnostics := ValidatePage(gowdk.Config{}, page)
 	if len(diagnostics) != 1 {
 		t.Fatalf("expected 1 diagnostic, got %d", len(diagnostics))
 	}
@@ -3565,7 +3563,7 @@ func TestValidatePageRequiresPathsForSPADynamicRoutes(t *testing.T) {
 func TestValidatePageAllowsSPADynamicRoutesWithPaths(t *testing.T) {
 	page := manifest.Page{ID: "blog.post", Route: "/blog/{slug}", Render: gowdk.SPA, Paths: true, Blocks: manifest.Blocks{View: true}}
 
-	diagnostics := ValidatePage(gowdk.Config{}, irPage(page))
+	diagnostics := ValidatePage(gowdk.Config{}, page)
 	if len(diagnostics) != 0 {
 		t.Fatalf("expected no diagnostics, got %#v", diagnostics)
 	}
@@ -3582,7 +3580,7 @@ func TestValidatePageAllowsSPAActionsWithoutSSR(t *testing.T) {
 		},
 	}
 
-	diagnostics := ValidatePage(gowdk.Config{}, irPage(page))
+	diagnostics := ValidatePage(gowdk.Config{}, page)
 	if len(diagnostics) != 0 {
 		t.Fatalf("expected no diagnostics, got %#v", diagnostics)
 	}
@@ -3599,7 +3597,7 @@ func TestValidatePageRejectsLoadOnSPAPage(t *testing.T) {
 		},
 	}
 
-	diagnostics := ValidatePage(gowdk.Config{}, irPage(page))
+	diagnostics := ValidatePage(gowdk.Config{}, page)
 	if len(diagnostics) != 1 {
 		t.Fatalf("expected 1 diagnostic, got %d", len(diagnostics))
 	}
@@ -3618,7 +3616,7 @@ func TestValidatePageRequiresSSRAddonForHybridWithoutLoad(t *testing.T) {
 		},
 	}
 
-	diagnostics := ValidatePage(gowdk.Config{}, irPage(page))
+	diagnostics := ValidatePage(gowdk.Config{}, page)
 	if len(diagnostics) != 1 {
 		t.Fatalf("expected 1 diagnostic, got %#v", diagnostics)
 	}
@@ -3637,7 +3635,7 @@ func TestValidatePageAllowsDynamicHybridWithoutLoadAsRequestTime(t *testing.T) {
 		},
 	}
 
-	diagnostics := ValidatePage(gowdk.Config{Addons: []gowdk.Addon{ssr.Addon()}}, irPage(page))
+	diagnostics := ValidatePage(gowdk.Config{Addons: []gowdk.Addon{ssr.Addon()}}, page)
 	if len(diagnostics) != 0 {
 		t.Fatalf("expected no diagnostics, got %#v", diagnostics)
 	}
@@ -3654,7 +3652,7 @@ func TestValidatePageAllowsHybridWithExplicitLoadAndSSRAddon(t *testing.T) {
 		},
 	}
 
-	diagnostics := ValidatePage(gowdk.Config{Addons: []gowdk.Addon{ssr.Addon()}}, irPage(page))
+	diagnostics := ValidatePage(gowdk.Config{Addons: []gowdk.Addon{ssr.Addon()}}, page)
 	if len(diagnostics) != 0 {
 		t.Fatalf("expected no diagnostics, got %#v", diagnostics)
 	}
@@ -3663,7 +3661,7 @@ func TestValidatePageAllowsHybridWithExplicitLoadAndSSRAddon(t *testing.T) {
 func TestValidatePageRejectsMissingViewBlock(t *testing.T) {
 	page := manifest.Page{ID: "home", Route: "/", Render: gowdk.SPA}
 
-	diagnostics := ValidatePage(gowdk.Config{}, irPage(page))
+	diagnostics := ValidatePage(gowdk.Config{}, page)
 	if len(diagnostics) != 1 {
 		t.Fatalf("expected 1 diagnostic, got %#v", diagnostics)
 	}
@@ -3686,7 +3684,7 @@ func TestValidateManifestRejectsInvalidScriptGo(t *testing.T) {
 		},
 	}}}
 
-	err := validateManifest(gowdk.Config{}, app)
+	err := ValidateManifest(gowdk.Config{}, app)
 	if err == nil {
 		t.Fatal("expected invalid go block error")
 	}
@@ -3710,7 +3708,7 @@ func TestValidateManifestRejectsSSRScriptWithoutAddon(t *testing.T) {
 		},
 	}}}
 
-	err := validateManifest(gowdk.Config{}, app)
+	err := ValidateManifest(gowdk.Config{}, app)
 	if err == nil {
 		t.Fatal("expected ssr addon error")
 	}
@@ -3734,7 +3732,7 @@ func TestValidateManifestRejectsUnknownAddonGoBlockTarget(t *testing.T) {
 		},
 	}}}
 
-	err := validateManifest(gowdk.Config{}, app)
+	err := ValidateManifest(gowdk.Config{}, app)
 	if err == nil {
 		t.Fatal("expected unknown addon go block target error")
 	}
@@ -3758,7 +3756,7 @@ func TestValidateManifestAllowsKnownAddonGoBlockTarget(t *testing.T) {
 		},
 	}}}
 
-	err := validateManifest(gowdk.Config{Addons: []gowdk.Addon{gowdk.NewAddon("contracts", gowdk.FeatureContracts)}}, app)
+	err := ValidateManifest(gowdk.Config{Addons: []gowdk.Addon{gowdk.NewAddon("contracts", gowdk.FeatureContracts)}}, app)
 	if err != nil {
 		t.Fatalf("expected known addon target to validate, got %v", err)
 	}
@@ -3779,7 +3777,7 @@ func TestValidateManifestUsesAddonGoBlockConsumerDiagnostics(t *testing.T) {
 		},
 	}}}
 
-	err := validateManifest(gowdk.Config{Addons: []gowdk.Addon{compilerGoBlockAddon{diagnostic: "contract go block rejected"}}}, app)
+	err := ValidateManifest(gowdk.Config{Addons: []gowdk.Addon{compilerGoBlockAddon{diagnostic: "contract go block rejected"}}}, app)
 	if err == nil {
 		t.Fatal("expected addon go block diagnostic")
 	}
@@ -3833,7 +3831,7 @@ func TestValidateManifestAcceptsQualifiedCSSAssetUse(t *testing.T) {
 		},
 	}}
 
-	if err := validateManifest(gowdk.Config{}, app); err != nil {
+	if err := ValidateManifest(gowdk.Config{}, app); err != nil {
 		t.Fatalf("expected qualified CSS asset use to validate, got %v", err)
 	}
 }
@@ -3847,7 +3845,7 @@ func TestValidateManifestRejectsUnknownQualifiedCSSAssetUseAlias(t *testing.T) {
 		Blocks:  manifest.Blocks{View: true, ViewBody: `<main>Home</main>`},
 	}}}
 
-	err := validateManifest(gowdk.Config{}, app)
+	err := ValidateManifest(gowdk.Config{}, app)
 	if err == nil {
 		t.Fatal("expected unknown CSS asset alias diagnostic")
 	}
@@ -3867,7 +3865,7 @@ func TestValidatePageRejectsInvalidCSSSelection(t *testing.T) {
 		},
 	}
 
-	diagnostics := ValidatePage(gowdk.Config{}, irPage(page))
+	diagnostics := ValidatePage(gowdk.Config{}, page)
 	if !hasDiagnosticCode(diagnostics, "invalid_css_selection") {
 		t.Fatalf("Missing invalid_css_selection diagnostic: %#v", diagnostics)
 	}
@@ -3883,7 +3881,7 @@ func TestValidatePageRejectsDuplicateCSSSelection(t *testing.T) {
 		},
 	}
 
-	diagnostics := ValidatePage(gowdk.Config{}, irPage(page))
+	diagnostics := ValidatePage(gowdk.Config{}, page)
 	if !hasDiagnosticCode(diagnostics, "duplicate_css_selection") {
 		t.Fatalf("Missing duplicate_css_selection diagnostic: %#v", diagnostics)
 	}
@@ -3940,21 +3938,38 @@ func hasDiagnosticMessage(diagnostics []ValidationError, code string, parts ...s
 	return false
 }
 
-// validateManifest lowers a manifest fixture through the production
-// manifest->IR path and validates the IR, mirroring what the build pipeline
-// does. Keeping the fixtures manifest-typed pins the IR-native validators to
-// the diagnostics the manifest validators produced.
-func validateManifest(config gowdk.Config, app manifest.Manifest) error {
-	return ValidateProgram(config, gwdkanalysis.BuildIR(config, app))
+func TestValidateSourceManifestSkipsCrossFileUseChecks(t *testing.T) {
+	app := manifest.Manifest{Pages: []manifest.Page{{
+		Package: "pages",
+		ID:      "home",
+		Route:   "/",
+		Uses:    []manifest.Use{{Alias: "ui", Package: "components"}},
+		Blocks:  manifest.Blocks{View: true, ViewBody: `<main><ui.Hero /></main>`},
+	}}}
+
+	if err := ValidateSourceManifest(gowdk.Config{}, app); err != nil {
+		t.Fatalf("expected single-file manifest to skip cross-file use checks, got %v", err)
+	}
 }
 
-// irPage lowers a manifest page fixture through the production manifest->IR
-// path so page-level validator tests assert against exactly what the build
-// pipeline validates.
-func irPage(page manifest.Page) gwdkir.Page {
-	program := gwdkanalysis.BuildIR(gowdk.Config{}, manifest.Manifest{Pages: []manifest.Page{page}})
-	if len(program.Pages) != 1 {
-		panic(fmt.Sprintf("irPage: expected 1 IR page, got %d", len(program.Pages)))
+func TestValidateSourceManifestKeepsSingleFileUseChecks(t *testing.T) {
+	app := manifest.Manifest{Pages: []manifest.Page{{
+		Package: "pages",
+		ID:      "home",
+		Route:   "/",
+		Uses: []manifest.Use{
+			{Alias: "ui", Package: "components"},
+			{Alias: "ui", Package: "widgets"},
+		},
+		Blocks: manifest.Blocks{View: true, ViewBody: `<main><ui.Hero /></main>`},
+	}}}
+
+	err := ValidateSourceManifest(gowdk.Config{}, app)
+	if err == nil {
+		t.Fatal("expected duplicate alias diagnostic")
 	}
-	return program.Pages[0]
+	diagnostics := err.(ValidationErrors)
+	if !hasDiagnosticCode(diagnostics, "duplicate_gowdk_use_alias") {
+		t.Fatalf("missing duplicate alias diagnostic: %#v", diagnostics)
+	}
 }

--- a/internal/gotypes/gotypes.go
+++ b/internal/gotypes/gotypes.go
@@ -17,7 +17,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/cssbruno/gowdk/internal/gwdkir"
+	"github.com/cssbruno/gowdk/internal/manifest"
 )
 
 // Field describes one resolved Go struct field.
@@ -54,7 +54,7 @@ func (item Struct) FieldNames() []string {
 }
 
 // ResolveStruct resolves a Go struct type referenced by a component contract.
-func ResolveStruct(imports []gwdkir.Import, ref gwdkir.GoRef) (Struct, error) {
+func ResolveStruct(imports []manifest.Import, ref manifest.GoTypeRef) (Struct, error) {
 	importPath, err := ImportPathForAlias(imports, ref.Alias)
 	if err != nil {
 		return Struct{}, err
@@ -136,7 +136,7 @@ func collectFieldTypes(prefix string, typ types.Type, output map[string]string, 
 
 // ValidateStateInit verifies that the state init function can initialize the
 // declared state type.
-func ValidateStateInit(imports []gwdkir.Import, state gwdkir.StateContract) error {
+func ValidateStateInit(imports []manifest.Import, state manifest.StateContract) error {
 	statePath, err := ImportPathForAlias(imports, state.Type.Alias)
 	if err != nil {
 		return err
@@ -191,7 +191,7 @@ func ValidateStateInit(imports []gwdkir.Import, state gwdkir.StateContract) erro
 
 // RunStateInitJSON runs a declared state init function and returns its JSON
 // encoding.
-func RunStateInitJSON(imports []gwdkir.Import, state gwdkir.StateContract) ([]byte, error) {
+func RunStateInitJSON(imports []manifest.Import, state manifest.StateContract) ([]byte, error) {
 	importPath, err := ImportPathForAlias(imports, state.Init.Alias)
 	if err != nil {
 		return nil, err
@@ -219,9 +219,11 @@ func RunStateInitJSON(imports []gwdkir.Import, state gwdkir.StateContract) ([]by
 		return nil, err
 	}
 	command := exec.Command("go", "run", path)
-	output, err := command.CombinedOutput()
+	var stderr bytes.Buffer
+	command.Stderr = &stderr
+	output, err := command.Output()
 	if err != nil {
-		return nil, fmt.Errorf("run state init function %s.%s: %w\n%s", state.Init.Alias, state.Init.Name, err, strings.TrimSpace(string(output)))
+		return nil, fmt.Errorf("run state init function %s.%s: %w\n%s", state.Init.Alias, state.Init.Name, err, strings.TrimSpace(stderr.String()))
 	}
 	output = bytes.TrimSpace(output)
 	if len(output) == 0 {
@@ -410,7 +412,7 @@ func stateInitEncodeGuardStmt() ast.Stmt {
 
 // ImportPathForAlias returns the concrete Go import path for a .gwdk import
 // alias and rejects relative import paths.
-func ImportPathForAlias(imports []gwdkir.Import, alias string) (string, error) {
+func ImportPathForAlias(imports []manifest.Import, alias string) (string, error) {
 	if strings.TrimSpace(alias) == "" {
 		return "", fmt.Errorf("Go import alias is required")
 	}
@@ -428,7 +430,7 @@ func ImportPathForAlias(imports []gwdkir.Import, alias string) (string, error) {
 
 // EffectiveImportAlias returns the explicit import alias or the package name
 // used by Go for an unaliased import.
-func EffectiveImportAlias(item gwdkir.Import) (string, error) {
+func EffectiveImportAlias(item manifest.Import) (string, error) {
 	if strings.TrimSpace(item.Alias) != "" {
 		return item.Alias, nil
 	}

--- a/internal/lang/format.go
+++ b/internal/lang/format.go
@@ -1,20 +1,16 @@
 package lang
 
 import (
-	"bufio"
-	"bytes"
 	"strings"
 )
 
 // Format normalizes whitespace for top-level .gwdk annotations and blocks.
 func Format(source []byte) []byte {
-	scanner := bufio.NewScanner(bytes.NewReader(source))
 	var out []string
 	blankPending := false
 	depth := 0
 
-	for scanner.Scan() {
-		raw := strings.TrimRight(scanner.Text(), " \t")
+	for _, raw := range strings.Split(string(source), "\n") {
 		line := strings.TrimSpace(raw)
 		if line == "" {
 			blankPending = true
@@ -26,10 +22,11 @@ func Format(source []byte) []byte {
 		}
 		blankPending = false
 
-		if strings.HasPrefix(line, "}") && depth > 0 {
-			depth--
+		indent := depth
+		if strings.HasPrefix(line, "}") && indent > 0 {
+			indent--
 		}
-		out = append(out, strings.Repeat("  ", depth)+line)
+		out = append(out, strings.Repeat("  ", indent)+line)
 		depth += strings.Count(line, "{") - strings.Count(line, "}")
 		if depth < 0 {
 			depth = 0

--- a/internal/lang/format_test.go
+++ b/internal/lang/format_test.go
@@ -31,6 +31,34 @@ func TestFormatGoldenPreservesCommentsAndNestedMarkup(t *testing.T) {
 	}
 }
 
+func TestFormatPreservesLinesLongerThanScannerLimit(t *testing.T) {
+	longLine := "<p>" + strings.Repeat("x", 70_000) + "</p>"
+	source := []byte("@page home\n@route \"/\"\n\nview {\n" + longLine + "\n}\n")
+	got := string(Format(source))
+	want := "@page home\n@route \"/\"\n\nview {\n  " + longLine + "\n}\n"
+	if got != want {
+		t.Fatalf("long line was truncated or reformatted (got %d bytes, want %d bytes)", len(got), len(want))
+	}
+}
+
+func TestFormatIndentsSiblingsAfterNestedClose(t *testing.T) {
+	source := []byte("go {\nfunc Handler() {\nif ok {\nreturn\n}\nlog()\n}\n}\n")
+	got := string(Format(source))
+	want := "go {\n  func Handler() {\n    if ok {\n      return\n    }\n    log()\n  }\n}\n"
+	if got != want {
+		t.Fatalf("unexpected format:\n--- got ---\n%s--- want ---\n%s", got, want)
+	}
+}
+
+func TestFormatKeepsElseBranchesAligned(t *testing.T) {
+	source := []byte("go {\nif ok {\na()\n} else {\nb()\n}\n}\n")
+	got := string(Format(source))
+	want := "go {\n  if ok {\n    a()\n  } else {\n    b()\n  }\n}\n"
+	if got != want {
+		t.Fatalf("unexpected format:\n--- got ---\n%s--- want ---\n%s", got, want)
+	}
+}
+
 func TestFormatIsIdempotentForSupportedShapes(t *testing.T) {
 	tests := map[string]string{
 		"page": `package app

--- a/internal/lang/sitemap.go
+++ b/internal/lang/sitemap.go
@@ -61,6 +61,16 @@ type SiteMapEndpoint struct {
 	InputType     string                        `json:"inputType,omitempty"`
 }
 
+// BuildSiteMap converts a manifest into the editor-facing site map.
+func BuildSiteMap(config gowdk.Config, app manifest.Manifest) SiteMap {
+	pages := siteMapPages(config, app)
+	metadata, err := compiler.BuildRouteMetadata(config, app)
+	if err != nil {
+		return SiteMap{Pages: pages}
+	}
+	return siteMapFromMetadata(pages, metadata)
+}
+
 // BuildSiteMapFromIR converts stable compiler IR into the editor-facing site
 // map while preserving manifest-backed public page fields.
 func BuildSiteMapFromIR(config gowdk.Config, app manifest.Manifest, ir gwdkir.Program) SiteMap {

--- a/internal/lang/tools.go
+++ b/internal/lang/tools.go
@@ -12,10 +12,8 @@ import (
 	"github.com/cssbruno/gowdk/internal/compiler"
 	"github.com/cssbruno/gowdk/internal/contractscan"
 	"github.com/cssbruno/gowdk/internal/gwdkanalysis"
-	"github.com/cssbruno/gowdk/internal/gwdkir"
 	"github.com/cssbruno/gowdk/internal/manifest"
 	"github.com/cssbruno/gowdk/internal/parser"
-	"github.com/cssbruno/gowdk/internal/source"
 )
 
 // FileKind identifies the current source file category.
@@ -275,77 +273,38 @@ func isAnnotation(text, annotation string) bool {
 	return next == ' ' || next == '\t'
 }
 
-// CheckFiles parses and validates .gwdk files. The returned manifest carries
-// the discovered standalone Go endpoints and backend handler bindings so the
-// public manifest JSON report stays complete.
+// CheckFiles parses and validates .gwdk files.
 func CheckFiles(config gowdk.Config, paths []string) (manifest.Manifest, Diagnostics) {
 	app, diagnostics := ParseFiles(paths)
 	if diagnostics.HasErrors() {
 		return app, diagnostics
 	}
-	ir := gwdkanalysis.BuildIR(config, app)
-	if err := compiler.DiscoverGoEndpoints(&ir); err != nil {
+	var err error
+	app, err = compiler.DiscoverGoEndpointComments(app)
+	if err != nil {
 		diagnostics = append(diagnostics, compilerDiagnostics(err, app)...)
 		return app, diagnostics
 	}
-	app.Endpoints = append(app.Endpoints, manifestEndpointsFromIR(ir.GoEndpoints[len(app.Endpoints):])...)
-	if err := compiler.ValidateProgram(config, ir); err != nil {
+	validate := compiler.ValidateManifest
+	if len(paths) == 1 {
+		// A single file can never satisfy cross-file checks (use packages,
+		// component references), so validate it in source mode to avoid
+		// false project-level errors.
+		validate = compiler.ValidateSourceManifest
+	}
+	if err := validate(config, app); err != nil {
 		diagnostics = append(diagnostics, compilerDiagnostics(err, app)...)
 	}
 	diagnostics = append(diagnostics, accessibilityDiagnostics(app)...)
 	if !diagnostics.HasErrors() {
-		applyBackendBindings(&app, compiler.BindBackendHandlers(&ir))
-		diagnostics = append(diagnostics, validateContractReferences(config, ir, app)...)
+		app = compiler.BindBackendHandlers(app)
+		diagnostics = append(diagnostics, validateContractReferences(config, app)...)
 	}
 	return app, diagnostics
 }
 
-// manifestEndpointsFromIR mirrors discovered standalone Go endpoints back into
-// their manifest declaration form for the public manifest JSON report. The copy
-// is one-to-one.
-func manifestEndpointsFromIR(endpoints []gwdkir.GoEndpoint) []manifest.EndpointDeclaration {
-	if len(endpoints) == 0 {
-		return nil
-	}
-	out := make([]manifest.EndpointDeclaration, 0, len(endpoints))
-	for _, endpoint := range endpoints {
-		out = append(out, manifest.EndpointDeclaration{
-			Kind:          endpoint.Kind,
-			SourceKind:    manifest.EndpointSource(endpoint.SourceKind),
-			Package:       endpoint.Package,
-			Source:        endpoint.Source,
-			Name:          endpoint.Name,
-			Method:        endpoint.Method,
-			Route:         endpoint.Route,
-			ErrorPage:     endpoint.ErrorPage,
-			Span:          endpoint.Span,
-			RouteSpan:     endpoint.RouteSpan,
-			RouteParams:   append([]source.NamedSpan(nil), endpoint.RouteParams...),
-			ErrorPageSpan: endpoint.ErrorPageSpan,
-		})
-	}
-	return out
-}
-
-// applyBackendBindings mirrors backend handler binding records onto the
-// manifest for the public manifest JSON report, matching what handler binding
-// attached to the IR.
-func applyBackendBindings(app *manifest.Manifest, bindings []manifest.BackendBinding) {
-	app.BackendBindings = bindings
-	loadBindings := map[string]manifest.BackendBinding{}
-	for _, binding := range bindings {
-		if binding.Kind == "load" {
-			loadBindings[binding.PageID] = binding
-		}
-	}
-	for index := range app.Pages {
-		if binding, ok := loadBindings[app.Pages[index].ID]; ok {
-			app.Pages[index].LoadBinding = binding
-		}
-	}
-}
-
-func validateContractReferences(config gowdk.Config, ir gwdkir.Program, app manifest.Manifest) Diagnostics {
+func validateContractReferences(config gowdk.Config, app manifest.Manifest) Diagnostics {
+	ir := gwdkanalysis.BuildIR(config, app)
 	report, err := contractscan.Scan(".")
 	if err != nil {
 		return Diagnostics{{Severity: "error", Message: fmt.Sprintf("scan Go contracts: %v", err)}}
@@ -384,7 +343,7 @@ func CheckSource(config gowdk.Config, path string, source []byte) (manifest.Page
 			return manifest.Page{}, diagnostics
 		}
 		app := manifest.Manifest{Components: []manifest.Component{component}}
-		if err := compiler.ValidateProgram(config, gwdkanalysis.BuildIR(config, app)); err != nil {
+		if err := compiler.ValidateSourceManifest(config, app); err != nil {
 			diagnostics = append(diagnostics, compilerDiagnostics(err, app)...)
 		}
 		diagnostics = append(diagnostics, accessibilityDiagnostics(app)...)
@@ -409,7 +368,7 @@ func CheckSource(config gowdk.Config, path string, source []byte) (manifest.Page
 		return page, diagnostics
 	}
 	app := manifest.Manifest{Pages: []manifest.Page{page}}
-	if err := compiler.ValidateProgram(config, gwdkanalysis.BuildIR(config, app)); err != nil {
+	if err := compiler.ValidateSourceManifest(config, app); err != nil {
 		diagnostics = append(diagnostics, compilerDiagnostics(err, app)...)
 	}
 	diagnostics = append(diagnostics, accessibilityDiagnostics(app)...)

--- a/internal/parser/route_helpers.go
+++ b/internal/parser/route_helpers.go
@@ -3,6 +3,7 @@ package parser
 import (
 	"fmt"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/cssbruno/gowdk/internal/source"
 )
@@ -78,17 +79,27 @@ func namedValueSpans(values []string, lineNumber int, rawLine string) []source.N
 			continue
 		}
 		start := searchStart + index
-		end := start + len([]rune(value))
+		end := start + len(value)
 		spans = append(spans, source.NamedSpan{
 			Name: value,
 			Span: source.SourceSpan{
-				Start: source.SourcePosition{Line: lineNumber, Column: start + 1},
-				End:   source.SourcePosition{Line: lineNumber, Column: end + 1},
+				Start: source.SourcePosition{Line: lineNumber, Column: runeColumn(rawLine, start)},
+				End:   source.SourcePosition{Line: lineNumber, Column: runeColumn(rawLine, end)},
 			},
 		})
 		searchStart = end
 	}
 	return spans
+}
+
+// runeColumn converts a byte offset within line to the 1-based rune column the
+// lexer reports. Offsets past the end of the line are clamped so callers with a
+// fallback offset cannot slice out of range.
+func runeColumn(line string, byteOffset int) int {
+	if byteOffset > len(line) {
+		byteOffset = len(line)
+	}
+	return utf8.RuneCountInString(line[:byteOffset]) + 1
 }
 
 func parseRouteDeclaration(route string, lineNumber int, rawLine string) (string, []source.RouteParam, []source.NamedSpan, error) {
@@ -116,8 +127,8 @@ func parseRouteDeclaration(route string, lineNumber int, rawLine string) (string
 		start := routeStart + match[0]
 		end := routeStart + match[1]
 		span := source.SourceSpan{
-			Start: source.SourcePosition{Line: lineNumber, Column: start + 1},
-			End:   source.SourcePosition{Line: lineNumber, Column: end + 1},
+			Start: source.SourcePosition{Line: lineNumber, Column: runeColumn(rawLine, start)},
+			End:   source.SourcePosition{Line: lineNumber, Column: runeColumn(rawLine, end)},
 		}
 		params = append(params, source.RouteParam{Name: name, Type: paramType, Span: span})
 		spans = append(spans, source.NamedSpan{


### PR DESCRIPTION
Fixes six verified bugs in the compiler front-end, found in the second-pass code review.

- `gowdk fmt --write` truncated files containing a line over 64KiB (bufio.Scanner default limit, scanner.Err() unchecked) — reproduced destroying a 71KB file. Format now splits on newlines directly. Fixes #183
- The formatter double-counted a leading `}`, dedenting everything after a nested closing brace. Fixes #184
- `BackendBindingsFromIR` dropped page `load` bindings (missing SSR load handlers passed production builds) and round-tripped fragment bindings as kind `"action"`. Verified differentially against the manifest path. Fixes #185
- Route-param spans mixed byte offsets with rune columns, drifting editor squiggles on non-ASCII lines. Fixes #186
- `gotypes.RunStateInitJSON` parsed `CombinedOutput()` as JSON, so stderr noise failed builds with "produced invalid JSON". Fixes #187
- New `ValidateSourceManifest` skips cross-file use/component checks for single-file validation (LSP per keystroke, `gowdk check <file>`), eliminating false `unknown_gowdk_use_package` errors; multi-file validation is unchanged. Verified: `gowdk check examples/actions/newsletter.page.gwdk` now passes while multi-file checks still enforce cross-file rules. Fixes #188

Regression tests added for each fix. `go build`, `go vet`, and the package test suites pass.