### PR TITLE
chore: prepare v0.2.8 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,31 @@
 GOWDK is experimental 0.x software. Public syntax, generated output, runtime
 packages, and tooling contracts may change before a stable release.
 
+## v0.2.8 - 2026-06-10
+
+### Changed
+
+- Layout identity is now derived from the `.layout.gwdk` file name. An
+  `@layout` annotation inside a layout file no longer declares identity; it
+  declares the parent layout(s) the layout inherits from and is optional.
+- `gowdk version` and the VS Code extension metadata now report `0.2.8`.
+- Optional contract adapter modules require `github.com/cssbruno/gowdk v0.2.8`.
+
+### Implemented
+
+- A layout that references itself through `@layout` is now a compile error
+  (`layout_self_reference`), as is a cyclic layout inheritance chain
+  (`cyclic_layout_reference`).
+- A layout whose `@layout` parent does not resolve to a declared layout now
+  reports `unknown_layout_id` at validation time.
+- A layout must contain exactly one `<slot />` placeholder. Layouts with zero
+  or multiple slots now hard-error at validation time (`layout_slot_count`)
+  instead of failing later during composition.
+
+### Known Gaps
+
+- GOWDK remains not production-ready.
+
 ## v0.2.7 - 2026-06-09
 
 ### Implemented

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ curl -fsSL https://raw.githubusercontent.com/cssbruno/GoWDK/main/scripts/install
 Pin the current CLI release:
 
 ```sh
-GOWDK_VERSION=v0.2.7 GOWDK_INSTALL_DIR="$HOME/.local/bin" \
+GOWDK_VERSION=v0.2.8 GOWDK_INSTALL_DIR="$HOME/.local/bin" \
   sh -c "$(curl -fsSL https://raw.githubusercontent.com/cssbruno/GoWDK/main/scripts/install.sh)"
 ```
 

--- a/cmd/gowdk/main.go
+++ b/cmd/gowdk/main.go
@@ -11,7 +11,7 @@ import (
 	"github.com/cssbruno/gowdk/addons/ssr"
 )
 
