### PR TITLE
feat(compiler): require exactly one layout slot

### DIFF
--- a/internal/lang/tools.go
+++ b/internal/lang/tools.go
@@ -357,6 +357,9 @@ func CheckSource(config gowdk.Config, path string, source []byte) (gwdkir.Page, 
 			return gwdkir.Page{}, diagnostics
 		}
 		ir := gwdkanalysis.BuildProgram(config, gwdkanalysis.Sources{Layouts: []gwdkir.Layout{layout}})
+		if err := compiler.ValidateSourceProgram(config, ir); err != nil {
+			diagnostics = append(diagnostics, compilerDiagnostics(err, ir)...)
+		}
 		diagnostics = append(diagnostics, accessibilityDiagnostics(ir)...)
 		return gwdkir.Page{}, diagnostics
 	case FileKindAsset, FileKindPlugin:

--- a/internal/lang/tools_test.go
+++ b/internal/lang/tools_test.go
@@ -60,6 +60,24 @@ view {
 	}
 }
 
+func TestCheckSourceValidatesUnsavedLayoutSlots(t *testing.T) {
+	_, diagnostics := CheckSource(gowdk.Config{}, "root.layout.gwdk", []byte(`package app
+
+view {
+  <main></main>
+}
+`))
+	if !diagnostics.HasErrors() {
+		t.Fatal("expected layout slot diagnostic")
+	}
+	if diagnostics[0].Code != "layout_slot_count" {
+		t.Fatalf("expected layout_slot_count diagnostic, got %#v", diagnostics[0])
+	}
+	if diagnostics[0].File != "root.layout.gwdk" {
+		t.Fatalf("expected source path on diagnostic, got %#v", diagnostics[0])
+	}
+}
+
 func TestCompletionsIncludeCoreLanguageKeywords(t *testing.T) {
 	completions := Completions()
 	if len(completions) == 0 {


### PR DESCRIPTION
## Summary

- adds compiler validation that every layout contains exactly one self-closing `<slot />`
- reports a stable `layout_slot_count` diagnostic when layouts have zero or multiple slots
- updates layout validation tests to cover missing and duplicate slots

## Impact

This turns invalid layout composition into an early compiler error instead of allowing slot-less or ambiguous layouts to reach later composition behavior.

## Validation

- Not run locally; PR created from the existing remote branch.