### PR TITLE
fix: parser brace counting, discover pruning, and explicit generator errors (#149, #154, #162)

### DIFF
--- a/internal/appgen/appgen.go
+++ b/internal/appgen/appgen.go
@@ -85,7 +85,11 @@ func GenerateWithOptions(outputDir, appDir string, options Options) (Result, err
 	if err := writeFileIfChanged(filepath.Join(absApp, modFileName), []byte(modulePayload)); err != nil {
 		return Result{}, err
 	}
-	appSource, err := formatGeneratedGo(appFileName, []byte(appPackageSource(options)))
+	packageSource, err := appPackageSource(options)
+	if err != nil {
+		return Result{}, err
+	}
+	appSource, err := formatGeneratedGo(appFileName, []byte(packageSource))
 	if err != nil {
 		return Result{}, err
 	}
@@ -102,7 +106,11 @@ func GenerateWithOptions(outputDir, appDir string, options Options) (Result, err
 	}
 	files = append(files, scriptFiles...)
 	files = append(files, addonGoBlockFiles...)
-	if err := writeFileIfChanged(filepath.Join(absApp, mainFileName), []byte(serverMainSource())); err != nil {
+	mainSource, err := serverMainSource()
+	if err != nil {
+		return Result{}, err
+	}
+	if err := writeFileIfChanged(filepath.Join(absApp, mainFileName), []byte(mainSource)); err != nil {
 		return Result{}, err
 	}
 
@@ -149,7 +157,11 @@ func GenerateBackendWithOptions(appDir string, options Options) (Result, error) 
 	if err := writeFileIfChanged(filepath.Join(absApp, modFileName), []byte(modulePayload)); err != nil {
 		return Result{}, err
 	}
-	appSource, err := formatGeneratedGo(appFileName, []byte(backendAppPackageSource(options)))
+	packageSource, err := backendAppPackageSource(options)
+	if err != nil {
+		return Result{}, err
+	}
+	appSource, err := formatGeneratedGo(appFileName, []byte(packageSource))
 	if err != nil {
 		return Result{}, err
 	}
@@ -162,7 +174,11 @@ func GenerateBackendWithOptions(appDir string, options Options) (Result, error) 
 	if _, err := writeAddonGoBlockFiles(absApp, options); err != nil {
 		return Result{}, err
 	}
-	if err := writeFileIfChanged(filepath.Join(absApp, mainFileName), []byte(serverMainSource())); err != nil {
+	mainSource, err := serverMainSource()
+	if err != nil {
+		return Result{}, err
+	}
+	if err := writeFileIfChanged(filepath.Join(absApp, mainFileName), []byte(mainSource)); err != nil {
 		return Result{}, err
 	}
 	return Result{

--- a/internal/appgen/appgen_test.go
+++ b/internal/appgen/appgen_test.go
@@ -1049,7 +1049,7 @@ func TestAppShellSourceEmitterDoesNotUseRawTemplates(t *testing.T) {
 }
 
 func TestGeneratedPackageSourceIsGoFormatted(t *testing.T) {
-	source := appPackageSource(Options{IR: &gwdkir.Program{ContractRefs: []gwdkir.ContractReference{{
+	source, err := appPackageSource(Options{IR: &gwdkir.Program{ContractRefs: []gwdkir.ContractReference{{
 		Kind:        gwdkir.ContractCommand,
 		Name:        "patients.CreatePatient",
 		ImportAlias: "patients",
@@ -1064,6 +1064,9 @@ func TestGeneratedPackageSourceIsGoFormatted(t *testing.T) {
 		OwnerKind:   gwdkir.SourcePage,
 		OwnerID:     "patients",
 	}}}})
+	if err != nil {
+		t.Fatalf("appPackageSource: %v", err)
+	}
 	formatted, err := format.Source([]byte(source))
 	if err != nil {
 		t.Fatalf("generated package source is not valid Go: %v\n%s", err, source)
@@ -1074,7 +1077,7 @@ func TestGeneratedPackageSourceIsGoFormatted(t *testing.T) {
 }
 
 func TestGeneratedDeclarationSnippetIsGoFormatted(t *testing.T) {
-	source := actionHandlerSource([]ActionEndpoint{{
+	source, err := actionHandlerSource([]ActionEndpoint{{
 		PageID:      "newsletter",
 		ActionName:  "Subscribe",
 		Method:      http.MethodPost,
@@ -1082,6 +1085,9 @@ func TestGeneratedDeclarationSnippetIsGoFormatted(t *testing.T) {
 		InputFields: []string{"email"},
 		Redirect:    "/newsletter?ok=1",
 	}}, false)
+	if err != nil {
+		t.Fatalf("actionHandlerSource: %v", err)
+	}
 	wrapped := []byte("package gowdkapp\n\n" + source)
 	formatted, err := format.Source(wrapped)
 	if err != nil {

--- a/internal/appgen/source.go
+++ b/internal/appgen/source.go
@@ -2,6 +2,7 @@ package appgen
 
 import (
 	"bytes"
+	"fmt"
 	"go/ast"
 	"go/format"
 	"go/printer"
@@ -13,7 +14,7 @@ import (
 	"github.com/cssbruno/gowdk"
 )
 
-func appPackageSource(options Options) string {
+func appPackageSource(options Options) (string, error) {
 	direct := options
 	if options.ProxyBackend {
 		direct.Actions = nil
@@ -139,7 +140,7 @@ func runtimeImportMap(options Options) map[string]string {
 	return imports
 }
 
-func printGoFile(packageName string, imports map[string]string, decls []ast.Decl) string {
+func printGoFile(packageName string, imports map[string]string, decls []ast.Decl) (string, error) {
 	file := &ast.File{Name: id(packageName)}
 	if len(imports) > 0 {
 		file.Decls = append(file.Decls, importDecl(imports))
@@ -147,25 +148,34 @@ func printGoFile(packageName string, imports map[string]string, decls []ast.Decl
 	file.Decls = append(file.Decls, decls...)
 
 	var buffer bytes.Buffer
-	_ = printer.Fprint(&buffer, token.NewFileSet(), file)
+	if err := printer.Fprint(&buffer, token.NewFileSet(), file); err != nil {
+		return "", fmt.Errorf("print generated %s package: %w", packageName, err)
+	}
 	return formatGoSource(buffer.Bytes())
 }
 
-func formatGoSource(source []byte) string {
+// formatGoSource gofmt-formats generated Go source. A formatting failure means
+// the generator emitted syntactically invalid code; it is returned rather than
+// silently writing the broken source, which would otherwise surface much later
+// as a confusing `go build` error in the generated app.
+func formatGoSource(source []byte) (string, error) {
 	formatted, err := format.Source(source)
 	if err != nil {
-		return string(source)
+		return "", fmt.Errorf("format generated Go source: %w", err)
 	}
-	return string(formatted)
+	return string(formatted), nil
 }
 
-func formatGoDeclSnippet(source string) string {
+func formatGoDeclSnippet(source string) (string, error) {
 	const packagePrefix = "package gowdkapp\n\n"
-	formatted := formatGoSource([]byte(packagePrefix + source))
-	if strings.HasPrefix(formatted, packagePrefix) {
-		return strings.TrimSuffix(strings.TrimPrefix(formatted, packagePrefix), "\n")
+	formatted, err := formatGoSource([]byte(packagePrefix + source))
+	if err != nil {
+		return "", err
 	}
-	return source
+	if strings.HasPrefix(formatted, packagePrefix) {
+		return strings.TrimSuffix(strings.TrimPrefix(formatted, packagePrefix), "\n"), nil
+	}
+	return source, nil
 }
 
 func importDecl(imports map[string]string) ast.Decl {
@@ -485,9 +495,9 @@ func csrfEnabled(options Options) bool {
 	return options.Config.Build.CSRF.Enabled && (len(options.Actions) > 0 || contractExposuresParseForm(executableContractExposures(backendAdapterIR(options).ContractExposures)))
 }
 
-func csrfHelperSource(options Options) string {
+func csrfHelperSource(options Options) (string, error) {
 	if !csrfEnabled(options) {
-		return ""
+		return "", nil
 	}
 	return printActionDecls([]ast.Decl{
 		csrfValidatorVarDecl(),

--- a/internal/appgen/source_actions.go
+++ b/internal/appgen/source_actions.go
@@ -2,6 +2,7 @@ package appgen
 
 import (
 	"bytes"
+	"fmt"
 	"go/ast"
 	"go/printer"
 	"go/token"
@@ -13,7 +14,7 @@ import (
 	"github.com/cssbruno/gowdk/internal/source"
 )
 
-func actionHandlerSource(actions []ActionEndpoint, csrf bool) string {
+func actionHandlerSource(actions []ActionEndpoint, csrf bool) (string, error) {
 	sorted := sortedActionEndpoints(actions)
 	decls := []ast.Decl{actionFuncDecl(sorted, csrf, false)}
 	if len(sorted) > 0 {
@@ -23,14 +24,16 @@ func actionHandlerSource(actions []ActionEndpoint, csrf bool) string {
 	return printActionDecls(decls)
 }
 
-func printActionDecls(decls []ast.Decl) string {
+func printActionDecls(decls []ast.Decl) (string, error) {
 	var buffer bytes.Buffer
 	fileSet := token.NewFileSet()
 	for index, decl := range decls {
 		if index > 0 {
 			_, _ = buffer.Write([]byte("\n\n"))
 		}
-		_ = printer.Fprint(&buffer, fileSet, decl)
+		if err := printer.Fprint(&buffer, fileSet, decl); err != nil {
+			return "", fmt.Errorf("print generated declaration: %w", err)
+		}
 	}
 	return formatGoDeclSnippet(buffer.String())
 }

--- a/internal/appgen/source_api.go
+++ b/internal/appgen/source_api.go
@@ -7,7 +7,7 @@ import (
 	"github.com/cssbruno/gowdk/internal/source"
 )
 
-func apiHandlerSource(apis []APIEndpoint) string {
+func apiHandlerSource(apis []APIEndpoint) (string, error) {
 	return printActionDecls([]ast.Decl{apiFuncDecl(sortedAPIEndpoints(apis), false)})
 }
 

--- a/internal/appgen/source_backend.go
+++ b/internal/appgen/source_backend.go
@@ -87,9 +87,9 @@ func sortAPIEndpoints(apis []APIEndpoint) {
 	})
 }
 
-func backendProxySource(options Options) string {
+func backendProxySource(options Options) (string, error) {
 	if !options.ProxyBackend || !hasBackendRoutes(options) {
-		return ""
+		return "", nil
 	}
 	return printActionDecls([]ast.Decl{
 		backendProxyDecl(false),

--- a/internal/appgen/source_backend_app.go
+++ b/internal/appgen/source_backend_app.go
@@ -1,6 +1,6 @@
 package appgen
 
-func backendAppPackageSource(options Options) string {
+func backendAppPackageSource(options Options) (string, error) {
 	imports := backendRuntimeImportMap(options)
 	imports["http"] = "net/http"
 	return printGoFile("gowdkapp", imports, append(backendShellDecls(options), backendGeneratedDecls(options)...))

--- a/internal/appgen/source_ssr.go
+++ b/internal/appgen/source_ssr.go
@@ -8,7 +8,7 @@ import (
 	"github.com/cssbruno/gowdk/internal/source"
 )
 
-func ssrHandlerSource(routes []SSRRoute) string {
+func ssrHandlerSource(routes []SSRRoute) (string, error) {
 	sorted := sortedSSRRoutes(routes)
 	return printActionDecls([]ast.Decl{
 		ssrExactDecl(sorted, false),

--- a/internal/appgen/template.go
+++ b/internal/appgen/template.go
@@ -5,7 +5,7 @@ import (
 	"go/token"
 )
 
-func serverMainSource() string {
+func serverMainSource() (string, error) {
 	return printGoFile("main", map[string]string{
 		"gowdkapp": "gowdk-generated-app/gowdkapp",
 		"log":      "log",

--- a/internal/buildgen/runtime_islands.go
+++ b/internal/buildgen/runtime_islands.go
@@ -1,6 +1,7 @@
 package buildgen
 
 import (
+	"fmt"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -21,7 +22,7 @@ func islandRuntimeArtifacts(config gowdk.Config, pages []gwdkir.Page, allCompone
 		}
 		usages, err := recursiveManifestComponentCallUsages(source, components, page.Package, componentUses(page.Uses))
 		if err != nil {
-			continue
+			return nil, fmt.Errorf("resolve island components for page %q: %w", page.ID, err)
 		}
 		for _, usage := range usages {
 			component := usage.component

--- a/internal/compiler/go_endpoints.go
+++ b/internal/compiler/go_endpoints.go
@@ -1,6 +1,7 @@
 package compiler
 
 import (
+	"errors"
 	"fmt"
 	"go/ast"
 	"go/parser"
@@ -77,7 +78,14 @@ func endpointSourceDirs(ir gwdkir.Program) []string {
 func discoverGoEndpointsInDir(dir string) ([]gwdkir.GoEndpoint, []ValidationError) {
 	entries, err := os.ReadDir(dir)
 	if err != nil {
-		return nil, nil
+		// A source directory that simply does not exist is not an error - the
+		// program may declare no Go endpoints there. Any other read failure
+		// (permissions, I/O) is surfaced so it is not mistaken for "no
+		// endpoints found".
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, []ValidationError{goEndpointDiagnostic(token.NewFileSet(), dir, nil, "go_endpoint_read_error", fmt.Sprintf("read Go endpoint directory: %v", err))}
 	}
 	fileSet := token.NewFileSet()
 	var endpoints []gwdkir.GoEndpoint

--- a/internal/diagnostics/registry.go
+++ b/internal/diagnostics/registry.go
@@ -60,6 +60,7 @@ var Registry = []Code{
 	{Code: "generated_app_import_cycle", Area: "generated-go", Stability: StabilityStable, Summary: "generated app would import itself through user code"},
 	{Code: "go_client_requires_page", Area: "go-block", Stability: StabilityExperimental, Summary: "go client block was declared outside a page"},
 	{Code: "go_endpoint_parse_error", Area: "backend", Stability: StabilityStable, Summary: "Go endpoint comment scan failed to parse a Go file"},
+	{Code: "go_endpoint_read_error", Area: "backend", Stability: StabilityStable, Summary: "Go endpoint scan failed to read a source directory"},
 	{Code: "go_package_error", Area: "packages", Stability: StabilityStable, Summary: "sibling Go package parse, package, or type-check validation failed"},
 	{Code: "go_ssr_requires_request_render", Area: "go-block", Stability: StabilityExperimental, Summary: "go ssr block requires request-time page rendering"},
 	{Code: "guard_requires_request_render", Area: "pages", Stability: StabilityStable, Summary: "protected page guard metadata requires request-time page rendering"},

--- a/internal/discover/discover.go
+++ b/internal/discover/discover.go
@@ -23,9 +23,16 @@ func Files(root string, includes, excludes []string) ([]string, error) {
 
 	if err := filepath.WalkDir(root, func(path string, entry fs.DirEntry, err error) error {
 		if err != nil {
-			return err
-		}
-		if entry.IsDir() {
+			// A failure to read root is fatal; there is nothing to discover.
+			// Errors deeper in the tree (e.g. an unreadable directory, possibly
+			// inside an excluded subtree) must not abort the whole walk - skip
+			// the offending entry and keep going.
+			if path == root {
+				return err
+			}
+			if entry != nil && entry.IsDir() {
+				return filepath.SkipDir
+			}
 			return nil
 		}
 
@@ -34,6 +41,16 @@ func Files(root string, includes, excludes []string) ([]string, error) {
 			return err
 		}
 		rel = filepath.ToSlash(rel)
+
+		if entry.IsDir() {
+			// Prune excluded directories so we never descend into large trees
+			// like .git, node_modules, or vendor.
+			if rel != "." && matchesExcludedDir(excludeMatchers, rel) {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+
 		if !matchesAny(includeMatchers, rel) || matchesAny(excludeMatchers, rel) {
 			return nil
 		}
@@ -58,6 +75,15 @@ func compileGlobs(patterns []string) ([]globPattern, error) {
 		matchers = append(matchers, globPattern(filepath.ToSlash(pattern)))
 	}
 	return matchers, nil
+}
+
+// matchesExcludedDir reports whether a directory (given by its slash-separated
+// relative path) is fully covered by an exclude pattern and can be pruned. A
+// directory matches either directly (a pattern naming the directory itself) or
+// when a `dir/**`-style pattern covers everything beneath it, tested by
+// appending a trailing slash so the pattern's `**` matches the empty remainder.
+func matchesExcludedDir(matchers []globPattern, dir string) bool {
+	return matchesAny(matchers, dir) || matchesAny(matchers, dir+"/")
 }
 
 func matchesAny(matchers []globPattern, value string) bool {

--- a/internal/discover/discover_test.go
+++ b/internal/discover/discover_test.go
@@ -31,6 +31,72 @@ func TestFilesMatchesRecursiveGWDKIncludes(t *testing.T) {
 	}
 }
 
+func TestFilesPrunesExcludedDirectories(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "src/home.page.gwdk")
+	writeFile(t, root, "node_modules/pkg/dep.page.gwdk")
+	writeFile(t, root, "vendor/lib/thing.page.gwdk")
+
+	files, err := Files(root, []string{"**/*.gwdk"}, []string{"node_modules/**", "vendor/**"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got := relFiles(t, root, files)
+	want := []string{"src/home.page.gwdk"}
+	if len(got) != len(want) || got[0] != want[0] {
+		t.Fatalf("expected %v, got %v", want, got)
+	}
+}
+
+func TestMatchesExcludedDir(t *testing.T) {
+	matchers, err := compileGlobs([]string{"node_modules/**", "vendor/**", "**/testdata/**", "src/**/card.cmp.gwdk"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	tests := []struct {
+		dir  string
+		want bool
+	}{
+		{"node_modules", true},
+		{"vendor", true},
+		{"pkg/testdata", true},
+		{"src", false},        // file-glob exclude must not prune the whole src tree
+		{"src/nested", false}, // intermediate dir of a file exclude stays
+	}
+	for _, test := range tests {
+		if got := matchesExcludedDir(matchers, test.dir); got != test.want {
+			t.Fatalf("matchesExcludedDir(%q) = %v, want %v", test.dir, got, test.want)
+		}
+	}
+}
+
+func TestFilesToleratesUnreadableDirectory(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("root bypasses directory permissions")
+	}
+	root := t.TempDir()
+	writeFile(t, root, "src/home.page.gwdk")
+	blocked := filepath.Join(root, "blocked")
+	if err := os.MkdirAll(blocked, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, root, "blocked/secret.page.gwdk")
+	if err := os.Chmod(blocked, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(blocked, 0o755) })
+
+	files, err := Files(root, []string{"**/*.gwdk"}, nil)
+	if err != nil {
+		t.Fatalf("expected unreadable directory to be skipped, got error: %v", err)
+	}
+	got := relFiles(t, root, files)
+	if len(got) != 1 || got[0] != "src/home.page.gwdk" {
+		t.Fatalf("expected only src/home.page.gwdk, got %v", got)
+	}
+}
+
 func TestGlobPatternMatch(t *testing.T) {
 	tests := []struct {
 		pattern string

--- a/internal/parser/braces.go
+++ b/internal/parser/braces.go
@@ -1,0 +1,120 @@
+package parser
+
+// braceLang selects the lexical rules used when scanning an embedded block body
+// for brace depth. The supported embedded languages differ in their string and
+// comment syntax, and braces inside strings or comments must be skipped so that
+// valid code such as `return "}"` does not corrupt block-depth tracking.
+type braceLang int
+
+const (
+	braceLangGo  braceLang = iota // " strings, ` raw strings, ' runes, // and /* */ comments
+	braceLangJS                   // " ' strings, ` template literals, // and /* */ comments
+	braceLangCSS                  // " ' strings, /* */ comments only
+)
+
+// braceScanner tracks brace depth across the lines of an embedded code block,
+// ignoring braces that appear inside string literals or comments. It is
+// stateful so multi-line constructs (block comments, Go raw strings, JS
+// template literals) are handled across line boundaries.
+//
+// Regular-expression literals in JS are not recognized; a `/` is only treated
+// as the start of a comment when immediately followed by `/` or `*`. Braces
+// inside a JS regex literal can therefore still miscount, which is an accepted
+// limitation versus the far larger cost of full tokenization.
+type braceScanner struct {
+	lang           braceLang
+	inBlockComment bool // inside an open /* ... */ comment
+	inRawString    bool // inside an open Go raw string or JS template literal
+}
+
+// inMultiline reports whether the scanner is currently inside a construct that
+// spans line boundaries. While true, a line that is exactly "}" is body text
+// (e.g. a `}` inside a block comment) rather than a block terminator.
+func (s *braceScanner) inMultiline() bool {
+	return s.inBlockComment || s.inRawString
+}
+
+// delta scans one line and returns the net change in brace depth it
+// contributes, skipping braces inside strings and comments. Multi-line state is
+// carried over to subsequent calls.
+func (s *braceScanner) delta(line string) int {
+	delta := 0
+	runes := []rune(line)
+	for i := 0; i < len(runes); i++ {
+		r := runes[i]
+		if s.inBlockComment {
+			if r == '*' && i+1 < len(runes) && runes[i+1] == '/' {
+				s.inBlockComment = false
+				i++
+			}
+			continue
+		}
+		if s.inRawString {
+			// JS template literals honor backslash escapes; Go raw strings do
+			// not, but they also cannot contain a backtick, so the escape
+			// branch is harmless there.
+			if s.lang == braceLangJS && r == '\\' {
+				i++
+				continue
+			}
+			if r == '`' {
+				s.inRawString = false
+			}
+			continue
+		}
+		switch r {
+		case '{':
+			delta++
+		case '}':
+			delta--
+		case '/':
+			if s.lang != braceLangCSS && i+1 < len(runes) && runes[i+1] == '/' {
+				return delta // rest of the line is a line comment
+			}
+			if i+1 < len(runes) && runes[i+1] == '*' {
+				s.inBlockComment = true
+				i++
+			}
+		case '"':
+			i = skipQuoted(runes, i, '"')
+		case '\'':
+			i = skipQuoted(runes, i, '\'')
+		case '`':
+			if s.lang != braceLangCSS {
+				s.inRawString = true // Go raw string or JS template literal
+			}
+		}
+	}
+	return delta
+}
+
+// blockScanLang maps a top-level block kind to the lexical rules used to scan
+// its body for brace depth. Kinds whose bodies are not brace-scanned default to
+// Go rules, which is harmless because their scanner is never fed.
+func blockScanLang(kind string) braceLang {
+	switch kind {
+	case "style":
+		return braceLangCSS
+	case "client", "js":
+		return braceLangJS
+	default:
+		return braceLangGo
+	}
+}
+
+// skipQuoted advances past a quoted run starting at runes[start] (the opening
+// quote) and returns the index of the matching closing quote, honoring
+// backslash escapes. Single-line quoted strings cannot span lines in any of the
+// supported languages, so an unterminated quote returns the last index, ending
+// the scan for this line.
+func skipQuoted(runes []rune, start int, quote rune) int {
+	for i := start + 1; i < len(runes); i++ {
+		switch runes[i] {
+		case '\\':
+			i++ // skip the escaped rune
+		case quote:
+			return i
+		}
+	}
+	return len(runes) - 1
+}

--- a/internal/parser/braces_test.go
+++ b/internal/parser/braces_test.go
@@ -1,0 +1,110 @@
+package parser
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBraceScannerSkipsStringsAndComments(t *testing.T) {
+	tests := []struct {
+		name string
+		lang braceLang
+		line string
+		want int
+	}{
+		{"go open", braceLangGo, "func Greet() string {", 1},
+		{"go brace in string", braceLangGo, `func Greet() string { return "}" }`, 0},
+		{"go brace in rune", braceLangGo, `if c == '}' {`, 1},
+		{"go brace in line comment", braceLangGo, `x := 1 // closes with }`, 0},
+		{"go brace in block comment", braceLangGo, `y := 2 /* } } */ + 3`, 0},
+		{"js brace in single quotes", braceLangJS, `const s = '}'`, 0},
+		{"js one-liner balanced", braceLangJS, `fn Inc() { Count++ }`, 0},
+		{"js else", braceLangJS, `} else {`, 0},
+		{"css brace in string", braceLangCSS, `content: "}";`, 0},
+		{"css no line comment", braceLangCSS, `a { // not a comment }`, 0},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			scanner := braceScanner{lang: test.lang}
+			if got := scanner.delta(test.line); got != test.want {
+				t.Fatalf("delta(%q) = %d, want %d", test.line, got, test.want)
+			}
+		})
+	}
+}
+
+func TestBraceScannerCarriesMultilineState(t *testing.T) {
+	scanner := braceScanner{lang: braceLangGo}
+	// Opening a block comment that contains a lone "}" on its own line must not
+	// be counted, and inMultiline must report the open comment between lines.
+	if got := scanner.delta("x := 1 /* start"); got != 0 {
+		t.Fatalf("line 1 delta = %d, want 0", got)
+	}
+	if !scanner.inMultiline() {
+		t.Fatal("expected scanner to be inside a block comment after line 1")
+	}
+	if got := scanner.delta("}"); got != 0 {
+		t.Fatalf("brace inside comment counted: delta = %d, want 0", got)
+	}
+	if got := scanner.delta("end */"); got != 0 {
+		t.Fatalf("line 3 delta = %d, want 0", got)
+	}
+	if scanner.inMultiline() {
+		t.Fatal("expected block comment to be closed after line 3")
+	}
+}
+
+func TestBraceScannerRawStringSpansLines(t *testing.T) {
+	scanner := braceScanner{lang: braceLangGo}
+	if got := scanner.delta("s := `start {"); got != 0 {
+		t.Fatalf("raw string open delta = %d, want 0", got)
+	}
+	if !scanner.inMultiline() {
+		t.Fatal("expected scanner inside raw string")
+	}
+	if got := scanner.delta("still } in string`"); got != 0 {
+		t.Fatalf("raw string close delta = %d, want 0", got)
+	}
+}
+
+func TestParseSyntaxGoBlockWithBraceInString(t *testing.T) {
+	file, err := ParseSyntax([]byte("go {\n\tfunc Greet() string { return \"}\" }\n}\n"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(file.Blocks) != 1 || file.Blocks[0].Kind != "go" {
+		t.Fatalf("expected one go block, got %#v", file.Blocks)
+	}
+	if !strings.Contains(file.Blocks[0].Body, `return "}"`) {
+		t.Fatalf("go block body lost content: %q", file.Blocks[0].Body)
+	}
+}
+
+func TestParseSyntaxClientBlockOneLinersAndStrings(t *testing.T) {
+	file, err := ParseSyntax([]byte("client {\n\tfn Inc() { Count++ }\n\tif x { y() } else { z() }\n\tlet s = \"}\"\n}\n"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var client *SyntaxBlock
+	for i := range file.Blocks {
+		if file.Blocks[i].Kind == "client" {
+			client = &file.Blocks[i]
+		}
+	}
+	if client == nil {
+		t.Fatalf("expected a client block, got %#v", file.Blocks)
+	}
+	if !strings.Contains(client.Body, "} else {") {
+		t.Fatalf("client block body lost content: %q", client.Body)
+	}
+}
+
+func TestParseComponentClientBlockOneLiner(t *testing.T) {
+	component, err := ParseComponent([]byte("@component Counter\nclient {\n\tfn Inc() { Count++ }\n}\nview {\n\t<div></div>\n}\n"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(component.Blocks.ClientBody, "Count++") {
+		t.Fatalf("client body lost content: %q", component.Blocks.ClientBody)
+	}
+}

--- a/internal/parser/component.go
+++ b/internal/parser/component.go
@@ -33,13 +33,14 @@ func ParseComponent(src []byte) (gwdkir.Component, error) {
 	goBlockTarget := ""
 	seenGoBlocks := map[string]source.SourceSpan{}
 	seenDeclaration := false
+	var blockScanner braceScanner
 
 	scanner := bufio.NewScanner(bytes.NewReader(src))
 	for lineNumber := 1; scanner.Scan(); lineNumber++ {
 		rawLine := scanner.Text()
 		line := strings.TrimSpace(rawLine)
 		if inGoBlock {
-			if line == "}" {
+			if line == "}" && !blockScanner.inMultiline() {
 				goBlockDepth--
 				if goBlockDepth == 0 {
 					component.Blocks.GoBlocks = append(component.Blocks.GoBlocks, gwdkir.GoBlock{
@@ -57,7 +58,7 @@ func ParseComponent(src []byte) (gwdkir.Component, error) {
 				goBlockBody = append(goBlockBody, rawLine)
 				continue
 			}
-			goBlockDepth += braceDelta(rawLine)
+			goBlockDepth += blockScanner.delta(rawLine)
 			if goBlockDepth < 1 {
 				return gwdkir.Component{}, fmt.Errorf("line %d: go block closed unexpectedly", lineNumber)
 			}
@@ -65,7 +66,7 @@ func ParseComponent(src []byte) (gwdkir.Component, error) {
 			continue
 		}
 		if inStyle {
-			styleDepth += braceDelta(rawLine)
+			styleDepth += blockScanner.delta(rawLine)
 			if styleDepth < 0 {
 				return gwdkir.Component{}, fmt.Errorf("line %d: style block closed unexpectedly", lineNumber)
 			}
@@ -81,7 +82,7 @@ func ParseComponent(src []byte) (gwdkir.Component, error) {
 			continue
 		}
 		if inClient {
-			if line == "}" && clientDepth == 1 {
+			if line == "}" && clientDepth == 1 && !blockScanner.inMultiline() {
 				component.Blocks.ClientBody = strings.TrimSpace(strings.Join(clientBody, "\n"))
 				inClient = false
 				clientBody = nil
@@ -89,14 +90,14 @@ func ParseComponent(src []byte) (gwdkir.Component, error) {
 				continue
 			}
 			clientBody = append(clientBody, rawLine)
-			clientDepth += braceDelta(rawLine)
+			clientDepth += blockScanner.delta(rawLine)
 			if clientDepth < 1 {
 				return gwdkir.Component{}, fmt.Errorf("line %d: client block closed unexpectedly", lineNumber)
 			}
 			continue
 		}
 		if inJS {
-			if line == "}" {
+			if line == "}" && !blockScanner.inMultiline() {
 				jsDepth--
 				if jsDepth == 0 {
 					name := source.InlineScriptName(len(component.InlineJS))
@@ -113,7 +114,7 @@ func ParseComponent(src []byte) (gwdkir.Component, error) {
 				jsBody = append(jsBody, rawLine)
 				continue
 			}
-			jsDepth += braceDelta(rawLine)
+			jsDepth += blockScanner.delta(rawLine)
 			if jsDepth < 1 {
 				return gwdkir.Component{}, fmt.Errorf("line %d: js block closed unexpectedly", lineNumber)
 			}
@@ -237,6 +238,7 @@ func ParseComponent(src []byte) (gwdkir.Component, error) {
 			component.Spans.InlineJS = append(component.Spans.InlineJS, source.NamedSpan{Name: name, Span: span})
 			inJS = true
 			jsDepth = 1
+			blockScanner = braceScanner{lang: braceLangJS}
 			continue
 		}
 		if isMalformedJS(line) {
@@ -302,6 +304,7 @@ func ParseComponent(src []byte) (gwdkir.Component, error) {
 			component.Blocks.Spans.Client = sourceLineSpan(lineNumber, rawLine)
 			inClient = true
 			clientDepth = 1
+			blockScanner = braceScanner{lang: braceLangJS}
 			continue
 		case "go {":
 			span := sourceLineSpan(lineNumber, rawLine)
@@ -312,6 +315,7 @@ func ParseComponent(src []byte) (gwdkir.Component, error) {
 			inGoBlock = true
 			goBlockDepth = 1
 			goBlockTarget = ""
+			blockScanner = braceScanner{lang: braceLangGo}
 			continue
 		case "emits {":
 			if len(component.Emits) > 0 {
@@ -332,6 +336,7 @@ func ParseComponent(src []byte) (gwdkir.Component, error) {
 			component.Blocks.Style = true
 			inStyle = true
 			styleDepth = 1
+			blockScanner = braceScanner{lang: braceLangCSS}
 			continue
 		}
 		if match := goBlockPattern.FindStringSubmatch(line); match != nil {
@@ -348,6 +353,7 @@ func ParseComponent(src []byte) (gwdkir.Component, error) {
 			inGoBlock = true
 			goBlockDepth = 1
 			goBlockTarget = target
+			blockScanner = braceScanner{lang: braceLangGo}
 			continue
 		}
 

--- a/internal/parser/helpers.go
+++ b/internal/parser/helpers.go
@@ -21,19 +21,6 @@ func unsupportedTopLevelBlockName(line string) string {
 	return name
 }
 
-func braceDelta(line string) int {
-	delta := 0
-	for _, r := range line {
-		switch r {
-		case '{':
-			delta++
-		case '}':
-			delta--
-		}
-	}
-	return delta
-}
-
 func isMalformedImport(line string) bool {
 	fields := strings.Fields(line)
 	return len(fields) > 0 && fields[0] == "import"

--- a/internal/parser/layout.go
+++ b/internal/parser/layout.go
@@ -24,13 +24,14 @@ func ParseLayout(src []byte) (gwdkir.Layout, error) {
 	goBlockTarget := ""
 	seenGoBlocks := map[string]source.SourceSpan{}
 	seenDeclaration := false
+	var blockScanner braceScanner
 
 	scanner := bufio.NewScanner(bytes.NewReader(src))
 	for lineNumber := 1; scanner.Scan(); lineNumber++ {
 		rawLine := scanner.Text()
 		line := strings.TrimSpace(rawLine)
 		if inGoBlock {
-			if line == "}" {
+			if line == "}" && !blockScanner.inMultiline() {
 				goBlockDepth--
 				if goBlockDepth == 0 {
 					layout.Blocks.GoBlocks = append(layout.Blocks.GoBlocks, gwdkir.GoBlock{
@@ -48,7 +49,7 @@ func ParseLayout(src []byte) (gwdkir.Layout, error) {
 				goBlockBody = append(goBlockBody, rawLine)
 				continue
 			}
-			goBlockDepth += braceDelta(rawLine)
+			goBlockDepth += blockScanner.delta(rawLine)
 			if goBlockDepth < 1 {
 				return gwdkir.Layout{}, fmt.Errorf("line %d: go block closed unexpectedly", lineNumber)
 			}
@@ -56,7 +57,7 @@ func ParseLayout(src []byte) (gwdkir.Layout, error) {
 			continue
 		}
 		if inStyle {
-			styleDepth += braceDelta(rawLine)
+			styleDepth += blockScanner.delta(rawLine)
 			if styleDepth < 0 {
 				return gwdkir.Layout{}, fmt.Errorf("line %d: style block closed unexpectedly", lineNumber)
 			}
@@ -140,6 +141,7 @@ func ParseLayout(src []byte) (gwdkir.Layout, error) {
 			layout.Blocks.Style = true
 			inStyle = true
 			styleDepth = 1
+			blockScanner = braceScanner{lang: braceLangCSS}
 			continue
 		case "go {":
 			span := sourceLineSpan(lineNumber, rawLine)
@@ -150,6 +152,7 @@ func ParseLayout(src []byte) (gwdkir.Layout, error) {
 			inGoBlock = true
 			goBlockDepth = 1
 			goBlockTarget = ""
+			blockScanner = braceScanner{lang: braceLangGo}
 			continue
 		}
 		if match := goBlockPattern.FindStringSubmatch(line); match != nil {
@@ -166,6 +169,7 @@ func ParseLayout(src []byte) (gwdkir.Layout, error) {
 			inGoBlock = true
 			goBlockDepth = 1
 			goBlockTarget = target
+			blockScanner = braceScanner{lang: braceLangGo}
 			continue
 		}
 

--- a/internal/parser/syntax.go
+++ b/internal/parser/syntax.go
@@ -40,6 +40,7 @@ func ParseSyntax(src []byte) (SyntaxFile, error) {
 	var body []syntaxBodyLine
 	var captured SyntaxBlock
 	var capturedFragment *SyntaxFragmentEndpoint
+	var blockScanner braceScanner
 	depth := 0
 	seenDeclaration := false
 	seenGoBlocks := map[string]source.SourceSpan{}
@@ -63,7 +64,7 @@ func ParseSyntax(src []byte) (SyntaxFile, error) {
 			if captured.Kind == "view" && line == "style {" {
 				return SyntaxFile{}, fmt.Errorf("line %d: style block must be outside view {}", lineNumber)
 			}
-			if line == "}" {
+			if line == "}" && !blockScanner.inMultiline() {
 				depth--
 				if depth == 0 {
 					if captured.Kind == "js" {
@@ -91,23 +92,26 @@ func ParseSyntax(src []byte) (SyntaxFile, error) {
 			if captured.Kind == "act" && actionFragmentPattern.FindStringSubmatch(line) != nil {
 				depth++
 			}
-			if captured.Kind == "client" && strings.Contains(line, "{") {
-				depth += strings.Count(line, "{")
+			if captured.Kind == "client" {
+				depth += blockScanner.delta(rawLine)
+				if depth < 1 {
+					return SyntaxFile{}, fmt.Errorf("line %d: client block closed unexpectedly", lineNumber)
+				}
 			}
 			if captured.Kind == "go" {
-				depth += braceDelta(rawLine)
+				depth += blockScanner.delta(rawLine)
 				if depth < 1 {
 					return SyntaxFile{}, fmt.Errorf("line %d: go block closed unexpectedly", lineNumber)
 				}
 			}
 			if captured.Kind == "style" {
-				depth += braceDelta(rawLine)
+				depth += blockScanner.delta(rawLine)
 				if depth < 1 {
 					return SyntaxFile{}, fmt.Errorf("line %d: style block closed unexpectedly", lineNumber)
 				}
 			}
 			if captured.Kind == "js" {
-				depth += braceDelta(rawLine)
+				depth += blockScanner.delta(rawLine)
 				if depth < 1 {
 					return SyntaxFile{}, fmt.Errorf("line %d: js block closed unexpectedly", lineNumber)
 				}
@@ -186,6 +190,7 @@ func ParseSyntax(src []byte) (SyntaxFile, error) {
 		}
 		if jsBlockPattern.MatchString(line) {
 			captured = SyntaxBlock{Kind: "js", Span: sourceLineSpan(lineNumber, rawLine)}
+			blockScanner = braceScanner{lang: braceLangJS}
 			depth = 1
 			continue
 		}
@@ -225,6 +230,7 @@ func ParseSyntax(src []byte) (SyntaxFile, error) {
 		}
 		if match := syntaxBlockPattern.FindStringSubmatch(line); match != nil {
 			captured = SyntaxBlock{Kind: match[1], Span: sourceLineSpan(lineNumber, rawLine)}
+			blockScanner = braceScanner{lang: blockScanLang(match[1])}
 			depth = 1
 			continue
 		}
@@ -240,6 +246,7 @@ func ParseSyntax(src []byte) (SyntaxFile, error) {
 			span := sourceLineSpan(lineNumber, rawLine)
 			seenGoBlocks[target] = span
 			captured = SyntaxBlock{Kind: "go", Name: target, Span: span}
+			blockScanner = braceScanner{lang: braceLangGo}
 			depth = 1
 			continue
 		}

--- a/internal/view/component.go
+++ b/internal/view/component.go
@@ -215,7 +215,10 @@ func renderComponentIsland(out *renderOutput, island componentIslandRender) erro
 	if err != nil {
 		return err
 	}
-	stateJSON := componentStateJSON(island.Component.StateJSON, island.Props, island.ComputedValues)
+	stateJSON, err := componentStateJSON(island.Component.StateJSON, island.Props, island.ComputedValues)
+	if err != nil {
+		return err
+	}
 	if stateJSON == "" {
 		stateJSON = "{}"
 	}

--- a/internal/view/island_helpers.go
+++ b/internal/view/island_helpers.go
@@ -172,13 +172,15 @@ func evalComputedValues(computeds []clientlang.Computed, values map[string]strin
 	return stringsOut, valuesOut, nil
 }
 
-func componentStateJSON(stateJSON string, props map[string]string, computed map[string]any) string {
+func componentStateJSON(stateJSON string, props map[string]string, computed map[string]any) (string, error) {
 	if stateJSON == "" && len(props) == 0 && len(computed) == 0 {
-		return ""
+		return "", nil
 	}
 	values := map[string]any{}
 	if stateJSON != "" {
-		_ = json.Unmarshal([]byte(stateJSON), &values)
+		if err := json.Unmarshal([]byte(stateJSON), &values); err != nil {
+			return "", fmt.Errorf("decode component state JSON: %w", err)
+		}
 	}
 	for key, value := range props {
 		values[key] = value
@@ -188,9 +190,9 @@ func componentStateJSON(stateJSON string, props map[string]string, computed map[
 	}
 	payload, err := json.Marshal(values)
 	if err != nil {
-		return stateJSON
+		return "", fmt.Errorf("encode component state JSON: %w", err)
 	}
-	return string(payload)
+	return string(payload), nil
 }
 
 func scalarString(value any) (string, bool) {


### PR DESCRIPTION
Fixes three open bugs. Full non-example test suite passes (`go test ./internal/... ./cmd/... ./addons/...`); gofmt and `go vet` clean.

## #149 — Parser brace counting breaks on valid code (high)
`braceDelta` counted every `{`/`}` with no string/comment awareness, so `go { func Greet() string { return "}" } }` failed with *"go block closed unexpectedly"*; and the client-block tracker in `syntax.go` only incremented on `{` while decrementing solely on a lone `}` line, so `fn Inc() { Count++ }` and `} else {` failed with *"client block missing closing }"*.

- New shared, stateful, string/comment-aware `braceScanner` (`internal/parser/braces.go`) — skips braces inside strings, runes, line/block comments, Go raw strings, and JS template literals, and carries multi-line state across lines.
- The three diverging copies (`syntax.go`, `component.go`, `layout.go`) now share it; client blocks use the same consistent delta; the lone-`}` close check is guarded by `!inMultiline()`.
- New unit + parser-level regression tests (`braces_test.go`) cover the reported cases plus multi-line comment/raw-string state.
- Known limitation (documented in code): JS regex literals aren't tokenized.

## #154 — discover.Files never prunes excluded dirs, aborts on any walk error (medium)
- Excluded `dir/**` directories are now pruned with `filepath.SkipDir` (`matchesExcludedDir`), so we no longer descend into `.git`/`node_modules`/`vendor`. File-glob excludes like `src/**/card.cmp.gwdk` still don't prune the whole `src` tree.
- Per-entry walk errors skip the offending entry instead of aborting the build; only a failure to read `root` stays fatal.
- New tests for pruning, the dir matcher, and an unreadable-directory case.

## #162 — Silent error swallowing (medium) — partial
Fixed:
- **appgen**: `printGoFile`/`formatGoSource`/`formatGoDeclSnippet`/`printActionDecls` now return errors instead of swallowing `printer.Fprint` failures and returning unformatted source; propagated through `appPackageSource`, `backendAppPackageSource`, and `serverMainSource` (the last is written directly and was previously unvalidated).
- **buildgen**: `islandRuntimeArtifacts` returns the component-resolution error instead of `continue`.
- **compiler**: `discoverGoEndpointsInDir` distinguishes an absent directory (skipped) from a real read failure (new `go_endpoint_read_error` diagnostic) instead of reading it as "no endpoints found".
- **view**: `componentStateJSON` no longer ignores `json.Unmarshal`/`Marshal` failures; `renderComponentIsland` propagates them.

Deferred to follow-up PRs (with rationale):
- **config loader non-literal fields**: doing this correctly requires threading a "non-literal" signal through ~12 parse helpers without misfiring on the fields that legitimately accept enum selectors/idents (`Build.Mode`, `Render.Default`). It's a high-blast-radius change to config loading that warrants its own focused PR + tests; the common computed-value case already triggers the executable-load fallback via non-literal `Addons`.
- **islandScriptHrefs / appendContractReferences**: need render-path signature changes or a new IR-builder diagnostics sink. The same parse failures already surface elsewhere (e.g. `islandRuntimeArtifacts`, `view.Parse`).

Closes #149
Closes #154

🤖 Generated with [Claude Code](https://claude.com/claude-code)