### PR TITLE
fix(cli): LSP config loading, doctor --json, installer latest, VS Code extension hardening

### DIFF
--- a/cmd/gowdk/dev.go
+++ b/cmd/gowdk/dev.go
@@ -54,10 +54,11 @@ func dev(args []string) error {
 		fmt.Printf("Dev cache hit: inputs unchanged for %s\n", absDir)
 	}
 
-	reload := newLiveReloadBroker()
+	var reload *liveReloadBroker
 	var server *http.Server
 	var process *devRuntimeProcess
 	if runtime.Enabled {
+		fmt.Println("Live reload is not available for app targets; reload the browser manually after each rebuild.")
 		if _, err := appgen.BuildBinary(runtime.AppDir, runtime.BinaryPath); err != nil {
 			return err
 		}
@@ -67,6 +68,7 @@ func dev(args []string) error {
 		}
 		defer process.stop()
 	} else {
+		reload = newLiveReloadBroker()
 		server = &http.Server{
 			Addr:              options.Addr,
 			Handler:           liveReloadFileHandler(absDir, reload),

--- a/cmd/gowdk/doctor.go
+++ b/cmd/gowdk/doctor.go
@@ -101,7 +101,9 @@ func runDoctor(args []string) (doctorReport, bool) {
 			},
 		})
 		report.finalize()
-		return report, options.JSON
+		// parseProjectOptions stops at the first bad argument, so honor a
+		// requested --json output format regardless of flag order.
+		return report, options.JSON || argsRequestJSON(args)
 	}
 
 	report.Environment.ConfigPath = doctorConfigDisplayPath(configPath)
