### PR TITLE
chore: remove lowering helpers orphaned by the manifest drop; update docs

### DIFF
--- a/docs/compiler/README.md
+++ b/docs/compiler/README.md
@@ -8,7 +8,7 @@ Implemented today:
 
 - Recursive `.gwdk` discovery through `internal/discover`.
 - Page and component metadata parsing through `internal/parser`.
-- Manifest and site-map models through `internal/manifest` and `internal/lang`.
+- IR-derived manifest JSON and site-map reports through `internal/lang`.
 - Render-rule, duplicate identity, redundant component, and component contract
   validation through `internal/compiler`.
 - SPA `view {}` markup and component invocation parsing through `internal/view`.

--- a/docs/engineering/architecture.md
+++ b/docs/engineering/architecture.md
@@ -131,13 +131,12 @@ fields there first.
 | `internal/discover` | Find portable `.gwdk` files from include/exclude patterns. | Compiler | Recursive glob discovery implemented. |
 | `internal/gwdkast` | Define the typed GOWDK source AST. | Compiler | Package declarations, typed page/component/layout/route/render/layout/guard/CSS declarations, component CSS scope/hash metadata, annotations, Go imports, GOWDK uses, stores, typed component contracts, blocks, endpoint declarations, parsed view nodes, literal records, and source spans implemented. |
 | `internal/parser` | Parse `.gwdk` files into AST and manifest structs. | Compiler | First-slice parser for pages, components, layouts, route params, imported Go build functions, action/API metadata, component CSS scope/hash metadata, GOWDK `use` declarations, package declarations, package spans, and source spans implemented. `ParseSyntax` returns `internal/gwdkast.File`; manifest records remain for compatibility while compiler entrypoints move to analyzer IR. |
-| `internal/gwdkanalysis` | Lower GOWDK AST into normalized compiler metadata. | Compiler | Lowers typed AST files into manifest compatibility records and `internal/gwdkir.Program`, including packages, routes, endpoints, templates, client behavior, source-selected assets with component CSS scope/hash metadata, stores, imports, uses, and source spans. |
+| `internal/gwdkanalysis` | Assemble `internal/gwdkir.Program` from parsed IR records. | Compiler | `BuildProgram` derives packages, routes, endpoints, templates, client behavior, source-selected assets with component CSS scope/hash metadata, stores, imports, uses, and source spans from parsed records; exposes standalone-endpoint and backend-binding attachment for post-assembly enrichment. |
 | `internal/gwdkir` | Stable internal compiler IR shared by generated-output passes. | Compiler | Versioned IR for packages, source files, page routes, backend endpoints, templates, client behavior, asset scope/hash metadata, and generated output plans implemented. |
 | `internal/view` | Parse and render the first spa `view {}` markup subset. | Compiler | Lowercase HTML elements, spa/boolean/expression attributes, shorthand class/id normalization, escaped text/attribute interpolation, self-closing component calls, prop/state interpolation, `g:on:*`, and `g:island` handling implemented. |
 | `internal/gotypes` | Resolve Go props/state contracts for components. | Compiler | Uses `go list`, `go/parser`, and `go/types` to resolve imported structs and state init signatures. |
-| `internal/lang` | Language tooling for lexing, diagnostics, formatting, checking, and manifest output. | Tools | Initial CLI-backed tools implemented. |
+| `internal/lang` | Language tooling for lexing, diagnostics, formatting, checking, and the IR-derived manifest JSON report. | Tools | Initial CLI-backed tools implemented. |
 | `internal/lsp` | Language Server Protocol bridge for diagnostics, formatting, completions, and hover. | Tools | Dependency-free stdio server implemented with baseline and open-project completions plus hover for known language tokens and open-project symbols. |
