### PR TITLE
Hard-error layouts without exactly one <slot />

### DIFF
--- a/internal/compiler/validate.go
+++ b/internal/compiler/validate.go
@@ -57,6 +57,7 @@ func validateProgram(config gowdk.Config, ir gwdkir.Program, crossFile bool) err
 	diagnostics = append(diagnostics, validateGOWDKUses(ir, crossFile)...)
 	diagnostics = append(diagnostics, validatePageAssetUses(ir)...)
 	diagnostics = append(diagnostics, validateUniqueLayouts(ir.Layouts)...)
+	diagnostics = append(diagnostics, validateLayoutSlots(ir.Layouts)...)
 	diagnostics = append(diagnostics, validateLayoutReferences(ir.Layouts)...)
 	diagnostics = append(diagnostics, validatePageLayoutReferences(ir.Pages, ir.Layouts)...)
 	diagnostics = append(diagnostics, validateGoBlocks(config, ir)...)

--- a/internal/compiler/validate_identity.go
+++ b/internal/compiler/validate_identity.go
@@ -262,6 +262,62 @@ func detectLayoutCycles(layouts []gwdkir.Layout, edges map[string][]string) []Va
 	return diagnostics
 }
 
+// validateLayoutSlots enforces that every layout contains exactly one
+// `<slot />` placeholder, the spot where the page or inner layout is injected.
+// This runs at validation time, so a slot-less layout is a hard error even if
+// no page references it yet (composition would otherwise only catch it on use).
+func validateLayoutSlots(layouts []gwdkir.Layout) []ValidationError {
+	var diagnostics []ValidationError
+	for _, layout := range layouts {
+		count := countLayoutSlots(layout.Blocks.ViewBody)
+		if count == 1 {
+			continue
+		}
+		span := layout.Blocks.Spans.View
+		if (span == source.SourceSpan{}) {
+			span = layout.PackageSpan
+		}
+		diagnostics = append(diagnostics, ValidationError{
+			Code:   "layout_slot_count",
+			Source: layout.Source,
+			Span:   span,
+			Message: fmt.Sprintf(
+				"layout %s must contain exactly one <slot /> placeholder for the page or inner layout, found %d",
+				layoutDisplayName(layout.Package, layout.ID),
+				count,
+			),
+		})
+	}
+	return diagnostics
+}
+
+// countLayoutSlots counts self-closing `<slot />` placeholders, mirroring the
+// app-shell composition slot scan (whitespace tolerated, named slots ignored).
+func countLayoutSlots(body string) int {
+	isSpace := func(b byte) bool { return b == ' ' || b == '\t' || b == '\n' || b == '\r' }
+	count := 0
+	for index := 0; index < len(body); index++ {
+		if body[index] != '<' || !strings.HasPrefix(body[index:], "<slot") {
+			continue
+		}
+		cursor := index + len("<slot")
+		for cursor < len(body) && isSpace(body[cursor]) {
+			cursor++
+		}
+		if cursor >= len(body) || body[cursor] != '/' {
+			continue
+		}
+		cursor++
+		for cursor < len(body) && isSpace(body[cursor]) {
+			cursor++
+		}
+		if cursor < len(body) && body[cursor] == '>' {
+			count++
+		}
+	}
+	return count
+}
+
 func layoutUsesByAlias(layout gwdkir.Layout) map[string]gwdkir.Use {
 	usesByAlias := map[string]gwdkir.Use{}
 	for _, use := range layout.Uses {

--- a/internal/compiler/validate_test.go
+++ b/internal/compiler/validate_test.go
@@ -3181,6 +3181,7 @@ func TestValidateManifestAcceptsQualifiedLayoutUse(t *testing.T) {
 			Package: "layouts",
 			ID:      "root",
 			Source:  "layouts/root.layout.gwdk",
+			Blocks:  gwdkir.Blocks{View: true, ViewBody: "<slot />"},
 		}},
 	}
 