-const version = "0.2.7"
+const version = "0.2.8"
 
 var (
 	defaultSourceIncludes = []string{"**/*.gwdk"}

--- a/docs/engineering/release-notes-v0.2.md
+++ b/docs/engineering/release-notes-v0.2.md
@@ -90,6 +90,16 @@ tooling contracts may change before a stable release.
 - `gowdk doctor` checks the local Go/GOWDK toolchain, project config, source
   discovery, language validation, route metadata, and relevant optional tools
   without writing generated output.
+- `v0.2.8` release metadata: CLI/editor versions, optional module root-version
+  requirements, root changelog, and release-doc current-version examples.
+- Layout identity now comes from the `.layout.gwdk` file name. `@layout` inside
+  a layout is optional and declares the parent layout(s) the layout inherits
+  from instead of its own identity.
+- Self-referential and cyclic layout inheritance are compile errors
+  (`layout_self_reference`, `cyclic_layout_reference`), and an `@layout` parent
+  that does not resolve reports `unknown_layout_id`.
+- A layout must contain exactly one `<slot />` placeholder; zero or multiple
+  slots hard-error at validation time (`layout_slot_count`).
 
 ## Partial
 

--- a/docs/engineering/release.md
+++ b/docs/engineering/release.md
@@ -6,7 +6,7 @@ pre-releases with downloadable assets from `v*` tags or a manual workflow
 dispatch. VS Code Marketplace publishing lives in
 `.github/workflows/vscode-extension-publish.yml`.
 
-The current CLI version is `0.2.7`, but this is not a production-readiness
+The current CLI version is `0.2.8`, but this is not a production-readiness
 claim. It identifies the current development line while the compiler, generated
 runtime, and docs continue through the 0.x line. Public release notes must
 call the build experimental until the release gates below are satisfied.
@@ -85,14 +85,14 @@ After those gates pass on the release commit, run the release workflow manually
 for the current CLI line or push the corresponding tag:
 
 ```sh
-gh workflow run release.yml -f version=v0.2.7
+gh workflow run release.yml -f version=v0.2.8
 ```
 
 After the release workflow completes, smoke the published artifacts for each
 supported OS artifact:
 
 ```sh
-gh workflow run release-smoke.yml -f version=v0.2.7
+gh workflow run release-smoke.yml -f version=v0.2.8
 ```
 
 ## Artifacts
@@ -103,7 +103,7 @@ gh workflow run release-smoke.yml -f version=v0.2.7
 - `gowdk-darwin-arm64`
 - `gowdk-windows-amd64.exe`
 - `checksums.txt`
-- `gowdk-vscode-0.2.7.vsix`
+- `gowdk-vscode-0.2.8.vsix`
 
 ## Install Script
 
@@ -117,7 +117,7 @@ binary SHA-256, and writes `gowdk` into `GOWDK_INSTALL_DIR` or
 Pinned install:
 
 ```sh
-GOWDK_VERSION=v0.2.7 GOWDK_INSTALL_DIR="$HOME/.local/bin" \
+GOWDK_VERSION=v0.2.8 GOWDK_INSTALL_DIR="$HOME/.local/bin" \
   sh -c "$(curl -fsSL https://raw.githubusercontent.com/cssbruno/GoWDK/main/scripts/install.sh)"
 ```
 
@@ -138,7 +138,7 @@ gh attestation verify <artifact> -R <owner>/<repo>
 ## Extension Publishing
 
 The release workflow packages the extension into a `.vsix` named from
-`editors/vscode/package.json`, currently `gowdk-vscode-0.2.7.vsix`.
+`editors/vscode/package.json`, currently `gowdk-vscode-0.2.8.vsix`.
 Marketplace publishing is handled by the `Publish VS Code Extension` workflow.
 It is manual-only so CLI/runtime releases do not accidentally republish an
 extension version that already exists on the Marketplace.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -21,7 +21,7 @@ gowdk version
 Pin the current CLI release or install into a user-writable directory:
 
 ```sh
-GOWDK_VERSION=v0.2.7 GOWDK_INSTALL_DIR="$HOME/.local/bin" \
+GOWDK_VERSION=v0.2.8 GOWDK_INSTALL_DIR="$HOME/.local/bin" \
   sh -c "$(curl -fsSL https://raw.githubusercontent.com/cssbruno/GoWDK/main/scripts/install.sh)"
 ```
 
@@ -96,7 +96,7 @@ Direct artifact names:
 Manual Linux install:
 
 ```sh
-version=v0.2.7
+version=v0.2.8
 curl -fsSLO "https://github.com/cssbruno/GoWDK/releases/download/$version/gowdk-linux-amd64"
 curl -fsSLO "https://github.com/cssbruno/GoWDK/releases/download/$version/checksums.txt"
 grep ' gowdk-linux-amd64$' checksums.txt | sha256sum -c -
@@ -109,7 +109,7 @@ gowdk version
 Manual macOS Intel install:
 
 ```sh
-version=v0.2.7
+version=v0.2.8
 curl -fsSLO "https://github.com/cssbruno/GoWDK/releases/download/$version/gowdk-darwin-amd64"
 curl -fsSLO "https://github.com/cssbruno/GoWDK/releases/download/$version/checksums.txt"
 expected="$(awk '$2 == "gowdk-darwin-amd64" { print $1 }' checksums.txt)"
@@ -124,7 +124,7 @@ gowdk version
 Manual macOS ARM install:
 
 ```sh
-version=v0.2.7
+version=v0.2.8
 curl -fsSLO "https://github.com/cssbruno/GoWDK/releases/download/$version/gowdk-darwin-arm64"
 curl -fsSLO "https://github.com/cssbruno/GoWDK/releases/download/$version/checksums.txt"
 expected="$(awk '$2 == "gowdk-darwin-arm64" { print $1 }' checksums.txt)"
@@ -139,7 +139,7 @@ gowdk version
 Manual Windows install from PowerShell:
 
 ```powershell
-$version = "v0.2.7"
+$version = "v0.2.8"
 Invoke-WebRequest "https://github.com/cssbruno/GoWDK/releases/download/$version/gowdk-windows-amd64.exe" -OutFile "gowdk.exe"
 Invoke-WebRequest "https://github.com/cssbruno/GoWDK/releases/download/$version/checksums.txt" -OutFile "checksums.txt"
 $expected = (Select-String -Path checksums.txt -Pattern "gowdk-windows-amd64.exe").Line.Split(" ")[0]

--- a/docs/language/layouts.md
+++ b/docs/language/layouts.md
@@ -7,19 +7,40 @@ references:
 @layout root, dashboard
 ```
 
-Layout files can declare layout identity and view markup:
+A layout's identity comes from its file name. A file named `root.layout.gwdk`
+declares the layout `root`, and `dashboard.layout.gwdk` declares `dashboard`.
+Layout files do not declare identity with `@layout`; they only provide view
+markup and, optionally, the parent layout they nest within:
 
 ```gwdk
-@layout root
-
 view {
   <slot />
 }
 ```
 
+Inside a layout file, `@layout` is optional and declares the parent layout(s)
+this layout nests within, not the layout's own identity. For example,
+`dashboard.layout.gwdk` can declare `@layout root` to nest the `dashboard` shell
+inside the `root` shell:
+
+```gwdk
+@layout root
+
+view {
+  <aside>Dashboard nav</aside>
+  <slot />
+}
+```
+
+A layout that references itself, or that forms a cycle through other layouts,
+is a compile error (`layout_self_reference`, `cyclic_layout_reference`). A
+`@layout` parent that does not resolve to a declared layout reports
+`unknown_layout_id`.
+
 Bare layout references are same-package references. A page in package `pages`
-can use `@layout root` when a discovered layout in package `pages` declares
-`@layout root`. Package-less fixtures keep the legacy package-less lookup.
+can use `@layout root` when a discovered layout file in package `pages` declares
+the layout `root` (that is, `root.layout.gwdk`). Package-less fixtures keep the
+legacy package-less lookup.
 
 Cross-package layouts require a GOWDK source import and a qualified layout
 reference:
@@ -39,9 +60,9 @@ view {
 ```
 
 The quoted `use` target is a discovered `.gwdk` package name, not a Go import
-path. The qualified reference `chrome.root` resolves to `@layout root` in
-package `layouts`. Unqualified cross-package lookup is rejected so layout reuse
-does not depend on global IDs or file locations.
+path. The qualified reference `chrome.root` resolves to the layout `root` (the
+file `root.layout.gwdk`) in package `layouts`. Unqualified cross-package lookup
+is rejected so layout reuse does not depend on global IDs or folder locations.
 
 When layout files are part of the project manifest, compiler validation resolves
 page `@layout` references by package and declared ID and reports unknown or
@@ -56,17 +77,24 @@ wiring is planned.
 
 Current app-shell layout rules:
 
+- A layout's identity is its file name: `root.layout.gwdk` declares the layout
+  `root`.
 - Layouts are declared outermost to innermost, for example
   `@layout root, dashboard`.
+- Inside a layout file, `@layout` is optional and names the parent layout(s) the
+  layout nests within.
 - Cross-package layouts use `@layout alias.id` with a page-level
   `use alias "package"` declaration.
-- Each applied app-shell layout must contain exactly one `<slot />` placeholder.
+- Each layout must contain exactly one `<slot />` placeholder. Layouts with zero
+  or multiple slots are rejected at validation time (`layout_slot_count`).
+- A layout may not reference itself or form a cyclic inheritance chain.
 - Layout markup is rendered through the same escaped view renderer as
   pages.
 
 Rules that should remain true as implementation grows:
 
-- Layout identity is declared by ID, not inferred from folder location.
-- Page portability must not depend on the source file path.
-- Missing or same-package duplicate layout IDs produce validation diagnostics
-  when layout files are included in the manifest.
+- Layout identity comes from the file's base name, not from its folder location
+  or a global ID.
+- Page portability must not depend on the source folder path.
+- Missing, self-referential, cyclic, or same-package duplicate layout IDs
+  produce validation diagnostics when layout files are included in the manifest.

--- a/docs/language/spec.md
+++ b/docs/language/spec.md
@@ -33,7 +33,9 @@ Current file kinds:
 - Page files declare `@route`, `@guard`, and `view {}`. They may declare
   `@page` when they need an explicit stable page ID.
 - Component files declare `@component` and usually `view {}`.
-- Layout files declare `@layout` and `view {}` with a `<slot />`.
+- Layout files take their identity from the file name (`root.layout.gwdk`
+  declares the layout `root`) and declare `view {}` with exactly one `<slot />`.
+  They may declare `@layout` to name the parent layout(s) they nest within.
 
 Planned or partial file kinds:
 

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "gowdk-vscode",
   "displayName": "GOWDK",
   "description": "Language tools for portable .gwdk files.",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "publisher": "gowdk",
   "license": "MIT",
   "icon": "icons/gowdk.png",

--- a/runtime/contracts/natsbroker/go.mod
+++ b/runtime/contracts/natsbroker/go.mod
@@ -3,7 +3,7 @@ module github.com/cssbruno/gowdk/runtime/contracts/natsbroker
 go 1.26.4
 
 require (
-	github.com/cssbruno/gowdk v0.2.7
+	github.com/cssbruno/gowdk v0.2.8
 	github.com/nats-io/nats.go v1.52.0
 )
 

--- a/runtime/contracts/redisstream/go.mod
+++ b/runtime/contracts/redisstream/go.mod
@@ -3,7 +3,7 @@ module github.com/cssbruno/gowdk/runtime/contracts/redisstream
 go 1.26.4
 
 require (
-	github.com/cssbruno/gowdk v0.2.7
+	github.com/cssbruno/gowdk v0.2.8
 	github.com/redis/go-redis/v9 v9.20.0
 )
 

--- a/runtime/contracts/websocketfanout/go.mod
+++ b/runtime/contracts/websocketfanout/go.mod
@@ -4,7 +4,7 @@ go 1.26.4
 
 require (
 	github.com/coder/websocket v1.8.14
-	github.com/cssbruno/gowdk v0.2.7
+	github.com/cssbruno/gowdk v0.2.8
 )
 
 replace github.com/cssbruno/gowdk => ../../..


### PR DESCRIPTION
Prepares the **v0.2.8** experimental pre-release.

Bumps the CLI version source of truth (`cmd/gowdk/main.go`), the VS Code
extension manifest, and the optional contract-module root-version requirements
to `0.2.8`, and documents the layout-model changes that landed since v0.2.7
(PRs #219 and #221).

## Version bumps
- `cmd/gowdk/main.go` — `const version = "0.2.8"`
- `editors/vscode/package.json` — `0.2.8` (verified by `sync-version.js --check`)
- `runtime/contracts/{natsbroker,redisstream,websocketfanout}/go.mod` — require `v0.2.8`
- README / getting-started / release docs — pinned-install + workflow examples

## Notes
- `CHANGELOG.md` and `docs/engineering/release-notes-v0.2.md` document:
  - layout identity now derived from the `.layout.gwdk` file name; `@layout`
    means inheritance and is optional
  - `layout_self_reference` / `cyclic_layout_reference` / `unknown_layout_id`
  - `layout_slot_count` — exactly one `<slot />` enforced at validation time

## Gates verified locally
- `go build ./cmd/gowdk` + `gowdk version --json` → `0.2.8`
- `node editors/vscode/scripts/sync-version.js --check` → match
- `scripts/test-go-modules.sh`
- `gowdk check / routes / manifest / sitemap --ssr` over the example set
- `go test ./...`

After merge, pushing the `v0.2.8` tag at the merge commit triggers
`.github/workflows/release.yml` to build artifacts and publish the pre-release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)