-| `internal/manifest` | Normalize discovered pages, routes, blocks, layouts, render modes, paths, and guards. | Compiler | Initial page model implemented. Public manifest JSON is currently narrower than the internal model. |
 | `internal/project` | Load project-level config, module source groups, build targets, and future source roots. | Compiler | SPA `gowdk.config.go` subset implemented for build discovery, output, and `Build.Targets`; project-level CLI commands require this config or an explicit `--config` file before compiling `.gwdk` code. |
 | `internal/compiler` | Validate manifests and coordinate compilation metadata. | Compiler | Render-mode, duplicate identity, redundant component implementation, component Go contract, saved default `go {}` package type-checking with sibling Go files, route shape, duplicate route param, duplicate route pattern, route-method, required page-view validation, default `go {}` backend endpoint binding fallback, and backend binding implemented. CLI route/endpoint reports now convert through `internal/gwdkir.Program`. |
 | `internal/buildgen` | Emit route-derived spa HTML files for build-time pages and SSR render artifacts. | Compiler | Disk builds, memory builds, incremental SPA builds, and SSR artifact planning consume `internal/gwdkir.Program`. Initial simple page, literal build data, imported Go build data calls, literal dynamic path expansion, component expansion, partial runtime asset emission, default JS island asset emission, component-level non-CSS asset emission, component-level WASM island asset emission, page-level `go client {}` WASM mount asset emission, concrete and dynamic SSR page rendering with declared `load {}` placeholders, route manifest emission, asset manifest emission, mandatory build report emission, identical-output write skipping, and incremental changed-page spa rendering implemented. |
@@ -323,8 +322,9 @@ same parser and compiler rules as `gowdk check`.
 flowchart LR
   Source[.gwdk files] --> Discover[internal/discover]
   Discover --> Parser[internal/parser]
-  Parser --> Manifest[internal/manifest]
-  Manifest --> Compiler[internal/compiler]
+  Parser --> IR[internal/gwdkir records]
+  IR --> Assembly[internal/gwdkanalysis]
+  Assembly --> Compiler[internal/compiler]
   Compiler --> Buildgen[internal/buildgen]
   Compiler --> Appgen[internal/appgen]
   Buildgen --> SPA[SPA pages/assets]

--- a/docs/engineering/testing.md
+++ b/docs/engineering/testing.md
@@ -77,7 +77,7 @@ must pass `--config <file>`.
   route output paths, and no partial output on unsupported pages.
 - `internal/lang` tests cover lexical tokenization, diagnostics, formatting, file checks, and manifest JSON from parsed source files.
 - `internal/lang` tests cover site-map JSON for movable page files.
-- `internal/manifest` tests cover route manifest JSON render/path/guard/action output.
+- `internal/lang` golden tests cover the IR-derived manifest JSON render/path/guard/action output.
 - `internal/compiler` tests cover route metadata for SPA/SSR routes, endpoint
   metadata for actions/APIs, and missing SSR addon rejection.
 - `internal/clientrt` tests cover the emitted partial-update runtime source and

--- a/docs/product/language-server.md
+++ b/docs/product/language-server.md
@@ -90,7 +90,7 @@ Developers editing `.gwdk` files need live feedback from the same language tooli
 
 ## Dependencies
 
-- Internal: `internal/lang`, `internal/parser`, `internal/compiler`, `internal/manifest`.
+- Internal: `internal/lang`, `internal/parser`, `internal/compiler`, `internal/gwdkir`.
 - External: none.
 
 ## Open Questions

--- a/internal/gwdkanalysis/routes.go
+++ b/internal/gwdkanalysis/routes.go
@@ -4,7 +4,6 @@ import (
 	"sort"
 
 	"github.com/cssbruno/gowdk/internal/gwdkir"
-	"github.com/cssbruno/gowdk/internal/source"
 )
 
 func routeParams(route string) []string {
@@ -18,36 +17,5 @@ func routeParams(route string) []string {
 		}
 	}
 	sort.Strings(out)
-	return out
-}
-
-func typedRouteParams(route string) []source.RouteParam {
-	params := gwdkir.RouteParamsFromPath(route)
-	out := make([]source.RouteParam, 0, len(params))
-	seen := map[string]bool{}
-	for _, param := range params {
-		if seen[param.Name] {
-			continue
-		}
-		seen[param.Name] = true
-		out = append(out, param)
-	}
-	return out
-}
-
-func routeParamSpans(route string, fallback source.SourceSpan) []source.NamedSpan {
-	params := routeParams(route)
-	out := make([]source.NamedSpan, 0, len(params))
-	for _, param := range params {
-		out = append(out, source.NamedSpan{Name: param, Span: fallback})
-	}
-	return out
-}
-
-func namedSpans(values []string, fallback source.SourceSpan) []source.NamedSpan {
-	out := make([]source.NamedSpan, 0, len(values))
-	for _, value := range values {
-		out = append(out, source.NamedSpan{Name: value, Span: fallback})
-	}
 	return out
 }