@@ -3236,8 +3237,8 @@ func TestValidateManifestRejectsDuplicateLayoutIDs(t *testing.T) {
 func TestValidateManifestAllowsDuplicateLayoutIDsAcrossPackages(t *testing.T) {
 	app := appFixture{
 		Layouts: []gwdkir.Layout{
-			{Package: "pages", ID: "root", Source: "pages/root.layout.gwdk"},
-			{Package: "admin", ID: "root", Source: "admin/root.layout.gwdk"},
+			{Package: "pages", ID: "root", Source: "pages/root.layout.gwdk", Blocks: gwdkir.Blocks{View: true, ViewBody: "<slot />"}},
+			{Package: "admin", ID: "root", Source: "admin/root.layout.gwdk", Blocks: gwdkir.Blocks{View: true, ViewBody: "<slot />"}},
 		},
 	}
 
@@ -3302,8 +3303,8 @@ func TestValidateManifestRejectsCyclicLayoutInheritance(t *testing.T) {
 func TestValidateManifestAcceptsLayoutInheritanceChain(t *testing.T) {
 	app := appFixture{
 		Layouts: []gwdkir.Layout{
-			{Package: "app", ID: "root", Source: "app/root.layout.gwdk"},
-			{Package: "app", ID: "docs", Layouts: []string{"root"}, Source: "app/docs.layout.gwdk"},
+			{Package: "app", ID: "root", Source: "app/root.layout.gwdk", Blocks: gwdkir.Blocks{View: true, ViewBody: "<slot />"}},
+			{Package: "app", ID: "docs", Layouts: []string{"root"}, Source: "app/docs.layout.gwdk", Blocks: gwdkir.Blocks{View: true, ViewBody: "<slot />"}},
 		},
 	}
 
@@ -3326,6 +3327,40 @@ func TestValidateManifestRejectsUnknownLayoutParent(t *testing.T) {
 	diagnostics := err.(ValidationErrors)
 	if !hasDiagnosticCode(diagnostics, "unknown_layout_id") {
 		t.Fatalf("Missing unknown_layout_id diagnostic: %#v", diagnostics)
+	}
+}
+
+func TestValidateManifestRejectsLayoutWithoutSlot(t *testing.T) {
+	app := appFixture{
+		Layouts: []gwdkir.Layout{
+			{Package: "app", ID: "root", Source: "app/root.layout.gwdk", Blocks: gwdkir.Blocks{View: true, ViewBody: "<main></main>"}},
+		},
+	}
+
+	err := validateManifest(gowdk.Config{}, app)
+	if err == nil {
+		t.Fatal("expected layout slot diagnostic")
+	}
+	diagnostics := err.(ValidationErrors)
+	if !hasDiagnosticCode(diagnostics, "layout_slot_count") {
+		t.Fatalf("Missing layout_slot_count diagnostic: %#v", diagnostics)
+	}
+}
+
+func TestValidateManifestRejectsLayoutWithMultipleSlots(t *testing.T) {
+	app := appFixture{
+		Layouts: []gwdkir.Layout{
+			{Package: "app", ID: "root", Source: "app/root.layout.gwdk", Blocks: gwdkir.Blocks{View: true, ViewBody: "<slot />\n<slot />"}},
+		},
+	}
+
+	err := validateManifest(gowdk.Config{}, app)
+	if err == nil {
+		t.Fatal("expected layout slot diagnostic")
+	}
+	diagnostics := err.(ValidationErrors)
+	if !hasDiagnosticCode(diagnostics, "layout_slot_count") {
+		t.Fatalf("Missing layout_slot_count diagnostic: %#v", diagnostics)
 	}
 }
 

--- a/internal/diagnostics/registry.go
+++ b/internal/diagnostics/registry.go
@@ -70,6 +70,7 @@ var Registry = []Code{
 	{Code: "invalid_go_endpoint_handler", Area: "backend", Stability: StabilityStable, Summary: "Go endpoint comment is not attached to an exported package-level function"},
 	{Code: "invalid_go_import", Area: "packages", Stability: StabilityStable, Summary: "GOWDK source Go import declaration is invalid"},
 	{Code: "layout_self_reference", Area: "layouts", Stability: StabilityStable, Summary: "layout lists itself in @layout; a layout cannot inherit from itself"},
+	{Code: "layout_slot_count", Area: "layouts", Stability: StabilityStable, Summary: "layout must contain exactly one <slot /> placeholder"},
 	{Code: "load_requires_request_render", Area: "rendering", Stability: StabilityStable, Summary: "load block requires request-time page rendering"},
 	{Code: "malformed_gowdk_use", Area: "source-imports", Stability: StabilityStable, Summary: "GOWDK use declaration is malformed"},
 	{Code: "malformed_route", Area: "routing", Stability: StabilityStable, Summary: "route path violates GOWDK route syntax"},


### PR DESCRIPTION
Closes #220.

Follow-up to #218/#219. The "exactly one `<slot />`" rule was only enforced during app-shell composition, so a slot-less or multi-slot layout slipped through validation unless a page referenced it. This promotes it to a validation-time diagnostic `layout_slot_count`, checked for every layout even when unused.

- `validateLayoutSlots` + a slot counter mirroring the composition scan (whitespace tolerated; named slots ignored).
- Registered `layout_slot_count`.
- Tests: zero-slot and multi-slot layouts rejected; slot-bearing fixtures unaffected.

`go test ./...` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)