### PR TITLE
test: pin IR migration closeout goldens

### DIFF
--- a/cmd/gowdk/main_test.go
+++ b/cmd/gowdk/main_test.go
@@ -3328,6 +3328,43 @@ func TestInspectIRCommandMatchesGoldenFixture(t *testing.T) {
 	}
 }
 
+func TestRoutesCommandMatchesGoldenFixture(t *testing.T) {
+	fixture := filepath.FromSlash("testdata/routes_golden")
+	var output string
+	withWorkingDir(t, fixture, func() {
+		stdout, _, err := captureCLIOutput(t, func() error {
+			return run([]string{"routes", "--config", "gowdk.config.go", "newsletter.page.gwdk"})
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		output = stdout
+	})
+
+	expected, err := os.ReadFile(filepath.Join(fixture, "routes.golden.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	expectedJSON := canonicalRoutesGolden(t, expected)
+	actualJSON := canonicalRoutesGolden(t, []byte(output))
+	if actualJSON != expectedJSON {
+		t.Fatalf("routes golden mismatch\nexpected:\n%s\nactual:\n%s", expectedJSON, actualJSON)
+	}
+}
+
+func canonicalRoutesGolden(t *testing.T, payload []byte) string {
+	t.Helper()
+	var report routeMetadataReport
+	if err := json.Unmarshal(payload, &report); err != nil {
+		t.Fatalf("invalid routes golden JSON: %v\n%s", err, payload)
+	}
+	canonical, err := json.MarshalIndent(report, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(canonical)
+}
+
 func TestInspectIRCommandDiscoversSelectedModuleOnly(t *testing.T) {
 	root := t.TempDir()
 	writeCLIFile(t, filepath.Join(root, "gowdk.config.go"), `package app

--- a/cmd/gowdk/testdata/routes_golden/gowdk.config.go
+++ b/cmd/gowdk/testdata/routes_golden/gowdk.config.go
@@ -1,0 +1,5 @@
+package app
+
+import "github.com/cssbruno/gowdk"
+
+var Config = gowdk.Config{}

--- a/cmd/gowdk/testdata/routes_golden/newsletter.page.gwdk
+++ b/cmd/gowdk/testdata/routes_golden/newsletter.page.gwdk
@@ -1,0 +1,14 @@
+package app
+
+@page newsletter
+@route "/newsletter"
+@guard public
+
+act Subscribe POST "/newsletter"
+
+view {
+  <form g:post={Subscribe}>
+    <input name="email" required />
+    <button type="submit">Subscribe</button>
+  </form>
+}

--- a/cmd/gowdk/testdata/routes_golden/routes.golden.json
+++ b/cmd/gowdk/testdata/routes_golden/routes.golden.json
@@ -1,0 +1,53 @@
+{
+  "version": 1,
+  "routes": [
+    {
+      "kind": "spa",
+      "method": "GET",
+      "route": "/newsletter",
+      "pageId": "newsletter",
+      "handler": "embedded.SPA(\"pages/newsletter.html\")"
+    }
+  ],
+  "endpoints": [
+    {
+      "kind": "action",
+      "endpointSource": "gwdk",
+      "source": "newsletter.page.gwdk",
+      "sourceSpan": {
+        "start": {
+          "line": 7,
+          "column": 1
+        },
+        "end": {
+          "line": 7,
+          "column": 33
+        }
+      },
+      "package": "app",
+      "packagePath": "github.com/cssbruno/gowdk/cmd/gowdk/testdata/routes_golden",
+      "packageName": "app",
+      "symbol": "Subscribe",
+      "method": "POST",
+      "route": "/newsletter",
+      "pageId": "newsletter",
+      "handler": "actions.NewsletterSubscribe",
+      "bindingStatus": "missing",
+      "backendBinding": {
+        "status": "missing",
+        "packageName": "app",
+        "importPath": "github.com/cssbruno/gowdk/cmd/gowdk/testdata/routes_golden",
+        "functionName": "Subscribe",
+        "message": "GOWDK action handler github.com/cssbruno/gowdk/cmd/gowdk/testdata/routes_golden.Subscribe is not implemented"
+      }
+    }
+  ],
+  "info": [
+    {
+      "code": "ssr_disabled",
+      "pageId": "newsletter",
+      "route": "/newsletter",
+      "message": "newsletter uses build-time page output; request-time page rendering is disabled for this route"
+    }
+  ]
+}

--- a/docs/engineering/architecture.md
+++ b/docs/engineering/architecture.md
@@ -122,6 +122,20 @@ compatibility model has been removed entirely:
 New generated-output work should consume `internal/gwdkir.Program` or add
 fields there first.
 
+No generation path depends on a manifest compatibility record. The remaining
+`manifest` references in the tree are not compatibility models: the build-time
+`routeManifest`/`assetManifest` JSON *output* artifacts (`internal/buildgen`),
+the IR-derived public `gowdk manifest` report (`internal/lang/manifest_json.go`),
+the runtime `LoadAssetManifest` asset lookup, the `<… manifest>` HTML attribute
+allow-list (`internal/view`), and historical-context code comments.
+
+Golden tests pin each handoff stage end to end: AST
+(`internal/parser/testdata/golden`), IR (`cmd/gowdk/testdata/inspect_ir_golden`),
+routes and endpoints (`cmd/gowdk/testdata/routes_golden`), generated Go
+(`internal/appgen/testdata/generated_go_golden`), generated HTML and route/asset
+output manifests (`internal/buildgen/testdata/full_fixture`), and the public
+manifest report (`internal/lang/testdata/manifest_golden`).
+
 ## Components
 
 | Component | Responsibility | Owner | Notes |
@@ -130,7 +144,7 @@ fields there first.
 | `gowdk` root package | Public config, render modes, addon registration, and extension contracts. | Core | Includes `Config`, `RenderMode`, `Addon`, `CSSConfig`, `CSSProcessor`, and `GoBlockConsumer`. |
 | `internal/discover` | Find portable `.gwdk` files from include/exclude patterns. | Compiler | Recursive glob discovery implemented. |
 | `internal/gwdkast` | Define the typed GOWDK source AST. | Compiler | Package declarations, typed page/component/layout/route/render/layout/guard/CSS declarations, component CSS scope/hash metadata, annotations, Go imports, GOWDK uses, stores, typed component contracts, blocks, endpoint declarations, parsed view nodes, literal records, and source spans implemented. |
-| `internal/parser` | Parse `.gwdk` files into AST and manifest structs. | Compiler | First-slice parser for pages, components, layouts, route params, imported Go build functions, action/API metadata, component CSS scope/hash metadata, GOWDK `use` declarations, package declarations, package spans, and source spans implemented. `ParseSyntax` returns `internal/gwdkast.File`; manifest records remain for compatibility while compiler entrypoints move to analyzer IR. |
+| `internal/parser` | Parse `.gwdk` files into typed AST and `internal/gwdkir` records. | Compiler | First-slice parser for pages, components, layouts, route params, imported Go build functions, action/API metadata, component CSS scope/hash metadata, GOWDK `use` declarations, package declarations, package spans, and source spans implemented. `ParseSyntax` returns `internal/gwdkast.File`; `ParsePage`/`ParseLayout`/`ParseComponent` lower the AST directly into `gwdkir` records. The former manifest compatibility model has been removed. |
 | `internal/gwdkanalysis` | Assemble `internal/gwdkir.Program` from parsed IR records. | Compiler | `BuildProgram` derives packages, routes, endpoints, templates, client behavior, source-selected assets with component CSS scope/hash metadata, stores, imports, uses, and source spans from parsed records; exposes standalone-endpoint and backend-binding attachment for post-assembly enrichment. |
 | `internal/gwdkir` | Stable internal compiler IR shared by generated-output passes. | Compiler | Versioned IR for packages, source files, page routes, backend endpoints, templates, client behavior, asset scope/hash metadata, and generated output plans implemented. |
 | `internal/view` | Parse and render the first spa `view {}` markup subset. | Compiler | Lowercase HTML elements, spa/boolean/expression attributes, shorthand class/id normalization, escaped text/attribute interpolation, self-closing component calls, prop/state interpolation, `g:on:*`, and `g:island` handling implemented. |

--- a/internal/appgen/appgen_test.go
+++ b/internal/appgen/appgen_test.go
@@ -375,6 +375,50 @@ func TestGenerateWritesBoundContractBackendRoutes(t *testing.T) {
 	}
 }
 
+func TestGeneratedGoMatchesGoldenFixture(t *testing.T) {
+	root := t.TempDir()
+	outputDir := filepath.Join(root, "dist")
+	appDir := filepath.Join(root, "generated-app")
+	writeTestFile(t, filepath.Join(outputDir, "patients", "index.html"), "<main>Patients</main>")
+
+	program := &gwdkir.Program{ContractRefs: []gwdkir.ContractReference{{
+		Kind:        gwdkir.ContractCommand,
+		Name:        "patients.CreatePatient",
+		ImportAlias: "patients",
+		ImportPath:  "example.com/app/contracts/patients",
+		Type:        "CreatePatient",
+		Result:      "CreatePatientResult",
+		InputFields: []source.BackendInputField{
+			{FieldName: "Name", FormName: "name", Type: "string"},
+		},
+		Method:    "POST",
+		Path:      "/patients",
+		Status:    gwdkir.ContractBindingBound,
+		Handler:   "HandleCreatePatient",
+		Register:  "Register",
+		OwnerKind: gwdkir.SourcePage,
+		OwnerID:   "patients",
+	}}}
+
+	result, err := GenerateWithOptions(outputDir, appDir, Options{IR: program})
+	if err != nil {
+		t.Fatal(err)
+	}
+	actual, err := os.ReadFile(result.PackagePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	goldenPath := filepath.FromSlash("testdata/generated_go_golden/app.go.golden")
+	expected, err := os.ReadFile(goldenPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(actual) != string(expected) {
+		t.Fatalf("generated Go golden mismatch (update %s if intentional)\nexpected:\n%s\nactual:\n%s", goldenPath, expected, actual)
+	}
+}
+
 func TestGenerateBackendAppRegistersBackendRoutes(t *testing.T) {
 	appDir := filepath.Join(t.TempDir(), "generated-backend")
 

--- a/internal/appgen/testdata/generated_go_golden/app.go.golden
+++ b/internal/appgen/testdata/generated_go_golden/app.go.golden
@@ -1,0 +1,133 @@
+package gowdkapp
+
+import (
+	"context"
+	"embed"
+	patients "example.com/app/contracts/patients"
+	gowdkruntime "github.com/cssbruno/gowdk/runtime/app"
+	gowdkcontracts "github.com/cssbruno/gowdk/runtime/contracts"
+	gowdkform "github.com/cssbruno/gowdk/runtime/form"
+	gowdkresponse "github.com/cssbruno/gowdk/runtime/response"
+	"io/fs"
+	"net/http"
+	"strings"
+	"sync"
+)
+
+const maxActionBodyBytes int64 = 1 << 20
+
+//go:embed app
+var embeddedFiles embed.FS
+
+func Handler() (http.Handler, error) {
+	return ServeMux()
+}
+func ServeMux() (*http.ServeMux, error) {
+	root, err := fs.Sub(embeddedFiles, "app")
+	if err != nil {
+		return nil, err
+	}
+	backendRouter, err := newBackendRouter()
+	if err != nil {
+		return nil, err
+	}
+	mux := http.NewServeMux()
+	mux.Handle("/", gowdkruntime.Handler{Root: root, Identity: gowdkruntime.InstanceIdentity(), Assets: gowdkruntime.LoadAssetManifest(root), ErrorPages: gowdkruntime.LoadErrorPages(root), Backend: backendRouter.HandlerFunc(), SSRExact: ssrExact, SSRDynamic: ssrDynamic, RequestTimeout: gowdkruntime.DefaultRequestTimeout})
+	return mux, nil
+}
+func action(response http.ResponseWriter, request *http.Request) bool {
+	return false
+}
+func api(response http.ResponseWriter, request *http.Request) bool {
+	return false
+}
+func fragment(response http.ResponseWriter, request *http.Request) bool {
+	return false
+}
+func commandPatientsCreatePatientPOSTPatients(contractRegistry *gowdkcontracts.Registry) gowdkruntime.BackendHandler {
+	return func(response http.ResponseWriter, request *http.Request) bool {
+		ctx := gowdkruntime.WithEndpoint(gowdkruntime.WithRequest(request.Context(), request), gowdkruntime.EndpointMetadata{Kind: "command", PageID: "patients", Name: "patients.CreatePatient", Method: "POST", Path: "/patients"})
+		request = request.WithContext(ctx)
+		request.Body = http.MaxBytesReader(response, request.Body, maxActionBodyBytes)
+		if err := request.ParseForm(); err != nil {
+			if strings.Contains(err.Error(), "request body too large") {
+				gowdkresponse.WriteNoStoreError(response, http.StatusRequestEntityTooLarge, "request body too large")
+				return true
+			}
+			gowdkresponse.WriteNoStoreError(response, http.StatusBadRequest, "invalid form")
+			return true
+		}
+		values := gowdkform.FromURLValues(request.PostForm)
+		input, err := decodeContractPatientsCreatePatientInput(values)
+		if err != nil {
+			gowdkresponse.WriteNoStoreError(response, http.StatusBadRequest, "invalid form")
+			return true
+		}
+		result, events, err := gowdkcontracts.CaptureCommandEventsForRole[patients.CreatePatient, patients.CreatePatientResult](ctx, contractRegistry, gowdkcontracts.RoleWeb, input)
+		if err != nil {
+			gowdkresponse.WriteNoStoreError(response, gowdkresponse.HandlerStatus(err, http.StatusInternalServerError), err.Error())
+			return true
+		}
+		if dispatchErr := gowdkcontracts.DispatchCommandEvents(ctx, currentContractEventSink(), contractRegistry, gowdkcontracts.RoleWeb, events); dispatchErr != nil {
+			gowdkresponse.WriteNoStoreError(response, gowdkresponse.HandlerStatus(dispatchErr, http.StatusInternalServerError), dispatchErr.Error())
+			return true
+		}
+		httpResult, err := gowdkresponse.JSONValue(http.StatusOK, result)
+		if err != nil {
+			gowdkresponse.WriteNoStoreError(response, http.StatusInternalServerError, err.Error())
+			return true
+		}
+		_ = gowdkresponse.WriteNoStoreHTTP(response, httpResult)
+		return true
+	}
+}
+func decodeContractPatientsCreatePatientInput(values gowdkform.Values) (patients.CreatePatient, error) {
+	decoded, err := gowdkform.DecodeExpected(values, gowdkform.Schema{Fields: []gowdkform.Field{{Name: "name"}}})
+	if err != nil {
+		return patients.CreatePatient{}, err
+	}
+	values = decoded
+	input := patients.CreatePatient{}
+	field0, ok, err := gowdkform.String(values, "name")
+	if err != nil {
+		return input, err
+	}
+	if ok {
+		input.Name = field0
+	}
+	return input, nil
+}
+
+var contractEventSinkMu sync.RWMutex
+var contractEventSink gowdkcontracts.CommandEventSink
+
+func RegisterContractEventSink(sink gowdkcontracts.CommandEventSink) {
+	contractEventSinkMu.Lock()
+	defer contractEventSinkMu.Unlock()
+	contractEventSink = sink
+}
+func currentContractEventSink() gowdkcontracts.CommandEventSink {
+	contractEventSinkMu.RLock()
+	defer contractEventSinkMu.RUnlock()
+	return contractEventSink
+}
+func NewContractRegistry() *gowdkcontracts.Registry {
+	contractRegistry := gowdkcontracts.NewRegistry()
+	patients.Register(contractRegistry)
+	return contractRegistry
+}
+func RunContractEventWorker(ctx context.Context, source gowdkcontracts.EventSource) error {
+	return gowdkcontracts.RunEventWorker(ctx, NewContractRegistry(), source)
+}
+func newBackendRouter() (*gowdkruntime.BackendRouter, error) {
+	contractRegistry := NewContractRegistry()
+	return gowdkruntime.NewBackendRouter(gowdkruntime.BackendRoute{Method: http.MethodPost, Path: "/patients", Kind: "command", Handler: commandPatientsCreatePatientPOSTPatients(contractRegistry)})
+}
+func ssrExact(response http.ResponseWriter, request *http.Request) (handled bool) {
+	switch request.URL.Path {
+	}
+	return false
+}
+func ssrDynamic(response http.ResponseWriter, request *http.Request) (handled bool) {
+	return false
+}


### PR DESCRIPTION
## Summary
- add a `gowdk routes` golden fixture covering route and action endpoint IR output
- add generated Go golden coverage for bound contract route generation
- update the architecture doc to close out the manifest compatibility model and list the current end-to-end golden coverage

## Tests
- `go test ./...`
- `scripts/test-go-modules.sh`