@@ -143,6 +145,17 @@ func runDoctor(args []string) (doctorReport, bool) {
 	report.runOptionalToolsCheck(options.Config)
 	report.finalize()
 	return report, options.JSON
+}
+
+// argsRequestJSON reports whether the raw arguments include --json, so error
+// reports can honor the requested format even when parsing stops early.
+func argsRequestJSON(args []string) bool {
+	for _, arg := range args {
+		if arg == "--json" {
+			return true
+		}
+	}
+	return false
 }
 
 func (report *doctorReport) runGOWDKCLICheck() {

--- a/cmd/gowdk/lsp.go
+++ b/cmd/gowdk/lsp.go
@@ -1,16 +1,60 @@
 package main
 
 import (
-	"fmt"
+	"errors"
 	"os"
+	"strings"
 
+	"github.com/cssbruno/gowdk"
+	"github.com/cssbruno/gowdk/addons/ssr"
 	"github.com/cssbruno/gowdk/internal/lsp"
+	"github.com/cssbruno/gowdk/internal/project"
 )
 
+const lspUsage = "usage: gowdk lsp [--config <file>] [--ssr]"
+
 func languageServer(args []string) error {
-	options, paths := parseOptions(args)
-	if len(paths) > 0 {
-		return fmt.Errorf("usage: gowdk lsp [--ssr]")
+	config, err := languageServerConfig(args)
+	if err != nil {
+		return err
 	}
-	return lsp.NewServer(options.Config).Serve(os.Stdin, os.Stdout)
+	return lsp.NewServer(config).Serve(os.Stdin, os.Stdout)
+}
+
+// languageServerConfig loads the project config for the language server the
+// same way check does, so config-declared addons (for example SSR) are honored
+// by editor diagnostics. When no config file exists and none was requested it
+// falls back to the flag-only config instead of failing.
+func languageServerConfig(args []string) (gowdk.Config, error) {
+	var options cliOptions
+	var configPath string
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		switch {
+		case arg == "--ssr":
+			options.Config.Addons = append(options.Config.Addons, ssr.Addon())
+		case arg == "--config":
+			i++
+			if i >= len(args) {
+				return gowdk.Config{}, errors.New(lspUsage)
+			}
+			configPath = args[i]
+		case strings.HasPrefix(arg, "--config="):
+			configPath = strings.TrimPrefix(arg, "--config=")
+		default:
+			return gowdk.Config{}, errors.New(lspUsage)
+		}
+	}
+	if strings.TrimSpace(configPath) == "" {
+		if _, err := os.Stat(project.DefaultConfigFile); err != nil {
+			if os.IsNotExist(err) {
+				return options.Config, nil
+			}
+			return gowdk.Config{}, err
+		}
+	}
+	if err := loadProjectConfig(&options, configPath); err != nil {
+		return gowdk.Config{}, err
+	}
+	return options.Config, nil
 }

--- a/cmd/gowdk/main.go
+++ b/cmd/gowdk/main.go
@@ -125,7 +125,7 @@ func usage() {
 	fmt.Println("  dev [--addr <addr>] [--interval <duration>] [build flags...] build, serve, rebuild, and live reload")
 	fmt.Println("  preview [--addr <addr>] [--hot] [build flags...] build and serve a local deploy preview")
 	fmt.Println("  serve --dir <dir> [--addr <addr>] serve generated build output locally")
-	fmt.Println("  lsp [--ssr]              start the language server over stdio")
+	fmt.Println("  lsp [--config <file>] [--ssr] start the language server over stdio")
 }
 
 type cliOptions struct {

--- a/cmd/gowdk/main_test.go
+++ b/cmd/gowdk/main_test.go
@@ -4669,3 +4669,115 @@ func waitForCLIStatus(url, method, body string) (*http.Response, error) {
 	}
 	return nil, os.ErrDeadlineExceeded
 }
+
+func TestLanguageServerConfigLoadsProjectConfigAddons(t *testing.T) {
+	root := t.TempDir()
+	writeCLIFile(t, filepath.Join(root, "gowdk.config.go"), `package app
+
+import (
+	"github.com/cssbruno/gowdk"
+	"github.com/cssbruno/gowdk/addons/ssr"
+)
+
+var Config = gowdk.Config{
+	Addons: []gowdk.Addon{
+		ssr.Addon(),
+	},
+}
+`)
+
+	withWorkingDir(t, root, func() {
+		config, err := languageServerConfig(nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(config.Addons) != 1 || config.Addons[0].Name() != "ssr" {
+			t.Fatalf("expected config-declared ssr addon, got %#v", config.Addons)
+		}
+	})
+}
+
+func TestLanguageServerConfigSupportsConfigFlag(t *testing.T) {
+	root := t.TempDir()
+	configPath := filepath.Join(root, "custom.config.go")
+	writeCLIFile(t, configPath, `package app
+
+import (
+	"github.com/cssbruno/gowdk"
+	"github.com/cssbruno/gowdk/addons/ssr"
+)
+
+var Config = gowdk.Config{
+	Addons: []gowdk.Addon{
+		ssr.Addon(),
+	},
+}
+`)
+
+	for _, args := range [][]string{
+		{"--config", configPath},
+		{"--config=" + configPath},
+	} {
+		config, err := languageServerConfig(args)
+		if err != nil {
+			t.Fatalf("languageServerConfig(%v): %v", args, err)
+		}
+		if len(config.Addons) != 1 || config.Addons[0].Name() != "ssr" {
+			t.Fatalf("languageServerConfig(%v): expected ssr addon, got %#v", args, config.Addons)
+		}
+	}
+}
+
+func TestLanguageServerConfigFallsBackWithoutConfigFile(t *testing.T) {
+	root := t.TempDir()
+	withWorkingDir(t, root, func() {
+		config, err := languageServerConfig(nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(config.Addons) != 0 {
+			t.Fatalf("expected zero config without gowdk.config.go, got %#v", config.Addons)
+		}
+
+		config, err = languageServerConfig([]string{"--ssr"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(config.Addons) != 1 || config.Addons[0].Name() != "ssr" {
+			t.Fatalf("expected --ssr addon without gowdk.config.go, got %#v", config.Addons)
+		}
+	})
+}
+
+func TestLanguageServerConfigRejectsUnknownArguments(t *testing.T) {
+	for _, args := range [][]string{
+		{"extra.gwdk"},
+		{"--unknown"},
+		{"--config"},
+	} {
+		if _, err := languageServerConfig(args); err == nil || !strings.Contains(err.Error(), "usage: gowdk lsp") {
+			t.Fatalf("languageServerConfig(%v): expected usage error, got %v", args, err)
+		}
+	}
+}
+
+func TestDoctorHonorsJSONFlagRegardlessOfOrderOnArgumentErrors(t *testing.T) {
+	for _, args := range [][]string{
+		{"--bad-flag", "--json"},
+		{"--json", "--bad-flag"},
+	} {
+		report, jsonOutput := runDoctor(args)
+		if !jsonOutput {
+			t.Fatalf("runDoctor(%v): expected JSON output to be requested", args)
+		}
+		if report.Status != "error" || !doctorReportHasCheck(report.Checks, "arguments", "error") {
+			t.Fatalf("runDoctor(%v): unexpected report %#v", args, report)
+		}
+	}
+}
+
+func TestLiveReloadBrokerNotifyIsNoOpOnNilBroker(t *testing.T) {
+	var broker *liveReloadBroker
+	broker.notify("reload")
+	broker.notifyData("build-error", "boom")
+}

--- a/cmd/gowdk/serve.go
+++ b/cmd/gowdk/serve.go
@@ -182,7 +182,12 @@ func (broker *liveReloadBroker) notify(event string) {
 	broker.notifyData(event, fmt.Sprint(time.Now().UnixMilli()))
 }
 
+// notifyData is a no-op on a nil broker so callers without live reload
+// (for example dev runtime mode) can skip wiring a broker entirely.
 func (broker *liveReloadBroker) notifyData(event string, data string) {
+	if broker == nil {
+		return
+	}
 	broker.mu.Lock()
 	defer broker.mu.Unlock()
 	for client := range broker.clients {

--- a/editors/vscode/extension.js
+++ b/editors/vscode/extension.js
@@ -9,6 +9,8 @@ const core = require('./extension-core');
 const LANGUAGE_ID = 'gwdk';
 const semanticLegend = new vscode.SemanticTokensLegend(core.SEMANTIC_TOKEN_TYPES, []);
 const missingExecutableNotifications = new Set();
+const projectMetadataCache = new Map();
+const projectDiagnosticUris = new Set();
 const treeIconColors = {
   page: new vscode.ThemeColor('charts.blue'),
   layout: new vscode.ThemeColor('charts.purple'),
@@ -26,6 +28,7 @@ function activate(context) {
   const siteMapTree = new SiteMapTreeProvider();
   const directoryOutline = new DirectoryOutlineTreeProvider();
   const refreshProjectViews = () => {
+    invalidateProjectMetadata();
     siteMapTree.refresh();
     directoryOutline.refresh();
   };
@@ -37,13 +40,13 @@ function activate(context) {
 
   context.subscriptions.push(vscode.workspace.onDidOpenTextDocument((doc) => validateSoon(doc, diagnostics, pending)));
   context.subscriptions.push(vscode.workspace.onDidChangeTextDocument((event) => validateSoon(event.document, diagnostics, pending)));
-  context.subscriptions.push(vscode.workspace.onDidSaveTextDocument((doc) => validateNow(doc, diagnostics)));
-  context.subscriptions.push(vscode.workspace.onDidCloseTextDocument((doc) => diagnostics.delete(doc.uri)));
   context.subscriptions.push(vscode.workspace.onDidSaveTextDocument((doc) => {
+    validateNow(doc, diagnostics);
     if (doc.languageId === LANGUAGE_ID) {
       refreshProjectViews();
     }
   }));
+  context.subscriptions.push(vscode.workspace.onDidCloseTextDocument((doc) => diagnostics.delete(doc.uri)));
 
   const watcher = vscode.workspace.createFileSystemWatcher('**/*.gwdk');
   context.subscriptions.push(watcher);
@@ -284,6 +287,8 @@ async function validateNow(document, diagnostics) {
   if (document.languageId !== LANGUAGE_ID || !config().get('enableDiagnostics')) {
     return;
   }
+  const startVersion = document.version;
+  const isStale = () => document.version !== startVersion;
   const root = projectRoot(document);
   const configPath = workspaceConfigPath(root);
   if (!configPath) {
@@ -299,6 +304,9 @@ async function validateNow(document, diagnostics) {
   try {
     if (document.uri.scheme === 'file' && !document.isDirty) {
       const projectReport = await loadProjectDiagnostics(document, configPath);
+      if (isStale()) {
+        return;
+      }
       if (projectReport) {
         setProjectDiagnostics(diagnostics, projectReport, document);
         return;
@@ -314,8 +322,14 @@ async function validateNow(document, diagnostics) {
       });
       return runGowdk(args, document).then(({ stdout }) => core.parseDiagnostics(stdout));
     });
+    if (isStale()) {
+      return;
+    }
     diagnostics.set(document.uri, report.map(toVSCodeDiagnostic));
   } catch (error) {
+    if (isStale()) {
+      return;
+    }
     const diagnostic = new vscode.Diagnostic(new vscode.Range(0, 0, 0, 1), error.message, vscode.DiagnosticSeverity.Error);
     diagnostic.source = 'gowdk';
     diagnostics.set(document.uri, [diagnostic]);
@@ -334,13 +348,28 @@ async function loadProjectDiagnostics(document, configPath) {
 }
 
 function setProjectDiagnostics(diagnostics, report, fallbackDocument) {
-  diagnostics.clear();
   const grouped = core.groupDiagnosticsByFile(report);
+  const nextUris = new Set();
   for (const [file, items] of Object.entries(grouped.files)) {
-    diagnostics.set(vscode.Uri.file(file), items.map(toVSCodeDiagnostic));
+    const uri = vscode.Uri.file(file);
+    diagnostics.set(uri, items.map(toVSCodeDiagnostic));
+    nextUris.add(uri.toString());
   }
   if (grouped.global.length > 0) {
     diagnostics.set(fallbackDocument.uri, grouped.global.map(toVSCodeDiagnostic));
+    nextUris.add(fallbackDocument.uri.toString());
+  }
+  if (!nextUris.has(fallbackDocument.uri.toString())) {
+    diagnostics.delete(fallbackDocument.uri);
+  }
+  for (const previous of projectDiagnosticUris) {
+    if (!nextUris.has(previous)) {
+      diagnostics.delete(vscode.Uri.parse(previous));
+    }
+  }
+  projectDiagnosticUris.clear();
+  for (const uri of nextUris) {
+    projectDiagnosticUris.add(uri);
   }
 }
 
@@ -368,13 +397,24 @@ async function withDocumentFile(document, callback) {
   }
 }
 
+function cliExecutionLimits() {
+  const settings = config();
+  const timeoutSeconds = Number(settings.get('cliTimeoutSeconds'));
+  const maxBufferMB = Number(settings.get('cliMaxBufferMB'));
+  return {
+    timeout: (Number.isFinite(timeoutSeconds) && timeoutSeconds > 0 ? timeoutSeconds : 60) * 1000,
+    maxBuffer: (Number.isFinite(maxBufferMB) && maxBufferMB > 0 ? maxBufferMB : 16) * 1024 * 1024
+  };
+}
+
 function runGowdk(args, document) {
   const invocation = toolInvocation(args, document);
+  const limits = cliExecutionLimits();
   return new Promise((resolve, reject) => {
     childProcess.execFile(invocation.command, invocation.args, {
       cwd: invocation.cwd,
-      timeout: 10000,
-      maxBuffer: 1024 * 1024
+      timeout: limits.timeout,
+      maxBuffer: limits.maxBuffer
     }, (error, stdout, stderr) => {
       if (error) {
         notifyMissingExecutable(invocation, error);
@@ -480,12 +520,36 @@ async function loadManifest(document) {
   return JSON.parse(stdout);
 }
 
-async function loadCompletionMetadata(document) {
-  const [siteMap, manifest, cssFiles] = await Promise.all([
+function invalidateProjectMetadata() {
+  projectMetadataCache.clear();
+}
+
+// loadSharedProjectMetadata memoizes the expensive project-wide metadata
+// (sitemap/manifest CLI runs plus CSS discovery) per project root, sharing one
+// in-flight promise across concurrent callers. The cache is invalidated by the
+// .gwdk/.css file watchers and save events through refreshProjectViews.
+function loadSharedProjectMetadata(document) {
+  const root = projectRoot(document) || '';
+  const cached = projectMetadataCache.get(root);
+  if (cached) {
+    return cached;
+  }
+  const promise = Promise.all([
     loadSiteMap(document),
     loadManifest(document),
     loadCSSFiles(document)
-  ]);
+  ]).then(([siteMap, manifest, cssFiles]) => ({ siteMap, manifest, cssFiles })).catch((error) => {
+    if (projectMetadataCache.get(root) === promise) {
+      projectMetadataCache.delete(root);
+    }
+    throw error;
+  });
+  projectMetadataCache.set(root, promise);
+  return promise;
+}
+
+async function loadCompletionMetadata(document) {
+  const { siteMap, manifest, cssFiles } = await loadSharedProjectMetadata(document);
   return {
     siteMap,
     manifest,
@@ -498,7 +562,7 @@ async function loadCompletionMetadata(document) {
 }
 
 async function loadProjectMetadata(document) {
-  return loadCompletionMetadata(document);
+  return loadSharedProjectMetadata(document);
 }
 
 function symbolContextForDocument(document, position) {

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -186,6 +186,18 @@
           "type": "boolean",
           "default": false,
           "description": "Pass --ssr to check/manifest commands so SSR pages validate as if the SSR addon is enabled."
+        },
+        "gowdk.cliTimeoutSeconds": {
+          "type": "number",
+          "default": 60,
+          "minimum": 1,
+          "description": "Timeout in seconds for gowdk CLI invocations. Raise this if `go run ./cmd/gowdk` builds are slow in source workspaces."
+        },
+        "gowdk.cliMaxBufferMB": {
+          "type": "number",
+          "default": 16,
+          "minimum": 1,
+          "description": "Maximum stdout/stderr buffer in megabytes for gowdk CLI invocations."
         }
       }
     }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -28,17 +28,33 @@ cleanup() {
 }
 trap cleanup EXIT INT TERM
 
-if [ "$version" = "latest" ]; then
-	api_url="https://api.github.com/repos/cssbruno/GoWDK/releases"
+fetch_release_json() {
 	if command -v curl >/dev/null 2>&1; then
-		curl -fsSL "$api_url" -o "$tmp_dir/releases.json"
-	elif command -v wget >/dev/null 2>&1; then
-		wget -qO "$tmp_dir/releases.json" "$api_url"
+		curl -fsSL "$1" -o "$2"
 	else
+		wget -qO "$2" "$1"
+	fi
+}
+
+release_tag_name() {
+	sed -n 's/.*"tag_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$1" | head -n 1
+}
+
+if [ "$version" = "latest" ]; then
+	api_base="https://api.github.com/repos/cssbruno/GoWDK/releases"
+	if ! command -v curl >/dev/null 2>&1 && ! command -v wget >/dev/null 2>&1; then
 		echo "curl or wget is required to download GOWDK" >&2
 		exit 1
 	fi
-	version="$(sed -n 's/.*"tag_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$tmp_dir/releases.json" | head -n 1)"
+	version=""
+	# /releases/latest excludes prereleases and drafts; the releases list is
+	# only a fallback because its first entry is order-sensitive.
+	if fetch_release_json "$api_base/latest" "$tmp_dir/latest.json"; then
+		version="$(release_tag_name "$tmp_dir/latest.json")"
+	fi
+	if [ -z "$version" ] && fetch_release_json "$api_base" "$tmp_dir/releases.json"; then
+		version="$(release_tag_name "$tmp_dir/releases.json")"
+	fi
 	if [ -z "$version" ]; then
 		echo "could not determine latest GOWDK release" >&2
 		exit 1


### PR DESCRIPTION
Fixes five verified bugs in the CLI, LSP entry point, installer, and VS Code extension from the second-pass code review.

- `gowdk lsp` never loaded `gowdk.config.go`, so config-declared addons (e.g. SSR) were invisible and the editor showed persistent errors that `gowdk check` didn't. The LSP now loads the project config the same way `check` does, with `--config` support. Fixes #201
- In runtime (generated-app) dev mode the reload broker had no server and no script injection, yet the loop kept notifying it — live reload was silently dead. The CLI now prints a clear one-time notice and skips the dead notify calls (a reload-injecting proxy remains future work). Fixes #202
- The VS Code extension spawned `gowdk sitemap` + `gowdk manifest` per hover/completion (a Go compile per hover in source workspaces), let stale async validations overwrite fresh diagnostics, wiped other files' diagnostics via `clear()`, and hard-coded 10s/1MB CLI limits. Metadata is now memoized with watcher invalidation and a shared in-flight promise; diagnostics are versioned and updated per-URI; limits default to 60s/16MB and are configurable (`gowdk.cliTimeoutSeconds`, `gowdk.cliMaxBufferMB`). Fixes #203
- `install.sh` took the first tag from `/releases`, which can be a prerelease; it now queries `/releases/latest` first with the list as fallback. Fixes #204
- `gowdk doctor --json` honored `--json` only if it preceded a bad argument; the format is now flag-order independent on argument errors. Fixes #205

Note: `TestInputChangeDetailsReportsChangedAddedAndRemovedPaths` fails on this branch exactly as it does on current `main` (verified on a clean checkout) — pre-existing, unrelated.

Regression tests added for the Go fixes; extension changes pass `node --check` and the existing `npm test` suite. `go build`, `go vet`, `gofmt`, and `sh -n` pass.