### PR TITLE
fix: surface silent compiler failures

### DIFF
--- a/internal/buildgen/islands_test.go
+++ b/internal/buildgen/islands_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cssbruno/gowdk/internal/gwdkanalysis"
 	"github.com/cssbruno/gowdk/internal/gwdkir"
 	"github.com/cssbruno/gowdk/internal/source"
+	"github.com/cssbruno/gowdk/internal/view"
 )
 
 func TestBuildEmitsJSIslandAssetsForStatefulComponent(t *testing.T) {
@@ -110,6 +111,28 @@ func TestBuildEmitsJSIslandAssetsForStatefulComponent(t *testing.T) {
 	}
 	if len(sourceMap.SourcesContent) != 1 || !strings.Contains(sourceMap.SourcesContent[0], `view {`) || !strings.Contains(sourceMap.SourcesContent[0], `{Count}`) {
 		t.Fatalf("expected component source content in source map: %#v", sourceMap.SourcesContent)
+	}
+}
+
+func TestPageScriptsReportsComponentTraversalErrors(t *testing.T) {
+	page := gwdkir.Page{
+		ID:    "home",
+		Route: "/",
+		Blocks: gwdkir.Blocks{
+			View:     true,
+			ViewBody: `<main><Broken /></main>`,
+		},
+	}
+	components := map[string]view.Component{
+		"Broken": {
+			Name: "Broken",
+			Body: `<a href="/broken"`,
+		},
+	}
+
+	_, err := pageScripts(gowdk.Config{}, page, page.Blocks.ViewBody, components, renderModeSPA)
+	if err == nil {
+		t.Fatal("expected component traversal error")
 	}
 }
 

