### PR TITLE
refactor(compiler): make validators IR-native (#145, phase 2 — the bulk)

### DIFF
--- a/internal/compiler/backend_bindings.go
+++ b/internal/compiler/backend_bindings.go
@@ -306,7 +306,7 @@ func baseBackendBinding(page manifest.Page, kind, blockName, method, route strin
 func baseStandaloneBackendBinding(endpoint manifest.EndpointDeclaration, kind, method string, pkg featurePackage) manifest.BackendBinding {
 	return manifest.BackendBinding{
 		Kind:         kind,
-		PageID:       standaloneEndpointPageID(endpoint),
+		PageID:       standaloneEndpointDeclarationPageID(endpoint),
 		Source:       endpoint.Source,
 		BlockName:    endpoint.Name,
 		Method:       method,
@@ -316,6 +316,16 @@ func baseStandaloneBackendBinding(endpoint manifest.EndpointDeclaration, kind, m
 		FunctionName: endpoint.Name,
 		Status:       source.BackendBindingMissing,
 	}
+}
+
+// standaloneEndpointDeclarationPageID mirrors standaloneEndpointPageID for the
+// manifest-typed backend-binding discovery path, which is not part of the
+// IR-native structural validators.
+func standaloneEndpointDeclarationPageID(endpoint manifest.EndpointDeclaration) string {
+	if endpoint.Package == "" {
+		return endpoint.Name
+	}
+	return endpoint.Package + "." + endpoint.Name
 }
 
 func packageLabel(pkg featurePackage) string {

--- a/internal/compiler/manifest_from_ir.go
+++ b/internal/compiler/manifest_from_ir.go
@@ -122,7 +122,7 @@ func pageFromIR(page gwdkir.Page) manifest.Page {
 		Imports:     importsFromIR(page.Imports),
 		Uses:        usesFromIR(page.Uses),
 		Stores:      storesFromIR(page.Stores),
-		Paths:       page.Blocks.PathsBody != "",
+		Paths:       page.Blocks.Paths,
 		Blocks:      blocksFromIR(page.Blocks),
 		LoadBinding: loadBindingFromIR(page),
 		Spans: manifest.PageSpans{
@@ -333,10 +333,14 @@ func fragmentEndpointsFromIR(fragments []gwdkir.FragmentEndpoint) []manifest.Fra
 	return out
 }
 
+func importFromIR(item gwdkir.Import) manifest.Import {
+	return manifest.Import{Alias: item.Alias, Path: item.Path, Span: item.Span}
+}
+
 func importsFromIR(imports []gwdkir.Import) []manifest.Import {
 	out := make([]manifest.Import, 0, len(imports))
 	for _, item := range imports {
-		out = append(out, manifest.Import{Alias: item.Alias, Path: item.Path, Span: item.Span})
+		out = append(out, importFromIR(item))
 	}
 	return out
 }

--- a/internal/compiler/manifest_from_ir_test.go
+++ b/internal/compiler/manifest_from_ir_test.go
@@ -23,6 +23,7 @@ func sampleProgram() gwdkir.Program {
 			Layouts: []string{"root"},
 			Guards:  []string{"public"},
 			Blocks: gwdkir.Blocks{
+				Paths:     true,
 				Build:     true,
 				BuildBody: `=> { title: "Home" }`,
 				View:      true,
@@ -81,6 +82,9 @@ func TestManifestFromIRReconstructsCoreRecords(t *testing.T) {
 	}
 	if len(app.Pages[0].Blocks.Fragments) != 1 || app.Pages[0].Blocks.Fragments[0].Name != "List" {
 		t.Fatalf("fragment endpoints not preserved: %#v", app.Pages[0].Blocks.Fragments)
+	}
+	if !app.Pages[0].Paths {
+		t.Fatalf("paths block presence not preserved: %#v", app.Pages[0])
 	}
 	if len(app.Components) != 1 || app.Components[0].Name != "Counter" {
 		t.Fatalf("unexpected components: %#v", app.Components)

--- a/internal/compiler/routes.go
+++ b/internal/compiler/routes.go
@@ -5,12 +5,12 @@ import (
 	"strings"
 	"unicode"
 
-	"github.com/cssbruno/gowdk/internal/manifest"
+	"github.com/cssbruno/gowdk/internal/gwdkir"
 	"github.com/cssbruno/gowdk/internal/source"
 )
 
-func validateUniquePageRoutes(pages []manifest.Page) []ValidationError {
-	seen := map[string]manifest.Page{}
+func validateUniquePageRoutes(pages []gwdkir.Page) []ValidationError {
+	seen := map[string]gwdkir.Page{}
 	var diagnostics []ValidationError
 	for _, page := range pages {
 		info, issues := parseRoute(page.Route)
@@ -50,7 +50,7 @@ func duplicateRouteMessage(route, firstID, firstSource, duplicateID, duplicateSo
 	return message
 }
 
-func validateAmbiguousDynamicPageRoutes(pages []manifest.Page) []ValidationError {
+func validateAmbiguousDynamicPageRoutes(pages []gwdkir.Page) []ValidationError {
 	var dynamicRoutes []routeRegistration
 	var diagnostics []ValidationError
 	for _, page := range pages {
@@ -125,7 +125,7 @@ func routePatternSegments(pattern string) []string {
 	return strings.Split(trimmed, "/")
 }
 
-func validateRouteMethodConflicts(pages []manifest.Page, endpoints []manifest.EndpointDeclaration) []ValidationError {
+func validateRouteMethodConflicts(pages []gwdkir.Page, endpoints []gwdkir.GoEndpoint) []ValidationError {
 	seen := map[string]routeRegistration{}
 	var diagnostics []ValidationError
 	for _, registration := range routeRegistrations(pages, endpoints) {
@@ -166,7 +166,7 @@ type routeRegistration struct {
 	Span    source.SourceSpan
 }
 
-func routeRegistrations(pages []manifest.Page, endpoints []manifest.EndpointDeclaration) []routeRegistration {
+func routeRegistrations(pages []gwdkir.Page, endpoints []gwdkir.GoEndpoint) []routeRegistration {
 	var registrations []routeRegistration
 	for _, page := range pages {
 		pageInfo, pageIssues := parseRoute(page.Route)
@@ -280,10 +280,10 @@ func routeRegistrations(pages []manifest.Page, endpoints []manifest.EndpointDecl
 	return registrations
 }
 
-func validateStandaloneEndpoints(endpoints []manifest.EndpointDeclaration) []ValidationError {
+func validateStandaloneEndpoints(endpoints []gwdkir.GoEndpoint) []ValidationError {
 	var diagnostics []ValidationError
 	for _, endpoint := range endpoints {
-		page := manifest.Page{ID: standaloneEndpointPageID(endpoint), Source: endpoint.Source}
+		page := gwdkir.Page{ID: standaloneEndpointPageID(endpoint), Source: endpoint.Source}
 		if !isExportedHandlerName(endpoint.Name) {
 			diagnostics = append(diagnostics, ValidationError{
 				Code:    "invalid_backend_handler_name",
@@ -319,14 +319,14 @@ func validateStandaloneEndpoints(endpoints []manifest.EndpointDeclaration) []Val
 	return diagnostics
 }
 
-func standaloneEndpointPageID(endpoint manifest.EndpointDeclaration) string {
+func standaloneEndpointPageID(endpoint gwdkir.GoEndpoint) string {
 	if endpoint.Package == "" {
 		return endpoint.Name
 	}
 	return endpoint.Package + "." + endpoint.Name
 }
 
-func routeDiagnostics(page manifest.Page, label string, issues []routeIssue, routeSpan source.SourceSpan, paramSpans []source.NamedSpan) []ValidationError {
+func routeDiagnostics(page gwdkir.Page, label string, issues []routeIssue, routeSpan source.SourceSpan, paramSpans []source.NamedSpan) []ValidationError {
 	if len(issues) == 0 {
 		return nil
 	}

--- a/internal/compiler/validate.go
+++ b/internal/compiler/validate.go
@@ -3,6 +3,7 @@ package compiler
 import (
 	"fmt"
 	"github.com/cssbruno/gowdk"
+	"github.com/cssbruno/gowdk/internal/gwdkanalysis"
 	"github.com/cssbruno/gowdk/internal/gwdkir"
 	"github.com/cssbruno/gowdk/internal/manifest"
 	"github.com/cssbruno/gowdk/internal/source"
@@ -27,27 +28,29 @@ func (err ValidationError) Error() string {
 	return fmt.Sprintf("%s: %s", err.PageID, err.Message)
 }
 
-// ValidateManifest checks render-mode invariants that must hold before codegen.
-func ValidateManifest(config gowdk.Config, app manifest.Manifest) error {
+// ValidateProgram is the IR-native structural validation. It checks the
+// render-mode invariants that must hold before codegen by calling the migrated
+// validators directly on the IR, with no manifest intermediary.
+func ValidateProgram(config gowdk.Config, ir gwdkir.Program) error {
 	var diagnostics []ValidationError
-	diagnostics = append(diagnostics, validatePackages(app)...)
-	diagnostics = append(diagnostics, validateUniquePages(app.Pages)...)
-	diagnostics = append(diagnostics, validateUniqueComponents(app.Components)...)
-	diagnostics = append(diagnostics, validateComponentEmits(app.Components)...)
-	diagnostics = append(diagnostics, validateComponentGoContracts(app.Components)...)
-	diagnostics = append(diagnostics, validateComponentStoreUses(app.Pages, app.Components)...)
-	diagnostics = append(diagnostics, validateRedundantComponents(app.Components)...)
-	diagnostics = append(diagnostics, validateGOWDKUses(app)...)
-	diagnostics = append(diagnostics, validatePageAssetUses(app)...)
-	diagnostics = append(diagnostics, validateUniqueLayouts(app.Layouts)...)
-	diagnostics = append(diagnostics, validatePageLayoutReferences(app.Pages, app.Layouts)...)
-	diagnostics = append(diagnostics, validateGoBlocks(config, app)...)
-	diagnostics = append(diagnostics, validateUniquePageRoutes(app.Pages)...)
-	diagnostics = append(diagnostics, validateAmbiguousDynamicPageRoutes(app.Pages)...)
-	diagnostics = append(diagnostics, validateRouteMethodConflicts(app.Pages, app.Endpoints)...)
-	diagnostics = append(diagnostics, validateStandaloneEndpoints(app.Endpoints)...)
-	for _, page := range app.Pages {
-		diagnostics = append(diagnostics, ValidatePage(config, page)...)
+	diagnostics = append(diagnostics, validatePackages(ir)...)
+	diagnostics = append(diagnostics, validateUniquePages(ir.Pages)...)
+	diagnostics = append(diagnostics, validateUniqueComponents(ir.Components)...)
+	diagnostics = append(diagnostics, validateComponentEmits(ir.Components)...)
+	diagnostics = append(diagnostics, validateComponentGoContracts(ir.Components)...)
+	diagnostics = append(diagnostics, validateComponentStoreUses(ir.Pages, ir.Components)...)
+	diagnostics = append(diagnostics, validateRedundantComponents(ir.Components)...)
+	diagnostics = append(diagnostics, validateGOWDKUses(ir)...)
+	diagnostics = append(diagnostics, validatePageAssetUses(ir)...)
+	diagnostics = append(diagnostics, validateUniqueLayouts(ir.Layouts)...)
+	diagnostics = append(diagnostics, validatePageLayoutReferences(ir.Pages, ir.Layouts)...)
+	diagnostics = append(diagnostics, validateGoBlocks(config, ir)...)
+	diagnostics = append(diagnostics, validateUniquePageRoutes(ir.Pages)...)
+	diagnostics = append(diagnostics, validateAmbiguousDynamicPageRoutes(ir.Pages)...)
+	diagnostics = append(diagnostics, validateRouteMethodConflicts(ir.Pages, ir.GoEndpoints)...)
+	diagnostics = append(diagnostics, validateStandaloneEndpoints(ir.GoEndpoints)...)
+	for _, page := range ir.Pages {
+		diagnostics = append(diagnostics, validatePageIR(config, page)...)
 	}
 	if len(diagnostics) == 0 {
 		return nil
@@ -55,11 +58,17 @@ func ValidateManifest(config gowdk.Config, app manifest.Manifest) error {
 	return ValidationErrors(diagnostics)
 }
 
-// ValidateProgram checks the same render-mode invariants as ValidateManifest
-// against an IR-first build path. It reconstructs the manifest from IR via
-// ManifestFromIR so generated-output packages no longer need to carry their own
-// IR->manifest converter. As validators move to read IR directly, the converter
-// shrinks until this entrypoint reads IR with no manifest intermediary.
-func ValidateProgram(config gowdk.Config, ir gwdkir.Program) error {
-	return ValidateManifest(config, ManifestFromIR(ir))
+// ValidateManifest validates a parsed manifest by lowering it to IR first.
+func ValidateManifest(config gowdk.Config, app manifest.Manifest) error {
+	return ValidateProgram(config, gwdkanalysis.BuildIR(config, app))
+}
+
+// ValidatePage stays exported (tests call it with a manifest.Page); it lowers a
+// single page to IR and validates it.
+func ValidatePage(config gowdk.Config, page manifest.Page) []ValidationError {
+	ir := gwdkanalysis.BuildIR(config, manifest.Manifest{Pages: []manifest.Page{page}})
+	if len(ir.Pages) == 0 {
+		return nil
+	}
+	return validatePageIR(config, ir.Pages[0])
 }

--- a/internal/compiler/validate_assets.go
+++ b/internal/compiler/validate_assets.go
@@ -4,14 +4,14 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/cssbruno/gowdk/internal/manifest"
+	"github.com/cssbruno/gowdk/internal/gwdkir"
 )
 
-func validatePageAssetUses(app manifest.Manifest) []ValidationError {
-	sourcePackages := gowdkSourcePackages(app)
+func validatePageAssetUses(ir gwdkir.Program) []ValidationError {
+	sourcePackages := gowdkSourcePackages(ir)
 	var diagnostics []ValidationError
-	for _, page := range app.Pages {
-		usesByAlias := map[string]manifest.Use{}
+	for _, page := range ir.Pages {
+		usesByAlias := map[string]gwdkir.Use{}
 		for _, use := range page.Uses {
 			if _, exists := usesByAlias[use.Alias]; !exists {
 				usesByAlias[use.Alias] = use
@@ -59,19 +59,19 @@ func validatePageAssetUses(app manifest.Manifest) []ValidationError {
 	return diagnostics
 }
 
-func gowdkSourcePackages(app manifest.Manifest) map[string]bool {
+func gowdkSourcePackages(ir gwdkir.Program) map[string]bool {
 	sourcePackages := map[string]bool{}
-	for _, page := range app.Pages {
+	for _, page := range ir.Pages {
 		if page.Package != "" {
 			sourcePackages[page.Package] = true
 		}
 	}
-	for _, component := range app.Components {
+	for _, component := range ir.Components {
 		if component.Package != "" {
 			sourcePackages[component.Package] = true
 		}
 	}
-	for _, layout := range app.Layouts {
+	for _, layout := range ir.Layouts {
 		if layout.Package != "" {
 			sourcePackages[layout.Package] = true
 		}

--- a/internal/compiler/validate_component_client.go
+++ b/internal/compiler/validate_component_client.go
@@ -4,13 +4,13 @@ import (
 	"errors"
 	"fmt"
 	"github.com/cssbruno/gowdk/internal/clientlang"
-	"github.com/cssbruno/gowdk/internal/manifest"
+	"github.com/cssbruno/gowdk/internal/gwdkir"
 	"github.com/cssbruno/gowdk/internal/source"
 	"github.com/cssbruno/gowdk/internal/view"
 	"strings"
 )
 
-func validateComponentClient(component manifest.Component, stateTypes map[string]clientlang.ValueType, symbolTypes map[string]clientlang.ValueType) (map[string]clientlang.Handler, map[string]clientlang.Helper, map[string]clientlang.Ref, map[string]bool, map[string]clientlang.ValueType, []ValidationError) {
+func validateComponentClient(component gwdkir.Component, stateTypes map[string]clientlang.ValueType, symbolTypes map[string]clientlang.ValueType) (map[string]clientlang.Handler, map[string]clientlang.Helper, map[string]clientlang.Ref, map[string]bool, map[string]clientlang.ValueType, []ValidationError) {
 	if !component.Blocks.Client && strings.TrimSpace(component.Blocks.ClientBody) == "" {
 		return nil, nil, nil, nil, nil, nil
 	}
@@ -230,7 +230,7 @@ func validateComponentClient(component manifest.Component, stateTypes map[string
 	return handlers, helpers, refs, usedRefs, computedTypes, diagnostics
 }
 
-func componentEmitMap(component manifest.Component) map[string]clientlang.Emit {
+func componentEmitMap(component gwdkir.Component) map[string]clientlang.Emit {
 	if len(component.Emits) == 0 {
 		return nil
 	}
@@ -247,7 +247,7 @@ func componentEmitMap(component manifest.Component) map[string]clientlang.Emit {
 	return out
 }
 
-func clientStatementErrorSpan(component manifest.Component, statements []string, spans []clientlang.Span, err error) source.SourceSpan {
+func clientStatementErrorSpan(component gwdkir.Component, statements []string, spans []clientlang.Span, err error) source.SourceSpan {
 	var statementErr view.StatementValidationError
 	if errors.As(err, &statementErr) && statementErr.Index >= 0 && statementErr.Index < len(spans) {
 		if statementErr.Index < len(statements) {
@@ -258,7 +258,7 @@ func clientStatementErrorSpan(component manifest.Component, statements []string,
 	return firstSpan(component.Blocks.Spans.Client, component.Span)
 }
 
-func clientParseErrorSpan(component manifest.Component, err error) source.SourceSpan {
+func clientParseErrorSpan(component gwdkir.Component, err error) source.SourceSpan {
 	var parseErr *clientlang.ParseError
 	if errors.As(err, &parseErr) && parseErr.Line > 0 {
 		return clientSpan(component, clientlang.Span{StartLine: parseErr.Line, EndLine: parseErr.Line})
@@ -266,7 +266,7 @@ func clientParseErrorSpan(component manifest.Component, err error) source.Source
 	return firstSpan(component.Blocks.Spans.Client, component.Span)
 }
 
-func clientExpressionErrorSpan(component manifest.Component, statement string, span clientlang.Span, err error) source.SourceSpan {
+func clientExpressionErrorSpan(component gwdkir.Component, statement string, span clientlang.Span, err error) source.SourceSpan {
 	var exprErr clientlang.ExprValidationError
 	if !errors.As(err, &exprErr) || exprErr.Span.StartColumn <= 0 {
 		return clientSpan(component, span)
@@ -300,11 +300,11 @@ func functionReturnSpan(function clientlang.Function) clientlang.Span {
 	return function.StatementSpans[len(function.StatementSpans)-1]
 }
 
-func clientSpan(component manifest.Component, span clientlang.Span) source.SourceSpan {
+func clientSpan(component gwdkir.Component, span clientlang.Span) source.SourceSpan {
 	return clientSpanColumns(component, span, 1, 2)
 }
 
-func clientSpanColumns(component manifest.Component, span clientlang.Span, startColumn, endColumn int) source.SourceSpan {
+func clientSpanColumns(component gwdkir.Component, span clientlang.Span, startColumn, endColumn int) source.SourceSpan {
 	if span.StartLine <= 0 {
 		return firstSpan(component.Blocks.Spans.Client, component.Span)
 	}

--- a/internal/compiler/validate_component_contracts.go
+++ b/internal/compiler/validate_component_contracts.go
@@ -5,12 +5,12 @@ import (
 
 	"github.com/cssbruno/gowdk/internal/clientlang"
 	"github.com/cssbruno/gowdk/internal/gotypes"
-	"github.com/cssbruno/gowdk/internal/manifest"
+	"github.com/cssbruno/gowdk/internal/gwdkir"
 	"github.com/cssbruno/gowdk/internal/source"
 	"strings"
 )
 
-func validateComponentGoContracts(components []manifest.Component) []ValidationError {
+func validateComponentGoContracts(components []gwdkir.Component) []ValidationError {
 	var diagnostics []ValidationError
 	for _, component := range components {
 		diagnostics = append(diagnostics, validateComponentGoContract(component)...)
@@ -37,7 +37,7 @@ type componentValidationContext struct {
 	UsedRefs      map[string]bool
 }
 
-func validateComponentGoContract(component manifest.Component) []ValidationError {
+func validateComponentGoContract(component gwdkir.Component) []ValidationError {
 	var diagnostics []ValidationError
 	diagnostics = append(diagnostics, validateComponentImports(component)...)
 	if component.PropsType.Name != "" && len(component.Props) > 0 {
@@ -73,7 +73,7 @@ func validateComponentGoContract(component manifest.Component) []ValidationError
 	return diagnostics
 }
 
-func resolveComponentContracts(component manifest.Component) (componentContracts, []ValidationError) {
+func resolveComponentContracts(component gwdkir.Component) (componentContracts, []ValidationError) {
 	contracts := componentContracts{
 		Props:      map[string]bool{},
 		PropTypes:  map[string]clientlang.ValueType{},
@@ -87,7 +87,7 @@ func resolveComponentContracts(component manifest.Component) (componentContracts
 
 	var diagnostics []ValidationError
 	if component.PropsType.Name != "" {
-		resolved, err := gotypes.ResolveStruct(component.Imports, component.PropsType)
+		resolved, err := gotypes.ResolveStruct(importsFromIR(component.Imports), goTypeRefFromIR(component.PropsType))
 		if err != nil {
 			diagnostics = append(diagnostics, componentContractDiagnostic(component, "component_contract_error", component.PropsType.Span, err))
 		} else {
@@ -96,13 +96,13 @@ func resolveComponentContracts(component manifest.Component) (componentContracts
 	}
 
 	if component.State.Type.Name != "" {
-		resolved, err := gotypes.ResolveStruct(component.Imports, component.State.Type)
+		resolved, err := gotypes.ResolveStruct(importsFromIR(component.Imports), goTypeRefFromIR(component.State.Type))
 		if err != nil {
 			diagnostics = append(diagnostics, componentContractDiagnostic(component, "component_contract_error", component.State.Type.Span, err))
 		} else {
 			addResolvedFields(contracts.State, contracts.StateTypes, resolved)
 		}
-		if err := gotypes.ValidateStateInit(component.Imports, component.State); err != nil {
+		if err := gotypes.ValidateStateInit(importsFromIR(component.Imports), stateContractFromIR(component.State)); err != nil {
 			diagnostics = append(diagnostics, componentContractDiagnostic(component, "component_contract_error", component.State.Init.Span, err))
 		}
 	} else if component.State.Init.Name != "" {
@@ -122,7 +122,7 @@ func addResolvedFields(names map[string]bool, types map[string]clientlang.ValueT
 	}
 }
 
-func validateComponentContractOverlap(component manifest.Component, contracts componentContracts) []ValidationError {
+func validateComponentContractOverlap(component gwdkir.Component, contracts componentContracts) []ValidationError {
 	var diagnostics []ValidationError
 	for name := range contracts.Props {
 		if !contracts.State[name] {
@@ -139,15 +139,15 @@ func validateComponentContractOverlap(component manifest.Component, contracts co
 	return diagnostics
 }
 
-func validateComponentImports(component manifest.Component) []ValidationError {
+func validateComponentImports(component gwdkir.Component) []ValidationError {
 	var diagnostics []ValidationError
-	seen := map[string]manifest.Import{}
+	seen := map[string]gwdkir.Import{}
 	for _, item := range component.Imports {
 		if err := gotypes.ValidateImportPath(item.Path); err != nil {
 			diagnostics = append(diagnostics, componentContractDiagnostic(component, "invalid_go_import", item.Span, err))
 			continue
 		}
-		alias, err := gotypes.EffectiveImportAlias(item)
+		alias, err := gotypes.EffectiveImportAlias(importFromIR(item))
 		if err != nil {
 			diagnostics = append(diagnostics, componentContractDiagnostic(component, "invalid_go_import", item.Span, err))
 			continue
@@ -167,7 +167,7 @@ func validateComponentImports(component manifest.Component) []ValidationError {
 	return diagnostics
 }
 
-func componentContractDiagnostic(component manifest.Component, code string, span source.SourceSpan, err error) ValidationError {
+func componentContractDiagnostic(component gwdkir.Component, code string, span source.SourceSpan, err error) ValidationError {
 	return ValidationError{
 		Code:          code,
 		ComponentName: component.Name,
@@ -177,7 +177,7 @@ func componentContractDiagnostic(component manifest.Component, code string, span
 	}
 }
 
-func importSource(sourcePath string, item manifest.Import) string {
+func importSource(sourcePath string, item gwdkir.Import) string {
 	if sourcePath == "" {
 		return ""
 	}

--- a/internal/compiler/validate_component_fingerprint.go
+++ b/internal/compiler/validate_component_fingerprint.go
@@ -4,15 +4,15 @@ import (
 	"fmt"
 	"github.com/cssbruno/gowdk/internal/clientlang"
 	"github.com/cssbruno/gowdk/internal/gotypes"
-	"github.com/cssbruno/gowdk/internal/manifest"
+	"github.com/cssbruno/gowdk/internal/gwdkir"
 	"github.com/cssbruno/gowdk/internal/view"
 	"sort"
 	"strings"
 )
 
-func validateRedundantComponents(components []manifest.Component) []ValidationError {
+func validateRedundantComponents(components []gwdkir.Component) []ValidationError {
 	seenNames := map[string]bool{}
-	seen := map[string]manifest.Component{}
+	seen := map[string]gwdkir.Component{}
 	var diagnostics []ValidationError
 	for _, component := range components {
 		if component.Name == "" || seenNames[component.Name] {
@@ -45,7 +45,7 @@ func validateRedundantComponents(components []manifest.Component) []ValidationEr
 	return diagnostics
 }
 
-func componentFingerprint(component manifest.Component) string {
+func componentFingerprint(component gwdkir.Component) string {
 	parts := []string{
 		"props=" + componentPropsFingerprint(component),
 		"state=" + componentStateFingerprint(component),
@@ -55,7 +55,7 @@ func componentFingerprint(component manifest.Component) string {
 	return strings.Join(parts, "\n")
 }
 
-func componentPropsFingerprint(component manifest.Component) string {
+func componentPropsFingerprint(component gwdkir.Component) string {
 	if component.PropsType.Name != "" {
 		return "type:" + canonicalGoType(component.Imports, component.PropsType)
 	}
@@ -70,14 +70,14 @@ func componentPropsFingerprint(component manifest.Component) string {
 	return "inline:" + strings.Join(props, ",")
 }
 
-func componentStateFingerprint(component manifest.Component) string {
+func componentStateFingerprint(component gwdkir.Component) string {
 	if component.State.Type.Name == "" {
 		return ""
 	}
 	return canonicalGoType(component.Imports, component.State.Type) + "=init:" + canonicalGoFunc(component.Imports, component.State.Init)
 }
 
-func componentViewFingerprint(component manifest.Component) string {
+func componentViewFingerprint(component gwdkir.Component) string {
 	canonical, err := view.Canonical(component.Blocks.ViewBody)
 	if err == nil {
 		return canonical
@@ -85,7 +85,7 @@ func componentViewFingerprint(component manifest.Component) string {
 	return strings.Join(strings.Fields(component.Blocks.ViewBody), " ")
 }
 
-func componentClientFingerprint(component manifest.Component) string {
+func componentClientFingerprint(component gwdkir.Component) string {
 	if !component.Blocks.Client && strings.TrimSpace(component.Blocks.ClientBody) == "" {
 		return ""
 	}
@@ -96,16 +96,16 @@ func componentClientFingerprint(component manifest.Component) string {
 	return strings.Join(strings.Fields(component.Blocks.ClientBody), " ")
 }
 
-func canonicalGoType(imports []manifest.Import, ref manifest.GoTypeRef) string {
-	path, err := gotypes.ImportPathForAlias(imports, ref.Alias)
+func canonicalGoType(imports []gwdkir.Import, ref gwdkir.GoRef) string {
+	path, err := gotypes.ImportPathForAlias(importsFromIR(imports), ref.Alias)
 	if err != nil {
 		return ref.Alias + "." + ref.Name
 	}
 	return path + "." + ref.Name
 }
 
-func canonicalGoFunc(imports []manifest.Import, ref manifest.GoFuncRef) string {
-	path, err := gotypes.ImportPathForAlias(imports, ref.Alias)
+func canonicalGoFunc(imports []gwdkir.Import, ref gwdkir.GoRef) string {
+	path, err := gotypes.ImportPathForAlias(importsFromIR(imports), ref.Alias)
 	if err != nil {
 		return ref.Alias + "." + ref.Name
 	}

--- a/internal/compiler/validate_component_lists.go
+++ b/internal/compiler/validate_component_lists.go
@@ -5,12 +5,12 @@ import (
 	"strings"
 
 	"github.com/cssbruno/gowdk/internal/clientlang"
-	"github.com/cssbruno/gowdk/internal/manifest"
+	"github.com/cssbruno/gowdk/internal/gwdkir"
 	"github.com/cssbruno/gowdk/internal/source"
 	"github.com/cssbruno/gowdk/internal/view"
 )
 
-func validateComponentListDirectives(component manifest.Component, symbols map[string]clientlang.ValueType, stateTypes map[string]clientlang.ValueType, handlers map[string]clientlang.Handler, helpers map[string]clientlang.ExprFunction) []ValidationError {
+func validateComponentListDirectives(component gwdkir.Component, symbols map[string]clientlang.ValueType, stateTypes map[string]clientlang.ValueType, handlers map[string]clientlang.Handler, helpers map[string]clientlang.ExprFunction) []ValidationError {
 	nodes, err := view.Parse(component.Blocks.ViewBody)
 	if err != nil {
 		return nil
@@ -38,7 +38,7 @@ type spannedMessage struct {
 	Span    source.SourceSpan
 }
 
-func validateListNodes(nodes []view.Node, component manifest.Component, symbols map[string]clientlang.ValueType, stateTypes map[string]clientlang.ValueType, handlers map[string]clientlang.Handler, helpers map[string]clientlang.ExprFunction, messages *[]spannedMessage) {
+func validateListNodes(nodes []view.Node, component gwdkir.Component, symbols map[string]clientlang.ValueType, stateTypes map[string]clientlang.ValueType, handlers map[string]clientlang.Handler, helpers map[string]clientlang.ExprFunction, messages *[]spannedMessage) {
 	for _, node := range nodes {
 		switch typed := node.(type) {
 		case view.Element:
@@ -53,7 +53,7 @@ func validateListNodes(nodes []view.Node, component manifest.Component, symbols 
 	}
 }
 
-func validateListElement(element view.Element, loopAttr view.Attr, component manifest.Component, symbols map[string]clientlang.ValueType, stateTypes map[string]clientlang.ValueType, handlers map[string]clientlang.Handler, helpers map[string]clientlang.ExprFunction, messages *[]spannedMessage) {
+func validateListElement(element view.Element, loopAttr view.Attr, component gwdkir.Component, symbols map[string]clientlang.ValueType, stateTypes map[string]clientlang.ValueType, handlers map[string]clientlang.Handler, helpers map[string]clientlang.ExprFunction, messages *[]spannedMessage) {
 	loopSpan := viewBodyNeedleSpan(component, loopAttr.Value)
 	loop, err := view.ParseForDirective(loopAttr.Value)
 	if err != nil {
@@ -93,7 +93,7 @@ func validateLoopSubtree(node view.Node, readSymbols map[string]clientlang.Value
 		validateInterpolations(typed.Value, readSymbols, messages)
 	case view.Element:
 		if loopAttr, hasLoop := elementForDirective(typed); hasLoop {
-			validateListElement(typed, loopAttr, manifest.Component{}, readSymbols, writeSymbols, handlers, helpers, messages)
+			validateListElement(typed, loopAttr, gwdkir.Component{}, readSymbols, writeSymbols, handlers, helpers, messages)
 			return
 		}
 		validateLoopElementBody(typed, readSymbols, writeSymbols, handlers, helpers, messages)

--- a/internal/compiler/validate_component_view_contract.go
+++ b/internal/compiler/validate_component_view_contract.go
@@ -5,11 +5,11 @@ import (
 	"strings"
 
 	"github.com/cssbruno/gowdk/internal/clientlang"
-	"github.com/cssbruno/gowdk/internal/manifest"
+	"github.com/cssbruno/gowdk/internal/gwdkir"
 	"github.com/cssbruno/gowdk/internal/view"
 )
 
-func validateComponentViewContract(component manifest.Component, ctx componentValidationContext) []ValidationError {
+func validateComponentViewContract(component gwdkir.Component, ctx componentValidationContext) []ValidationError {
 	viewRefs, err := componentViewReferences(component.Blocks.ViewBody)
 	if err != nil {
 		return []ValidationError{{
@@ -35,7 +35,7 @@ func validateComponentViewContract(component manifest.Component, ctx componentVa
 	return diagnostics
 }
 
-func validateUnknownViewFields(component manifest.Component, ctx componentValidationContext, viewRefs componentViewRefs) []ValidationError {
+func validateUnknownViewFields(component gwdkir.Component, ctx componentValidationContext, viewRefs componentViewRefs) []ValidationError {
 	var diagnostics []ValidationError
 	for field := range viewRefs.Fields {
 		if ctx.Props[field] || ctx.State[field] {
@@ -55,7 +55,7 @@ func validateUnknownViewFields(component manifest.Component, ctx componentValida
 	return diagnostics
 }
 
-func validateViewEventExpressions(component manifest.Component, ctx componentValidationContext, viewRefs componentViewRefs, helperFuncs map[string]clientlang.ExprFunction, emits map[string]clientlang.Emit) []ValidationError {
+func validateViewEventExpressions(component gwdkir.Component, ctx componentValidationContext, viewRefs componentViewRefs, helperFuncs map[string]clientlang.ExprFunction, emits map[string]clientlang.Emit) []ValidationError {
 	var diagnostics []ValidationError
 	for _, eventExpr := range viewRefs.Events {
 		if _, err := view.ParseEventDirective(eventExpr.Name); err != nil {
@@ -93,7 +93,7 @@ func mergeClientSymbols(left, right map[string]clientlang.ValueType) map[string]
 	return out
 }
 
-func validateViewBooleanExpressions(component manifest.Component, ctx componentValidationContext, viewRefs componentViewRefs) []ValidationError {
+func validateViewBooleanExpressions(component gwdkir.Component, ctx componentValidationContext, viewRefs componentViewRefs) []ValidationError {
 	var diagnostics []ValidationError
 	for _, expr := range viewRefs.Bools {
 		if err := view.ValidateIslandBoolExpressionTyped(expr, ctx.SymbolTypes); err != nil {
@@ -109,7 +109,7 @@ func validateViewBooleanExpressions(component manifest.Component, ctx componentV
 	return diagnostics
 }
 
-func validateViewAttributeExpressions(component manifest.Component, ctx componentValidationContext, viewRefs componentViewRefs) []ValidationError {
+func validateViewAttributeExpressions(component gwdkir.Component, ctx componentValidationContext, viewRefs componentViewRefs) []ValidationError {
 	var diagnostics []ValidationError
 	for _, attrExpr := range viewRefs.Attrs {
 		if err := view.ValidateReactiveAttrExpressionTyped(attrExpr.Name, attrExpr.Expression, ctx.SymbolTypes); err != nil {
@@ -147,7 +147,7 @@ func validateViewAttributeExpressions(component manifest.Component, ctx componen
 	return diagnostics
 }
 
-func validateViewValueBinds(component manifest.Component, ctx componentValidationContext, viewRefs componentViewRefs) []ValidationError {
+func validateViewValueBinds(component gwdkir.Component, ctx componentValidationContext, viewRefs componentViewRefs) []ValidationError {
 	var diagnostics []ValidationError
 	for _, field := range viewRefs.ValueBinds {
 		diagnostics = append(diagnostics, validateViewValueBind(component, ctx, field)...)
@@ -155,7 +155,7 @@ func validateViewValueBinds(component manifest.Component, ctx componentValidatio
 	return diagnostics
 }
 
-func validateViewValueBind(component manifest.Component, ctx componentValidationContext, field valueBindExpr) []ValidationError {
+func validateViewValueBind(component gwdkir.Component, ctx componentValidationContext, field valueBindExpr) []ValidationError {
 	typ, ok := ctx.StateTypes[field.Field]
 	if !ok {
 		return []ValidationError{componentFieldError(component, fmt.Sprintf("component %s g:bind:value target %q must be a state field", component.Name, field.Field))}
@@ -178,7 +178,7 @@ func validateViewValueBind(component manifest.Component, ctx componentValidation
 	return []ValidationError{componentFieldError(component, fmt.Sprintf("component %s g:bind:value target %q must be string or numeric, got %s", component.Name, field.Field, typ))}
 }
 
-func validateViewCheckedBinds(component manifest.Component, ctx componentValidationContext, viewRefs componentViewRefs) []ValidationError {
+func validateViewCheckedBinds(component gwdkir.Component, ctx componentValidationContext, viewRefs componentViewRefs) []ValidationError {
 	var diagnostics []ValidationError
 	for _, field := range viewRefs.CheckedBinds {
 		typ, ok := ctx.StateTypes[field]
@@ -193,7 +193,7 @@ func validateViewCheckedBinds(component manifest.Component, ctx componentValidat
 	return diagnostics
 }
 
-func validateViewRefBinds(component manifest.Component, ctx componentValidationContext, viewRefs componentViewRefs) []ValidationError {
+func validateViewRefBinds(component gwdkir.Component, ctx componentValidationContext, viewRefs componentViewRefs) []ValidationError {
 	boundRefs := map[string]bool{}
 	var diagnostics []ValidationError
 	for _, refName := range viewRefs.RefBinds {
@@ -225,7 +225,7 @@ func validateViewRefBinds(component manifest.Component, ctx componentValidationC
 	return diagnostics
 }
 
-func componentFieldError(component manifest.Component, message string) ValidationError {
+func componentFieldError(component gwdkir.Component, message string) ValidationError {
 	return ValidationError{
 		Code:          "component_field_error",
 		ComponentName: component.Name,

--- a/internal/compiler/validate_differential_test.go
+++ b/internal/compiler/validate_differential_test.go
@@ -1,6 +1,7 @@
 package compiler_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/cssbruno/gowdk"
@@ -9,12 +10,15 @@ import (
 	"github.com/cssbruno/gowdk/internal/manifest"
 )
 
-// TestValidateProgramMatchesValidateManifestDifferential is the safety proof for
-// flipping the CLI to validate IR instead of the parsed manifest: for a corpus of
-// valid and invalid programs, ValidateProgram(BuildIR(app)) must produce the exact
-// same diagnostics as ValidateManifest(app). If this ever diverges, the IR round
-// trip has lost or reordered something a validator depends on.
-func TestValidateProgramMatchesValidateManifestDifferential(t *testing.T) {
+// TestValidateProgramScenarios exercises the IR-native validators end to end
+// through both public entry points. ValidateManifest is now a thin adapter over
+// ValidateProgram(BuildIR(app)), so both must surface the same diagnostic for
+// each scenario — including the standalone-endpoint and route-conflict cases
+// that motivated #145 (these read manifest.Endpoints, reconstructed from the
+// lossless gwdkir.GoEndpoint mirror). Each case asserts the concrete expected
+// diagnostic rather than just comparing the two paths, so the test guards real
+// behavior and not a tautology.
+func TestValidateProgramScenarios(t *testing.T) {
 	view := func(body string) manifest.Blocks { return manifest.Blocks{View: true, ViewBody: body} }
 	page := func(id, route string) manifest.Page {
 		return manifest.Page{ID: id, Route: route, Package: "pages", Source: id + ".page.gwdk", Blocks: view("<main/>")}
@@ -23,18 +27,22 @@ func TestValidateProgramMatchesValidateManifestDifferential(t *testing.T) {
 	cases := []struct {
 		name string
 		app  manifest.Manifest
+		want string // expected diagnostic substring; "" means must validate cleanly
 	}{
 		{
 			name: "valid program",
 			app:  manifest.Manifest{Pages: []manifest.Page{page("home", "/"), page("about", "/about")}},
+			want: "",
 		},
 		{
 			name: "duplicate page identity",
 			app:  manifest.Manifest{Pages: []manifest.Page{page("home", "/"), page("home", "/other")}},
+			want: "home",
 		},
 		{
 			name: "duplicate route pattern",
 			app:  manifest.Manifest{Pages: []manifest.Page{page("home", "/dup"), page("other", "/dup")}},
+			want: "/dup",
 		},
 		{
 			name: "invalid standalone endpoint handler",
@@ -45,6 +53,7 @@ func TestValidateProgramMatchesValidateManifestDifferential(t *testing.T) {
 					Source: "h/x.go", Name: "lowercase", Method: "POST", Route: "/x",
 				}},
 			},
+			want: "must be an exported Go identifier",
 		},
 		{
 			name: "route method conflict between page and standalone endpoint",
@@ -55,6 +64,7 @@ func TestValidateProgramMatchesValidateManifestDifferential(t *testing.T) {
 					Source: "h/x.go", Name: "Clash", Method: "GET", Route: "/clash",
 				}},
 			},
+			want: "conflicts with",
 		},
 		{
 			name: "standalone action with unsupported method",
@@ -64,6 +74,7 @@ func TestValidateProgramMatchesValidateManifestDifferential(t *testing.T) {
 					Source: "h/x.go", Name: "Save", Method: "DELETE", Route: "/save",
 				}},
 			},
+			want: "actions currently require POST",
 		},
 	}
 
@@ -71,10 +82,21 @@ func TestValidateProgramMatchesValidateManifestDifferential(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			viaManifest := errText(compiler.ValidateManifest(config, tc.app))
-			ir := gwdkanalysis.BuildIR(config, tc.app)
-			viaProgram := errText(compiler.ValidateProgram(config, ir))
+			viaProgram := errText(compiler.ValidateProgram(config, gwdkanalysis.BuildIR(config, tc.app)))
+
+			// Both entry points must agree (ValidateManifest adapts to ValidateProgram).
 			if viaManifest != viaProgram {
-				t.Fatalf("diagnostic drift between manifest and IR validation:\nmanifest: %q\nIR:       %q", viaManifest, viaProgram)
+				t.Fatalf("entry points disagree:\nValidateManifest: %q\nValidateProgram:  %q", viaManifest, viaProgram)
+			}
+			// And the concrete diagnostic must match the scenario's expectation.
+			if tc.want == "" {
+				if viaProgram != "" {
+					t.Fatalf("expected clean validation, got: %q", viaProgram)
+				}
+				return
+			}
+			if !strings.Contains(viaProgram, tc.want) {
+				t.Fatalf("expected diagnostic containing %q, got: %q", tc.want, viaProgram)
 			}
 		})
 	}

--- a/internal/compiler/validate_identity.go
+++ b/internal/compiler/validate_identity.go
@@ -4,11 +4,11 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/cssbruno/gowdk/internal/manifest"
+	"github.com/cssbruno/gowdk/internal/gwdkir"
 )
 
-func validateUniquePages(pages []manifest.Page) []ValidationError {
-	seen := map[string]manifest.Page{}
+func validateUniquePages(pages []gwdkir.Page) []ValidationError {
+	seen := map[string]gwdkir.Page{}
 	var diagnostics []ValidationError
 	for _, page := range pages {
 		if page.ID == "" {
@@ -35,8 +35,8 @@ func validateUniquePages(pages []manifest.Page) []ValidationError {
 	return diagnostics
 }
 
-func validateUniqueLayouts(layouts []manifest.Layout) []ValidationError {
-	seen := map[string]manifest.Layout{}
+func validateUniqueLayouts(layouts []gwdkir.Layout) []ValidationError {
+	seen := map[string]gwdkir.Layout{}
 	var diagnostics []ValidationError
 	for _, layout := range layouts {
 		if layout.ID == "" {
@@ -63,11 +63,11 @@ func validateUniqueLayouts(layouts []manifest.Layout) []ValidationError {
 	return diagnostics
 }
 
-func validatePageLayoutReferences(pages []manifest.Page, layouts []manifest.Layout) []ValidationError {
+func validatePageLayoutReferences(pages []gwdkir.Page, layouts []gwdkir.Layout) []ValidationError {
 	if len(layouts) == 0 {
 		return nil
 	}
-	declared := map[string]manifest.Layout{}
+	declared := map[string]gwdkir.Layout{}
 	for _, layout := range layouts {
 		if layout.ID != "" {
 			declared[layoutIdentityKey(layout.Package, layout.ID)] = layout
@@ -140,8 +140,8 @@ func validatePageLayoutReferences(pages []manifest.Page, layouts []manifest.Layo
 	return diagnostics
 }
 
-func pageUsesByAlias(page manifest.Page) map[string]manifest.Use {
-	usesByAlias := map[string]manifest.Use{}
+func pageUsesByAlias(page gwdkir.Page) map[string]gwdkir.Use {
+	usesByAlias := map[string]gwdkir.Use{}
 	for _, use := range page.Uses {
 		if _, exists := usesByAlias[use.Alias]; !exists {
 			usesByAlias[use.Alias] = use
@@ -164,8 +164,8 @@ func layoutDisplayName(packageName, layoutID string) string {
 	return packageName + "." + layoutID
 }
 
-func validateUniqueComponents(components []manifest.Component) []ValidationError {
-	seen := map[string]manifest.Component{}
+func validateUniqueComponents(components []gwdkir.Component) []ValidationError {
+	seen := map[string]gwdkir.Component{}
 	var diagnostics []ValidationError
 	for _, component := range components {
 		if component.Name == "" {
@@ -192,10 +192,10 @@ func validateUniqueComponents(components []manifest.Component) []ValidationError
 	return diagnostics
 }
 
-func validateComponentEmits(components []manifest.Component) []ValidationError {
+func validateComponentEmits(components []gwdkir.Component) []ValidationError {
 	var diagnostics []ValidationError
 	for _, component := range components {
-		seen := map[string]manifest.Emit{}
+		seen := map[string]gwdkir.Emit{}
 		for _, event := range component.Emits {
 			if event.Name == "" {
 				continue

--- a/internal/compiler/validate_packages.go
+++ b/internal/compiler/validate_packages.go
@@ -18,7 +18,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/cssbruno/gowdk/internal/manifest"
+	"github.com/cssbruno/gowdk/internal/gwdkir"
 	"github.com/cssbruno/gowdk/internal/source"
 )
 
@@ -28,8 +28,8 @@ type packageDeclaration struct {
 	PageID        string
 	ComponentName string
 	Package       string
-	Imports       []manifest.Import
-	GoBlocks      []manifest.GoBlock
+	Imports       []gwdkir.Import
+	GoBlocks      []gwdkir.GoBlock
 	Span          source.SourceSpan
 }
 
@@ -39,8 +39,8 @@ type goPackageInfo struct {
 	Diagnostics []ValidationError
 }
 
-func validatePackages(app manifest.Manifest) []ValidationError {
-	declarations := packageDeclarations(app)
+func validatePackages(ir gwdkir.Program) []ValidationError {
+	declarations := packageDeclarations(ir)
 	var diagnostics []ValidationError
 	byDir := map[string][]packageDeclaration{}
 	for _, declaration := range declarations {
@@ -103,9 +103,9 @@ func shouldValidatePackageSource(sourcePath string) bool {
 	return false
 }
 
-func packageDeclarations(app manifest.Manifest) []packageDeclaration {
+func packageDeclarations(ir gwdkir.Program) []packageDeclaration {
 	var declarations []packageDeclaration
-	for _, page := range app.Pages {
+	for _, page := range ir.Pages {
 		declarations = append(declarations, packageDeclaration{
 			Source:   page.Source,
 			Label:    sourceLabel(page.Source, page.ID+".page.gwdk"),
@@ -116,7 +116,7 @@ func packageDeclarations(app manifest.Manifest) []packageDeclaration {
 			Span:     firstSpan(page.Spans.Package, page.Spans.Page, page.Spans.Route),
 		})
 	}
-	for _, component := range app.Components {
+	for _, component := range ir.Components {
 		declarations = append(declarations, packageDeclaration{
 			Source:        component.Source,
 			Label:         sourceLabel(component.Source, component.Name+".cmp.gwdk"),
@@ -127,7 +127,7 @@ func packageDeclarations(app manifest.Manifest) []packageDeclaration {
 			Span:          firstSpan(component.PackageSpan, component.Span),
 		})
 	}
-	for _, layout := range app.Layouts {
+	for _, layout := range ir.Layouts {
 		declarations = append(declarations, packageDeclaration{
 			Source:   layout.Source,
 			Label:    sourceLabel(layout.Source, layout.ID+".layout.gwdk"),
@@ -256,7 +256,7 @@ func inspectGoPackageForValidation(dir string, group []packageDeclaration) goPac
 	return info
 }
 
-func parseGoBlockPackageFileForValidation(fileSet *token.FileSet, declaration packageDeclaration, block manifest.GoBlock) (*ast.File, *ValidationError) {
+func parseGoBlockPackageFileForValidation(fileSet *token.FileSet, declaration packageDeclaration, block gwdkir.GoBlock) (*ast.File, *ValidationError) {
 	src, err := goBlockPackageSourceForValidation(declaration, block)
 	if err != nil {
 		return nil, nil
@@ -276,7 +276,7 @@ func parseGoBlockPackageFileForValidation(fileSet *token.FileSet, declaration pa
 	return file, nil
 }
 
-func goBlockPackageSourceForValidation(declaration packageDeclaration, block manifest.GoBlock) (string, error) {
+func goBlockPackageSourceForValidation(declaration packageDeclaration, block gwdkir.GoBlock) (string, error) {
 	packageName := strings.TrimSpace(declaration.Package)
 	if packageName == "" {
 		return "", fmt.Errorf("go block package is missing")
@@ -315,7 +315,7 @@ func goBlockPackageSourceForValidation(declaration packageDeclaration, block man
 	return buffer.String(), nil
 }
 
-func goBlockGOWDKImportSpecsForValidation(imports []manifest.Import, bodyFile *ast.File) []ast.Spec {
+func goBlockGOWDKImportSpecsForValidation(imports []gwdkir.Import, bodyFile *ast.File) []ast.Spec {
 	used := usedScriptIdentifiersForValidation(bodyFile)
 	localImports := goBlockImportAliasesForValidation(bodyFile)
 	var specs []ast.Spec
@@ -431,7 +431,7 @@ func goBlockImportAliasesForValidation(file *ast.File) map[string]bool {
 	return aliases
 }
 
-func goBlockImportAliasForValidation(item manifest.Import) string {
+func goBlockImportAliasForValidation(item gwdkir.Import) string {
 	if strings.TrimSpace(item.Alias) != "" {
 		return item.Alias
 	}

--- a/internal/compiler/validate_page.go
+++ b/internal/compiler/validate_page.go
@@ -7,12 +7,12 @@ import (
 
 	"github.com/cssbruno/gowdk"
 	"github.com/cssbruno/gowdk/internal/gotypes"
-	"github.com/cssbruno/gowdk/internal/manifest"
+	"github.com/cssbruno/gowdk/internal/gwdkir"
 	"github.com/cssbruno/gowdk/internal/source"
 	"github.com/cssbruno/gowdk/runtime/auth"
 )
 
-func ValidatePage(config gowdk.Config, page manifest.Page) []ValidationError {
+func validatePageIR(config gowdk.Config, page gwdkir.Page) []ValidationError {
 	mode := page.RenderMode(config.Render.DefaultMode())
 	var diagnostics []ValidationError
 	pageRoute, pageRouteIssues := parseRoute(page.Route)
@@ -141,7 +141,7 @@ func ValidatePage(config gowdk.Config, page manifest.Page) []ValidationError {
 	if len(pageRouteIssues) == 0 {
 		params = pageRoute.Params
 	}
-	if isBuildTimeRoute(mode, page) && len(params) > 0 && !page.Paths {
+	if isBuildTimeRoute(mode, page) && len(params) > 0 && !page.Blocks.Paths {
 		diagnostics = append(diagnostics, ValidationError{
 			Code:   "spa_dynamic_route_missing_paths",
 			PageID: page.ID,
@@ -173,11 +173,11 @@ func ValidatePage(config gowdk.Config, page manifest.Page) []ValidationError {
 	return diagnostics
 }
 
-func validatePageGuards(page manifest.Page) []ValidationError {
+func validatePageGuards(page gwdkir.Page) []ValidationError {
 	if !validateSourceBackedPageGuards(page) {
 		return nil
 	}
-	if len(page.Guard) == 0 {
+	if len(page.Guards) == 0 {
 		return []ValidationError{{
 			Code:   "missing_page_guard",
 			PageID: page.ID,
@@ -191,13 +191,13 @@ func validatePageGuards(page manifest.Page) []ValidationError {
 	}
 
 	public := false
-	for _, guard := range page.Guard {
+	for _, guard := range page.Guards {
 		if auth.IsPublicGuard(guard) {
 			public = true
 			break
 		}
 	}
-	if public && len(page.Guard) > 1 {
+	if public && len(page.Guards) > 1 {
 		return []ValidationError{{
 			Code:    "public_guard_exclusive",
 			PageID:  page.ID,
@@ -209,7 +209,7 @@ func validatePageGuards(page manifest.Page) []ValidationError {
 	return nil
 }
 
-func validateProtectedPageGuardRender(page manifest.Page, mode gowdk.RenderMode) []ValidationError {
+func validateProtectedPageGuardRender(page gwdkir.Page, mode gowdk.RenderMode) []ValidationError {
 	if !validateSourceBackedPageGuards(page) || !isBuildTimeRoute(mode, page) || !hasProtectedPageGuard(page) {
 		return nil
 	}
@@ -222,7 +222,7 @@ func validateProtectedPageGuardRender(page manifest.Page, mode gowdk.RenderMode)
 	}}
 }
 
-func validateSourceBackedPageGuards(page manifest.Page) bool {
+func validateSourceBackedPageGuards(page gwdkir.Page) bool {
 	if strings.TrimSpace(page.Source) == "" {
 		return false
 	}
@@ -232,8 +232,8 @@ func validateSourceBackedPageGuards(page manifest.Page) bool {
 	return true
 }
 
-func hasProtectedPageGuard(page manifest.Page) bool {
-	for _, guard := range page.Guard {
+func hasProtectedPageGuard(page gwdkir.Page) bool {
+	for _, guard := range page.Guards {
 		if !auth.IsPublicGuard(guard) {
 			return true
 		}
@@ -241,7 +241,7 @@ func hasProtectedPageGuard(page manifest.Page) bool {
 	return false
 }
 
-func firstGoBlockSpan(page manifest.Page, target string) source.SourceSpan {
+func firstGoBlockSpan(page gwdkir.Page, target string) source.SourceSpan {
 	for _, block := range page.Blocks.GoBlocks {
 		if block.Target == target {
 			return block.Span
@@ -250,11 +250,11 @@ func firstGoBlockSpan(page manifest.Page, target string) source.SourceSpan {
 	return source.SourceSpan{}
 }
 
-func requiresSSRFeature(mode gowdk.RenderMode, page manifest.Page) bool {
+func requiresSSRFeature(mode gowdk.RenderMode, page gwdkir.Page) bool {
 	return mode == gowdk.SSR || mode == gowdk.Hybrid
 }
 
-func isBuildTimeRoute(mode gowdk.RenderMode, page manifest.Page) bool {
+func isBuildTimeRoute(mode gowdk.RenderMode, page gwdkir.Page) bool {
 	switch mode {
 	case gowdk.SPA, gowdk.Action:
 		return true
@@ -263,7 +263,7 @@ func isBuildTimeRoute(mode gowdk.RenderMode, page manifest.Page) bool {
 	}
 }
 
-func validatePageCachePolicy(page manifest.Page) []ValidationError {
+func validatePageCachePolicy(page gwdkir.Page) []ValidationError {
 	if page.Revalidate == "" {
 		return nil
 	}
@@ -288,8 +288,8 @@ func validatePageCachePolicy(page manifest.Page) []ValidationError {
 	return nil
 }
 
-func validatePageStores(page manifest.Page) []ValidationError {
-	seen := map[string]manifest.Store{}
+func validatePageStores(page gwdkir.Page) []ValidationError {
+	seen := map[string]gwdkir.Store{}
 	var diagnostics []ValidationError
 	for _, store := range page.Stores {
 		if first, exists := seen[store.Name]; exists {
@@ -309,7 +309,7 @@ func validatePageStores(page manifest.Page) []ValidationError {
 			continue
 		}
 		seen[store.Name] = store
-		if _, err := gotypes.ResolveStruct(page.Imports, store.Type); err != nil {
+		if _, err := gotypes.ResolveStruct(importsFromIR(page.Imports), goTypeRefFromIR(store.Type)); err != nil {
 			diagnostics = append(diagnostics, ValidationError{
 				Code:    "page_store_error",
 				PageID:  page.ID,
@@ -319,7 +319,7 @@ func validatePageStores(page manifest.Page) []ValidationError {
 			})
 			continue
 		}
-		if err := gotypes.ValidateStateInit(page.Imports, manifest.StateContract{Type: store.Type, Init: store.Init, Span: store.Span}); err != nil {
+		if err := gotypes.ValidateStateInit(importsFromIR(page.Imports), stateContractFromIR(gwdkir.StateContract{Type: store.Type, Init: store.Init, Span: store.Span})); err != nil {
 			diagnostics = append(diagnostics, ValidationError{
 				Code:    "page_store_error",
 				PageID:  page.ID,
@@ -332,7 +332,7 @@ func validatePageStores(page manifest.Page) []ValidationError {
 	return diagnostics
 }
 
-func validatePageCSS(page manifest.Page) []ValidationError {
+func validatePageCSS(page gwdkir.Page) []ValidationError {
 	if len(page.CSS) == 0 {
 		return nil
 	}

--- a/internal/compiler/validate_scripts.go
+++ b/internal/compiler/validate_scripts.go
@@ -7,27 +7,27 @@ import (
 	"strings"
 
 	"github.com/cssbruno/gowdk"
-	"github.com/cssbruno/gowdk/internal/manifest"
+	"github.com/cssbruno/gowdk/internal/gwdkir"
 	"github.com/cssbruno/gowdk/internal/source"
 )
 
-func validateGoBlocks(config gowdk.Config, app manifest.Manifest) []ValidationError {
+func validateGoBlocks(config gowdk.Config, ir gwdkir.Program) []ValidationError {
 	var diagnostics []ValidationError
 	enabledAddons := addonsByName(config)
-	for _, page := range app.Pages {
+	for _, page := range ir.Pages {
 		mode := page.RenderMode(config.Render.DefaultMode())
 		for _, block := range page.Blocks.GoBlocks {
 			diagnostics = append(diagnostics, validateGoBlockSyntax(page.Package, page.Source, page.ID, "", block)...)
 			diagnostics = append(diagnostics, validateGoBlockTarget(config, enabledAddons, page.ID, "", page.Source, page.Package, mode, page.Blocks.Load, block)...)
 		}
 	}
-	for _, component := range app.Components {
+	for _, component := range ir.Components {
 		for _, block := range component.Blocks.GoBlocks {
 			diagnostics = append(diagnostics, validateGoBlockSyntax(component.Package, component.Source, "", component.Name, block)...)
 			diagnostics = append(diagnostics, validateNonPageGoBlockTarget(config, enabledAddons, "", component.Name, component.Source, component.Package, block)...)
 		}
 	}
-	for _, layout := range app.Layouts {
+	for _, layout := range ir.Layouts {
 		for _, block := range layout.Blocks.GoBlocks {
 			diagnostics = append(diagnostics, validateGoBlockSyntax(layout.Package, layout.Source, "", "", block)...)
 			diagnostics = append(diagnostics, validateNonPageGoBlockTarget(config, enabledAddons, "", "", layout.Source, layout.Package, block)...)
@@ -36,7 +36,7 @@ func validateGoBlocks(config gowdk.Config, app manifest.Manifest) []ValidationEr
 	return diagnostics
 }
 
-func validateGoBlockSyntax(packageName string, sourcePath string, pageID string, componentName string, block manifest.GoBlock) []ValidationError {
+func validateGoBlockSyntax(packageName string, sourcePath string, pageID string, componentName string, block gwdkir.GoBlock) []ValidationError {
 	if strings.TrimSpace(block.Body) == "" {
 		return nil
 	}
@@ -57,7 +57,7 @@ func validateGoBlockSyntax(packageName string, sourcePath string, pageID string,
 	}}
 }
 
-func validateGoBlockTarget(config gowdk.Config, enabledAddons map[string]gowdk.Addon, pageID string, componentName string, sourcePath string, packageName string, mode gowdk.RenderMode, hasLoad bool, block manifest.GoBlock) []ValidationError {
+func validateGoBlockTarget(config gowdk.Config, enabledAddons map[string]gowdk.Addon, pageID string, componentName string, sourcePath string, packageName string, mode gowdk.RenderMode, hasLoad bool, block gwdkir.GoBlock) []ValidationError {
 	target := strings.TrimSpace(block.Target)
 	switch {
 	case target == "" || target == "client":
@@ -88,7 +88,7 @@ func validateGoBlockTarget(config gowdk.Config, enabledAddons map[string]gowdk.A
 	}
 }
 
-func validateNonPageGoBlockTarget(config gowdk.Config, enabledAddons map[string]gowdk.Addon, pageID string, componentName string, sourcePath string, packageName string, block manifest.GoBlock) []ValidationError {
+func validateNonPageGoBlockTarget(config gowdk.Config, enabledAddons map[string]gowdk.Addon, pageID string, componentName string, sourcePath string, packageName string, block gwdkir.GoBlock) []ValidationError {
 	target := strings.TrimSpace(block.Target)
 	switch {
 	case target == "":
@@ -128,7 +128,7 @@ func validateNonPageGoBlockTarget(config gowdk.Config, enabledAddons map[string]
 	}
 }
 
-func validateAddonGoBlockTarget(enabledAddons map[string]gowdk.Addon, pageID string, componentName string, sourcePath string, packageName string, render gowdk.RenderMode, block manifest.GoBlock) []ValidationError {
+func validateAddonGoBlockTarget(enabledAddons map[string]gowdk.Addon, pageID string, componentName string, sourcePath string, packageName string, render gowdk.RenderMode, block gwdkir.GoBlock) []ValidationError {
 	name := strings.TrimPrefix(strings.TrimSpace(block.Target), "addon.")
 	addon, ok := enabledAddons[name]
 	if name != "" && ok {
@@ -167,7 +167,7 @@ func goBlockConsumerSupportsTarget(consumer gowdk.GoBlockConsumer, target string
 	return false
 }
 
-func addonGoBlockDiagnostics(consumer gowdk.GoBlockConsumer, pageID string, componentName string, sourcePath string, packageName string, render gowdk.RenderMode, block manifest.GoBlock) []ValidationError {
+func addonGoBlockDiagnostics(consumer gowdk.GoBlockConsumer, pageID string, componentName string, sourcePath string, packageName string, render gowdk.RenderMode, block gwdkir.GoBlock) []ValidationError {
 	target := gowdkGoBlockTarget(pageID, componentName, sourcePath, packageName, block)
 	context := gowdk.GoBlockContext{Render: render}
 	var diagnostics []ValidationError
@@ -200,7 +200,7 @@ func addonsByName(config gowdk.Config) map[string]gowdk.Addon {
 	return names
 }
 
-func gowdkGoBlockTarget(pageID string, componentName string, sourcePath string, packageName string, block manifest.GoBlock) gowdk.GoBlockTarget {
+func gowdkGoBlockTarget(pageID string, componentName string, sourcePath string, packageName string, block gwdkir.GoBlock) gowdk.GoBlockTarget {
 	ownerKind := "layout"
 	ownerID := ""
 	if pageID != "" {

--- a/internal/compiler/validate_source_uses.go
+++ b/internal/compiler/validate_source_uses.go
@@ -4,15 +4,15 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/cssbruno/gowdk/internal/manifest"
+	"github.com/cssbruno/gowdk/internal/gwdkir"
 	"github.com/cssbruno/gowdk/internal/view"
 )
 
-func validateGOWDKUses(app manifest.Manifest) []ValidationError {
+func validateGOWDKUses(ir gwdkir.Program) []ValidationError {
 	componentPackages := map[string]bool{}
 	componentByPackageName := map[string]bool{}
 	sourcePackages := map[string]bool{}
-	for _, component := range app.Components {
+	for _, component := range ir.Components {
 		if component.Package == "" || component.Name == "" {
 			continue
 		}
@@ -20,13 +20,13 @@ func validateGOWDKUses(app manifest.Manifest) []ValidationError {
 		sourcePackages[component.Package] = true
 		componentByPackageName[component.Package+"."+component.Name] = true
 	}
-	for _, layout := range app.Layouts {
+	for _, layout := range ir.Layouts {
 		if layout.Package == "" {
 			continue
 		}
 		sourcePackages[layout.Package] = true
 	}
-	for _, page := range app.Pages {
+	for _, page := range ir.Pages {
 		if page.Package == "" {
 			continue
 		}
@@ -34,12 +34,12 @@ func validateGOWDKUses(app manifest.Manifest) []ValidationError {
 	}
 
 	var diagnostics []ValidationError
-	for _, component := range app.Components {
-		usesByAlias := map[string]manifest.Use{}
+	for _, component := range ir.Components {
+		usesByAlias := map[string]gwdkir.Use{}
 		diagnostics = append(diagnostics, validateComponentUses(component, usesByAlias, sourcePackages)...)
 		diagnostics = append(diagnostics, validateComponentQualifiedComponentRefs(component, usesByAlias, componentPackages, componentByPackageName, sourcePackages)...)
 	}
-	for _, layout := range app.Layouts {
+	for _, layout := range ir.Layouts {
 		for _, use := range layout.Uses {
 			diagnostics = append(diagnostics, ValidationError{
 				Code:   "unsupported_gowdk_use_scope",
@@ -53,8 +53,8 @@ func validateGOWDKUses(app manifest.Manifest) []ValidationError {
 			})
 		}
 	}
-	for _, page := range app.Pages {
-		usesByAlias := map[string]manifest.Use{}
+	for _, page := range ir.Pages {
+		usesByAlias := map[string]gwdkir.Use{}
 		for _, use := range page.Uses {
 			if first, exists := usesByAlias[use.Alias]; exists {
 				diagnostics = append(diagnostics, ValidationError{
@@ -93,7 +93,7 @@ func validateGOWDKUses(app manifest.Manifest) []ValidationError {
 	return diagnostics
 }
 
-func validateComponentUses(component manifest.Component, usesByAlias map[string]manifest.Use, sourcePackages map[string]bool) []ValidationError {
+func validateComponentUses(component gwdkir.Component, usesByAlias map[string]gwdkir.Use, sourcePackages map[string]bool) []ValidationError {
 	var diagnostics []ValidationError
 	for _, use := range component.Uses {
 		if first, exists := usesByAlias[use.Alias]; exists {
@@ -131,7 +131,7 @@ func validateComponentUses(component manifest.Component, usesByAlias map[string]
 	return diagnostics
 }
 
-func validatePageQualifiedComponentRefs(page manifest.Page, usesByAlias map[string]manifest.Use, componentPackages map[string]bool, componentByPackageName map[string]bool, sourcePackages map[string]bool) []ValidationError {
+func validatePageQualifiedComponentRefs(page gwdkir.Page, usesByAlias map[string]gwdkir.Use, componentPackages map[string]bool, componentByPackageName map[string]bool, sourcePackages map[string]bool) []ValidationError {
 	if !page.Blocks.View || strings.TrimSpace(page.Blocks.ViewBody) == "" {
 		return nil
 	}
@@ -205,7 +205,7 @@ func validatePageQualifiedComponentRefs(page manifest.Page, usesByAlias map[stri
 	return diagnostics
 }
 
-func validateComponentQualifiedComponentRefs(component manifest.Component, usesByAlias map[string]manifest.Use, componentPackages map[string]bool, componentByPackageName map[string]bool, sourcePackages map[string]bool) []ValidationError {
+func validateComponentQualifiedComponentRefs(component gwdkir.Component, usesByAlias map[string]gwdkir.Use, componentPackages map[string]bool, componentByPackageName map[string]bool, sourcePackages map[string]bool) []ValidationError {
 	if !component.Blocks.View || strings.TrimSpace(component.Blocks.ViewBody) == "" {
 		return nil
 	}

--- a/internal/compiler/validate_spans.go
+++ b/internal/compiler/validate_spans.go
@@ -1,7 +1,7 @@
 package compiler
 
 import (
-	"github.com/cssbruno/gowdk/internal/manifest"
+	"github.com/cssbruno/gowdk/internal/gwdkir"
 	"github.com/cssbruno/gowdk/internal/source"
 	"strings"
 )
@@ -15,7 +15,7 @@ func firstSpan(spans ...source.SourceSpan) source.SourceSpan {
 	return source.SourceSpan{}
 }
 
-func viewBodyNeedleSpan(component manifest.Component, needle string) source.SourceSpan {
+func viewBodyNeedleSpan(component gwdkir.Component, needle string) source.SourceSpan {
 	needle = strings.TrimSpace(needle)
 	if needle == "" || component.Blocks.ViewBody == "" || !hasSpan(component.Blocks.Spans.View) {
 		return firstSpan(component.Blocks.Spans.View, component.Span)

--- a/internal/compiler/validate_stores.go
+++ b/internal/compiler/validate_stores.go
@@ -5,10 +5,10 @@ import (
 	"strings"
 
 	"github.com/cssbruno/gowdk/internal/clientlang"
-	"github.com/cssbruno/gowdk/internal/manifest"
+	"github.com/cssbruno/gowdk/internal/gwdkir"
 )
 
-func validateComponentStoreUses(pages []manifest.Page, components []manifest.Component) []ValidationError {
+func validateComponentStoreUses(pages []gwdkir.Page, components []gwdkir.Component) []ValidationError {
 	declared := declaredStoreNamesByPackage(pages)
 	if len(declared) == 0 {
 		return validateStoreUsesAgainst(nil, components)
@@ -16,7 +16,7 @@ func validateComponentStoreUses(pages []manifest.Page, components []manifest.Com
 	return validateStoreUsesAgainst(declared, components)
 }
 
-func declaredStoreNamesByPackage(pages []manifest.Page) map[string]map[string]bool {
+func declaredStoreNamesByPackage(pages []gwdkir.Page) map[string]map[string]bool {
 	declared := map[string]map[string]bool{}
 	for _, page := range pages {
 		for _, store := range page.Stores {
@@ -32,7 +32,7 @@ func declaredStoreNamesByPackage(pages []manifest.Page) map[string]map[string]bo
 	return declared
 }
 
-func validateStoreUsesAgainst(declared map[string]map[string]bool, components []manifest.Component) []ValidationError {
+func validateStoreUsesAgainst(declared map[string]map[string]bool, components []gwdkir.Component) []ValidationError {
 	var diagnostics []ValidationError
 	for _, component := range components {
 		if !component.Blocks.Client && strings.TrimSpace(component.Blocks.ClientBody) == "" {
@@ -102,8 +102,8 @@ func validateStoreUsesAgainst(declared map[string]map[string]bool, components []
 	return diagnostics
 }
 
-func componentUsesByAlias(component manifest.Component) map[string]manifest.Use {
-	usesByAlias := map[string]manifest.Use{}
+func componentUsesByAlias(component gwdkir.Component) map[string]gwdkir.Use {
+	usesByAlias := map[string]gwdkir.Use{}
 	for _, use := range component.Uses {
 		if _, exists := usesByAlias[use.Alias]; !exists {
 			usesByAlias[use.Alias] = use

--- a/internal/compiler/validate_test.go
+++ b/internal/compiler/validate_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/cssbruno/gowdk"
 	"github.com/cssbruno/gowdk/addons/ssr"
+	"github.com/cssbruno/gowdk/internal/gwdkir"
 	"github.com/cssbruno/gowdk/internal/manifest"
 	"github.com/cssbruno/gowdk/internal/source"
 )
@@ -292,7 +293,7 @@ func TestGoBlockPackageSourceForValidationPreservesLineDirective(t *testing.T) {
 	payload, err := goBlockPackageSourceForValidation(packageDeclaration{
 		Source:  sourcePath,
 		Package: "app",
-	}, manifest.GoBlock{
+	}, gwdkir.GoBlock{
 		Span: source.SourceSpan{Start: source.SourcePosition{Line: 8, Column: 1}},
 		Body: `func BrokenCopy() string {
 	return MissingTitle
@@ -3324,7 +3325,7 @@ func TestValidateManifestAllowsConcreteRouteBesideDynamicPageRoute(t *testing.T)
 	app := manifest.Manifest{
 		Pages: []manifest.Page{
 			{ID: "blog.about", Route: "/blog/about", Blocks: manifest.Blocks{View: true}},
-			{ID: "blog.post", Route: "/blog/{slug}", Paths: true, Blocks: manifest.Blocks{View: true}},
+			{ID: "blog.post", Route: "/blog/{slug}", Paths: true, Blocks: manifest.Blocks{PathsBody: "return nil", View: true}},
 		},
 	}
 

--- a/internal/gwdkanalysis/ir_lowering.go
+++ b/internal/gwdkanalysis/ir_lowering.go
@@ -19,6 +19,8 @@ func routeKind(mode gowdk.RenderMode, page manifest.Page) gwdkir.RouteKind {
 }
 
 func lowerIRPage(page manifest.Page) gwdkir.Page {
+	blocks := lowerIRBlocks(page.Blocks)
+	blocks.Paths = page.Paths
 	return gwdkir.Page{
 		Source:      page.Source,
 		Package:     page.Package,
@@ -38,7 +40,7 @@ func lowerIRPage(page manifest.Page) gwdkir.Page {
 		Imports:     lowerIRImports(page.Imports),
 		Uses:        lowerIRUses(page.Uses),
 		Stores:      lowerIRStores(page.Stores),
-		Blocks:      lowerIRBlocks(page.Blocks),
+		Blocks:      blocks,
 		Spans: gwdkir.PageSpans{
 			Package:     page.Spans.Package,
 			Page:        page.Spans.Page,

--- a/internal/gwdkir/ir.go
+++ b/internal/gwdkir/ir.go
@@ -108,6 +108,7 @@ type PageMetadata struct {
 }
 
 type Blocks struct {
+	Paths      bool
 	PathsBody  string
 	Build      bool
 	BuildBody  string


### PR DESCRIPTION
Phase 2 of **#145**, building on the merged #146. This completes the core goal: **`internal/compiler`'s structural validators no longer read the manifest model — they read the IR (`gwdkir`) directly.**

## What changed

All ~16 structural validators (identity, routes, packages, scripts, asset uses, store uses, component contracts/lists/view-contract, page) now take `gwdkir` types.

- `ValidateProgram(ir)` is the real implementation — it calls the IR-native validators on `ir.Pages/Components/Layouts/GoEndpoints`.
- `ValidateManifest(app)` and `ValidatePage(page)` are now **thin adapters** over `ValidateProgram(BuildIR(...))`. This is the key move that kept the change safe: the ~160 existing manifest-typed tests in `validate_test.go` now run end-to-end through the IR-native path, so they serve as a comprehensive regression guard — no test rewrites needed.
- `gwdkir.Blocks` gained a `Paths` field so paths-presence survives the round trip. The validator landmines were handled: `page.Guard`→`Guards`, `page.Paths`, `GoTypeRef`/`GoFuncRef`→`GoRef`, `EndpointDeclaration`→`GoEndpoint`.

## Result

**Every validator file is manifest-free.** The remaining `manifest.*` references in `internal/compiler` are confined to legitimate infrastructure that genuinely deals with the manifest model:
- `manifest_from_ir.go` — the IR→manifest adapter (still used by buildgen render helpers).
- `backend_bindings.go` / `go_endpoints.go` — Go-handler binding & endpoint discovery (produce manifest records).
- `backend_binding_policy.go`, and the `ValidateManifest`/`ValidatePage` compatibility entry points.

## Safety

- The 160 existing `ValidateManifest`/`ValidatePage` tests now exercise the IR path and all pass.
- The former differential test is converted from a now-tautological path comparison into concrete per-scenario diagnostic assertions (valid program, duplicate identity/route, invalid standalone endpoint, page-vs-endpoint route conflict, unsupported action method).
- ✅ Full `scripts/test-go-modules.sh` green (47 packages); gofmt/vet clean; no import cycle (`ValidateManifest` uses `gwdkanalysis.BuildIR`, which doesn't import compiler).

## Remaining #145 follow-ups (smaller, optional)

- Residual build-path double-validation (CLI + buildgen).
- `lang` report commands (`check`/`sitemap`/`manifest`) still call `ValidateManifest` (now the adapter, so they already validate via IR — just not directly).
- Collapse `AST → manifest → IR` to `AST → IR`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)