--- a/internal/gwdkanalysis/util.go
+++ b/internal/gwdkanalysis/util.go
@@ -1,10 +1,7 @@
 package gwdkanalysis
 
 import (
-	"fmt"
-	"strconv"
 	"strings"
-	"time"
 
 	"github.com/cssbruno/gowdk"
 	"github.com/cssbruno/gowdk/internal/gwdkir"
@@ -29,66 +26,6 @@ func assetUse(uses []gwdkir.Use, path string) (name string, useAlias string, use
 		}
 	}
 	return assetName, alias, ""
-}
-
-func splitCommaList(value string) []string {
-	parts := strings.Split(value, ",")
-	out := make([]string, 0, len(parts))
-	for _, part := range parts {
-		item := strings.TrimSpace(trimQuotes(part))
-		if item != "" {
-			out = append(out, item)
-		}
-	}
-	return out
-}
-
-func splitCSSList(value string) []string {
-	value = strings.ReplaceAll(value, ",", " ")
-	parts := strings.Fields(value)
-	out := make([]string, 0, len(parts))
-	for _, part := range parts {
-		item := strings.TrimSpace(trimQuotes(part))
-		if item != "" {
-			out = append(out, item)
-		}
-	}
-	return out
-}
-
-func cachePolicyValue(value string) (string, error) {
-	policy := strings.TrimSpace(trimQuotes(value))
-	if policy == "" {
-		return "", fmt.Errorf("@cache requires a value")
-	}
-	if strings.ContainsAny(policy, "\r\n") {
-		return "", fmt.Errorf("@cache must stay on one line")
-	}
-	return policy, nil
-}
-
-func revalidateSecondsValue(value string) (string, error) {
-	raw := strings.TrimSpace(trimQuotes(value))
-	if raw == "" {
-		return "", fmt.Errorf("@revalidate requires a value")
-	}
-	if strings.ContainsAny(raw, "\r\n") {
-		return "", fmt.Errorf("@revalidate must stay on one line")
-	}
-	if seconds, err := strconv.Atoi(raw); err == nil {
-		if seconds <= 0 {
-			return "", fmt.Errorf("@revalidate requires a positive duration")
-		}
-		return strconv.Itoa(seconds), nil
-	}
-	duration, err := time.ParseDuration(raw)
-	if err != nil || duration <= 0 {
-		return "", fmt.Errorf("@revalidate requires a positive duration such as 60s, 5m, or 1h")
-	}
-	if duration%time.Second != 0 {
-		return "", fmt.Errorf("@revalidate must resolve to whole seconds")
-	}
-	return strconv.FormatInt(int64(duration/time.Second), 10), nil
 }
 
 func spanForName(spans []source.NamedSpan, name string, fallback source.SourceSpan) source.SourceSpan {
@@ -125,10 +62,6 @@ func hasUse(values []gwdkir.Use, value gwdkir.Use) bool {
 		}
 	}
 	return false
-}
-
-func trimQuotes(value string) string {
-	return strings.Trim(strings.TrimSpace(value), `"`)
 }
 
 func routeKind(mode gowdk.RenderMode) gwdkir.RouteKind {


### PR DESCRIPTION
Follow-up audit after #210 ("is manifest fully dropped, anything not used anymore?"):

- **Code**: deletes the eight `gwdkanalysis` annotation/route helpers that only the removed AST→manifest lowering used (`splitCommaList`, `splitCSSList`, `cachePolicyValue`, `revalidateSecondsValue`, `trimQuotes`, `typedRouteParams`, `routeParamSpans`, `namedSpans`). Verified with `golang.org/x/tools/cmd/deadcode` diffed against `main`: with these gone, the branch introduces **zero net-new dead functions** — everything else flagged was already dead/test-only before the migration.
- **Docs**: the architecture package table and pipeline diagram, compiler README, language-server doc, and testing doc still described `internal/manifest`; they now describe the `parser → gwdkir records → gwdkanalysis.BuildProgram → compiler` pipeline and the IR-derived manifest JSON report.

Remaining `manifest` mentions in the tree are intentional: one historical comment in `internal/source`, the architecture doc's "former model removed" note, the completed migration plan in `.llm/plans/`, and local variables named `manifest` in `runtime/app`/`runtime/asset` that refer to route/asset manifests (a different concept).