--- a/internal/buildgen/render.go
+++ b/internal/buildgen/render.go
@@ -53,7 +53,11 @@ func renderPage(config gowdk.Config, page gwdkir.Page, components map[string]vie
 	if err != nil {
 		return "", fmt.Errorf("%s: %w", page.ID, err)
 	}
-	return document(config, page, body, stylesheets, storeSeeds, pageScripts(config, page, viewSource, pageComponents, policy)), nil
+	scripts, err := pageScripts(config, page, viewSource, pageComponents, policy)
+	if err != nil {
+		return "", fmt.Errorf("%s: %w", page.ID, err)
+	}
+	return document(config, page, body, stylesheets, storeSeeds, scripts), nil
 }
 
 func composePageViewSource(page gwdkir.Page, layouts map[string]gwdkir.Layout) (string, error) {
@@ -186,27 +190,35 @@ func actionRoutes(page gwdkir.Page, data map[string]string) map[string]string {
 	return routes
 }
 
-func pageScripts(config gowdk.Config, page gwdkir.Page, viewSource string, components map[string]view.Component, policy renderModePolicy) []gowdk.Script {
+func pageScripts(config gowdk.Config, page gwdkir.Page, viewSource string, components map[string]view.Component, policy renderModePolicy) ([]gowdk.Script, error) {
 	scripts := append([]gowdk.Script{}, nonEmptyScripts(config.Build.Scripts)...)
 	for _, href := range scopedScriptHrefs(page, viewSource, components) {
 		scripts = append(scripts, gowdk.Script{Src: href, Type: "module"})
 	}
 	if policy != renderModeSPA {
-		return scripts
+		return scripts, nil
 	}
-	if pageUsesPartialRuntime(page, viewSource) || pageUsesSPANavigationRuntime(config, page, viewSource, components) {
+	usesSPANavigation, err := pageUsesSPANavigationRuntime(config, page, viewSource, components)
+	if err != nil {
+		return nil, err
+	}
+	if pageUsesPartialRuntime(page, viewSource) || usesSPANavigation {
 		scripts = append(scripts, gowdk.Script{Src: clientRuntimeHref})
 	}
 	if len(page.Stores) > 0 {
 		scripts = append(scripts, gowdk.Script{Src: storeRuntimeHref})
 	}
-	for _, href := range islandScriptHrefs(viewSource, components, page.Package, componentUses(page.Uses)) {
+	islandScripts, err := islandScriptHrefs(viewSource, components, page.Package, componentUses(page.Uses))
+	if err != nil {
+		return nil, err
+	}
+	for _, href := range islandScripts {
 		scripts = append(scripts, gowdk.Script{Src: href})
 	}
 	for _, href := range clientGoBlockHrefs(page) {
 		scripts = append(scripts, gowdk.Script{Src: href})
 	}
-	return scripts
+	return scripts, nil
 }
 
 func pageUsesPartialRuntime(page gwdkir.Page, viewSource string) bool {
@@ -216,24 +228,24 @@ func pageUsesPartialRuntime(page gwdkir.Page, viewSource string) bool {
 	return len(page.Blocks.Actions) > 0
 }
 
-func pageUsesSPANavigationRuntime(config gowdk.Config, page gwdkir.Page, viewSource string, components map[string]view.Component) bool {
+func pageUsesSPANavigationRuntime(config gowdk.Config, page gwdkir.Page, viewSource string, components map[string]view.Component) (bool, error) {
 	mode := page.RenderMode(config.Render.DefaultMode())
 	if mode != gowdk.SPA && mode != gowdk.Action {
-		return false
+		return false, nil
 	}
 	if viewSourceHasInternalLink(viewSource) {
-		return true
+		return true, nil
 	}
 	usages, err := recursiveViewComponentCallUsages(viewSource, components, page.Package, componentUses(page.Uses))
 	if err != nil {
-		return false
+		return false, err
 	}
 	for _, usage := range usages {
 		if viewSourceHasInternalLink(usage.component.Body) {
-			return true
+			return true, nil
 		}
 	}
-	return false
+	return false, nil
 }
 
 func viewSourceHasInternalLink(source string) bool {

--- a/internal/buildgen/runtime_assets.go
+++ b/internal/buildgen/runtime_assets.go
@@ -9,24 +9,33 @@ import (
 	"github.com/cssbruno/gowdk/internal/view"
 )
 
-func clientRuntimeArtifacts(config gowdk.Config, pages []gwdkir.Page, outputDir string, layouts map[string]gwdkir.Layout, components map[string]view.Component) []plannedAssetArtifact {
+func clientRuntimeArtifacts(config gowdk.Config, pages []gwdkir.Page, outputDir string, layouts map[string]gwdkir.Layout, components map[string]view.Component) ([]plannedAssetArtifact, error) {
 	for _, page := range pages {
-		viewSource := page.Blocks.ViewBody
-		if source, err := composePageViewSource(page, layouts); err == nil {
-			viewSource = source
+		viewSource, err := composePageViewSource(page, layouts)
+		if err != nil {
+			return nil, err
 		}
-		if pageUsesPartialRuntime(page, viewSource) || pageUsesSPANavigationRuntime(config, page, viewSource, components) {
+		usesSPANavigation, err := pageUsesSPANavigationRuntime(config, page, viewSource, components)
+		if err != nil {
+			return nil, err
+		}
+		if pageUsesPartialRuntime(page, viewSource) || usesSPANavigation {
 			return []plannedAssetArtifact{{
 				AssetArtifact: AssetArtifact{Path: filepath.Join(outputDir, filepath.FromSlash(clientRuntimeAssetPath))},
 				contents:      clientrt.Source(),
-			}}
+			}}, nil
 		}
 	}
-	return nil
+	return nil, nil
 }
+
 func runtimeArtifacts(config gowdk.Config, ir gwdkir.Program, outputDir string, layouts map[string]gwdkir.Layout, components map[string]view.Component) ([]plannedAssetArtifact, error) {
 	var artifacts []plannedAssetArtifact
-	artifacts = append(artifacts, clientRuntimeArtifacts(config, ir.Pages, outputDir, layouts, components)...)
+	clientRuntime, err := clientRuntimeArtifacts(config, ir.Pages, outputDir, layouts, components)
+	if err != nil {
+		return nil, err
+	}
+	artifacts = append(artifacts, clientRuntime...)
 	artifacts = append(artifacts, storeRuntimeArtifacts(ir.Pages, outputDir)...)
 	islands, err := islandRuntimeArtifacts(config, ir.Pages, ir.Components, outputDir, layouts)
 	if err != nil {

--- a/internal/buildgen/runtime_islands.go
+++ b/internal/buildgen/runtime_islands.go
@@ -68,10 +68,10 @@ func islandRuntimeArtifacts(config gowdk.Config, pages []gwdkir.Page, allCompone
 	return artifacts, nil
 }
 
-func islandScriptHrefs(source string, components map[string]view.Component, ownerPackage string, uses map[string]string) []string {
+func islandScriptHrefs(source string, components map[string]view.Component, ownerPackage string, uses map[string]string) ([]string, error) {
 	usages, err := recursiveViewComponentCallUsages(source, components, ownerPackage, uses)
 	if err != nil {
-		return nil
+		return nil, err
 	}
 	seen := map[string]bool{}
 	var scripts []string
@@ -93,7 +93,7 @@ func islandScriptHrefs(source string, components map[string]view.Component, owne
 		scripts = append(scripts, href)
 	}
 	sort.Strings(scripts)
-	return scripts
+	return scripts, nil
 }
 
 func manifestComponentRuntimeMode(explicit string, component gwdkir.Component) string {

--- a/internal/compiler/validate.go
+++ b/internal/compiler/validate.go
@@ -78,6 +78,7 @@ func validateProgram(config gowdk.Config, ir gwdkir.Program, crossFile bool) Val
 		return ValidationErrors{{Message: fmt.Sprintf("internal compiler error: %v", err)}}
 	}
 	var diagnostics ValidationErrors
+	diagnostics = append(diagnostics, validateIRDiagnostics(ir.Diagnostics)...)
 	diagnostics = append(diagnostics, validatePackages(ir)...)
 	diagnostics = append(diagnostics, validateUniquePages(ir.Pages)...)
 	diagnostics = append(diagnostics, validateUniqueComponents(ir.Components)...)
@@ -98,6 +99,19 @@ func validateProgram(config gowdk.Config, ir gwdkir.Program, crossFile bool) Val
 	diagnostics = append(diagnostics, validateStandaloneEndpoints(ir.GoEndpoints)...)
 	for _, page := range ir.Pages {
 		diagnostics = append(diagnostics, ValidatePage(config, page)...)
+	}
+	return diagnostics
+}
+
+func validateIRDiagnostics(items []gwdkir.Diagnostic) []ValidationError {
+	diagnostics := make([]ValidationError, 0, len(items))
+	for _, item := range items {
+		diagnostics = append(diagnostics, ValidationError{
+			Code:    item.Code,
+			Source:  item.Source,
+			Span:    item.Span,
+			Message: item.Message,
+		})
 	}
 	return diagnostics
 }

--- a/internal/compiler/validate_test.go
+++ b/internal/compiler/validate_test.go
@@ -3377,6 +3377,30 @@ func TestValidateManifestRejectsUnknownLayoutParent(t *testing.T) {
 	}
 }
 
+func TestValidateManifestReportsContractReferenceParseErrors(t *testing.T) {
+	app := appFixture{
+		Pages: []gwdkir.Page{{
+			Package: "pages",
+			ID:      "home",
+			Route:   "/",
+			Source:  "pages/home.page.gwdk",
+			Blocks: gwdkir.Blocks{
+				View:     true,
+				ViewBody: `<form g:command="CreatePatient"></form>`,
+			},
+		}},
+	}
+
+	err := validateManifest(gowdk.Config{}, app)
+	if err == nil {
+		t.Fatal("expected contract reference parse diagnostic")
+	}
+	diagnostics := err.(ValidationErrors)
+	if !hasDiagnosticCode(diagnostics, "contract_reference_parse_error") {
+		t.Fatalf("Missing contract_reference_parse_error diagnostic: %#v", diagnostics)
+	}
+}
+
 func TestValidateManifestRejectsLayoutWithoutSlot(t *testing.T) {
 	app := appFixture{
 		Layouts: []gwdkir.Layout{

--- a/internal/diagnostics/registry.go
+++ b/internal/diagnostics/registry.go
@@ -38,6 +38,7 @@ var Registry = []Code{
 	{Code: "contract_input_invalid", Area: "contracts", Stability: StabilityExperimental, Summary: "contract input struct is invalid"},
 	{Code: "contract_reference_invalid", Area: "contracts", Stability: StabilityExperimental, Summary: "GOWDK command or query reference could not bind to a valid contract"},
 	{Code: "contract_reference_missing", Area: "contracts", Stability: StabilityExperimental, Summary: "GOWDK command or query reference has no matching contract"},
+	{Code: "contract_reference_parse_error", Area: "contracts", Stability: StabilityExperimental, Summary: "view contract reference directives could not be parsed"},
 	{Code: "contract_reference_role_not_allowed", Area: "contracts", Stability: StabilityExperimental, Summary: "contract reference targets a registration that is not available to the web role"},
 	{Code: "contract_result_invalid", Area: "contracts", Stability: StabilityExperimental, Summary: "contract result type is invalid"},
 	{Code: "contract_type_invalid", Area: "contracts", Stability: StabilityExperimental, Summary: "contract type is invalid"},

--- a/internal/gwdkanalysis/ir_contracts.go
+++ b/internal/gwdkanalysis/ir_contracts.go
@@ -1,6 +1,7 @@
 package gwdkanalysis
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/cssbruno/gowdk/internal/gwdkir"
@@ -11,6 +12,12 @@ import (
 func appendContractReferences(program *gwdkir.Program, template gwdkir.Template) {
 	refs, err := view.ContractReferences(template.Body)
 	if err != nil {
+		program.Diagnostics = append(program.Diagnostics, gwdkir.Diagnostic{
+			Code:    "contract_reference_parse_error",
+			Source:  template.Source,
+			Span:    template.Span,
+			Message: fmt.Sprintf("parse contract references in %s %s view: %v", template.OwnerKind, template.OwnerID, err),
+		})
 		return
 	}
 	for _, ref := range refs {

--- a/internal/gwdkir/ir.go
+++ b/internal/gwdkir/ir.go
@@ -23,7 +23,16 @@ type Program struct {
 	ContractRefs    []ContractReference
 	ClientBehaviors []ClientBehavior
 	Assets          []Asset
+	Diagnostics     []Diagnostic
 	Generated       GeneratedOutput
+}
+
+// Diagnostic records an author-facing problem found while assembling IR.
+type Diagnostic struct {
+	Code    string
+	Source  string
+	Span    source.SourceSpan
+	Message string
 }
 
 // Package groups analyzed GOWDK source files by declared package.

--- a/internal/project/config.go
+++ b/internal/project/config.go
@@ -59,7 +59,7 @@ func LoadConfigFile(path string) (gowdk.Config, error) {
 				if needsExecutableLoad {
 					config, err := loadExecutableConfig(path)
 					if err != nil {
-						return gowdk.Config{}, fmt.Errorf("%s contains addon constructors outside the AST-only config subset: %w", path, err)
+						return gowdk.Config{}, fmt.Errorf("%s contains config expressions outside the AST-only subset: %w", path, err)
 					}
 					if err := config.Env.Validate(os.LookupEnv); err != nil {
 						return gowdk.Config{}, fmt.Errorf("%s env contract: %w", path, err)
@@ -110,18 +110,46 @@ func parseConfigLiteral(expression ast.Expr, imports map[string]string) (gowdk.C
 		}
 		switch key.Name {
 		case "AppName":
+			if needsConfigExpressionEvaluation(keyValue.Value) {
+				needsExecutableLoad = true
+				continue
+			}
 			config.AppName = parseString(keyValue.Value)
 		case "Source":
+			if needsConfigExpressionEvaluation(keyValue.Value) {
+				needsExecutableLoad = true
+				continue
+			}
 			config.Source = parseSourceConfig(keyValue.Value)
 		case "Modules":
+			if needsConfigExpressionEvaluation(keyValue.Value) {
+				needsExecutableLoad = true
+				continue
+			}
 			config.Modules = parseModuleConfigs(keyValue.Value)
 		case "Build":
+			if needsConfigExpressionEvaluation(keyValue.Value) {
+				needsExecutableLoad = true
+				continue
+			}
 			config.Build = parseBuildConfig(keyValue.Value)
 		case "CSS":
+			if needsConfigExpressionEvaluation(keyValue.Value) {
+				needsExecutableLoad = true
+				continue
+			}
 			config.CSS = parseCSSConfig(keyValue.Value)
 		case "Render":
+			if needsConfigExpressionEvaluation(keyValue.Value) {
+				needsExecutableLoad = true
+				continue
+			}
 			config.Render = parseRenderConfig(keyValue.Value)
 		case "Env":
+			if needsConfigExpressionEvaluation(keyValue.Value) {
+				needsExecutableLoad = true
+				continue
+			}
 			var err error
 			config.Env, err = parseEnvConfig(keyValue.Value)
 			if err != nil {
@@ -132,6 +160,34 @@ func parseConfigLiteral(expression ast.Expr, imports map[string]string) (gowdk.C
 		}
 	}
 	return config, needsExecutableLoad, true, nil
+}
+
+func needsConfigExpressionEvaluation(expression ast.Expr) bool {
+	switch typed := expression.(type) {
+	case *ast.BasicLit:
+		return false
+	case *ast.Ident:
+		return typed.Name != "true" && typed.Name != "false" && typed.Name != "nil"
+	case *ast.SelectorExpr:
+		return false
+	case *ast.UnaryExpr:
+		return needsConfigExpressionEvaluation(typed.X)
+	case *ast.CompositeLit:
+		for _, element := range typed.Elts {
+			if keyValue, ok := element.(*ast.KeyValueExpr); ok {
+				if needsConfigExpressionEvaluation(keyValue.Value) {
+					return true
+				}
+				continue
+			}
+			if needsConfigExpressionEvaluation(element) {
+				return true
+			}
+		}
+		return false
+	default:
+		return true
+	}
 }
 
 func importNames(file *ast.File) map[string]string {

--- a/internal/project/config_test.go
+++ b/internal/project/config_test.go
@@ -299,14 +299,27 @@ var Config = gowdk.Config{
 	}
 }
 
-func TestLoadConfigFileIgnoresNonLiteralValues(t *testing.T) {
+func TestLoadConfigFileFallsBackForNonLiteralValues(t *testing.T) {
 	root := t.TempDir()
+	repoRoot := repositoryRoot(t)
+	writeTestFile(t, filepath.Join(root, "go.mod"), `module example.com/site
+
+go 1.22
+
+require github.com/cssbruno/gowdk v0.0.0
+
+replace github.com/cssbruno/gowdk => `+repoRoot+`
+`)
 	path := filepath.Join(root, DefaultConfigFile)
-	if err := os.WriteFile(path, []byte(`package app
+	writeTestFile(t, path, `package app
 
 import "github.com/cssbruno/gowdk"
 
 var includes = []string{"src/**/*.gwdk"}
+
+func outputDir() string {
+	return "dist/site"
+}
 
 var Config = gowdk.Config{
 	Source: gowdk.SourceConfig{
@@ -316,19 +329,18 @@ var Config = gowdk.Config{
 		Output: outputDir(),
 	},
 }
-`), 0o644); err != nil {
-		t.Fatal(err)
-	}
+`)
+	tidyTestModule(t, root)
 
 	config, err := LoadConfigFile(path)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(config.Source.Include) != 0 {
-		t.Fatalf("expected non-literal includes to be ignored, got %#v", config.Source.Include)
+	if len(config.Source.Include) != 1 || config.Source.Include[0] != "src/**/*.gwdk" {
+		t.Fatalf("expected executable config to load includes, got %#v", config.Source.Include)
 	}
-	if config.Build.Output != "" {
-		t.Fatalf("expected non-literal output to be ignored, got %q", config.Build.Output)
+	if config.Build.Output != "dist/site" {
+		t.Fatalf("expected executable config to load output, got %q", config.Build.Output)
 	}
 }
 


### PR DESCRIPTION
## Summary

- turns contract-reference parse failures into compiler diagnostics instead of silently dropping contract refs
- makes non-literal recognized config fields fall back to executable config loading instead of zeroing values
- propagates buildgen island/client runtime traversal and layout composition errors through artifact planning and rendering
- registers `contract_reference_parse_error` and adds regression tests for the fixed paths

## Impact

Invalid contract directives, dynamic config expressions, and malformed nested component views now fail at the relevant compiler/build phase with explicit errors instead of producing missing metadata or silently omitting runtime assets.

## Notes

Issue #163's dead `gwdkanalysis` manifest-lowering pipeline is already removed on current `main`; this PR keeps the remaining work focused on the live explicit-failure paths from #162 and the related buildgen fallback.

## Validation

- `go test ./internal/project`
- `go test ./internal/compiler`
- `go test ./internal/buildgen`
- `go test ./internal/gwdkanalysis ./internal/diagnostics`
- `go test ./internal/appgen` passed on rerun
- `go build ./cmd/gowdk`
- `git diff --check`

`go test ./...` was run but did not fully pass because `cmd/gowdk` has an unrelated reproducing failure in `TestInputChangeDetailsReportsChangedAddedAndRemovedPaths`: the test expects relative paths but receives absolute temp paths. The first full run also saw transient generated-binary appgen timeouts; `go test ./internal/appgen` passed when rerun.