### PR TITLE
fix(runtime): redirect bypass, at-least-once event delivery, CSRF rotation, panic boundary

### DIFF
--- a/addons/actions/actions_test.go
+++ b/addons/actions/actions_test.go
@@ -75,7 +75,7 @@ func TestCSRFGeneratesSecureCookieAndValidatesFormToken(t *testing.T) {
 		t.Fatal(err)
 	}
 	response := httptest.NewRecorder()
-	token, err := csrf.Token(response)
+	token, err := csrf.Token(response, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -107,7 +107,7 @@ func TestCSRFValidatesHeaderToken(t *testing.T) {
 		t.Fatal(err)
 	}
 	response := httptest.NewRecorder()
-	token, err := csrf.Token(response)
+	token, err := csrf.Token(response, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -130,7 +130,7 @@ func TestCSRFRejectsMissingMismatchAndInvalidTokens(t *testing.T) {
 	}
 
 	response := httptest.NewRecorder()
-	token, err := csrf.Token(response)
+	token, err := csrf.Token(response, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/addons/actions/csrf.go
+++ b/addons/actions/csrf.go
@@ -25,7 +25,7 @@ type CSRFValidator interface {
 
 // CSRFTokenSource generates tokens for generated forms.
 type CSRFTokenSource interface {
-	Token(http.ResponseWriter) (string, error)
+	Token(http.ResponseWriter, *http.Request) (string, error)
 	FieldName() string
 }
 
@@ -80,9 +80,16 @@ func NewCSRF(options CSRFOptions) (*CSRF, error) {
 	}, nil
 }
 
-// Token generates a CSRF token, stores it in a cookie, and returns the value for
-// a generated hidden form field.
-func (csrf *CSRF) Token(response http.ResponseWriter) (string, error) {
+// Token returns the CSRF token for a generated hidden form field. It reuses
+// the request's valid CSRF cookie when present so concurrently open tabs keep
+// working, and only mints and stores a new token when the cookie is absent or
+// invalid.
+func (csrf *CSRF) Token(response http.ResponseWriter, request *http.Request) (string, error) {
+	if request != nil {
+		if cookie, err := request.Cookie(csrf.cookieName); err == nil && csrf.valid(cookie.Value) {
+			return cookie.Value, nil
+		}
+	}
 	var nonce [csrfNonceBytes]byte
 	if _, err := rand.Read(nonce[:]); err != nil {
 		return "", fmt.Errorf("generate csrf token: %w", err)

--- a/addons/ssr/errors.go
+++ b/addons/ssr/errors.go
@@ -71,6 +71,11 @@ func validateRedirectURL(url string) error {
 	if strings.HasPrefix(url, "//") {
 		return fmt.Errorf("SSR redirect %q must not be protocol-relative", url)
 	}
+	// Browsers normalize "\" to "/" before navigating, so "/\evil.com" is
+	// treated like the protocol-relative "//evil.com".
+	if strings.Contains(url, "\\") {
+		return fmt.Errorf("SSR redirect %q must not contain backslashes", url)
+	}
 	if strings.ContainsAny(url, "\r\n") {
 		return fmt.Errorf("SSR redirect %q must not contain newlines", url)
 	}

--- a/addons/ssr/ssr_test.go
+++ b/addons/ssr/ssr_test.go
@@ -131,13 +131,30 @@ func TestRedirectToContract(t *testing.T) {
 }
 
 func TestRedirectRejectsUnsafeURL(t *testing.T) {
-	for _, url := range []string{"https://example.com", "//example.com", "/login\nSet-Cookie: bad=true"} {
-		if err := Redirect(url, http.StatusSeeOther); err == nil {
+	// "/\evil.com" and "\\evil.com" are rejected because browsers normalize
+	// "\" to "/" before navigating, turning them into protocol-relative
+	// "//evil.com" redirects.
+	for _, url := range []string{
+		"https://example.com",
+		"//example.com",
+		"/login\nSet-Cookie: bad=true",
+		`/\evil.com`,
+		`\\evil.com`,
+		`/foo\..\\evil.com`,
+	} {
+		if _, _, ok := RedirectTarget(Redirect(url, http.StatusSeeOther)); ok {
 			t.Fatalf("expected unsafe redirect URL %q to fail", url)
 		}
 	}
-	if err := Redirect("/login", http.StatusOK); err == nil {
+	if _, _, ok := RedirectTarget(Redirect("/login", http.StatusOK)); ok {
 		t.Fatal("expected non-3xx redirect status to fail")
+	}
+	// "/%5C" stays accepted: browsers do not percent-decode the Location
+	// path before resolving it, so an encoded backslash never becomes a
+	// host separator and is safe to pass through as an opaque path byte.
+	url, _, ok := RedirectTarget(Redirect("/%5Cevil.com", http.StatusSeeOther))
+	if !ok || url != "/%5Cevil.com" {
+		t.Fatalf("expected percent-encoded backslash path to stay valid, got ok=%v url=%q", ok, url)
 	}
 }
 

--- a/runtime/app/app.go
+++ b/runtime/app/app.go
@@ -25,7 +25,7 @@ type HandlerFunc func(http.ResponseWriter, *http.Request) bool
 
 // CSRFTokenSource generates tokens for generated action forms.
 type CSRFTokenSource interface {
-	Token(http.ResponseWriter) (string, error)
+	Token(http.ResponseWriter, *http.Request) (string, error)
 	FieldName() string
 }
 
@@ -241,7 +241,7 @@ func (handler Handler) csrfAwarePayload(response http.ResponseWriter, request *h
 			continue
 		}
 		if token == "" {
-			generated, err := handler.CSRF.Token(response)
+			generated, err := handler.CSRF.Token(response, request)
 			if err != nil {
 				response.Header().Set("Cache-Control", "no-store")
 				http.Error(response, "csrf token unavailable", http.StatusInternalServerError)

--- a/runtime/app/app_test.go
+++ b/runtime/app/app_test.go
@@ -286,14 +286,21 @@ func TestRecoverSSRRoutePanicUsesRouteErrorPage(t *testing.T) {
 	}
 }
 
-func TestRecoverSSRRoutePanicDoesNotWriteAfterHeaders(t *testing.T) {
+func TestRecoverSSRRoutePanicAbortsAfterHeaders(t *testing.T) {
 	recorder := httptest.NewRecorder()
 	writer := &boundaryResponseWriter{ResponseWriter: recorder}
 	writer.WriteHeader(http.StatusAccepted)
 
 	request := httptest.NewRequest(http.MethodGet, "/dashboard", nil)
-	RecoverSSRRoutePanic(writer, request, "secret panic detail")
+	recovered := func() (value any) {
+		defer func() { value = recover() }()
+		RecoverSSRRoutePanic(writer, request, "secret panic detail")
+		return nil
+	}()
 
+	if recovered != http.ErrAbortHandler {
+		t.Fatalf("expected started response to abort the connection, got %v", recovered)
+	}
 	if recorder.Code != http.StatusAccepted {
 		t.Fatalf("unexpected status: %d", recorder.Code)
 	}
@@ -407,7 +414,7 @@ type fakeCSRFTokenSource struct {
 	calls int
 }
 
-func (source *fakeCSRFTokenSource) Token(http.ResponseWriter) (string, error) {
+func (source *fakeCSRFTokenSource) Token(http.ResponseWriter, *http.Request) (string, error) {
 	source.calls++
 	return source.token, source.err
 }
@@ -1009,5 +1016,61 @@ func TestRecoverEndpointPanicUsesEndpointErrorPage(t *testing.T) {
 	}
 	if cache := recorder.Header().Get("Cache-Control"); cache != "no-store" {
 		t.Fatalf("expected no-store boundary response, got %q", cache)
+	}
+}
+
+func TestBoundaryRepanicsErrAbortHandler(t *testing.T) {
+	previous := BoundaryLogger
+	t.Cleanup(func() { BoundaryLogger = previous })
+	var logged string
+	BoundaryLogger = func(message string) { logged = message }
+
+	handler := Boundary("api", func(http.ResponseWriter, *http.Request) bool {
+		panic(http.ErrAbortHandler)
+	})
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/api/x", nil)
+
+	recovered := func() (value any) {
+		defer func() { value = recover() }()
+		handler(recorder, request)
+		return nil
+	}()
+	if recovered != http.ErrAbortHandler {
+		t.Fatalf("expected http.ErrAbortHandler to propagate, got %v", recovered)
+	}
+	if logged != "" {
+		t.Fatalf("deliberate abort should not be logged as a failure: %q", logged)
+	}
+}
+
+func TestBoundaryAbortsConnectionAfterResponseStarted(t *testing.T) {
+	previous := BoundaryLogger
+	t.Cleanup(func() { BoundaryLogger = previous })
+	var logged string
+	BoundaryLogger = func(message string) { logged = message }
+
+	handler := Boundary("api", func(writer http.ResponseWriter, _ *http.Request) bool {
+		if _, err := writer.Write([]byte("partial")); err != nil {
+			t.Fatal(err)
+		}
+		panic("boom mid-stream")
+	})
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/api/x", nil)
+
+	recovered := func() (value any) {
+		defer func() { value = recover() }()
+		handler(recorder, request)
+		return nil
+	}()
+	if recovered != http.ErrAbortHandler {
+		t.Fatalf("expected started response to abort the connection, got %v", recovered)
+	}
+	if logged == "" {
+		t.Fatal("expected mid-stream panic to be logged")
+	}
+	if body := recorder.Body.String(); body != "partial" {
+		t.Fatalf("expected truncated body to stay as written, got %q", body)
 	}
 }

--- a/runtime/app/boundary.go
+++ b/runtime/app/boundary.go
@@ -38,11 +38,20 @@ func Boundary(kind string, handler HandlerFunc) HandlerFunc {
 		boundaryWriter := &boundaryResponseWriter{ResponseWriter: writer}
 		defer func() {
 			if value := recover(); value != nil {
+				if value == http.ErrAbortHandler {
+					// Deliberate abort signal: let net/http kill the
+					// connection without logging it as a failure.
+					panic(value)
+				}
 				handled = true
 				logBoundaryPanic(kind, value)
-				if !boundaryWriter.wrote {
-					writeBoundaryError(boundaryWriter, request, kind, value)
+				if boundaryWriter.wrote {
+					// The response already started; aborting the connection
+					// is the only way to keep the client from treating the
+					// truncated body as complete.
+					panic(http.ErrAbortHandler)
 				}
+				writeBoundaryError(boundaryWriter, request, kind, value)
 			}
 		}()
 		return handler(boundaryWriter, request)
@@ -110,9 +119,12 @@ func RecoverSSRRoutePanic(writer http.ResponseWriter, request *http.Request, val
 	if value == nil {
 		return
 	}
+	if value == http.ErrAbortHandler {
+		panic(value)
+	}
 	logBoundaryPanic("ssr", value)
 	if written, ok := writer.(interface{ Written() bool }); ok && written.Written() {
-		return
+		panic(http.ErrAbortHandler)
 	}
 	WriteErrorPage(writer, request, http.StatusInternalServerError, "GOWDK SSR handler failed")
 }
@@ -123,9 +135,12 @@ func RecoverEndpointPanic(writer http.ResponseWriter, request *http.Request, val
 	if value == nil {
 		return
 	}
+	if value == http.ErrAbortHandler {
+		panic(value)
+	}
 	logBoundaryPanic("endpoint", value)
 	if written, ok := writer.(interface{ Written() bool }); ok && written.Written() {
-		return
+		panic(http.ErrAbortHandler)
 	}
 	WriteErrorPage(writer, request, http.StatusInternalServerError, "GOWDK endpoint handler failed")
 }

--- a/runtime/contracts/fileoutbox/fileoutbox.go
+++ b/runtime/contracts/fileoutbox/fileoutbox.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -38,6 +39,10 @@ type Record struct {
 // Store appends event envelopes to a JSON Lines file and can replay them as an
 // EventSource. Ack removes delivered records; Nack records retry metadata and
 // leaves records for later delivery.
+//
+// Store synchronizes access within a single process only. Pointing multiple
+// processes at the same outbox file is not supported and can lose or
+// double-deliver records.
 type Store struct {
 	mu             sync.Mutex
 	path           string
@@ -201,16 +206,18 @@ func (store *Store) ReceiveEventBatch(ctx context.Context) (contracts.EventBatch
 		limit = len(records)
 	}
 	selected := append([]Record(nil), records[:limit]...)
-	events, err := store.decodeRecordsLocked(selected)
+	events, acked, failed, decodeErr := store.decodeRecordsLocked(selected)
+	if len(failed) > 0 {
+		if err := store.markRecordsFailedLocked(failed, decodeErr); err != nil {
+			store.mu.Unlock()
+			return contracts.EventBatch{}, err
+		}
+	}
 	store.mu.Unlock()
-	if err != nil {
-		return contracts.EventBatch{}, err
+	if len(events) == 0 {
+		return contracts.EventBatch{}, decodeErr
 	}
 
-	acked := map[string]bool{}
-	for _, record := range selected {
-		acked[record.ID] = true
-	}
 	return contracts.EventBatch{
 		Events: events,
 		Ack: func(ctx context.Context) error {
@@ -245,24 +252,36 @@ func typeName[T any]() string {
 	return t.PkgPath() + "." + t.Name()
 }
 
-func (store *Store) decodeRecordsLocked(records []Record) ([]contracts.EventEnvelope, error) {
+// decodeRecordsLocked decodes records into typed envelopes. Records that have
+// no decoder or fail to decode are reported as failed instead of failing the
+// whole batch so one poison record cannot wedge delivery of the rest; failed
+// records flow through the regular Nack retry and dead-letter machinery.
+func (store *Store) decodeRecordsLocked(records []Record) ([]contracts.EventEnvelope, map[string]bool, map[string]bool, error) {
 	events := make([]contracts.EventEnvelope, 0, len(records))
+	decoded := map[string]bool{}
+	failed := map[string]bool{}
+	var failure error
 	for _, record := range records {
 		decoder := store.decoders[record.Type]
 		if decoder == nil {
-			return nil, fmt.Errorf("file outbox event %s has no decoder", record.Type)
+			failed[record.ID] = true
+			failure = errors.Join(failure, fmt.Errorf("file outbox event %s has no decoder", record.Type))
+			continue
 		}
 		value, err := decoder(record.Value)
 		if err != nil {
-			return nil, fmt.Errorf("file outbox event %s cannot be decoded: %w", record.Type, err)
+			failed[record.ID] = true
+			failure = errors.Join(failure, fmt.Errorf("file outbox event %s cannot be decoded: %w", record.Type, err))
+			continue
 		}
+		decoded[record.ID] = true
 		events = append(events, contracts.EventEnvelope{
 			Category: record.Category,
 			Type:     record.Type,
 			Value:    value,
 		})
 	}
-	return events, nil
+	return events, decoded, failed, failure
 }
 
 func (store *Store) readRecordsLocked() ([]Record, error) {

--- a/runtime/contracts/fileoutbox/fileoutbox_test.go
+++ b/runtime/contracts/fileoutbox/fileoutbox_test.go
@@ -241,6 +241,99 @@ func TestRunEventWorkerConsumesFileOutbox(t *testing.T) {
 	}
 }
 
+func TestReceiveEventBatchDeliversDecodableRecordsAroundPoisonRecord(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "outbox.jsonl")
+	store := New(path, WithJSONTypeDecoder[patientCreated]())
+	if err := store.StoreEvents(context.Background(), []contracts.EventEnvelope{
+		{Category: contracts.DomainEvent, Type: patientCreatedType, Value: 42},
+		{Category: contracts.DomainEvent, Type: patientCreatedType, Value: patientCreated{ID: "patient-1"}},
+	}); err != nil {
+		t.Fatalf("store events: %v", err)
+	}
+
+	batch, err := store.ReceiveEventBatch(context.Background())
+	if err != nil {
+		t.Fatalf("receive batch: %v", err)
+	}
+	if len(batch.Events) != 1 {
+		t.Fatalf("len(batch.Events) = %d, want 1", len(batch.Events))
+	}
+	if value, ok := batch.Events[0].Value.(patientCreated); !ok || value.ID != "patient-1" {
+		t.Fatalf("event value = %#v, want patientCreated patient-1", batch.Events[0].Value)
+	}
+	if err := batch.Ack(context.Background()); err != nil {
+		t.Fatalf("ack batch: %v", err)
+	}
+
+	records, err := store.Records(context.Background())
+	if err != nil {
+		t.Fatalf("records: %v", err)
+	}
+	if len(records) != 1 {
+		t.Fatalf("len(records) = %d, want 1 pending poison record", len(records))
+	}
+	if records[0].Attempts != 1 || !strings.Contains(records[0].LastError, "cannot be decoded") || records[0].LastAttemptAt == nil {
+		t.Fatalf("unexpected poison record retry metadata: %#v", records[0])
+	}
+}
+
+func TestReceiveEventBatchDeadLettersPoisonRecordAfterMaxAttempts(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "outbox.jsonl")
+	deadLetterPath := filepath.Join(root, "dead-letter.jsonl")
+	store := New(path, WithJSONTypeDecoder[patientCreated](), WithDeadLetter(deadLetterPath, 2))
+	if err := store.StoreEvents(context.Background(), []contracts.EventEnvelope{
+		{Category: contracts.DomainEvent, Type: patientCreatedType, Value: 42},
+		{Category: contracts.DomainEvent, Type: patientCreatedType, Value: patientCreated{ID: "patient-1"}},
+	}); err != nil {
+		t.Fatalf("store events: %v", err)
+	}
+
+	for attempt := 1; attempt <= 2; attempt++ {
+		batch, err := store.ReceiveEventBatch(context.Background())
+		if err != nil {
+			t.Fatalf("receive batch attempt %d: %v", attempt, err)
+		}
+		if len(batch.Events) != 1 {
+			t.Fatalf("len(batch.Events) attempt %d = %d, want 1", attempt, len(batch.Events))
+		}
+	}
+
+	records, err := store.Records(context.Background())
+	if err != nil {
+		t.Fatalf("records: %v", err)
+	}
+	for _, record := range records {
+		if record.LastError != "" {
+			t.Fatalf("expected poison record to leave pending outbox, still have %#v", record)
+		}
+	}
+	dead, err := store.DeadLetterRecords(context.Background())
+	if err != nil {
+		t.Fatalf("dead letter records: %v", err)
+	}
+	if len(dead) != 1 {
+		t.Fatalf("len(dead) = %d, want 1: %#v", len(dead), dead)
+	}
+	if dead[0].Attempts != 2 || !strings.Contains(dead[0].LastError, "cannot be decoded") {
+		t.Fatalf("unexpected dead letter metadata: %#v", dead[0])
+	}
+
+	batch, err := store.ReceiveEventBatch(context.Background())
+	if err != nil {
+		t.Fatalf("receive after dead-letter: %v", err)
+	}
+	if len(batch.Events) != 1 {
+		t.Fatalf("len(batch.Events) after dead-letter = %d, want 1", len(batch.Events))
+	}
+	if err := batch.Ack(context.Background()); err != nil {
+		t.Fatalf("ack after dead-letter: %v", err)
+	}
+	if _, err := store.ReceiveEventBatch(context.Background()); !errors.Is(err, contracts.ErrEventSourceClosed) {
+		t.Fatalf("receive after drain error = %v, want closed source", err)
+	}
+}
+
 func TestReceiveEventBatchRequiresDecoder(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "outbox.jsonl")
 	store := New(path)

--- a/runtime/contracts/redisstream/redisstream.go
+++ b/runtime/contracts/redisstream/redisstream.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/cssbruno/gowdk/runtime/contracts"
@@ -28,6 +29,13 @@ type Store struct {
 	batchSize int64
 	block     time.Duration
 	decoders  map[string]Decoder
+
+	mu sync.Mutex
+	// readPending makes the next receive re-read this consumer's pending
+	// entries (read but never acked) before consuming new messages. It starts
+	// true so entries stranded by a crash or restart are redelivered, and it
+	// is set again by Nack so failed batches are retried.
+	readPending bool
 }
 
 // Decoder converts one JSON event value into the typed value expected by
@@ -78,12 +86,13 @@ func WithJSONDecoder[T any](eventType string) Option {
 // New creates a Redis Streams store.
 func New(client *redis.Client, stream, group, consumer string, options ...Option) *Store {
 	store := &Store{
-		client:    client,
-		stream:    stream,
-		group:     group,
-		consumer:  consumer,
-		batchSize: defaultBatchSize,
-		decoders:  map[string]Decoder{},
+		client:      client,
+		stream:      stream,
+		group:       group,
+		consumer:    consumer,
+		batchSize:   defaultBatchSize,
+		decoders:    map[string]Decoder{},
+		readPending: true,
 	}
 	for _, option := range options {
 		if option != nil {
@@ -128,7 +137,9 @@ func (store *Store) PublishEvents(ctx context.Context, events []contracts.EventE
 	return nil
 }
 
-// ReceiveEventBatch reads the next stream batch for this consumer.
+// ReceiveEventBatch reads the next stream batch for this consumer. It first
+// drains this consumer's pending entries (read earlier but never acked, for
+// example before a crash or after a Nack) and only then consumes new messages.
 func (store *Store) ReceiveEventBatch(ctx context.Context) (contracts.EventBatch, error) {
 	if err := store.validate(); err != nil {
 		return contracts.EventBatch{}, err
@@ -136,18 +147,51 @@ func (store *Store) ReceiveEventBatch(ctx context.Context) (contracts.EventBatch
 	if err := ctx.Err(); err != nil {
 		return contracts.EventBatch{}, err
 	}
+	if store.pendingFirst() {
+		batch, ok, err := store.readBatch(ctx, "0")
+		if err != nil {
+			return contracts.EventBatch{}, err
+		}
+		if ok {
+			return batch, nil
+		}
+		store.setPendingFirst(false)
+	}
+	batch, ok, err := store.readBatch(ctx, ">")
+	if err != nil {
+		return contracts.EventBatch{}, err
+	}
+	if !ok {
+		return contracts.EventBatch{}, contracts.ErrEventSourceClosed
+	}
+	return batch, nil
+}
+
+func (store *Store) pendingFirst() bool {
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	return store.readPending
+}
+
+func (store *Store) setPendingFirst(pending bool) {
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	store.readPending = pending
+}
+
+func (store *Store) readBatch(ctx context.Context, start string) (contracts.EventBatch, bool, error) {
 	streams, err := store.client.XReadGroup(ctx, &redis.XReadGroupArgs{
 		Group:    store.group,
 		Consumer: store.consumer,
-		Streams:  []string{store.stream, ">"},
+		Streams:  []string{store.stream, start},
 		Count:    store.batchSize,
 		Block:    store.block,
 	}).Result()
 	if err != nil {
 		if errors.Is(err, redis.Nil) {
-			return contracts.EventBatch{}, contracts.ErrEventSourceClosed
+			return contracts.EventBatch{}, false, nil
 		}
-		return contracts.EventBatch{}, err
+		return contracts.EventBatch{}, false, err
 	}
 	var ids []string
 	var events []contracts.EventEnvelope
@@ -155,14 +199,14 @@ func (store *Store) ReceiveEventBatch(ctx context.Context) (contracts.EventBatch
 		for _, message := range stream.Messages {
 			event, err := store.decodeMessage(message)
 			if err != nil {
-				return contracts.EventBatch{}, err
+				return contracts.EventBatch{}, false, err
 			}
 			ids = append(ids, message.ID)
 			events = append(events, event)
 		}
 	}
 	if len(events) == 0 {
-		return contracts.EventBatch{}, contracts.ErrEventSourceClosed
+		return contracts.EventBatch{}, false, nil
 	}
 	return contracts.EventBatch{
 		Events: events,
@@ -175,7 +219,18 @@ func (store *Store) ReceiveEventBatch(ctx context.Context) (contracts.EventBatch
 			}
 			return store.client.XDel(ctx, store.stream, ids...).Err()
 		},
-	}, nil
+		Nack: func(ctx context.Context, cause error) error {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+			// The messages stay in this consumer's pending entries list;
+			// rewind the next read so they are redelivered. Redis tracks the
+			// delivery count for observability via XPENDING.
+			_ = cause
+			store.setPendingFirst(true)
+			return nil
+		},
+	}, true, nil
 }
 
 func (store *Store) validate() error {

--- a/runtime/contracts/redisstream/redisstream_test.go
+++ b/runtime/contracts/redisstream/redisstream_test.go
@@ -60,3 +60,18 @@ func TestValidateRequiresClientAndNames(t *testing.T) {
 		t.Fatalf("validate error = %v, want client required", err)
 	}
 }
+
+func TestNewStartsByDrainingPendingEntries(t *testing.T) {
+	store := New(nil, "events", "workers", "worker-1")
+	if !store.pendingFirst() {
+		t.Fatal("expected a new store to drain pending entries before new messages")
+	}
+	store.setPendingFirst(false)
+	if store.pendingFirst() {
+		t.Fatal("expected pending drain to be cleared")
+	}
+	store.setPendingFirst(true)
+	if !store.pendingFirst() {
+		t.Fatal("expected Nack rewind to re-enable the pending drain")
+	}
+}

--- a/runtime/contracts/worker.go
+++ b/runtime/contracts/worker.go
@@ -3,10 +3,26 @@ package contracts
 import (
 	"context"
 	"errors"
+	"log"
 )
 
 // ErrEventSourceClosed tells RunEventWorker that the source drained cleanly.
 var ErrEventSourceClosed = errors.New("event source closed")
+
+// WorkerLogger receives dispatch failures that RunEventWorker recovered from
+// by nacking the batch. Set it to nil to silence recovered-dispatch logging.
+// It defaults to the standard log package.
+var WorkerLogger func(message string) = func(message string) {
+	log.Print(message)
+}
+
+func logWorkerDispatchFailure(err error) {
+	logger := WorkerLogger
+	if logger == nil {
+		return
+	}
+	logger("gowdk: event worker nacked batch after dispatch failure: " + err.Error())
+}
 
 // EventBatch is one ordered delivery batch from an outbox, queue, or broker
 // adapter. Ack and Nack are optional adapter hooks.
@@ -28,7 +44,9 @@ func RunEventWorker(ctx context.Context, registry *Registry, source EventSource)
 }
 
 // RunEventWorkerForRole reads batches from source and dispatches them to
-// subscribers available to role.
+// subscribers available to role. Dispatch failures that the source accepts
+// through Nack are logged via WorkerLogger and the worker keeps consuming;
+// it only stops when ctx ends, the source closes, or Ack/Nack fail.
 func RunEventWorkerForRole(ctx context.Context, registry *Registry, role Role, source EventSource) error {
 	if source == nil {
 		return Error{Kind: ErrNilHandler, Message: "event source cannot be nil"}
@@ -58,12 +76,16 @@ func dispatchEventBatch(ctx context.Context, registry *Registry, role Role, batc
 		return ackEventBatch(ctx, batch)
 	}
 	if err := PublishEnvelopesForRole(ctx, registry, role, batch.Events); err != nil {
-		if batch.Nack != nil {
-			if nackErr := batch.Nack(ctx, err); nackErr != nil {
-				return errors.Join(err, nackErr)
-			}
+		if batch.Nack == nil {
+			return err
 		}
-		return err
+		if nackErr := batch.Nack(ctx, err); nackErr != nil {
+			return errors.Join(err, nackErr)
+		}
+		// The source accepted the Nack and owns redelivery, so the worker
+		// records the failure and keeps consuming instead of exiting.
+		logWorkerDispatchFailure(err)
+		return nil
 	}
 	return ackEventBatch(ctx, batch)
 }

--- a/runtime/contracts/worker_test.go
+++ b/runtime/contracts/worker_test.go
@@ -3,6 +3,7 @@ package contracts
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 )
 
@@ -72,12 +73,18 @@ func TestRunEventWorkerDispatchesAndAcks(t *testing.T) {
 	}
 }
 
-func TestRunEventWorkerNacksSubscriberFailure(t *testing.T) {
+func TestRunEventWorkerNacksSubscriberFailureAndContinues(t *testing.T) {
 	registry := NewRegistry()
 	subscriberErr := errors.New("subscriber unavailable")
 	must(t, RegisterDomainEvent[patientCreated](registry, func(ctx context.Context, event patientCreated) error {
 		return subscriberErr
 	}, RoleWorker))
+	var logged []string
+	previousLogger := WorkerLogger
+	WorkerLogger = func(message string) {
+		logged = append(logged, message)
+	}
+	defer func() { WorkerLogger = previousLogger }()
 	var acked int
 	var nackCause error
 	source := &scriptedEventSource{
@@ -96,6 +103,40 @@ func TestRunEventWorkerNacksSubscriberFailure(t *testing.T) {
 				return nil
 			},
 		}},
+		err: ErrEventSourceClosed,
+	}
+
+	if err := RunEventWorker(context.Background(), registry, source); err != nil {
+		t.Fatalf("run event worker error = %v, want nil after successful nack", err)
+	}
+	if source.received != 2 {
+		t.Fatalf("source.received = %d, want worker to keep consuming after nack", source.received)
+	}
+	if acked != 0 {
+		t.Fatalf("acked = %d, want 0", acked)
+	}
+	if !Is(nackCause, ErrSubscriberFailed) {
+		t.Fatalf("nack cause = %v, want subscriber failure", nackCause)
+	}
+	if len(logged) != 1 || !strings.Contains(logged[0], subscriberErr.Error()) {
+		t.Fatalf("logged = %#v, want one recovered dispatch failure", logged)
+	}
+}
+
+func TestRunEventWorkerReturnsSubscriberFailureWithoutNack(t *testing.T) {
+	registry := NewRegistry()
+	subscriberErr := errors.New("subscriber unavailable")
+	must(t, RegisterDomainEvent[patientCreated](registry, func(ctx context.Context, event patientCreated) error {
+		return subscriberErr
+	}, RoleWorker))
+	source := &scriptedEventSource{
+		batches: []EventBatch{{
+			Events: []EventEnvelope{{
+				Category: DomainEvent,
+				Type:     typeName[patientCreated](),
+				Value:    patientCreated{ID: "patient-1"},
+			}},
+		}},
 	}
 
 	err := RunEventWorker(context.Background(), registry, source)
@@ -104,12 +145,6 @@ func TestRunEventWorkerNacksSubscriberFailure(t *testing.T) {
 	}
 	if !errors.Is(err, subscriberErr) {
 		t.Fatalf("run event worker error = %v, want subscriber cause", err)
-	}
-	if acked != 0 {
-		t.Fatalf("acked = %d, want 0", acked)
-	}
-	if !Is(nackCause, ErrSubscriberFailed) {
-		t.Fatalf("nack cause = %v, want subscriber failure", nackCause)
 	}
 }
 


### PR DESCRIPTION
Fixes six verified bugs in the runtime and addons from the second-pass code review.

- `validateRedirectURL` accepted `/\evil.com`; browsers normalize `\` to `/`, making it protocol-relative — an open-redirect bypass. Backslashes are now rejected (`/%5C` stays valid: browsers don't percent-decode Location paths). Fixes #195
- fileoutbox decoded batches before returning them, so one undecodable record blocked the entire outbox forever and dead-lettering could never trigger; undecodable records now flow through the regular Attempts/dead-letter machinery. `RunEventWorker` also returned the dispatch error after a *successful* Nack, permanently stopping the worker on the first failing event; it now logs and keeps consuming, stopping only when ctx ends, the source closes, or Ack/Nack fail. Fixes #196
- redisstream was at-most-once: no Nack, and reads only with `">"` stranded read-but-unacked messages in the PEL forever. The store now drains this consumer's own pending entries (`"0"`) before consuming new messages and exposes a Nack that rewinds to the pending read. Note: unit-tested; the package has no live-Redis harness, so not verified against a real Redis. Fixes #197
- The CSRF cookie was rotated on every page render, so submits from any older open tab deterministically failed; the existing cookie is now reused while valid. Fixes #198
- The panic boundary logged deliberate `http.ErrAbortHandler` panics as failures and ended mid-stream panics as clean truncated responses; it now re-panics the abort sentinel, and started responses abort the connection. Fixes #199
- Cookie-rewritten HTML (the cookie notice) was served with conditional 304s and no `Vary: Cookie`, so the stale variant persisted after ack. Fixes #200

Regression tests added for each fix. All runtime/addons suites pass, including the nested modules.