### PR TITLE
Add registry-backed diagnostic fixes and dedupe compiler paths

### DIFF
--- a/.llm/features/diagnostic-code-registry.md
+++ b/.llm/features/diagnostic-code-registry.md
@@ -1,16 +1,22 @@
-# Feature Spec: Diagnostic Code Registry
+# Feature Spec: Diagnostic Registry Severity And Fixes
 
 ## Problem
 
-M2 needs stable diagnostic names before exact spans, formatter recovery, LSP
-explain output, and broader parser diagnostics can be reviewed safely. Codes
-are currently emitted as string literals across compiler, parser, build, and
-contract paths, and docs can drift from implementation.
+The diagnostic registry has stable codes, areas, summaries, and stability
+levels, but severity and machine-readable fixes can still drift between CLI,
+LSP, and future browser overlay consumers. Existing quick fixes are hardcoded
+in the LSP path, and there is no headless `gowdk fix` command for safe
+single-file rewrites.
 
 ## Goals
 
 - Inventory current public diagnostic codes in one source of truth.
 - Mark each code with an area and stability level.
+- Mark each code with default severity.
+- Store safe fix metadata in the registry.
+- Apply registry fixes through `gowdk fix`.
+- Serve LSP code actions from registry fix metadata.
+- Include severity and fix metadata in JSON/explain outputs.
 - Add a test that fails when implementation emits a new code without registry
   coverage.
 - Document naming, severity, and stability conventions.
@@ -18,9 +24,9 @@ contract paths, and docs can drift from implementation.
 ## Non-Goals
 
 - Replace all string literals with constants in this slice.
-- Implement `gowdk explain`.
-- Change diagnostic JSON shape.
-- Change emitted diagnostic behavior.
+- Multi-file refactors.
+- Guessing rewrites for old endpoint blocks that still contain behavior.
+- New diagnostic codes.
 
 ## Users And Permissions
 
@@ -33,14 +39,27 @@ contract paths, and docs can drift from implementation.
 
 1. A contributor adds or renames a diagnostic code.
 2. `go test ./internal/diagnostics` fails if the registry is not updated.
-3. The contributor updates the registry and docs in the same change.
+3. The contributor records severity and optional fix metadata in the registry.
+4. Users run `gowdk check --json`, `gowdk explain`, LSP quick fixes, or
+   `gowdk fix` and see the same registry-backed metadata.
 
 ## Requirements
 
 ### Functional
 
-- Registry entries include code, area, stability, and summary.
+- Registry entries include code, area, stability, severity, and summary.
 - Stability supports stable, experimental, and addon-owned codes.
+- Severity supports error, warning, and info.
+- Fix metadata includes a title, description, and named safe rewriter.
+- `gowdk fix [--dry-run] [--code <code>]` applies registered single-file
+  fixes and rejects ambiguous edits.
+- LSP code actions are selected from registry fix metadata rather than
+  diagnostic-code switches.
+- `gowdk check --json` includes `fix` metadata when a diagnostic has a
+  registered fix.
+- `gowdk explain` includes severity and available fix metadata.
+- `gowdk check --warnings-as-errors` fails when warning diagnostics are
+  present.
 - Tests scan non-test Go source for emitted diagnostic-code literals.
 - Docs link to the registry as the source of truth.
 
@@ -54,10 +73,15 @@ contract paths, and docs can drift from implementation.
 
 ## Acceptance Criteria
 
-- [ ] `internal/diagnostics/registry.go` exists.
-- [ ] Registry tests fail on unregistered emitted code literals.
-- [ ] Diagnostics docs describe naming, severity, and stability conventions.
-- [ ] Verification passes for diagnostics tests and repository gates.
+- [x] `internal/diagnostics/registry.go` records severity for every code.
+- [x] Registry tests fail on unregistered emitted code literals and invalid
+  severity/fix metadata.
+- [x] `gowdk fix` migrates empty old endpoint syntax through registry fixes.
+- [x] LSP quick fixes for old endpoints and missing use aliases are
+  registry-driven.
+- [x] `check --json` and `gowdk explain` expose fix metadata.
+- [x] Diagnostics docs describe naming, severity, stability, and fixes.
+- [ ] Full repository verification passes.
 
 ## Edge Cases
 
@@ -74,3 +98,5 @@ contract paths, and docs can drift from implementation.
 
 - Should a later slice move emitted codes from string literals to exported
   constants in `internal/diagnostics`?
+- Should browser overlay payloads receive full structured diagnostics instead
+  of formatted build-error strings?

--- a/.llm/plans/diagnostic-code-registry.md
+++ b/.llm/plans/diagnostic-code-registry.md
@@ -1,10 +1,10 @@
-# Implementation Plan: Diagnostic Code Registry
+# Implementation Plan: Diagnostic Registry Severity And Fixes
 
 ## Context
 
 Spec: `.llm/features/diagnostic-code-registry.md`
 
-Issue: https://github.com/cssbruno/GoWDK/issues/75
+Issue: https://github.com/cssbruno/GoWDK/issues/178
 
 Milestone: M2 - Compiler + Language Contract
 
@@ -15,34 +15,50 @@ Milestone: M2 - Compiler + Language Contract
   this slice.
 - Addon-provided custom codes stay outside the core registry unless they are
   emitted by repository code.
+- Single-file fixes are safe only when a named rewriter can compute bounded,
+  non-overlapping text edits.
 
 ## Proposed Changes
 
-- Add `internal/diagnostics` with a public registry of emitted codes.
+- Extend `internal/diagnostics` with severity and optional fix metadata.
+- Add `internal/diagnosticfix` for named source rewriters shared by CLI and
+  LSP.
+- Add `gowdk fix [--dry-run] [--code <code>]`.
+- Add `--warnings-as-errors` to `gowdk check`.
+- Route LSP code actions through registry fix metadata.
+- Include registry fix metadata in diagnostic JSON serialization and explain
+  output.
 - Add registry tests for sorting, uniqueness, metadata completeness, stability
-  values, and source coverage.
-- Update language and reference diagnostics docs.
+  values, severity values, fix metadata, and source coverage.
+- Update language, CLI, and reference diagnostics docs.
 
 ## Files Expected To Change
 
 - `.llm/features/diagnostic-code-registry.md`
 - `.llm/plans/diagnostic-code-registry.md`
+- `cmd/gowdk/fix.go`
+- `cmd/gowdk/lang.go`
+- `cmd/gowdk/main.go`
 - `internal/diagnostics/registry.go`
 - `internal/diagnostics/registry_test.go`
+- `internal/diagnosticfix/fix.go`
+- `internal/lang/diagnostic.go`
+- `internal/lsp/features.go`
 - `docs/language/diagnostics.md`
 - `docs/reference/diagnostics.md`
 
 ## Data And API Impact
 
-- No diagnostic JSON changes.
+- `check --json` emits optional `fix` metadata for registered fixable
+  diagnostics.
 - No emitted code changes.
-- New internal package only.
+- New `gowdk fix` CLI command.
 
 ## Tests
 
-- Unit: `go test ./internal/diagnostics`
-- Integration: root Go tests for unchanged behavior.
-- End-to-end: all nested module tests.
+- Unit: `go test ./internal/diagnostics ./internal/diagnosticfix`
+- Integration: root Go tests for CLI, lang, LSP, compiler, and buildgen.
+- End-to-end: nested module tests for contract adapters.
 - Manual: inspect docs for stale code names.
 
 ## Verification Commands

--- a/cmd/gowdk/build.go
+++ b/cmd/gowdk/build.go
@@ -20,29 +20,14 @@ import (
 const buildUsage = "usage: gowdk build [--config <file>] [--debug] [--ssr] [--allow-missing-backend] [--target <name>] [--module <name>] [--out <dir>] [--app <dir>] [--bin <file>] [--wasm <file>] [--backend-app <dir>] [--backend-bin <file>] [files...]"
 
 func build(args []string) error {
-	options, outputDir, appDir, binaryPath, wasmPath, backendAppDir, backendBinaryPath, configPath, targetNames, moduleNames, paths, err := parseBuildOptions(args)
+	plan, err := loadBuildOptions(args)
 	if err != nil {
 		return err
 	}
-	if err := loadBuildConfig(&options, configPath); err != nil {
-		return err
+	if plan.shouldBuildConfiguredTargets() {
+		return buildConfiguredTargets(plan.Options, plan.TargetNames)
 	}
-	if len(targetNames) > 0 && hasAdHocBuildArgs(outputDir, appDir, binaryPath, wasmPath, backendAppDir, backendBinaryPath, moduleNames, paths) {
-		return fmt.Errorf("--target cannot be combined with --module, --out, --app, --bin, --wasm, --backend-app, --backend-bin, or explicit files")
-	}
-	if shouldBuildConfiguredTargets(options.Config, targetNames, outputDir, appDir, binaryPath, wasmPath, backendAppDir, backendBinaryPath, moduleNames, paths) {
-		return buildConfiguredTargets(options, targetNames)
-	}
-	return buildOnce(options, buildRequest{
-		OutputDir:         outputDir,
-		AppDir:            appDir,
-		BinaryPath:        binaryPath,
-		WASMPath:          wasmPath,
-		BackendAppDir:     backendAppDir,
-		BackendBinaryPath: backendBinaryPath,
-		Modules:           moduleNames,
-		Paths:             paths,
-	})
+	return buildOnce(plan.Options, plan.request())
 }
 
 type buildRequest struct {
@@ -54,6 +39,55 @@ type buildRequest struct {
 	BackendBinaryPath string
 	Modules           []string
 	Paths             []string
+}
+
+type buildOptions struct {
+	Options           cliOptions
+	OutputDir         string
+	AppDir            string
+	BinaryPath        string
+	WASMPath          string
+	BackendAppDir     string
+	BackendBinaryPath string
+	ConfigPath        string
+	TargetNames       []string
+	ModuleNames       []string
+	Paths             []string
+}
+
+func loadBuildOptions(args []string) (buildOptions, error) {
+	plan, err := parseBuildOptions(args)
+	if err != nil {
+		return buildOptions{}, err
+	}
+	if err := loadBuildConfig(&plan.Options, plan.ConfigPath); err != nil {
+		return buildOptions{}, err
+	}
+	if len(plan.TargetNames) > 0 && plan.hasAdHocArgs() {
+		return buildOptions{}, fmt.Errorf("--target cannot be combined with --module, --out, --app, --bin, --wasm, --backend-app, --backend-bin, or explicit files")
+	}
+	return plan, nil
+}
+
+func (plan buildOptions) request() buildRequest {
+	return buildRequest{
+		OutputDir:         plan.OutputDir,
+		AppDir:            plan.AppDir,
+		BinaryPath:        plan.BinaryPath,
+		WASMPath:          plan.WASMPath,
+		BackendAppDir:     plan.BackendAppDir,
+		BackendBinaryPath: plan.BackendBinaryPath,
+		Modules:           plan.ModuleNames,
+		Paths:             plan.Paths,
+	}
+}
+
+func (plan buildOptions) hasAdHocArgs() bool {
+	return hasAdHocBuildArgs(plan.OutputDir, plan.AppDir, plan.BinaryPath, plan.WASMPath, plan.BackendAppDir, plan.BackendBinaryPath, plan.ModuleNames, plan.Paths)
+}
+
+func (plan buildOptions) shouldBuildConfiguredTargets() bool {
+	return shouldBuildConfiguredTargets(plan.Options.Config, plan.TargetNames, plan.OutputDir, plan.AppDir, plan.BinaryPath, plan.WASMPath, plan.BackendAppDir, plan.BackendBinaryPath, plan.ModuleNames, plan.Paths)
 }
 
 func buildOnce(options cliOptions, request buildRequest) error {
@@ -359,137 +393,126 @@ func buildgenBuildEventDetails(event buildgen.BuildEvent) string {
 	return strings.Join(details, ", ")
 }
 
-func parseBuildOptions(args []string) (cliOptions, string, string, string, string, string, string, string, []string, []string, []string, error) {
-	var options cliOptions
-	var outputDir string
-	var appDir string
-	var binaryPath string
-	var wasmPath string
-	var backendAppDir string
-	var backendBinaryPath string
-	var configPath string
-	var targetNames []string
-	var moduleNames []string
-	var paths []string
-
+func parseBuildOptions(args []string) (buildOptions, error) {
+	var plan buildOptions
 	for i := 0; i < len(args); i++ {
 		arg := args[i]
 		switch {
 		case arg == "--ssr":
-			options.Config.Addons = append(options.Config.Addons, ssr.Addon())
+			plan.Options.Config.Addons = append(plan.Options.Config.Addons, ssr.Addon())
 		case arg == "--debug":
-			options.Debug = true
+			plan.Options.Debug = true
 		case arg == "--allow-missing-backend":
-			options.AllowMissingBackend = true
-			options.Config.Build.AllowMissingBackend = true
+			plan.Options.AllowMissingBackend = true
+			plan.Options.Config.Build.AllowMissingBackend = true
 		case arg == "--out":
 			i++
 			if i >= len(args) {
-				return options, "", "", "", "", "", "", "", nil, nil, nil, fmt.Errorf(buildUsage)
+				return buildOptions{}, fmt.Errorf(buildUsage)
 			}
-			outputDir = args[i]
+			plan.OutputDir = args[i]
 		case len(arg) > len("--out=") && arg[:len("--out=")] == "--out=":
-			outputDir = arg[len("--out="):]
+			plan.OutputDir = arg[len("--out="):]
 		case arg == "--app":
 			i++
 			if i >= len(args) {
-				return options, "", "", "", "", "", "", "", nil, nil, nil, fmt.Errorf(buildUsage)
+				return buildOptions{}, fmt.Errorf(buildUsage)
 			}
-			appDir = args[i]
-			if strings.TrimSpace(appDir) == "" {
-				return options, "", "", "", "", "", "", "", nil, nil, nil, fmt.Errorf("generated app directory is required")
+			plan.AppDir = args[i]
+			if strings.TrimSpace(plan.AppDir) == "" {
+				return buildOptions{}, fmt.Errorf("generated app directory is required")
 			}
 		case len(arg) > len("--app=") && arg[:len("--app=")] == "--app=":
-			appDir = arg[len("--app="):]
-			if strings.TrimSpace(appDir) == "" {
-				return options, "", "", "", "", "", "", "", nil, nil, nil, fmt.Errorf("generated app directory is required")
+			plan.AppDir = arg[len("--app="):]
+			if strings.TrimSpace(plan.AppDir) == "" {
+				return buildOptions{}, fmt.Errorf("generated app directory is required")
 			}
 		case arg == "--bin":
 			i++
 			if i >= len(args) {
-				return options, "", "", "", "", "", "", "", nil, nil, nil, fmt.Errorf(buildUsage)
+				return buildOptions{}, fmt.Errorf(buildUsage)
 			}
-			binaryPath = args[i]
-			if strings.TrimSpace(binaryPath) == "" {
-				return options, "", "", "", "", "", "", "", nil, nil, nil, fmt.Errorf("binary output path is required")
+			plan.BinaryPath = args[i]
+			if strings.TrimSpace(plan.BinaryPath) == "" {
+				return buildOptions{}, fmt.Errorf("binary output path is required")
 			}
 		case len(arg) > len("--bin=") && arg[:len("--bin=")] == "--bin=":
-			binaryPath = arg[len("--bin="):]
-			if strings.TrimSpace(binaryPath) == "" {
-				return options, "", "", "", "", "", "", "", nil, nil, nil, fmt.Errorf("binary output path is required")
+			plan.BinaryPath = arg[len("--bin="):]
+			if strings.TrimSpace(plan.BinaryPath) == "" {
+				return buildOptions{}, fmt.Errorf("binary output path is required")
 			}
 		case arg == "--wasm":
 			i++
 			if i >= len(args) {
-				return options, "", "", "", "", "", "", "", nil, nil, nil, fmt.Errorf(buildUsage)
+				return buildOptions{}, fmt.Errorf(buildUsage)
 			}
-			wasmPath = args[i]
-			if strings.TrimSpace(wasmPath) == "" {
-				return options, "", "", "", "", "", "", "", nil, nil, nil, fmt.Errorf("wasm output path is required")
+			plan.WASMPath = args[i]
+			if strings.TrimSpace(plan.WASMPath) == "" {
+				return buildOptions{}, fmt.Errorf("wasm output path is required")
 			}
 		case len(arg) > len("--wasm=") && arg[:len("--wasm=")] == "--wasm=":
-			wasmPath = arg[len("--wasm="):]
-			if strings.TrimSpace(wasmPath) == "" {
-				return options, "", "", "", "", "", "", "", nil, nil, nil, fmt.Errorf("wasm output path is required")
+			plan.WASMPath = arg[len("--wasm="):]
+			if strings.TrimSpace(plan.WASMPath) == "" {
+				return buildOptions{}, fmt.Errorf("wasm output path is required")
 			}
 		case arg == "--backend-app":
 			i++
 			if i >= len(args) {
-				return options, "", "", "", "", "", "", "", nil, nil, nil, fmt.Errorf(buildUsage)
+				return buildOptions{}, fmt.Errorf(buildUsage)
 			}
-			backendAppDir = args[i]
-			if strings.TrimSpace(backendAppDir) == "" {
-				return options, "", "", "", "", "", "", "", nil, nil, nil, fmt.Errorf("generated backend app directory is required")
+			plan.BackendAppDir = args[i]
+			if strings.TrimSpace(plan.BackendAppDir) == "" {
+				return buildOptions{}, fmt.Errorf("generated backend app directory is required")
 			}
 		case len(arg) > len("--backend-app=") && arg[:len("--backend-app=")] == "--backend-app=":
-			backendAppDir = arg[len("--backend-app="):]
-			if strings.TrimSpace(backendAppDir) == "" {
-				return options, "", "", "", "", "", "", "", nil, nil, nil, fmt.Errorf("generated backend app directory is required")
+			plan.BackendAppDir = arg[len("--backend-app="):]
+			if strings.TrimSpace(plan.BackendAppDir) == "" {
+				return buildOptions{}, fmt.Errorf("generated backend app directory is required")
 			}
 		case arg == "--backend-bin":
 			i++
 			if i >= len(args) {
-				return options, "", "", "", "", "", "", "", nil, nil, nil, fmt.Errorf(buildUsage)
+				return buildOptions{}, fmt.Errorf(buildUsage)
 			}
-			backendBinaryPath = args[i]
-			if strings.TrimSpace(backendBinaryPath) == "" {
-				return options, "", "", "", "", "", "", "", nil, nil, nil, fmt.Errorf("backend binary output path is required")
+			plan.BackendBinaryPath = args[i]
+			if strings.TrimSpace(plan.BackendBinaryPath) == "" {
+				return buildOptions{}, fmt.Errorf("backend binary output path is required")
 			}
 		case len(arg) > len("--backend-bin=") && arg[:len("--backend-bin=")] == "--backend-bin=":
-			backendBinaryPath = arg[len("--backend-bin="):]
-			if strings.TrimSpace(backendBinaryPath) == "" {
-				return options, "", "", "", "", "", "", "", nil, nil, nil, fmt.Errorf("backend binary output path is required")
+			plan.BackendBinaryPath = arg[len("--backend-bin="):]
+			if strings.TrimSpace(plan.BackendBinaryPath) == "" {
+				return buildOptions{}, fmt.Errorf("backend binary output path is required")
 			}
 		case arg == "--config":
 			i++
 			if i >= len(args) {
-				return options, "", "", "", "", "", "", "", nil, nil, nil, fmt.Errorf(buildUsage)
+				return buildOptions{}, fmt.Errorf(buildUsage)
 			}
-			configPath = args[i]
+			plan.ConfigPath = args[i]
 		case len(arg) > len("--config=") && arg[:len("--config=")] == "--config=":
-			configPath = arg[len("--config="):]
+			plan.ConfigPath = arg[len("--config="):]
 		case arg == "--target":
 			i++
 			if i >= len(args) {
-				return options, "", "", "", "", "", "", "", nil, nil, nil, fmt.Errorf(buildUsage)
+				return buildOptions{}, fmt.Errorf(buildUsage)
 			}
-			targetNames = appendNames(targetNames, args[i])
+			plan.TargetNames = appendNames(plan.TargetNames, args[i])
 		case len(arg) > len("--target=") && arg[:len("--target=")] == "--target=":
-			targetNames = appendNames(targetNames, arg[len("--target="):])
+			plan.TargetNames = appendNames(plan.TargetNames, arg[len("--target="):])
 		case arg == "--module":
 			i++
 			if i >= len(args) {
-				return options, "", "", "", "", "", "", "", nil, nil, nil, fmt.Errorf(buildUsage)
+				return buildOptions{}, fmt.Errorf(buildUsage)
 			}
-			moduleNames = appendNames(moduleNames, args[i])
+			plan.ModuleNames = appendNames(plan.ModuleNames, args[i])
 		case len(arg) > len("--module=") && arg[:len("--module=")] == "--module=":
-			moduleNames = appendNames(moduleNames, arg[len("--module="):])
+			plan.ModuleNames = appendNames(plan.ModuleNames, arg[len("--module="):])
 		case len(arg) > 0 && arg[0] == '-':
-			return options, "", "", "", "", "", "", "", nil, nil, nil, fmt.Errorf("unknown build flag %q", arg)
+			return buildOptions{}, fmt.Errorf("unknown build flag %q", arg)
 		default:
-			paths = append(paths, arg)
+			plan.Paths = append(plan.Paths, arg)
 		}
 	}
 
-	return options, outputDir, appDir, binaryPath, wasmPath, backendAppDir, backendBinaryPath, configPath, targetNames, moduleNames, paths, nil
+	return plan, nil
 }

--- a/cmd/gowdk/dev.go
+++ b/cmd/gowdk/dev.go
@@ -241,18 +241,12 @@ func devRuntimePlan(args []string, outputDir string) (devRuntime, []string, erro
 }
 
 func devAppAndBinary(args []string, _ string) (string, string, error) {
-	options, outputDir, appDir, binaryPath, wasmPath, backendAppDir, backendBinaryPath, configPath, targetNames, moduleNames, paths, err := parseBuildOptions(args)
+	plan, err := loadBuildOptions(args)
 	if err != nil {
 		return "", "", err
 	}
-	if err := loadBuildConfig(&options, configPath); err != nil {
-		return "", "", err
-	}
-	if len(targetNames) > 0 && hasAdHocBuildArgs(outputDir, appDir, binaryPath, wasmPath, backendAppDir, backendBinaryPath, moduleNames, paths) {
-		return "", "", fmt.Errorf("--target cannot be combined with --module, --out, --app, --bin, --wasm, --backend-app, --backend-bin, or explicit files")
-	}
-	if len(targetNames) > 0 {
-		targets, err := selectBuildTargets(options.Config.Build.Targets, targetNames)
+	if len(plan.TargetNames) > 0 {
+		targets, err := selectBuildTargets(plan.Options.Config.Build.Targets, plan.TargetNames)
 		if err != nil {
 			return "", "", err
 		}
@@ -261,25 +255,19 @@ func devAppAndBinary(args []string, _ string) (string, string, error) {
 		}
 		return targets[0].App, targets[0].Binary, nil
 	}
-	return appDir, binaryPath, nil
+	return plan.AppDir, plan.BinaryPath, nil
 }
 
 func devOutputDir(args []string) (string, error) {
-	options, outputDir, appDir, binaryPath, wasmPath, backendAppDir, backendBinaryPath, configPath, targetNames, moduleNames, paths, err := parseBuildOptions(args)
+	plan, err := loadBuildOptions(args)
 	if err != nil {
 		return "", err
 	}
-	if err := loadBuildConfig(&options, configPath); err != nil {
-		return "", err
+	if strings.TrimSpace(plan.OutputDir) != "" {
+		return plan.OutputDir, nil
 	}
-	if len(targetNames) > 0 && hasAdHocBuildArgs(outputDir, appDir, binaryPath, wasmPath, backendAppDir, backendBinaryPath, moduleNames, paths) {
-		return "", fmt.Errorf("--target cannot be combined with --module, --out, --app, --bin, --wasm, --backend-app, --backend-bin, or explicit files")
-	}
-	if strings.TrimSpace(outputDir) != "" {
-		return outputDir, nil
-	}
-	if len(targetNames) > 0 {
-		targets, err := selectBuildTargets(options.Config.Build.Targets, targetNames)
+	if len(plan.TargetNames) > 0 {
+		targets, err := selectBuildTargets(plan.Options.Config.Build.Targets, plan.TargetNames)
 		if err != nil {
 			return "", err
 		}
@@ -290,9 +278,6 @@ func devOutputDir(args []string) (string, error) {
 			return "", fmt.Errorf("dev target %q is missing Output", targets[0].Name)
 		}
 		return targets[0].Output, nil
-	}
-	if strings.TrimSpace(outputDir) != "" {
-		return outputDir, nil
 	}
 	return defaultDevOutputDir, nil
 }

--- a/cmd/gowdk/dev_loop.go
+++ b/cmd/gowdk/dev_loop.go
@@ -33,25 +33,22 @@ func buildIncrementalSPA(args []string, change inputChange) (bool, error) {
 		return false, nil
 	}
 
-	options, outputDir, appDir, binaryPath, wasmPath, backendAppDir, backendBinaryPath, configPath, targetNames, moduleNames, paths, err := parseBuildOptions(args)
+	plan, err := loadBuildOptions(args)
 	if err != nil {
 		return true, err
 	}
-	if err := loadBuildConfig(&options, configPath); err != nil {
-		return true, err
-	}
-	if len(targetNames) > 0 && hasAdHocBuildArgs(outputDir, appDir, binaryPath, wasmPath, backendAppDir, backendBinaryPath, moduleNames, paths) {
-		return true, fmt.Errorf("--target cannot be combined with --module, --out, --app, --bin, --wasm, --backend-app, --backend-bin, or explicit files")
-	}
-	if shouldBuildConfiguredTargets(options.Config, targetNames, outputDir, appDir, binaryPath, wasmPath, backendAppDir, backendBinaryPath, moduleNames, paths) {
+	if plan.shouldBuildConfiguredTargets() {
 		return false, nil
 	}
-	if strings.TrimSpace(appDir) != "" || strings.TrimSpace(binaryPath) != "" || strings.TrimSpace(wasmPath) != "" || strings.TrimSpace(backendAppDir) != "" || strings.TrimSpace(backendBinaryPath) != "" {
+	if strings.TrimSpace(plan.AppDir) != "" || strings.TrimSpace(plan.BinaryPath) != "" || strings.TrimSpace(plan.WASMPath) != "" || strings.TrimSpace(plan.BackendAppDir) != "" || strings.TrimSpace(plan.BackendBinaryPath) != "" {
 		return false, nil
 	}
-	if inputChangeTouchesConfig(change, configPath) {
+	if inputChangeTouchesConfig(change, plan.ConfigPath) {
 		return false, nil
 	}
+	options := plan.Options
+	outputDir := plan.OutputDir
+	paths := append([]string(nil), plan.Paths...)
 	if outputDir == "" {
 		outputDir = options.Config.Build.Output
 	}
@@ -60,7 +57,7 @@ func buildIncrementalSPA(args []string, change inputChange) (bool, error) {
 	}
 	options.Config.Build.Output = outputDir
 	if len(paths) == 0 {
-		discovered, err := discoverBuildFiles(options.Config, outputDir, moduleNames)
+		discovered, err := discoverBuildFiles(options.Config, outputDir, plan.ModuleNames)
 		if err != nil {
 			return true, err
 		}
@@ -331,18 +328,15 @@ func canonicalDisplayPaths(base, path string) (string, string, bool) {
 }
 
 func buildInputSnapshot(args []string) (inputSnapshot, error) {
-	options, outputDir, appDir, binaryPath, wasmPath, backendAppDir, backendBinaryPath, configPath, targetNames, moduleNames, paths, err := parseBuildOptions(args)
+	plan, err := loadBuildOptions(args)
 	if err != nil {
 		return nil, err
 	}
-	if err := loadBuildConfig(&options, configPath); err != nil {
-		return nil, err
-	}
-	if len(targetNames) > 0 && hasAdHocBuildArgs(outputDir, appDir, binaryPath, wasmPath, backendAppDir, backendBinaryPath, moduleNames, paths) {
-		return nil, fmt.Errorf("--target cannot be combined with --module, --out, --app, --bin, --wasm, --backend-app, --backend-bin, or explicit files")
-	}
-	if shouldBuildConfiguredTargets(options.Config, targetNames, outputDir, appDir, binaryPath, wasmPath, backendAppDir, backendBinaryPath, moduleNames, paths) {
-		targets, err := selectBuildTargets(options.Config.Build.Targets, targetNames)
+	options := plan.Options
+	outputDir := plan.OutputDir
+	paths := append([]string(nil), plan.Paths...)
+	if plan.shouldBuildConfiguredTargets() {
+		targets, err := selectBuildTargets(options.Config.Build.Targets, plan.TargetNames)
 		if err != nil {
 			return nil, err
 		}
@@ -361,7 +355,7 @@ func buildInputSnapshot(args []string) (inputSnapshot, error) {
 	} else if outputDir == "" {
 		outputDir = options.Config.Build.Output
 		if len(paths) == 0 {
-			discovered, err := discoverBuildFiles(options.Config, outputDir, moduleNames)
+			discovered, err := discoverBuildFiles(options.Config, outputDir, plan.ModuleNames)
 			if err != nil {
 				return nil, err
 			}
@@ -373,7 +367,7 @@ func buildInputSnapshot(args []string) (inputSnapshot, error) {
 		}
 		paths = append(paths, css...)
 	} else if len(paths) == 0 {
-		discovered, err := discoverBuildFiles(options.Config, outputDir, moduleNames)
+		discovered, err := discoverBuildFiles(options.Config, outputDir, plan.ModuleNames)
 		if err != nil {
 			return nil, err
 		}
@@ -390,8 +384,8 @@ func buildInputSnapshot(args []string) (inputSnapshot, error) {
 		}
 		paths = append(paths, css...)
 	}
-	if strings.TrimSpace(configPath) != "" {
-		paths = append(paths, configPath)
+	if strings.TrimSpace(plan.ConfigPath) != "" {
+		paths = append(paths, plan.ConfigPath)
 	} else if _, err := os.Stat("gowdk.config.go"); err == nil {
 		paths = append(paths, "gowdk.config.go")
 	}

--- a/cmd/gowdk/explain.go
+++ b/cmd/gowdk/explain.go
@@ -50,7 +50,11 @@ func printDiagnosticExplanation(explanation diagnostics.Explanation) {
 	fmt.Println(explanation.Code)
 	fmt.Printf("Area: %s\n", explanation.Area)
 	fmt.Printf("Stability: %s\n", explanation.Stability)
+	fmt.Printf("Severity: %s\n", explanation.Severity)
 	fmt.Printf("Summary: %s\n", explanation.Summary)
+	if explanation.Fix != nil {
+		fmt.Printf("Fix: %s\n", explanation.Fix.Title)
+	}
 	if explanation.Details != "" {
 		fmt.Println()
 		fmt.Println(explanation.Details)

--- a/cmd/gowdk/fix.go
+++ b/cmd/gowdk/fix.go
@@ -1,0 +1,271 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/cssbruno/gowdk/internal/diagnosticfix"
+	"github.com/cssbruno/gowdk/internal/diagnostics"
+	"github.com/cssbruno/gowdk/internal/lang"
+)
+
+type fixOptions struct {
+	DryRun bool
+	Code   string
+	Args   []string
+}
+
+func fixCommand(args []string) error {
+	fixOptions, err := parseFixOptions(args)
+	if err != nil {
+		return err
+	}
+	options, paths, err := loadCommandInputs(fixOptions.Args, "fix", false)
+	if err != nil {
+		return err
+	}
+	_, foundDiagnostics := lang.CheckFiles(options.Config, paths)
+	summary, err := collectFixes(foundDiagnostics, fixOptions.Code)
+	if err != nil {
+		return err
+	}
+	if len(summary.files) == 0 {
+		fmt.Println("no fixes available")
+		return nil
+	}
+	if fixOptions.DryRun {
+		for _, path := range summary.paths() {
+			fmt.Printf("%s: %d fix(es) available\n", path, len(summary.files[path].edits))
+		}
+		return nil
+	}
+	for _, path := range summary.paths() {
+		if err := writeFixedFile(path, summary.files[path]); err != nil {
+			return err
+		}
+		fmt.Printf("%s: applied %d fix(es)\n", path, len(summary.files[path].edits))
+	}
+	return nil
+}
+
+func parseFixOptions(args []string) (fixOptions, error) {
+	var options fixOptions
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		switch {
+		case arg == "--dry-run":
+			options.DryRun = true
+		case arg == "--code":
+			i++
+			if i >= len(args) {
+				return fixOptions{}, fmt.Errorf(fixUsage)
+			}
+			options.Code = args[i]
+		case strings.HasPrefix(arg, "--code="):
+			options.Code = strings.TrimPrefix(arg, "--code=")
+		case strings.HasPrefix(arg, "-"):
+			options.Args = append(options.Args, arg)
+		default:
+			options.Args = append(options.Args, arg)
+		}
+	}
+	if strings.TrimSpace(options.Code) != "" {
+		if _, ok := diagnostics.Lookup(options.Code); !ok {
+			return fixOptions{}, fmt.Errorf("unknown diagnostic code %q", options.Code)
+		}
+		if _, ok := diagnostics.FixFor(options.Code); !ok {
+			return fixOptions{}, fmt.Errorf("diagnostic code %q has no registered fix", options.Code)
+		}
+	}
+	return options, nil
+}
+
+const fixUsage = "usage: gowdk fix [--dry-run] [--code <diagnostic-code>] [--config <file>] [--module <name>] [--ssr] [files...]"
+
+type fileFixes struct {
+	source string
+	edits  []diagnosticfix.TextEdit
+}
+
+type fixSummary struct {
+	files map[string]fileFixes
+}
+
+func (summary fixSummary) paths() []string {
+	paths := make([]string, 0, len(summary.files))
+	for path := range summary.files {
+		paths = append(paths, path)
+	}
+	sort.Strings(paths)
+	return paths
+}
+
+func collectFixes(foundDiagnostics lang.Diagnostics, codeFilter string) (fixSummary, error) {
+	summary := fixSummary{files: map[string]fileFixes{}}
+	for _, item := range foundDiagnostics {
+		if codeFilter != "" && item.Code != codeFilter {
+			continue
+		}
+		fix, ok := diagnostics.FixFor(item.Code)
+		if !ok {
+			continue
+		}
+		if strings.TrimSpace(item.File) == "" {
+			return fixSummary{}, fmt.Errorf("%s fix is ambiguous: diagnostic has no file", item.Code)
+		}
+		fileFixes, err := fixesForFile(summary.files, item.File)
+		if err != nil {
+			return fixSummary{}, err
+		}
+		edits, err := diagnosticfix.Edits(fix, fileFixes.source, diagnosticfix.Diagnostic{
+			Code:    item.Code,
+			Message: item.Message,
+			Range:   diagnosticRange(item),
+		})
+		if err != nil {
+			return fixSummary{}, err
+		}
+		fileFixes.edits = append(fileFixes.edits, edits...)
+		summary.files[item.File] = fileFixes
+	}
+	for path, fileFixes := range summary.files {
+		edits, err := normalizeEdits(fileFixes.source, fileFixes.edits)
+		if err != nil {
+			return fixSummary{}, fmt.Errorf("%s: %w", path, err)
+		}
+		fileFixes.edits = edits
+		summary.files[path] = fileFixes
+	}
+	return summary, nil
+}
+
+func fixesForFile(files map[string]fileFixes, path string) (fileFixes, error) {
+	if fileFixes, ok := files[path]; ok {
+		return fileFixes, nil
+	}
+	source, err := os.ReadFile(path)
+	if err != nil {
+		return fileFixes{}, err
+	}
+	return fileFixes{source: string(source)}, nil
+}
+
+func diagnosticRange(item lang.Diagnostic) diagnosticfix.Range {
+	if item.Range != nil {
+		return diagnosticfix.Range{
+			Start: diagnosticfix.Position{Line: item.Range.Start.Line, Column: item.Range.Start.Column},
+			End:   diagnosticfix.Position{Line: item.Range.End.Line, Column: item.Range.End.Column},
+		}
+	}
+	endColumn := item.Pos.Column + 1
+	if endColumn <= 1 {
+		endColumn = 2
+	}
+	return diagnosticfix.Range{
+		Start: diagnosticfix.Position{Line: item.Pos.Line, Column: item.Pos.Column},
+		End:   diagnosticfix.Position{Line: item.Pos.Line, Column: endColumn},
+	}
+}
+
+func normalizeEdits(source string, edits []diagnosticfix.TextEdit) ([]diagnosticfix.TextEdit, error) {
+	if len(edits) == 0 {
+		return nil, nil
+	}
+	type indexedEdit struct {
+		edit  diagnosticfix.TextEdit
+		start int
+		end   int
+	}
+	byKey := map[string]indexedEdit{}
+	for _, edit := range edits {
+		start, err := offsetForPosition(source, edit.Range.Start)
+		if err != nil {
+			return nil, err
+		}
+		end, err := offsetForPosition(source, edit.Range.End)
+		if err != nil {
+			return nil, err
+		}
+		if end < start {
+			return nil, fmt.Errorf("fix edit has an invalid range")
+		}
+		key := fmt.Sprintf("%d:%d:%s", start, end, edit.NewText)
+		byKey[key] = indexedEdit{edit: edit, start: start, end: end}
+	}
+	indexed := make([]indexedEdit, 0, len(byKey))
+	for _, edit := range byKey {
+		indexed = append(indexed, edit)
+	}
+	sort.Slice(indexed, func(i, j int) bool {
+		if indexed[i].start == indexed[j].start {
+			return indexed[i].end < indexed[j].end
+		}
+		return indexed[i].start < indexed[j].start
+	})
+	for i := 1; i < len(indexed); i++ {
+		if indexed[i].start < indexed[i-1].end {
+			return nil, fmt.Errorf("fix edits overlap")
+		}
+	}
+	out := make([]diagnosticfix.TextEdit, 0, len(indexed))
+	for _, edit := range indexed {
+		out = append(out, edit.edit)
+	}
+	return out, nil
+}
+
+func writeFixedFile(path string, fileFixes fileFixes) error {
+	source := fileFixes.source
+	indexed := make([]struct {
+		edit  diagnosticfix.TextEdit
+		start int
+		end   int
+	}, 0, len(fileFixes.edits))
+	for _, edit := range fileFixes.edits {
+		start, err := offsetForPosition(source, edit.Range.Start)
+		if err != nil {
+			return err
+		}
+		end, err := offsetForPosition(source, edit.Range.End)
+		if err != nil {
+			return err
+		}
+		indexed = append(indexed, struct {
+			edit  diagnosticfix.TextEdit
+			start int
+			end   int
+		}{edit: edit, start: start, end: end})
+	}
+	sort.Slice(indexed, func(i, j int) bool {
+		return indexed[i].start > indexed[j].start
+	})
+	for _, item := range indexed {
+		source = source[:item.start] + item.edit.NewText + source[item.end:]
+	}
+	return os.WriteFile(path, []byte(source), 0o644)
+}
+
+func offsetForPosition(source string, position diagnosticfix.Position) (int, error) {
+	if position.Line <= 0 || position.Column <= 0 {
+		return 0, fmt.Errorf("fix edit has an invalid position")
+	}
+	line := 1
+	column := 1
+	for offset, char := range source {
+		if line == position.Line && column == position.Column {
+			return offset, nil
+		}
+		if char == '\n' {
+			line++
+			column = 1
+			continue
+		}
+		column++
+	}
+	if line == position.Line && column == position.Column {
+		return len(source), nil
+	}
+	return 0, fmt.Errorf("fix edit position %d:%d is outside the file", position.Line, position.Column)
+}

--- a/cmd/gowdk/lang.go
+++ b/cmd/gowdk/lang.go
@@ -76,7 +76,7 @@ func check(args []string) error {
 		if len(payload) > 0 {
 			fmt.Print(string(payload))
 		}
-		if diagnostics.HasErrors() {
+		if checkShouldFail(options, diagnostics) {
 			return fmt.Errorf("check failed")
 		}
 		return nil
@@ -90,10 +90,17 @@ func check(args []string) error {
 	for _, diagnostic := range diagnostics {
 		fmt.Fprintln(os.Stderr, diagnostic.String())
 	}
-	if diagnostics.HasErrors() {
+	if checkShouldFail(options, diagnostics) {
 		return fmt.Errorf("check failed")
 	}
 	return nil
+}
+
+func checkShouldFail(options cliOptions, diagnostics lang.Diagnostics) bool {
+	if diagnostics.HasErrors() {
+		return true
+	}
+	return options.WarningsAsErrors && len(diagnostics) > 0
 }
 
 func manifestJSON(args []string) error {

--- a/cmd/gowdk/main.go
+++ b/cmd/gowdk/main.go
@@ -46,6 +46,8 @@ func run(args []string) error {
 		return format(args[1:])
 	case "check":
 		return check(args[1:])
+	case "fix":
+		return fixCommand(args[1:])
 	case "manifest":
 		return manifestJSON(args[1:])
 	case "sitemap":
@@ -110,7 +112,8 @@ func usage() {
 	fmt.Println("  add <addon> [--config <file>] | add --list  wire an addon into gowdk.config.go")
 	fmt.Println("  tokens <file.gwdk>       print language tokens")
 	fmt.Println("  fmt [--write] <files>    format .gwdk files")
-	fmt.Println("  check [--config <file>] [--module <name>] [--json] [--ssr] [files...] parse and validate .gwdk files")
+	fmt.Println("  check [--config <file>] [--module <name>] [--json] [--warnings-as-errors] [--ssr] [files...] parse and validate .gwdk files")
+	fmt.Println("  fix [--dry-run] [--code <diagnostic-code>] [--config <file>] [--module <name>] [--ssr] [files...] apply registered safe diagnostic fixes")
 	fmt.Println("  manifest [--config <file>] [--module <name>] [--ssr] [files...] print validated manifest JSON")
 	fmt.Println("  sitemap [--config <file>] [--module <name>] [--ssr] [files...] print editor site-map JSON")
 	fmt.Println("  routes [--config <file>] [--module <name>] [--ssr] [files...] print route and endpoint metadata JSON")
@@ -133,6 +136,7 @@ type cliOptions struct {
 	JSON                bool
 	Debug               bool
 	AllowMissingBackend bool
+	WarningsAsErrors    bool
 }
 
 func appendModuleNames(moduleNames []string, value string) []string {

--- a/cmd/gowdk/main_test.go
+++ b/cmd/gowdk/main_test.go
@@ -2671,6 +2671,74 @@ route "/bad"
 	}
 }
 
+func TestCheckCommandPromotesWarnings(t *testing.T) {
+	root := t.TempDir()
+	source := filepath.Join(root, "home.page.gwdk")
+	config := writeMinimalCLIConfig(t, root)
+	writeCLIFile(t, source, `package app
+
+page home
+route "/"
+guard public
+
+view {
+  <img src="/hero.png" />
+}
+`)
+
+	_, _, err := captureCLIOutput(t, func() error {
+		return run([]string{"check", "--config", config, source})
+	})
+	if err != nil {
+		t.Fatalf("check should allow warnings by default: %v", err)
+	}
+	_, stderr, err := captureCLIOutput(t, func() error {
+		return run([]string{"check", "--warnings-as-errors", "--config", config, source})
+	})
+	if err == nil || !strings.Contains(stderr, "warning:") || !strings.Contains(stderr, "alt") {
+		t.Fatalf("expected warnings-as-errors failure with accessibility warning, stderr=%q err=%v", stderr, err)
+	}
+}
+
+func TestFixCommandMigratesOldActionSyntax(t *testing.T) {
+	root := t.TempDir()
+	source := filepath.Join(root, "signup.page.gwdk")
+	config := writeMinimalCLIConfig(t, root)
+	writeCLIFile(t, source, `package app
+
+page signup
+route "/signup"
+guard public
+
+act submit {
+}
+
+view {
+  <main>Signup</main>
+}
+`)
+
+	output, err := captureCLIStdout(t, func() error {
+		return run([]string{"fix", "--config", config, source})
+	})
+	if err != nil {
+		t.Fatalf("fix failed: %v", err)
+	}
+	if !strings.Contains(output, "applied 1 fix") {
+		t.Fatalf("expected fix output, got %q", output)
+	}
+	fixed, err := os.ReadFile(source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(fixed), "act submit {") || !strings.Contains(string(fixed), `act Submit POST "/signup"`) {
+		t.Fatalf("old action syntax was not migrated:\n%s", fixed)
+	}
+	if err := run([]string{"check", "--config", config, source}); err != nil {
+		t.Fatalf("fixed source should validate: %v\n%s", err, fixed)
+	}
+}
+
 func TestManifestCommandHandlesMultipleFiles(t *testing.T) {
 	root := t.TempDir()
 	home := filepath.Join(root, "home.page.gwdk")

--- a/cmd/gowdk/project_inputs.go
+++ b/cmd/gowdk/project_inputs.go
@@ -195,6 +195,11 @@ func parseProjectOptions(args []string, command string, allowJSON bool) (cliOpti
 			options.JSON = true
 		case arg == "--json":
 			return options, "", nil, nil, fmt.Errorf("unknown %s flag %q", command, arg)
+		case arg == "--warnings-as-errors":
+			if command != "check" {
+				return options, "", nil, nil, fmt.Errorf("unknown %s flag %q", command, arg)
+			}
+			options.WarningsAsErrors = true
 		case arg == "--config":
 			i++
 			if i >= len(args) {
@@ -222,7 +227,11 @@ func parseProjectOptions(args []string, command string, allowJSON bool) (cliOpti
 
 func projectCommandUsage(command string, allowJSON bool) string {
 	if allowJSON {
-		return fmt.Sprintf("usage: gowdk %s [--config <file>] [--module <name>] [--json] [--ssr] [files...]", command)
+		warningsFlag := ""
+		if command == "check" {
+			warningsFlag = " [--warnings-as-errors]"
+		}
+		return fmt.Sprintf("usage: gowdk %s [--config <file>] [--module <name>] [--json]%s [--ssr] [files...]", command, warningsFlag)
 	}
 	return fmt.Sprintf("usage: gowdk %s [--config <file>] [--module <name>] [--ssr] [files...]", command)
 }

--- a/docs/language/diagnostics.md
+++ b/docs/language/diagnostics.md
@@ -33,12 +33,16 @@ The optional `suggestion` field carries a short structured fix hint for common
 mistakes such as missing `paths {}` on dynamic spa routes, unknown client or
 view fields, missing `g:key`, and malformed `g:for` syntax.
 
-Warnings are non-fatal. `missing_img_alt` is emitted for literal `<img>`
-elements without an explicit `alt` attribute. `missing_page_guard` is emitted
-for a page that declares no `guard`: the build still succeeds, but the page is
-not public by default — its route is denied (403) at request time until the
-author adds `guard public` (or a protective guard). Access is never granted by
-omission.
+The optional `fix` field carries registry-backed machine-readable fix metadata
+for safe rewrites. `gowdk fix` and LSP code actions use the same fix title,
+description, and named rewriter from the registry.
+
+Warnings are non-fatal unless `gowdk check --warnings-as-errors` is used.
+`missing_img_alt` is emitted for literal `<img>` elements without an explicit
+`alt` attribute. `missing_page_guard` is emitted for a page that declares no
+`guard`: the build still succeeds, but the page is not public by default; its
+route is denied (403) at request time until the author adds `guard public` (or
+a protective guard). Access is never granted by omission.
 
 ## Current Code Registry
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -13,7 +13,8 @@ gowdk add <addon> [--config <file>]
 gowdk add --list
 gowdk tokens <file.gwdk>
 gowdk fmt [--write] <files>
-gowdk check [--config <file>] [--module <name>] [--json] [--ssr] [files...]
+gowdk check [--config <file>] [--module <name>] [--json] [--warnings-as-errors] [--ssr] [files...]
+gowdk fix [--dry-run] [--code <diagnostic-code>] [--config <file>] [--module <name>] [--ssr] [files...]
 gowdk manifest [--config <file>] [--module <name>] [--ssr] [files...]
 gowdk sitemap [--config <file>] [--module <name>] [--ssr] [files...]
 gowdk routes [--config <file>] [--module <name>] [--ssr] [files...]
@@ -41,9 +42,15 @@ gowdk lsp [--ssr]
 - `--json`: supported by `check`, `doctor`, `explain`, `contracts`, `graph`, `trace`, and `list`; prints
   editor/tooling-friendly JSON. Contract JSON includes same-file handler
   signature diagnostics when available.
+- `--warnings-as-errors`: supported by `check`; exits non-zero when warning
+  diagnostics are present.
 - `gowdk doctor --json`: prints a versioned health report with overall status,
   summary counts, environment metadata, and check records.
 - `--write`: supported by `fmt`; overwrites formatted files.
+- `--dry-run`: supported by `fix`; prints files with available registered fixes
+  without writing changes.
+- `--code`: supported by `fix`; limits rewrites to one diagnostic code that has
+  a registered fix.
 - `--config`: supported by `add`, `check`, `doctor`, `manifest`, `sitemap`, `routes`, `inspect ir`, and `build`; selects the config file. Compile commands load a literal config subset from the given path instead of the required default `gowdk.config.go`.
 - `--debug`: supported by `build` and forwarded by `dev`; prints the structured SPA build report to stderr while generated paths remain on stdout.
 - `gowdk build` writes `contract_reference` build-report events for
@@ -76,6 +83,8 @@ go run ./cmd/gowdk add --list
 go run ./cmd/gowdk add ssr actions partial
 go run ./cmd/gowdk check examples/pages/home.page.gwdk
 go run ./cmd/gowdk check --config gowdk.config.go
+go run ./cmd/gowdk check --warnings-as-errors --config gowdk.config.go
+go run ./cmd/gowdk fix --dry-run --code old_action_block_syntax --config gowdk.config.go
 go run ./cmd/gowdk check --ssr examples/ssr/dashboard.page.gwdk
 go run ./cmd/gowdk explain missing_ssr_addon
 go run ./cmd/gowdk explain --json spa_dynamic_route_missing_paths

--- a/docs/reference/diagnostic-codes.md
+++ b/docs/reference/diagnostic-codes.md
@@ -30,6 +30,7 @@ gowdk explain missing_ssr_adon
   "code": "missing_ssr_addon",
   "area": "rendering",
   "stability": "stable",
+  "severity": "error",
   "summary": "request-time page behavior requires the SSR addon",
   "details": "The source selects request-time page rendering...",
   "nextSteps": [
@@ -51,6 +52,9 @@ The registry stores:
 - `area`: broad subsystem such as `parser`, `routing`, `components`, or
   `contracts`.
 - `stability`: compatibility level.
+- `severity`: default severity, one of `error`, `warning`, or `info`.
+- `fix`: optional safe rewrite metadata with a title, description, and named
+  rewriter.
 - `summary`: short description.
 
 `go test ./internal/diagnostics` scans non-test Go source for emitted
@@ -65,9 +69,23 @@ registry.
   feature hardens.
 - `addon`: emitted by addon-owned validation or fallback addon diagnostics.
 
-Most diagnostics use severity `error`. Accessibility diagnostics can use
-severity `warning`; warnings are reported by `gowdk check` but do not make the
-command fail.
+Most diagnostics use severity `error`. Accessibility diagnostics and
+guardless-page diagnostics can use severity `warning`; route-mode notes can use
+severity `info`. Warnings are reported by `gowdk check` but do not make the
+command fail unless `--warnings-as-errors` is passed.
+
+## Fixes
+
+Some diagnostics have registry-backed fixes. `gowdk fix` applies those safe
+single-file rewrites, and LSP code actions use the same metadata:
+
+```sh
+gowdk fix --dry-run --code old_action_block_syntax
+gowdk fix --code unknown_gowdk_use_alias
+```
+
+Old endpoint syntax fixes migrate empty blocks. Blocks that still contain
+behavior are refused because moving behavior into Go is not mechanically safe.
 
 ## Naming
 
@@ -136,7 +154,8 @@ gets more specific stable codes.
 
 When adding or renaming a diagnostic code:
 
-1. Add or update the registry entry in `internal/diagnostics/registry.go`.
+1. Add or update the registry entry in `internal/diagnostics/registry.go`,
+   including severity and any safe fix metadata.
 2. Add or update `gowdk explain` detail when the next step is not obvious.
 3. Update this page when a new area or stability rule appears.
 4. Run `go test ./internal/diagnostics`.

--- a/docs/reference/diagnostics.md
+++ b/docs/reference/diagnostics.md
@@ -6,16 +6,20 @@
 {
   "diagnostics": [
     {
-      "file": "examples/ssr/dashboard.page.gwdk",
-      "code": "missing_ssr_addon",
-      "pos": {"line": 5, "column": 1},
+      "file": "examples/actions/signup.page.gwdk",
+      "code": "old_action_block_syntax",
+      "pos": {"line": 6, "column": 1},
       "range": {
-        "start": {"line": 5, "column": 1},
-        "end": {"line": 5, "column": 7}
+        "start": {"line": 6, "column": 1},
+        "end": {"line": 8, "column": 2}
       },
       "severity": "error",
-      "message": "dashboard: dashboard.page.gwdk uses request-time page behavior, but the SSR addon is not enabled. Fix: enable ssr.Addon() in gowdk.config.go",
-      "suggestion": "Enable ssr.Addon() in gowdk.config.go or remove request-time page behavior."
+      "fix": {
+        "title": "Replace old endpoint block header",
+        "description": "Replace the removed endpoint block form with the current metadata declaration.",
+        "rewriter": "endpoint_header_from_message"
+      },
+      "message": "line 6: old action block syntax is not supported; use `act Submit POST \"<path>\"` and move behavior to Go"
     }
   ]
 }
@@ -28,9 +32,22 @@ Current diagnostic fields:
 - `pos.line`: 1-based line when known; zero means no exact position is available.
 - `pos.column`: 1-based column when known; zero means no exact position is available.
 - `range`: optional 1-based source range. End is exclusive.
-- `severity`: currently `error`.
+- `severity`: `error`, `warning`, or `info`.
+- `fix`: optional registry-backed machine-readable fix metadata. A fix includes
+  a title, description, and named rewriter used by `gowdk fix` and LSP code
+  actions.
 - `message`: user-facing diagnostic message.
 - `suggestion`: optional editor-facing fix hint for common mistakes.
+
+Run registered safe rewrites with:
+
+```sh
+gowdk fix --dry-run --code old_action_block_syntax
+gowdk fix --code old_api_block_syntax
+```
+
+`gowdk fix` applies single-file non-overlapping edits only. Old endpoint block
+fixes migrate empty blocks and refuse blocks that still contain behavior.
 
 ## Code Registry
 

--- a/internal/appgen/source_actions.go
+++ b/internal/appgen/source_actions.go
@@ -690,35 +690,11 @@ func convertIfNeeded(goType string, value ast.Expr) ast.Expr {
 }
 
 func actionDecoderName(action ActionEndpoint) string {
-	return "decode" + exportedIdentifier(action.PageID) + exportedIdentifier(action.ActionName) + "Input"
+	return "decode" + source.ExportedIdentifier(action.PageID, "Action") + source.ExportedIdentifier(action.ActionName, "Action") + "Input"
 }
 
 func boundActionDecoderName(action ActionEndpoint) string {
-	return "decode" + exportedIdentifier(action.PageID) + exportedIdentifier(action.ActionName) + "BoundInput"
-}
-
-func exportedIdentifier(value string) string {
-	var out []rune
-	upperNext := true
-	for _, char := range strings.TrimSpace(value) {
-		valid := char >= 'a' && char <= 'z' || char >= 'A' && char <= 'Z' || char >= '0' && char <= '9'
-		if !valid {
-			upperNext = true
-			continue
-		}
-		if len(out) == 0 && char >= '0' && char <= '9' {
-			out = append(out, 'X')
-		}
-		if upperNext && char >= 'a' && char <= 'z' {
-			char -= 'a' - 'A'
-		}
-		out = append(out, char)
-		upperNext = false
-	}
-	if len(out) == 0 {
-		return "Action"
-	}
-	return string(out)
+	return "decode" + source.ExportedIdentifier(action.PageID, "Action") + source.ExportedIdentifier(action.ActionName, "Action") + "BoundInput"
 }
 
 func backendNotImplementedStmts(binding source.BackendBinding, kind string) []ast.Stmt {

--- a/internal/appgen/source_contracts.go
+++ b/internal/appgen/source_contracts.go
@@ -401,12 +401,12 @@ func hasRoutableContractReferences(options Options) bool {
 
 func contractHandlerName(exposure BackendContractExposure) string {
 	return string(exposure.Endpoint.Kind) +
-		exportedIdentifier(exposure.OwnerID) +
-		exportedIdentifier(exposure.Type) +
-		exportedIdentifier(exposure.Endpoint.Method) +
-		exportedIdentifier(exposure.Endpoint.Path)
+		source.ExportedIdentifier(exposure.OwnerID, "Contract") +
+		source.ExportedIdentifier(exposure.Type, "Contract") +
+		source.ExportedIdentifier(exposure.Endpoint.Method, "Method") +
+		source.ExportedIdentifier(exposure.Endpoint.Path, "Path")
 }
 
 func contractDecoderName(exposure BackendContractExposure) string {
-	return "decodeContract" + exportedIdentifier(exposure.ImportAlias) + exportedIdentifier(exposure.Type) + "Input"
+	return "decodeContract" + source.ExportedIdentifier(exposure.ImportAlias, "Contract") + source.ExportedIdentifier(exposure.Type, "Contract") + "Input"
 }

--- a/internal/buildgen/runtime_asset_paths.go
+++ b/internal/buildgen/runtime_asset_paths.go
@@ -8,6 +8,7 @@ import (
 	"runtime"
 
 	"github.com/cssbruno/gowdk/internal/gwdkir"
+	"github.com/cssbruno/gowdk/internal/source"
 )
 
 func islandWASMLoaderArtifact(outputDir, componentName string) plannedAssetArtifact {
@@ -67,44 +68,13 @@ func islandJSSourceMapAssetPath(componentName string) string {
 }
 
 func componentAssetName(componentName string) string {
-	name := exportedPascalSafe(componentName)
-	if name == "" {
-		return "Component"
-	}
-	return name
+	return source.ExportedIdentifier(componentName, "Component")
 }
 
 func clientGoBlockAssetName(page gwdkir.Page) string {
-	name := exportedPascalSafe(page.ID)
-	if name == "" {
-		return "Page"
-	}
-	return name
+	return source.ExportedIdentifier(page.ID, "Page")
 }
 
 func clientGoBlockMountExportName(page gwdkir.Page) string {
 	return "GOWDKMount" + clientGoBlockAssetName(page)
-}
-
-func exportedPascalSafe(value string) string {
-	out := make([]rune, 0, len(value))
-	upperNext := true
-	for _, char := range value {
-		validLower := char >= 'a' && char <= 'z'
-		validUpper := char >= 'A' && char <= 'Z'
-		validDigit := char >= '0' && char <= '9'
-		if !validLower && !validUpper && !validDigit {
-			upperNext = true
-			continue
-		}
-		if len(out) == 0 && validDigit {
-			out = append(out, 'P')
-		}
-		if upperNext && validLower {
-			char -= 'a' - 'A'
-		}
-		out = append(out, char)
-		upperNext = false
-	}
-	return string(out)
 }

--- a/internal/buildgen/runtime_islands.go
+++ b/internal/buildgen/runtime_islands.go
@@ -18,9 +18,9 @@ func islandRuntimeArtifacts(config gowdk.Config, pages []gwdkir.Page, allCompone
 	for _, page := range pages {
 		source, err := composePageViewSource(page, layouts)
 		if err != nil {
-			source = page.Blocks.ViewBody
+			return nil, fmt.Errorf("compose island view source for page %q: %w", page.ID, err)
 		}
-		usages, err := recursiveManifestComponentCallUsages(source, components, page.Package, componentUses(page.Uses))
+		usages, err := recursiveComponentCallUsages(source, components, page.Package, componentUses(page.Uses), manifestComponentResolver)
 		if err != nil {
 			return nil, fmt.Errorf("resolve island components for page %q: %w", page.ID, err)
 		}
@@ -69,7 +69,7 @@ func islandRuntimeArtifacts(config gowdk.Config, pages []gwdkir.Page, allCompone
 }
 
 func islandScriptHrefs(source string, components map[string]view.Component, ownerPackage string, uses map[string]string) ([]string, error) {
-	usages, err := recursiveViewComponentCallUsages(source, components, ownerPackage, uses)
+	usages, err := recursiveComponentCallUsages(source, components, ownerPackage, uses, viewComponentResolver)
 	if err != nil {
 		return nil, err
 	}
@@ -113,13 +113,38 @@ func viewComponentRuntimeMode(explicit string, component view.Component) string 
 	return component.DefaultIsland
 }
 
-type resolvedViewComponentCallUsage struct {
-	call      view.ComponentCallUsage
-	component view.Component
+type componentResolver[T any] struct {
+	Body     func(T) string
+	Identity func(T) string
+	Package  func(T) string
+	Uses     func(T) map[string]string
 }
 
-func recursiveViewComponentCallUsages(source string, components map[string]view.Component, ownerPackage string, uses map[string]string) ([]resolvedViewComponentCallUsage, error) {
-	var usages []resolvedViewComponentCallUsage
+type resolvedComponentCallUsage[T any] struct {
+	call      view.ComponentCallUsage
+	component T
+}
+
+var viewComponentResolver = componentResolver[view.Component]{
+	Body:     func(component view.Component) string { return component.Body },
+	Identity: func(component view.Component) string { return component.Identity() },
+	Package:  func(component view.Component) string { return component.Package },
+	Uses:     func(component view.Component) map[string]string { return component.Uses },
+}
+
+var manifestComponentResolver = componentResolver[gwdkir.Component]{
+	Body:     func(component gwdkir.Component) string { return component.Blocks.ViewBody },
+	Identity: manifestComponentIdentity,
+	Package:  func(component gwdkir.Component) string { return component.Package },
+	Uses:     func(component gwdkir.Component) map[string]string { return componentUses(component.Uses) },
+}
+
+func recursiveViewComponentCallUsages(source string, components map[string]view.Component, ownerPackage string, uses map[string]string) ([]resolvedComponentCallUsage[view.Component], error) {
+	return recursiveComponentCallUsages(source, components, ownerPackage, uses, viewComponentResolver)
+}
+
+func recursiveComponentCallUsages[T any](source string, components map[string]T, ownerPackage string, uses map[string]string, resolver componentResolver[T]) ([]resolvedComponentCallUsage[T], error) {
+	var usages []resolvedComponentCallUsage[T]
 	visiting := map[string]bool{}
 	var walk func(string, string, map[string]string) error
 	walk = func(source string, ownerPackage string, uses map[string]string) error {
@@ -128,17 +153,17 @@ func recursiveViewComponentCallUsages(source string, components map[string]view.
 			return err
 		}
 		for _, usage := range direct {
-			component, ok := lookupViewComponent(components, usage.Component, ownerPackage, uses)
+			component, ok := lookupComponent(components, usage.Component, ownerPackage, uses)
 			if !ok {
 				continue
 			}
-			usages = append(usages, resolvedViewComponentCallUsage{call: usage, component: component})
-			identity := component.Identity()
+			usages = append(usages, resolvedComponentCallUsage[T]{call: usage, component: component})
+			identity := resolver.Identity(component)
 			if visiting[identity] {
 				continue
 			}
 			visiting[identity] = true
-			if err := walk(component.Body, component.Package, component.Uses); err != nil {
+			if err := walk(resolver.Body(component), resolver.Package(component), resolver.Uses(component)); err != nil {
 				return err
 			}
 			delete(visiting, identity)
@@ -151,7 +176,8 @@ func recursiveViewComponentCallUsages(source string, components map[string]view.
 	return usages, nil
 }
 
-func lookupViewComponent(components map[string]view.Component, name string, ownerPackage string, uses map[string]string) (view.Component, bool) {
+func lookupComponent[T any](components map[string]T, name string, ownerPackage string, uses map[string]string) (T, bool) {
+	var zero T
 	if strings.Contains(name, ".") {
 		if component, ok := components[name]; ok {
 			return component, true
@@ -159,66 +185,7 @@ func lookupViewComponent(components map[string]view.Component, name string, owne
 		alias, componentName, _ := strings.Cut(name, ".")
 		packageName := uses[alias]
 		if packageName == "" {
-			return view.Component{}, false
-		}
-		component, ok := components[componentRegistryKey(packageName, componentName)]
-		return component, ok
-	}
-	if ownerPackage != "" {
-		component, ok := components[componentRegistryKey(ownerPackage, name)]
-		return component, ok
-	}
-	component, ok := components[name]
-	return component, ok
-}
-
-type resolvedManifestComponentCallUsage struct {
-	call      view.ComponentCallUsage
-	component gwdkir.Component
-}
-
-func recursiveManifestComponentCallUsages(source string, components map[string]gwdkir.Component, ownerPackage string, uses map[string]string) ([]resolvedManifestComponentCallUsage, error) {
-	var usages []resolvedManifestComponentCallUsage
-	visiting := map[string]bool{}
-	var walk func(string, string, map[string]string) error
-	walk = func(source string, ownerPackage string, uses map[string]string) error {
-		direct, err := view.ComponentCallUsages(source)
-		if err != nil {
-			return err
-		}
-		for _, usage := range direct {
-			component, ok := lookupManifestComponent(components, usage.Component, ownerPackage, uses)
-			if !ok {
-				continue
-			}
-			usages = append(usages, resolvedManifestComponentCallUsage{call: usage, component: component})
-			identity := manifestComponentIdentity(component)
-			if visiting[identity] {
-				continue
-			}
-			visiting[identity] = true
-			if err := walk(component.Blocks.ViewBody, component.Package, componentUses(component.Uses)); err != nil {
-				return err
-			}
-			delete(visiting, identity)
-		}
-		return nil
-	}
-	if err := walk(source, ownerPackage, uses); err != nil {
-		return nil, err
-	}
-	return usages, nil
-}
-
-func lookupManifestComponent(components map[string]gwdkir.Component, name string, ownerPackage string, uses map[string]string) (gwdkir.Component, bool) {
-	if strings.Contains(name, ".") {
-		if component, ok := components[name]; ok {
-			return component, true
-		}
-		alias, componentName, _ := strings.Cut(name, ".")
-		packageName := uses[alias]
-		if packageName == "" {
-			return gwdkir.Component{}, false
+			return zero, false
 		}
 		component, ok := components[componentRegistryKey(packageName, componentName)]
 		return component, ok

--- a/internal/compiler/backend_bindings.go
+++ b/internal/compiler/backend_bindings.go
@@ -164,7 +164,10 @@ func bindStandaloneAction(endpoint gwdkir.GoEndpoint, pkg featurePackage) source
 	if method == "" {
 		method = "POST"
 	}
-	binding := baseStandaloneBackendBinding(endpoint, actionHandlerKind, method, pkg)
+	return bindActionEndpoint(baseStandaloneBackendBinding(endpoint, actionHandlerKind, method, pkg), pkg)
+}
+
+func bindActionEndpoint(binding source.BackendBinding, pkg featurePackage) source.BackendBinding {
 	function, ok := pkg.Functions[binding.FunctionName]
 	if !ok {
 		binding.Status = source.BackendBindingMissing
@@ -193,7 +196,10 @@ func bindStandaloneAPI(endpoint gwdkir.GoEndpoint, pkg featurePackage) source.Ba
 	if method == "" {
 		method = "GET"
 	}
-	binding := baseStandaloneBackendBinding(endpoint, apiHandlerKind, method, pkg)
+	return bindAPIEndpoint(baseStandaloneBackendBinding(endpoint, apiHandlerKind, method, pkg), pkg)
+}
+
+func bindAPIEndpoint(binding source.BackendBinding, pkg featurePackage) source.BackendBinding {
 	function, ok := pkg.Functions[binding.FunctionName]
 	if !ok {
 		binding.Status = source.BackendBindingMissing
@@ -219,28 +225,7 @@ func bindAction(page gwdkir.Page, action gwdkir.Action, pkg featurePackage) sour
 	if route == "" {
 		route = page.Route
 	}
-	binding := baseBackendBinding(page, actionHandlerKind, action.Name, method, route, pkg)
-	function, ok := pkg.Functions[binding.FunctionName]
-	if !ok {
-		binding.Status = source.BackendBindingMissing
-		binding.Message = fmt.Sprintf("GOWDK action handler %s.%s is not implemented", packageLabel(pkg), binding.FunctionName)
-		return binding
-	}
-	if !function.Action() {
-		binding.Status = source.BackendBindingUnsupportedSignature
-		if function.SupportMessage != "" {
-			binding.Message = fmt.Sprintf("GOWDK action handler %s.%s is unsupported: %s", packageLabel(pkg), binding.FunctionName, function.SupportMessage)
-		} else {
-			binding.Message = fmt.Sprintf("GOWDK action handler %s.%s must have signature func(context.Context) (response.Response, error), func(context.Context, Input) (response.Response, error), func(context.Context, *Input) (response.Response, error), or func(context.Context, form.Values) (response.Response, error)", packageLabel(pkg), binding.FunctionName)
-		}
-		return binding
-	}
-	binding.Signature = function.Signature
-	binding.InputType = function.InputType
-	binding.InputPointer = function.InputPointer
-	binding.InputFields = function.InputFields
-	binding.Status = source.BackendBindingBound
-	return binding
+	return bindActionEndpoint(baseBackendBinding(page, actionHandlerKind, action.Name, method, route, pkg), pkg)
 }
 
 func bindAPI(page gwdkir.Page, api gwdkir.API, pkg featurePackage) source.BackendBinding {
@@ -252,21 +237,7 @@ func bindAPI(page gwdkir.Page, api gwdkir.API, pkg featurePackage) source.Backen
 	if route == "" {
 		route = page.Route
 	}
-	binding := baseBackendBinding(page, apiHandlerKind, api.Name, method, route, pkg)
-	function, ok := pkg.Functions[binding.FunctionName]
-	if !ok {
-		binding.Status = source.BackendBindingMissing
-		binding.Message = fmt.Sprintf("GOWDK API handler %s.%s is not implemented", packageLabel(pkg), binding.FunctionName)
-		return binding
-	}
-	if !function.API() {
-		binding.Status = source.BackendBindingUnsupportedSignature
-		binding.Message = fmt.Sprintf("GOWDK API handler %s.%s must have signature func(context.Context, *http.Request) (response.Response, error)", packageLabel(pkg), binding.FunctionName)
-		return binding
-	}
-	binding.Signature = function.Signature
-	binding.Status = source.BackendBindingBound
-	return binding
+	return bindAPIEndpoint(baseBackendBinding(page, apiHandlerKind, api.Name, method, route, pkg), pkg)
 }
 
 func bindFragment(page gwdkir.Page, fragment gwdkir.FragmentEndpoint, pkg featurePackage) (source.BackendBinding, bool) {
@@ -788,35 +759,7 @@ func isMapStringAny(expression ast.Expr) bool {
 }
 
 func loadFunctionName(pageID string) string {
-	return "Load" + exportedIdentifier(pageID)
-}
-
-func exportedIdentifier(value string) string {
-	out := make([]rune, 0, len(value))
-	uppercaseNext := true
-	for _, char := range strings.TrimSpace(value) {
-		if char >= 'a' && char <= 'z' {
-			if uppercaseNext {
-				char = char - 'a' + 'A'
-			}
-			out = append(out, char)
-			uppercaseNext = false
-			continue
-		}
-		if char >= 'A' && char <= 'Z' || char >= '0' && char <= '9' {
-			if len(out) == 0 && char >= '0' && char <= '9' {
-				out = append(out, 'P')
-			}
-			out = append(out, char)
-			uppercaseNext = false
-			continue
-		}
-		uppercaseNext = true
-	}
-	if len(out) == 0 {
-		return "Page"
-	}
-	return string(out)
+	return "Load" + source.ExportedIdentifier(pageID, "Page")
 }
 
 func isSelector(expression ast.Expr, imports map[string]string, importPath, name string) bool {

--- a/internal/diagnosticfix/fix.go
+++ b/internal/diagnosticfix/fix.go
@@ -1,0 +1,218 @@
+package diagnosticfix
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/cssbruno/gowdk/internal/diagnostics"
+)
+
+// Position is a 1-based text position.
+type Position struct {
+	Line   int
+	Column int
+}
+
+// Range is a 1-based text range. End is exclusive.
+type Range struct {
+	Start Position
+	End   Position
+}
+
+// Diagnostic is the small diagnostic shape needed by registry rewriters.
+type Diagnostic struct {
+	Code    string
+	Message string
+	Range   Range
+}
+
+// TextEdit replaces Range with NewText.
+type TextEdit struct {
+	Range   Range
+	NewText string
+}
+
+// Edits returns source edits for a registry fix and diagnostic.
+func Edits(fix diagnostics.Fix, source string, diagnostic Diagnostic) ([]TextEdit, error) {
+	switch fix.Rewriter {
+	case diagnostics.FixEndpointHeaderFromMessage:
+		return endpointHeaderEdits(source, diagnostic)
+	case diagnostics.FixInsertMissingUse:
+		return missingUseEdits(source, diagnostic)
+	default:
+		return nil, fmt.Errorf("diagnostic fix %q has no rewriter", fix.Title)
+	}
+}
+
+func endpointHeaderEdits(source string, diagnostic Diagnostic) ([]TextEdit, error) {
+	replacement, ok := EndpointHeaderReplacement(diagnostic.Message)
+	if !ok {
+		return nil, fmt.Errorf("%s diagnostic does not include an endpoint replacement", diagnostic.Code)
+	}
+	replacement = endpointReplacementRoute(source, replacement)
+	if emptyRange(diagnostic.Range) {
+		return nil, fmt.Errorf("%s diagnostic has no source range", diagnostic.Code)
+	}
+	editRange, err := endpointBlockRange(source, diagnostic.Range)
+	if err != nil {
+		return nil, err
+	}
+	return []TextEdit{{Range: editRange, NewText: replacement}}, nil
+}
+
+func missingUseEdits(source string, diagnostic Diagnostic) ([]TextEdit, error) {
+	alias, ok := MissingUseAlias(diagnostic.Message)
+	if !ok {
+		return nil, fmt.Errorf("%s diagnostic does not include a missing use alias", diagnostic.Code)
+	}
+	insert := UseInsertionPosition(source, diagnostic.Range.Start)
+	return []TextEdit{{
+		Range:   Range{Start: insert, End: insert},
+		NewText: `use ` + alias + ` "package"` + "\n",
+	}}, nil
+}
+
+// EndpointHeaderReplacement extracts the current endpoint declaration from an
+// old endpoint syntax diagnostic message.
+func EndpointHeaderReplacement(message string) (string, bool) {
+	start := strings.Index(message, "use `")
+	if start < 0 {
+		return "", false
+	}
+	start += len("use `")
+	end := strings.IndexByte(message[start:], '`')
+	if end < 0 {
+		return "", false
+	}
+	replacement := message[start : start+end]
+	if strings.HasPrefix(replacement, "act ") || strings.HasPrefix(replacement, "api ") {
+		if strings.Contains(message[start+end+1:], "and move behavior to Go") {
+			return replacement, true
+		}
+	}
+	return "", false
+}
+
+func endpointReplacementRoute(source string, replacement string) string {
+	if !strings.Contains(replacement, `"<path>"`) {
+		return replacement
+	}
+	if strings.HasPrefix(replacement, "act ") {
+		if route, ok := pageRoute(source); ok {
+			return strings.Replace(replacement, `"<path>"`, quoteRoute(route), 1)
+		}
+	}
+	if strings.HasPrefix(replacement, "api ") {
+		fields := strings.Fields(replacement)
+		if len(fields) >= 2 {
+			return strings.Replace(replacement, `"<path>"`, quoteRoute("/api/"+strings.ToLower(fields[1])), 1)
+		}
+	}
+	return replacement
+}
+
+func pageRoute(source string) (string, bool) {
+	for _, line := range strings.Split(source, "\n") {
+		text := strings.TrimSpace(line)
+		routeText, ok := strings.CutPrefix(text, "route ")
+		if !ok {
+			routeText, ok = strings.CutPrefix(text, "@route ")
+		}
+		if !ok {
+			continue
+		}
+		route := strings.TrimSpace(routeText)
+		if len(route) >= 2 && route[0] == '"' && route[len(route)-1] == '"' {
+			return strings.Trim(route, `"`), true
+		}
+	}
+	return "", false
+}
+
+func quoteRoute(route string) string {
+	if strings.TrimSpace(route) == "" {
+		route = "/"
+	}
+	return `"` + route + `"`
+}
+
+// MissingUseAlias extracts the missing GOWDK use alias from a diagnostic.
+func MissingUseAlias(message string) (string, bool) {
+	start := strings.Index(message, "Add `use ")
+	if start < 0 {
+		return "", false
+	}
+	start += len("Add `use ")
+	end := strings.Index(message[start:], ` "<package>"`)
+	if end < 0 {
+		return "", false
+	}
+	alias := message[start : start+end]
+	if !isIdentifier(alias) {
+		return "", false
+	}
+	return alias, true
+}
+
+// UseInsertionPosition inserts use declarations before view when possible.
+func UseInsertionPosition(source string, fallback Position) Position {
+	lines := strings.Split(source, "\n")
+	for index, line := range lines {
+		if strings.TrimSpace(line) == "view {" {
+			return Position{Line: index + 1, Column: 1}
+		}
+	}
+	if fallback.Line <= 0 || fallback.Column <= 0 {
+		return Position{Line: 1, Column: 1}
+	}
+	return fallback
+}
+
+func emptyRange(item Range) bool {
+	return item.Start.Line <= 0 || item.Start.Column <= 0 || item.End.Line <= 0 || item.End.Column <= 0
+}
+
+func endpointBlockRange(source string, header Range) (Range, error) {
+	lines := strings.Split(source, "\n")
+	lineIndex := header.Start.Line - 1
+	if lineIndex < 0 || lineIndex >= len(lines) {
+		return Range{}, fmt.Errorf("endpoint diagnostic range is outside the file")
+	}
+	line := lines[lineIndex]
+	open := strings.IndexByte(line, '{')
+	if open < 0 {
+		return header, nil
+	}
+	if strings.TrimSpace(line[open+1:]) == "}" {
+		header.End = Position{Line: header.Start.Line, Column: len([]rune(line)) + 1}
+		return header, nil
+	}
+	for index := lineIndex + 1; index < len(lines); index++ {
+		text := strings.TrimSpace(lines[index])
+		if text == "" {
+			continue
+		}
+		if text != "}" {
+			return Range{}, fmt.Errorf("old endpoint block contains behavior; move behavior to Go before applying the fix")
+		}
+		header.End = Position{Line: index + 1, Column: len([]rune(lines[index])) + 1}
+		return header, nil
+	}
+	return Range{}, fmt.Errorf("old endpoint block has no closing brace")
+}
+
+func isIdentifier(value string) bool {
+	if value == "" {
+		return false
+	}
+	for index, char := range value {
+		if char >= 'a' && char <= 'z' || char >= 'A' && char <= 'Z' || char == '_' {
+			continue
+		}
+		if index > 0 && char >= '0' && char <= '9' {
+			continue
+		}
+		return false
+	}
+	return true
+}

--- a/internal/diagnosticfix/fix_test.go
+++ b/internal/diagnosticfix/fix_test.go
@@ -1,0 +1,29 @@
+package diagnosticfix
+
+import (
+	"testing"
+
+	"github.com/cssbruno/gowdk/internal/diagnostics"
+)
+
+func TestMissingUseFixUsesParseablePlaceholder(t *testing.T) {
+	edits, err := Edits(diagnostics.Fix{Title: "Add use", Rewriter: diagnostics.FixInsertMissingUse}, `package app
+
+page home
+route "/"
+
+view {
+  <ui.Button />
+}
+`, Diagnostic{
+		Code:    "unknown_gowdk_use_alias",
+		Message: `home references component <ui.Button />, but alias "ui" is not declared. Add ` + "`" + `use ui "<package>"` + "`" + ` before the view block`,
+		Range:   Range{Start: Position{Line: 7, Column: 4}, End: Position{Line: 7, Column: 6}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(edits) != 1 || edits[0].NewText != "use ui \"package\"\n" {
+		t.Fatalf("unexpected edits: %#v", edits)
+	}
+}

--- a/internal/diagnostics/explain.go
+++ b/internal/diagnostics/explain.go
@@ -10,6 +10,8 @@ type Explanation struct {
 	Code      string    `json:"code"`
 	Area      string    `json:"area"`
 	Stability Stability `json:"stability"`
+	Severity  Severity  `json:"severity"`
+	Fix       *Fix      `json:"fix,omitempty"`
 	Summary   string    `json:"summary"`
 	Details   string    `json:"details,omitempty"`
 	NextSteps []string  `json:"nextSteps,omitempty"`
@@ -186,6 +188,8 @@ func Explain(code string) (Explanation, bool) {
 		Code:      entry.Code,
 		Area:      entry.Area,
 		Stability: entry.Stability,
+		Severity:  entry.Severity,
+		Fix:       entry.Fix,
 		Summary:   entry.Summary,
 		NextSteps: defaultNextSteps(entry),
 	}

--- a/internal/diagnostics/registry.go
+++ b/internal/diagnostics/registry.go
@@ -9,114 +9,151 @@ const (
 	StabilityAddon        Stability = "addon"
 )
 
+// Severity describes the default impact of a diagnostic code. Individual
+// emitters may still upgrade or downgrade a diagnostic when runtime context
+// makes that more precise.
+type Severity string
+
+const (
+	SeverityError   Severity = "error"
+	SeverityWarning Severity = "warning"
+	SeverityInfo    Severity = "info"
+)
+
+// Fix describes one machine-readable rewrite available for a diagnostic code.
+type Fix struct {
+	Title       string `json:"title"`
+	Description string `json:"description"`
+	Rewriter    string `json:"rewriter,omitempty"`
+}
+
+const (
+	FixEndpointHeaderFromMessage = "endpoint_header_from_message"
+	FixInsertMissingUse          = "insert_missing_use"
+)
+
 // Code describes one public diagnostic code emitted by GOWDK tooling.
 type Code struct {
 	Code      string
 	Area      string
 	Stability Stability
+	Severity  Severity
+	Fix       *Fix
 	Summary   string
+}
+
+var endpointHeaderFix = &Fix{
+	Title:       "Replace old endpoint block header",
+	Description: "Replace the removed endpoint block form with the current metadata declaration.",
+	Rewriter:    FixEndpointHeaderFromMessage,
+}
+
+var missingUseFix = &Fix{
+	Title:       "Add missing use declaration",
+	Description: "Insert a use declaration for the referenced GOWDK component package alias.",
+	Rewriter:    FixInsertMissingUse,
 }
 
 // Registry is the current inventory of diagnostic codes emitted by the parser,
 // compiler, build generator, contract scanner, and language tooling.
 var Registry = []Code{
-	{Code: "addon_go_block_diagnostic", Area: "go-block", Stability: StabilityAddon, Summary: "addon-provided go block diagnostic without a custom code"},
-	{Code: "ambiguous_dynamic_route", Area: "routing", Stability: StabilityStable, Summary: "dynamic page route overlaps another dynamic page route"},
-	{Code: "backend_binding_required", Area: "backend", Stability: StabilityStable, Summary: "strict builds require a supported backend handler binding"},
-	{Code: "client_go_block_wasm_build_error", Area: "wasm", Stability: StabilityExperimental, Summary: "page go client WASM build failed"},
-	{Code: "client_go_block_wasm_entrypoint_error", Area: "wasm", Stability: StabilityExperimental, Summary: "page go client WASM entrypoint is missing or invalid"},
-	{Code: "client_go_block_wasm_export_error", Area: "wasm", Stability: StabilityExperimental, Summary: "page go client WASM exports are missing or invalid"},
-	{Code: "client_go_block_wasm_import_error", Area: "wasm", Stability: StabilityExperimental, Summary: "page go client WASM imports are invalid"},
-	{Code: "client_go_block_wasm_source_error", Area: "wasm", Stability: StabilityExperimental, Summary: "page go client source materialization failed"},
-	{Code: "component_client_error", Area: "components", Stability: StabilityStable, Summary: "component client block or local island behavior is invalid"},
-	{Code: "component_contract_error", Area: "components", Stability: StabilityStable, Summary: "component Go props or state contract is invalid"},
-	{Code: "component_field_error", Area: "components", Stability: StabilityStable, Summary: "component view references an invalid field or directive expression"},
-	{Code: "contract_event_category_invalid", Area: "contracts", Stability: StabilityExperimental, Summary: "contract emitted-event category does not match scanned registrations"},
-	{Code: "contract_event_name_invalid", Area: "contracts", Stability: StabilityExperimental, Summary: "contract event name is too broad or UI-owned"},
-	{Code: "contract_handler_invalid", Area: "contracts", Stability: StabilityExperimental, Summary: "contract handler signature or export shape is invalid"},
-	{Code: "contract_handler_missing", Area: "contracts", Stability: StabilityExperimental, Summary: "contract handler was not found in the scanned package"},
-	{Code: "contract_input_invalid", Area: "contracts", Stability: StabilityExperimental, Summary: "contract input struct is invalid"},
-	{Code: "contract_reference_invalid", Area: "contracts", Stability: StabilityExperimental, Summary: "GOWDK command or query reference could not bind to a valid contract"},
-	{Code: "contract_reference_missing", Area: "contracts", Stability: StabilityExperimental, Summary: "GOWDK command or query reference has no matching contract"},
-	{Code: "contract_reference_parse_error", Area: "contracts", Stability: StabilityExperimental, Summary: "view contract reference directives could not be parsed"},
-	{Code: "contract_reference_role_not_allowed", Area: "contracts", Stability: StabilityExperimental, Summary: "contract reference targets a registration that is not available to the web role"},
-	{Code: "contract_result_invalid", Area: "contracts", Stability: StabilityExperimental, Summary: "contract result type is invalid"},
-	{Code: "contract_type_invalid", Area: "contracts", Stability: StabilityExperimental, Summary: "contract type is invalid"},
-	{Code: "cyclic_layout_reference", Area: "layouts", Stability: StabilityStable, Summary: "layout layout inheritance forms a cycle"},
-	{Code: "duplicate_command_owner", Area: "contracts", Stability: StabilityExperimental, Summary: "command has more than one owner registration"},
-	{Code: "duplicate_component_emit", Area: "components", Stability: StabilityExperimental, Summary: "component declares the same emitted event more than once"},
-	{Code: "duplicate_component_name", Area: "components", Stability: StabilityStable, Summary: "component name is declared more than once"},
-	{Code: "duplicate_css_selection", Area: "css", Stability: StabilityStable, Summary: "page repeats the same CSS selection"},
-	{Code: "duplicate_env_name", Area: "config", Stability: StabilityStable, Summary: "environment variable or secret name is declared more than once"},
-	{Code: "duplicate_go_endpoint_comment", Area: "backend", Stability: StabilityStable, Summary: "Go handler has more than one gowdk endpoint comment"},
-	{Code: "duplicate_go_import_alias", Area: "packages", Stability: StabilityStable, Summary: "GOWDK source declares the same Go import alias more than once"},
-	{Code: "duplicate_gowdk_use_alias", Area: "source-imports", Stability: StabilityStable, Summary: "GOWDK source declares the same use alias more than once"},
-	{Code: "duplicate_layout_id", Area: "layouts", Stability: StabilityStable, Summary: "layout identity is declared more than once"},
-	{Code: "duplicate_page_id", Area: "pages", Stability: StabilityStable, Summary: "page identity is declared more than once"},
-	{Code: "duplicate_page_store", Area: "stores", Stability: StabilityExperimental, Summary: "page declares the same store more than once"},
-	{Code: "duplicate_revalidate_policy", Area: "cache", Stability: StabilityStable, Summary: "page combines revalidate with a cache policy that already declares stale-while-revalidate"},
-	{Code: "duplicate_route", Area: "routing", Stability: StabilityStable, Summary: "page route pattern is duplicated"},
-	{Code: "duplicate_route_param", Area: "routing", Stability: StabilityStable, Summary: "route declares the same param more than once"},
-	{Code: "env_name_required", Area: "config", Stability: StabilityStable, Summary: "environment variable contract entry is missing a name"},
-	{Code: "fragment_dynamic_route", Area: "partials", Stability: StabilityExperimental, Summary: "fragment endpoint path is dynamic, which is not supported yet"},
-	{Code: "generated_app_import_cycle", Area: "generated-go", Stability: StabilityStable, Summary: "generated app would import itself through user code"},
-	{Code: "go_client_requires_page", Area: "go-block", Stability: StabilityExperimental, Summary: "go client block was declared outside a page"},
-	{Code: "go_endpoint_parse_error", Area: "backend", Stability: StabilityStable, Summary: "Go endpoint comment scan failed to parse a Go file"},
-	{Code: "go_endpoint_read_error", Area: "backend", Stability: StabilityStable, Summary: "Go endpoint scan failed to read a source directory"},
-	{Code: "go_package_error", Area: "packages", Stability: StabilityStable, Summary: "sibling Go package parse, package, or type-check validation failed"},
-	{Code: "go_ssr_requires_request_render", Area: "go-block", Stability: StabilityExperimental, Summary: "go ssr block requires request-time page rendering"},
-	{Code: "guard_requires_request_render", Area: "pages", Stability: StabilityStable, Summary: "protected page guard metadata requires request-time page rendering"},
-	{Code: "invalid_backend_handler_name", Area: "backend", Stability: StabilityStable, Summary: "endpoint handler name is not an exported Go identifier"},
-	{Code: "invalid_css_selection", Area: "css", Stability: StabilityStable, Summary: "page CSS selection is invalid"},
-	{Code: "invalid_go_block", Area: "go-block", Stability: StabilityExperimental, Summary: "inline Go block does not parse as valid Go"},
-	{Code: "invalid_go_endpoint_handler", Area: "backend", Stability: StabilityStable, Summary: "Go endpoint comment is not attached to an exported package-level function"},
-	{Code: "invalid_go_import", Area: "packages", Stability: StabilityStable, Summary: "GOWDK source Go import declaration is invalid"},
-	{Code: "layout_self_reference", Area: "layouts", Stability: StabilityStable, Summary: "layout lists itself in layout; a layout cannot inherit from itself"},
-	{Code: "layout_slot_count", Area: "layouts", Stability: StabilityStable, Summary: "layout must contain exactly one <slot /> placeholder"},
-	{Code: "load_requires_request_render", Area: "rendering", Stability: StabilityStable, Summary: "load block requires request-time page rendering"},
-	{Code: "malformed_gowdk_use", Area: "source-imports", Stability: StabilityStable, Summary: "GOWDK use declaration is malformed"},
-	{Code: "malformed_route", Area: "routing", Stability: StabilityStable, Summary: "route path violates GOWDK route syntax"},
-	{Code: "missing_img_alt", Area: "accessibility", Stability: StabilityStable, Summary: "image element is missing explicit alt text"},
-	{Code: "missing_package_declaration", Area: "packages", Stability: StabilityStable, Summary: "GOWDK source is missing a package declaration"},
-	{Code: "missing_page_guard", Area: "pages", Stability: StabilityStable, Summary: "page declares no guard; warning (route denied 403) or error when it defines act/api/fragment endpoints"},
-	{Code: "missing_required_env", Area: "config", Stability: StabilityStable, Summary: "required environment variable is not set"},
-	{Code: "missing_required_secret", Area: "config", Stability: StabilityStable, Summary: "required secret environment variable is not set"},
-	{Code: "missing_ssr_addon", Area: "rendering", Stability: StabilityStable, Summary: "request-time page behavior requires the SSR addon"},
-	{Code: "missing_view_block", Area: "pages", Stability: StabilityStable, Summary: "page source is missing view markup for its GET route"},
-	{Code: "old_action_block_syntax", Area: "backend", Stability: StabilityStable, Summary: "source uses removed action block syntax"},
-	{Code: "old_api_block_syntax", Area: "backend", Stability: StabilityStable, Summary: "source uses removed API block syntax"},
-	{Code: "package_mismatch", Area: "packages", Stability: StabilityStable, Summary: "GOWDK package does not match sibling Go files"},
-	{Code: "package_must_be_first", Area: "packages", Stability: StabilityStable, Summary: "package declaration is not the first non-comment declaration"},
-	{Code: "page_store_error", Area: "stores", Stability: StabilityExperimental, Summary: "page store type or initializer is invalid"},
-	{Code: "parse_error", Area: "parser", Stability: StabilityStable, Summary: "line-oriented parser rejected source without a more specific code"},
-	{Code: "public_guard_exclusive", Area: "pages", Stability: StabilityStable, Summary: "guard public must be the only guard on an intentionally public page"},
-	{Code: "redundant_component_implementation", Area: "components", Stability: StabilityStable, Summary: "same component has both GOWDK and generated Go implementations"},
-	{Code: "revalidate_requires_cache", Area: "cache", Stability: StabilityStable, Summary: "revalidate requires an explicit cache policy"},
-	{Code: "route_method_conflict", Area: "routing", Stability: StabilityStable, Summary: "two generated handlers claim the same method and route pattern"},
-	{Code: "secret_env_in_vars", Area: "config", Stability: StabilityStable, Summary: "secret-looking environment variable is declared as a normal variable"},
-	{Code: "secret_env_name_required", Area: "config", Stability: StabilityStable, Summary: "secret environment contract entry is missing a name"},
-	{Code: "spa_disabled", Area: "routing", Stability: StabilityExperimental, Summary: "SPA route binding is disabled for this generated route lane"},
-	{Code: "spa_dynamic_route_missing_paths", Area: "routing", Stability: StabilityStable, Summary: "dynamic SPA route is missing paths declarations"},
-	{Code: "ssr_disabled", Area: "routing", Stability: StabilityExperimental, Summary: "SSR route binding is disabled for this generated route lane"},
-	{Code: "unknown_addon_go_block_target", Area: "go-block", Stability: StabilityExperimental, Summary: "go addon block references an addon that is not enabled"},
-	{Code: "unknown_component_store", Area: "stores", Stability: StabilityExperimental, Summary: "component references a page store that does not exist"},
-	{Code: "unknown_go_block_target", Area: "go-block", Stability: StabilityExperimental, Summary: "go block target is not recognized"},
-	{Code: "unknown_gowdk_component", Area: "source-imports", Stability: StabilityStable, Summary: "qualified component call references an unknown GOWDK component"},
-	{Code: "unknown_gowdk_use_alias", Area: "source-imports", Stability: StabilityStable, Summary: "source references a GOWDK use alias that is not declared"},
-	{Code: "unknown_gowdk_use_package", Area: "source-imports", Stability: StabilityStable, Summary: "use declaration references a GOWDK package that was not discovered"},
-	{Code: "unknown_layout_id", Area: "layouts", Stability: StabilityStable, Summary: "page references a layout that does not exist"},
-	{Code: "unsupported_action_method", Area: "backend", Stability: StabilityStable, Summary: "action endpoint uses a method other than POST"},
-	{Code: "unsupported_addon_go_block_target", Area: "go-block", Stability: StabilityExperimental, Summary: "enabled addon does not consume the requested go block target"},
-	{Code: "unsupported_fragment_method", Area: "partials", Stability: StabilityExperimental, Summary: "fragment endpoint uses an unsupported method"},
-	{Code: "unsupported_gowdk_use_scope", Area: "source-imports", Stability: StabilityStable, Summary: "use declaration appears in an unsupported source scope"},
-	{Code: "unsupported_markup_directive", Area: "markup", Stability: StabilityStable, Summary: "view markup uses a g: directive outside the GOWDK-owned directive contract"},
-	{Code: "unsupported_markup_syntax", Area: "markup", Stability: StabilityStable, Summary: "view markup uses foreign template syntax instead of GOWDK-owned AST nodes and directives"},
-	{Code: "unsupported_wasm_import", Area: "wasm", Stability: StabilityExperimental, Summary: "browser WASM package imports an unsupported Go package"},
-	{Code: "unterminated_string", Area: "lexer", Stability: StabilityStable, Summary: "lexer found a string literal without a closing quote"},
-	{Code: "view_parse_error", Area: "markup", Stability: StabilityStable, Summary: "view markup parser rejected source"},
-	{Code: "wasm_package_build_error", Area: "wasm", Stability: StabilityExperimental, Summary: "component WASM package build failed"},
-	{Code: "wasm_package_entrypoint_error", Area: "wasm", Stability: StabilityExperimental, Summary: "component WASM package entrypoint is missing or invalid"},
-	{Code: "wasm_package_export_error", Area: "wasm", Stability: StabilityExperimental, Summary: "component WASM exports are missing or invalid"},
+	{Code: "addon_go_block_diagnostic", Area: "go-block", Stability: StabilityAddon, Severity: SeverityError, Summary: "addon-provided go block diagnostic without a custom code"},
+	{Code: "ambiguous_dynamic_route", Area: "routing", Stability: StabilityStable, Severity: SeverityError, Summary: "dynamic page route overlaps another dynamic page route"},
+	{Code: "backend_binding_required", Area: "backend", Stability: StabilityStable, Severity: SeverityError, Summary: "strict builds require a supported backend handler binding"},
+	{Code: "client_go_block_wasm_build_error", Area: "wasm", Stability: StabilityExperimental, Severity: SeverityError, Summary: "page go client WASM build failed"},
+	{Code: "client_go_block_wasm_entrypoint_error", Area: "wasm", Stability: StabilityExperimental, Severity: SeverityError, Summary: "page go client WASM entrypoint is missing or invalid"},
+	{Code: "client_go_block_wasm_export_error", Area: "wasm", Stability: StabilityExperimental, Severity: SeverityError, Summary: "page go client WASM exports are missing or invalid"},
+	{Code: "client_go_block_wasm_import_error", Area: "wasm", Stability: StabilityExperimental, Severity: SeverityError, Summary: "page go client WASM imports are invalid"},
+	{Code: "client_go_block_wasm_source_error", Area: "wasm", Stability: StabilityExperimental, Severity: SeverityError, Summary: "page go client source materialization failed"},
+	{Code: "component_client_error", Area: "components", Stability: StabilityStable, Severity: SeverityError, Summary: "component client block or local island behavior is invalid"},
+	{Code: "component_contract_error", Area: "components", Stability: StabilityStable, Severity: SeverityError, Summary: "component Go props or state contract is invalid"},
+	{Code: "component_field_error", Area: "components", Stability: StabilityStable, Severity: SeverityError, Summary: "component view references an invalid field or directive expression"},
+	{Code: "contract_event_category_invalid", Area: "contracts", Stability: StabilityExperimental, Severity: SeverityError, Summary: "contract emitted-event category does not match scanned registrations"},
+	{Code: "contract_event_name_invalid", Area: "contracts", Stability: StabilityExperimental, Severity: SeverityError, Summary: "contract event name is too broad or UI-owned"},
+	{Code: "contract_handler_invalid", Area: "contracts", Stability: StabilityExperimental, Severity: SeverityError, Summary: "contract handler signature or export shape is invalid"},
+	{Code: "contract_handler_missing", Area: "contracts", Stability: StabilityExperimental, Severity: SeverityError, Summary: "contract handler was not found in the scanned package"},
+	{Code: "contract_input_invalid", Area: "contracts", Stability: StabilityExperimental, Severity: SeverityError, Summary: "contract input struct is invalid"},
+	{Code: "contract_reference_invalid", Area: "contracts", Stability: StabilityExperimental, Severity: SeverityError, Summary: "GOWDK command or query reference could not bind to a valid contract"},
+	{Code: "contract_reference_missing", Area: "contracts", Stability: StabilityExperimental, Severity: SeverityError, Summary: "GOWDK command or query reference has no matching contract"},
+	{Code: "contract_reference_parse_error", Area: "contracts", Stability: StabilityExperimental, Severity: SeverityError, Summary: "view contract reference directives could not be parsed"},
+	{Code: "contract_reference_role_not_allowed", Area: "contracts", Stability: StabilityExperimental, Severity: SeverityError, Summary: "contract reference targets a registration that is not available to the web role"},
+	{Code: "contract_result_invalid", Area: "contracts", Stability: StabilityExperimental, Severity: SeverityError, Summary: "contract result type is invalid"},
+	{Code: "contract_type_invalid", Area: "contracts", Stability: StabilityExperimental, Severity: SeverityError, Summary: "contract type is invalid"},
+	{Code: "cyclic_layout_reference", Area: "layouts", Stability: StabilityStable, Severity: SeverityError, Summary: "layout layout inheritance forms a cycle"},
+	{Code: "duplicate_command_owner", Area: "contracts", Stability: StabilityExperimental, Severity: SeverityError, Summary: "command has more than one owner registration"},
+	{Code: "duplicate_component_emit", Area: "components", Stability: StabilityExperimental, Severity: SeverityError, Summary: "component declares the same emitted event more than once"},
+	{Code: "duplicate_component_name", Area: "components", Stability: StabilityStable, Severity: SeverityError, Summary: "component name is declared more than once"},
+	{Code: "duplicate_css_selection", Area: "css", Stability: StabilityStable, Severity: SeverityError, Summary: "page repeats the same CSS selection"},
+	{Code: "duplicate_env_name", Area: "config", Stability: StabilityStable, Severity: SeverityError, Summary: "environment variable or secret name is declared more than once"},
+	{Code: "duplicate_go_endpoint_comment", Area: "backend", Stability: StabilityStable, Severity: SeverityError, Summary: "Go handler has more than one gowdk endpoint comment"},
+	{Code: "duplicate_go_import_alias", Area: "packages", Stability: StabilityStable, Severity: SeverityError, Summary: "GOWDK source declares the same Go import alias more than once"},
+	{Code: "duplicate_gowdk_use_alias", Area: "source-imports", Stability: StabilityStable, Severity: SeverityError, Summary: "GOWDK source declares the same use alias more than once"},
+	{Code: "duplicate_layout_id", Area: "layouts", Stability: StabilityStable, Severity: SeverityError, Summary: "layout identity is declared more than once"},
+	{Code: "duplicate_page_id", Area: "pages", Stability: StabilityStable, Severity: SeverityError, Summary: "page identity is declared more than once"},
+	{Code: "duplicate_page_store", Area: "stores", Stability: StabilityExperimental, Severity: SeverityError, Summary: "page declares the same store more than once"},
+	{Code: "duplicate_revalidate_policy", Area: "cache", Stability: StabilityStable, Severity: SeverityError, Summary: "page combines revalidate with a cache policy that already declares stale-while-revalidate"},
+	{Code: "duplicate_route", Area: "routing", Stability: StabilityStable, Severity: SeverityError, Summary: "page route pattern is duplicated"},
+	{Code: "duplicate_route_param", Area: "routing", Stability: StabilityStable, Severity: SeverityError, Summary: "route declares the same param more than once"},
+	{Code: "env_name_required", Area: "config", Stability: StabilityStable, Severity: SeverityError, Summary: "environment variable contract entry is missing a name"},
+	{Code: "fragment_dynamic_route", Area: "partials", Stability: StabilityExperimental, Severity: SeverityError, Summary: "fragment endpoint path is dynamic, which is not supported yet"},
+	{Code: "generated_app_import_cycle", Area: "generated-go", Stability: StabilityStable, Severity: SeverityError, Summary: "generated app would import itself through user code"},
+	{Code: "go_client_requires_page", Area: "go-block", Stability: StabilityExperimental, Severity: SeverityError, Summary: "go client block was declared outside a page"},
+	{Code: "go_endpoint_parse_error", Area: "backend", Stability: StabilityStable, Severity: SeverityError, Summary: "Go endpoint comment scan failed to parse a Go file"},
+	{Code: "go_endpoint_read_error", Area: "backend", Stability: StabilityStable, Severity: SeverityError, Summary: "Go endpoint scan failed to read a source directory"},
+	{Code: "go_package_error", Area: "packages", Stability: StabilityStable, Severity: SeverityError, Summary: "sibling Go package parse, package, or type-check validation failed"},
+	{Code: "go_ssr_requires_request_render", Area: "go-block", Stability: StabilityExperimental, Severity: SeverityError, Summary: "go ssr block requires request-time page rendering"},
+	{Code: "guard_requires_request_render", Area: "pages", Stability: StabilityStable, Severity: SeverityError, Summary: "protected page guard metadata requires request-time page rendering"},
+	{Code: "invalid_backend_handler_name", Area: "backend", Stability: StabilityStable, Severity: SeverityError, Summary: "endpoint handler name is not an exported Go identifier"},
+	{Code: "invalid_css_selection", Area: "css", Stability: StabilityStable, Severity: SeverityError, Summary: "page CSS selection is invalid"},
+	{Code: "invalid_go_block", Area: "go-block", Stability: StabilityExperimental, Severity: SeverityError, Summary: "inline Go block does not parse as valid Go"},
+	{Code: "invalid_go_endpoint_handler", Area: "backend", Stability: StabilityStable, Severity: SeverityError, Summary: "Go endpoint comment is not attached to an exported package-level function"},
+	{Code: "invalid_go_import", Area: "packages", Stability: StabilityStable, Severity: SeverityError, Summary: "GOWDK source Go import declaration is invalid"},
+	{Code: "layout_self_reference", Area: "layouts", Stability: StabilityStable, Severity: SeverityError, Summary: "layout lists itself in layout; a layout cannot inherit from itself"},
+	{Code: "layout_slot_count", Area: "layouts", Stability: StabilityStable, Severity: SeverityError, Summary: "layout must contain exactly one <slot /> placeholder"},
+	{Code: "load_requires_request_render", Area: "rendering", Stability: StabilityStable, Severity: SeverityError, Summary: "load block requires request-time page rendering"},
+	{Code: "malformed_gowdk_use", Area: "source-imports", Stability: StabilityStable, Severity: SeverityError, Summary: "GOWDK use declaration is malformed"},
+	{Code: "malformed_route", Area: "routing", Stability: StabilityStable, Severity: SeverityError, Summary: "route path violates GOWDK route syntax"},
+	{Code: "missing_img_alt", Area: "accessibility", Stability: StabilityStable, Severity: SeverityWarning, Summary: "image element is missing explicit alt text"},
+	{Code: "missing_package_declaration", Area: "packages", Stability: StabilityStable, Severity: SeverityError, Summary: "GOWDK source is missing a package declaration"},
+	{Code: "missing_page_guard", Area: "pages", Stability: StabilityStable, Severity: SeverityWarning, Summary: "page declares no guard; warning (route denied 403) or error when it defines act/api/fragment endpoints"},
+	{Code: "missing_required_env", Area: "config", Stability: StabilityStable, Severity: SeverityError, Summary: "required environment variable is not set"},
+	{Code: "missing_required_secret", Area: "config", Stability: StabilityStable, Severity: SeverityError, Summary: "required secret environment variable is not set"},
+	{Code: "missing_ssr_addon", Area: "rendering", Stability: StabilityStable, Severity: SeverityError, Summary: "request-time page behavior requires the SSR addon"},
+	{Code: "missing_view_block", Area: "pages", Stability: StabilityStable, Severity: SeverityError, Summary: "page source is missing view markup for its GET route"},
+	{Code: "old_action_block_syntax", Area: "backend", Stability: StabilityStable, Severity: SeverityError, Fix: endpointHeaderFix, Summary: "source uses removed action block syntax"},
+	{Code: "old_api_block_syntax", Area: "backend", Stability: StabilityStable, Severity: SeverityError, Fix: endpointHeaderFix, Summary: "source uses removed API block syntax"},
+	{Code: "package_mismatch", Area: "packages", Stability: StabilityStable, Severity: SeverityError, Summary: "GOWDK package does not match sibling Go files"},
+	{Code: "package_must_be_first", Area: "packages", Stability: StabilityStable, Severity: SeverityError, Summary: "package declaration is not the first non-comment declaration"},
+	{Code: "page_store_error", Area: "stores", Stability: StabilityExperimental, Severity: SeverityError, Summary: "page store type or initializer is invalid"},
+	{Code: "parse_error", Area: "parser", Stability: StabilityStable, Severity: SeverityError, Summary: "line-oriented parser rejected source without a more specific code"},
+	{Code: "public_guard_exclusive", Area: "pages", Stability: StabilityStable, Severity: SeverityError, Summary: "guard public must be the only guard on an intentionally public page"},
+	{Code: "redundant_component_implementation", Area: "components", Stability: StabilityStable, Severity: SeverityError, Summary: "same component has both GOWDK and generated Go implementations"},
+	{Code: "revalidate_requires_cache", Area: "cache", Stability: StabilityStable, Severity: SeverityError, Summary: "revalidate requires an explicit cache policy"},
+	{Code: "route_method_conflict", Area: "routing", Stability: StabilityStable, Severity: SeverityError, Summary: "two generated handlers claim the same method and route pattern"},
+	{Code: "secret_env_in_vars", Area: "config", Stability: StabilityStable, Severity: SeverityError, Summary: "secret-looking environment variable is declared as a normal variable"},
+	{Code: "secret_env_name_required", Area: "config", Stability: StabilityStable, Severity: SeverityError, Summary: "secret environment contract entry is missing a name"},
+	{Code: "spa_disabled", Area: "routing", Stability: StabilityExperimental, Severity: SeverityInfo, Summary: "SPA route binding is disabled for this generated route lane"},
+	{Code: "spa_dynamic_route_missing_paths", Area: "routing", Stability: StabilityStable, Severity: SeverityError, Summary: "dynamic SPA route is missing paths declarations"},
+	{Code: "ssr_disabled", Area: "routing", Stability: StabilityExperimental, Severity: SeverityInfo, Summary: "SSR route binding is disabled for this generated route lane"},
+	{Code: "unknown_addon_go_block_target", Area: "go-block", Stability: StabilityExperimental, Severity: SeverityError, Summary: "go addon block references an addon that is not enabled"},
+	{Code: "unknown_component_store", Area: "stores", Stability: StabilityExperimental, Severity: SeverityError, Summary: "component references a page store that does not exist"},
+	{Code: "unknown_go_block_target", Area: "go-block", Stability: StabilityExperimental, Severity: SeverityError, Summary: "go block target is not recognized"},
+	{Code: "unknown_gowdk_component", Area: "source-imports", Stability: StabilityStable, Severity: SeverityError, Summary: "qualified component call references an unknown GOWDK component"},
+	{Code: "unknown_gowdk_use_alias", Area: "source-imports", Stability: StabilityStable, Severity: SeverityError, Fix: missingUseFix, Summary: "source references a GOWDK use alias that is not declared"},
+	{Code: "unknown_gowdk_use_package", Area: "source-imports", Stability: StabilityStable, Severity: SeverityError, Summary: "use declaration references a GOWDK package that was not discovered"},
+	{Code: "unknown_layout_id", Area: "layouts", Stability: StabilityStable, Severity: SeverityError, Summary: "page references a layout that does not exist"},
+	{Code: "unsupported_action_method", Area: "backend", Stability: StabilityStable, Severity: SeverityError, Summary: "action endpoint uses a method other than POST"},
+	{Code: "unsupported_addon_go_block_target", Area: "go-block", Stability: StabilityExperimental, Severity: SeverityError, Summary: "enabled addon does not consume the requested go block target"},
+	{Code: "unsupported_fragment_method", Area: "partials", Stability: StabilityExperimental, Severity: SeverityError, Summary: "fragment endpoint uses an unsupported method"},
+	{Code: "unsupported_gowdk_use_scope", Area: "source-imports", Stability: StabilityStable, Severity: SeverityError, Summary: "use declaration appears in an unsupported source scope"},
+	{Code: "unsupported_markup_directive", Area: "markup", Stability: StabilityStable, Severity: SeverityError, Summary: "view markup uses a g: directive outside the GOWDK-owned directive contract"},
+	{Code: "unsupported_markup_syntax", Area: "markup", Stability: StabilityStable, Severity: SeverityError, Summary: "view markup uses foreign template syntax instead of GOWDK-owned AST nodes and directives"},
+	{Code: "unsupported_wasm_import", Area: "wasm", Stability: StabilityExperimental, Severity: SeverityError, Summary: "browser WASM package imports an unsupported Go package"},
+	{Code: "unterminated_string", Area: "lexer", Stability: StabilityStable, Severity: SeverityError, Summary: "lexer found a string literal without a closing quote"},
+	{Code: "view_parse_error", Area: "markup", Stability: StabilityStable, Severity: SeverityError, Summary: "view markup parser rejected source"},
+	{Code: "wasm_package_build_error", Area: "wasm", Stability: StabilityExperimental, Severity: SeverityError, Summary: "component WASM package build failed"},
+	{Code: "wasm_package_entrypoint_error", Area: "wasm", Stability: StabilityExperimental, Severity: SeverityError, Summary: "component WASM package entrypoint is missing or invalid"},
+	{Code: "wasm_package_export_error", Area: "wasm", Stability: StabilityExperimental, Severity: SeverityError, Summary: "component WASM exports are missing or invalid"},
 }
 
 // Lookup returns the registry entry for code.
@@ -127,4 +164,22 @@ func Lookup(code string) (Code, bool) {
 		}
 	}
 	return Code{}, false
+}
+
+// DefaultSeverity returns the registry severity for code.
+func DefaultSeverity(code string) (Severity, bool) {
+	entry, ok := Lookup(code)
+	if !ok {
+		return "", false
+	}
+	return entry.Severity, true
+}
+
+// FixFor returns the registry fix metadata for code.
+func FixFor(code string) (Fix, bool) {
+	entry, ok := Lookup(code)
+	if !ok || entry.Fix == nil {
+		return Fix{}, false
+	}
+	return *entry.Fix, true
 }

--- a/internal/diagnostics/registry_test.go
+++ b/internal/diagnostics/registry_test.go
@@ -31,6 +31,21 @@ func TestRegistryIsSortedUniqueAndComplete(t *testing.T) {
 		default:
 			t.Fatalf("unknown stability for %s: %q", entry.Code, entry.Stability)
 		}
+		switch entry.Severity {
+		case SeverityError, SeverityWarning, SeverityInfo:
+		default:
+			t.Fatalf("unknown severity for %s: %q", entry.Code, entry.Severity)
+		}
+		if entry.Fix != nil {
+			if entry.Fix.Title == "" || entry.Fix.Description == "" || entry.Fix.Rewriter == "" {
+				t.Fatalf("fix metadata for %s must include title, description, and rewriter: %#v", entry.Code, entry.Fix)
+			}
+			switch entry.Fix.Rewriter {
+			case FixEndpointHeaderFromMessage, FixInsertMissingUse:
+			default:
+				t.Fatalf("unknown fix rewriter for %s: %q", entry.Code, entry.Fix.Rewriter)
+			}
+		}
 		if seen[entry.Code] {
 			t.Fatalf("duplicate diagnostic code %q", entry.Code)
 		}

--- a/internal/lang/diagnostic.go
+++ b/internal/lang/diagnostic.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+
+	"github.com/cssbruno/gowdk/internal/diagnostics"
 )
 
 // Position is a 1-based source location.
@@ -20,13 +22,14 @@ type Range struct {
 
 // Diagnostic describes a language-tool finding.
 type Diagnostic struct {
-	File       string   `json:"file"`
-	Code       string   `json:"code,omitempty"`
-	Pos        Position `json:"pos"`
-	Range      *Range   `json:"range,omitempty"`
-	Severity   string   `json:"severity"`
-	Message    string   `json:"message"`
-	Suggestion string   `json:"suggestion,omitempty"`
+	File       string           `json:"file"`
+	Code       string           `json:"code,omitempty"`
+	Pos        Position         `json:"pos"`
+	Range      *Range           `json:"range,omitempty"`
+	Severity   string           `json:"severity"`
+	Fix        *diagnostics.Fix `json:"fix,omitempty"`
+	Message    string           `json:"message"`
+	Suggestion string           `json:"suggestion,omitempty"`
 }
 
 func (diagnostic Diagnostic) String() string {
@@ -53,6 +56,16 @@ func (diagnostic Diagnostic) String() string {
 func (diagnostic Diagnostic) MarshalJSON() ([]byte, error) {
 	type alias Diagnostic
 	redacted := alias(diagnostic)
+	if redacted.Severity == "" && redacted.Code != "" {
+		if severity, ok := diagnostics.DefaultSeverity(redacted.Code); ok {
+			redacted.Severity = string(severity)
+		}
+	}
+	if redacted.Fix == nil && redacted.Code != "" {
+		if fix, ok := diagnostics.FixFor(redacted.Code); ok {
+			redacted.Fix = &fix
+		}
+	}
 	redacted.Message = RedactMessage(redacted.Message)
 	redacted.Suggestion = RedactMessage(redacted.Suggestion)
 	return json.Marshal(redacted)

--- a/internal/lang/tools_test.go
+++ b/internal/lang/tools_test.go
@@ -545,6 +545,33 @@ route "/bad"
 	}
 }
 
+func TestCheckJSONIncludesRegisteredFixMetadata(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "old.page.gwdk")
+	writeGWDK(t, path, `package app
+
+page old
+route "/old"
+
+act submit {
+}
+
+view {
+}
+`)
+
+	payload, diagnostics := CheckJSON(gowdk.Config{}, []string{path})
+	if !diagnostics.HasErrors() {
+		t.Fatal("expected old endpoint syntax diagnostic")
+	}
+	output := string(payload)
+	if !strings.Contains(output, `"code": "old_action_block_syntax"`) ||
+		!strings.Contains(output, `"fix": {`) ||
+		!strings.Contains(output, `"rewriter": "endpoint_header_from_message"`) {
+		t.Fatalf("expected registered fix metadata in JSON: %s", output)
+	}
+}
+
 func TestCheckJSONReportsUnsupportedBuildStatementDiagnostic(t *testing.T) {
 	root := t.TempDir()
 	path := filepath.Join(root, "bad-build.page.gwdk")

--- a/internal/lsp/features.go
+++ b/internal/lsp/features.go
@@ -2,8 +2,9 @@ package lsp
 
 import (
 	"sort"
-	"strings"
 
+	"github.com/cssbruno/gowdk/internal/diagnosticfix"
+	"github.com/cssbruno/gowdk/internal/diagnostics"
 	"github.com/cssbruno/gowdk/internal/lang"
 )
 
@@ -102,15 +103,12 @@ func (server *Server) codeActions(params codeActionParams) []codeAction {
 	}
 	var actions []codeAction
 	for _, diagnostic := range params.Context.Diagnostics {
-		switch diagnostic.Code {
-		case "old_action_block_syntax", "old_api_block_syntax":
-			if action, ok := endpointMigrationCodeAction(params.TextDocument.URI, diagnostic); ok {
-				actions = append(actions, action)
-			}
-		case "unknown_gowdk_use_alias":
-			if action, ok := missingUseCodeAction(params.TextDocument.URI, doc.Text, diagnostic); ok {
-				actions = append(actions, action)
-			}
+		fix, ok := diagnostics.FixFor(diagnostic.Code)
+		if !ok {
+			continue
+		}
+		if action, ok := registryFixCodeAction(params.TextDocument.URI, doc.Text, diagnostic, fix); ok {
+			actions = append(actions, action)
 		}
 	}
 	if actions == nil {
@@ -119,87 +117,54 @@ func (server *Server) codeActions(params codeActionParams) []codeAction {
 	return actions
 }
 
-func endpointMigrationCodeAction(uri string, item diagnostic) (codeAction, bool) {
-	replacement, ok := endpointMigrationReplacement(item.Message)
-	if !ok {
+func registryFixCodeAction(uri string, sourceText string, item diagnostic, fix diagnostics.Fix) (codeAction, bool) {
+	edits, err := diagnosticfix.Edits(fix, sourceText, diagnosticfix.Diagnostic{
+		Code:    item.Code,
+		Message: item.Message,
+		Range:   fixRangeFromLSP(item.Range),
+	})
+	if err != nil || len(edits) == 0 {
 		return codeAction{}, false
 	}
+	textEdits := make([]textEdit, 0, len(edits))
+	for _, edit := range edits {
+		textEdits = append(textEdits, textEdit{
+			Range:   lspRangeFromFix(edit.Range),
+			NewText: edit.NewText,
+		})
+	}
 	return codeAction{
-		Title:       "Replace old endpoint block header",
+		Title:       fix.Title,
 		Kind:        "quickfix",
 		Diagnostics: []diagnostic{item},
-		Edit: workspaceEdit{Changes: map[string][]textEdit{
-			uri: {{
-				Range:   item.Range,
-				NewText: replacement,
-			}},
-		}},
+		Edit:        workspaceEdit{Changes: map[string][]textEdit{uri: textEdits}},
 	}, true
 }
 
-func missingUseCodeAction(uri string, source string, item diagnostic) (codeAction, bool) {
-	alias, ok := missingUseAlias(item.Message)
-	if !ok {
-		return codeAction{}, false
+func fixRangeFromLSP(item lspRange) diagnosticfix.Range {
+	return diagnosticfix.Range{
+		Start: diagnosticfix.Position{Line: item.Start.Line + 1, Column: item.Start.Character + 1},
+		End:   diagnosticfix.Position{Line: item.End.Line + 1, Column: item.End.Character + 1},
 	}
-	insert := useInsertionPosition(source, item.Range.Start)
-	return codeAction{
-		Title:       `Add use ` + alias + ` "<package>"`,
-		Kind:        "quickfix",
-		Diagnostics: []diagnostic{item},
-		Edit: workspaceEdit{Changes: map[string][]textEdit{
-			uri: {{
-				Range:   lspRange{Start: insert, End: insert},
-				NewText: `use ` + alias + ` "<package>"` + "\n",
-			}},
-		}},
-	}, true
 }
 
-func endpointMigrationReplacement(message string) (string, bool) {
-	start := strings.Index(message, "use `")
-	if start < 0 {
-		return "", false
+func lspRangeFromFix(item diagnosticfix.Range) lspRange {
+	return lspRange{
+		Start: positionFromFix(item.Start),
+		End:   positionFromFix(item.End),
 	}
-	start += len("use `")
-	end := strings.IndexByte(message[start:], '`')
-	if end < 0 {
-		return "", false
-	}
-	replacement := message[start : start+end]
-	if strings.HasPrefix(replacement, "act ") || strings.HasPrefix(replacement, "api ") {
-		if strings.Contains(message[start+end+1:], "and move behavior to Go") {
-			return replacement, true
-		}
-	}
-	return "", false
 }
 
-func missingUseAlias(message string) (string, bool) {
-	start := strings.Index(message, "Add `use ")
-	if start < 0 {
-		return "", false
+func positionFromFix(item diagnosticfix.Position) position {
+	line := item.Line - 1
+	if line < 0 {
+		line = 0
 	}
-	start += len("Add `use ")
-	end := strings.Index(message[start:], ` "<package>"`)
-	if end < 0 {
-		return "", false
+	character := item.Column - 1
+	if character < 0 {
+		character = 0
 	}
-	alias := message[start : start+end]
-	if !isLSPIdentifier(alias) {
-		return "", false
-	}
-	return alias, true
-}
-
-func useInsertionPosition(source string, fallback position) position {
-	lines := strings.Split(source, "\n")
-	for index, line := range lines {
-		if strings.TrimSpace(line) == "view {" {
-			return position{Line: index, Character: 0}
-		}
-	}
-	return fallback
+	return position{Line: line, Character: character}
 }
 
 func (server *Server) semanticTokens(params semanticTokensParams) semanticTokensResult {

--- a/internal/lsp/server_test.go
+++ b/internal/lsp/server_test.go
@@ -412,9 +412,9 @@ func TestServerReturnsCodeActionsForMigrationsAndMissingUses(t *testing.T) {
 		t.Fatalf("expected code action provider capability, got %#v", capabilities)
 	}
 	assertResponseID(t, messages[3], float64(2))
-	assertCodeActionEdit(t, messages[3], oldURI, "Replace old endpoint block header", `act Refresh POST "<path>"`, 5)
+	assertCodeActionEdit(t, messages[3], oldURI, "Replace old endpoint block header", `act Refresh POST "/old"`, 5)
 	assertResponseID(t, messages[4], float64(3))
-	assertCodeActionEdit(t, messages[4], useURI, `Add use ui "<package>"`, "use ui \"<package>\"\n", 5)
+	assertCodeActionEdit(t, messages[4], useURI, "Add missing use declaration", "use ui \"package\"\n", 5)
 	assertResponseID(t, messages[5], float64(4))
 }
 

--- a/internal/source/ident.go
+++ b/internal/source/ident.go
@@ -1,0 +1,40 @@
+package source
+
+import "strings"
+
+// ExportedIdentifier returns a PascalCase Go identifier fragment derived from
+// value. Underscores are preserved because they are valid Go identifier
+// characters and can distinguish otherwise identical generated names.
+// fallback is returned when value contains no identifier characters.
+func ExportedIdentifier(value string, fallback string) string {
+	out := make([]rune, 0, len(value))
+	uppercaseNext := true
+	for _, char := range strings.TrimSpace(value) {
+		if char >= 'a' && char <= 'z' {
+			if uppercaseNext {
+				char = char - 'a' + 'A'
+			}
+			out = append(out, char)
+			uppercaseNext = false
+			continue
+		}
+		if char >= 'A' && char <= 'Z' || char >= '0' && char <= '9' {
+			if len(out) == 0 && char >= '0' && char <= '9' {
+				out = append(out, 'P')
+			}
+			out = append(out, char)
+			uppercaseNext = false
+			continue
+		}
+		if char == '_' {
+			out = append(out, char)
+			uppercaseNext = false
+			continue
+		}
+		uppercaseNext = true
+	}
+	if len(out) == 0 {
+		return fallback
+	}
+	return string(out)
+}

--- a/internal/source/ident_test.go
+++ b/internal/source/ident_test.go
@@ -1,0 +1,21 @@
+package source
+
+import "testing"
+
+func TestExportedIdentifierPreservesUnderscores(t *testing.T) {
+	if got := ExportedIdentifier("Save_User", "Action"); got != "Save_User" {
+		t.Fatalf("ExportedIdentifier(Save_User) = %q, want Save_User", got)
+	}
+	if left, right := ExportedIdentifier("Save_User", "Action"), ExportedIdentifier("SaveUser", "Action"); left == right {
+		t.Fatalf("expected underscore to distinguish generated names, got %q and %q", left, right)
+	}
+}
+
+func TestExportedIdentifierFallbackAndDigitPrefix(t *testing.T) {
+	if got := ExportedIdentifier("!!!", "Action"); got != "Action" {
+		t.Fatalf("ExportedIdentifier fallback = %q, want Action", got)
+	}
+	if got := ExportedIdentifier("1-save", "Action"); got != "P1Save" {
+		t.Fatalf("ExportedIdentifier digit prefix = %q, want P1Save", got)
+	}
+}

--- a/runtime/contracts/contracts.go
+++ b/runtime/contracts/contracts.go
@@ -4,6 +4,7 @@ package contracts
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"reflect"
@@ -54,6 +55,58 @@ type EventEnvelope struct {
 	Category EventCategory
 	Type     string
 	Value    any
+}
+
+// EventDecoder converts a stored JSON event value back into the typed Go value
+// expected by subscribers.
+type EventDecoder func(json.RawMessage) (any, error)
+
+// StoredEventEnvelope is the JSON transport shape shared by contract outbox
+// and broker adapters.
+type StoredEventEnvelope struct {
+	Category EventCategory   `json:"category"`
+	Type     string          `json:"type"`
+	Value    json.RawMessage `json:"value"`
+}
+
+// JSONEventDecoder registers a generic JSON decoder for a contract event type.
+func JSONEventDecoder[T any]() EventDecoder {
+	return func(raw json.RawMessage) (any, error) {
+		var value T
+		if err := json.Unmarshal(raw, &value); err != nil {
+			return nil, err
+		}
+		return value, nil
+	}
+}
+
+// MarshalEventEnvelopeJSON encodes an event envelope into the shared JSON
+// transport shape.
+func MarshalEventEnvelopeJSON(event EventEnvelope) ([]byte, error) {
+	value, err := json.Marshal(event.Value)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(StoredEventEnvelope{Category: event.Category, Type: event.Type, Value: value})
+}
+
+// DecodeEventEnvelopeJSON decodes the shared JSON transport shape and uses a
+// registered decoder when one exists for the event type. Without a decoder the
+// event value remains json.RawMessage.
+func DecodeEventEnvelopeJSON(payload []byte, decoders map[string]EventDecoder) (EventEnvelope, error) {
+	var stored StoredEventEnvelope
+	if err := json.Unmarshal(payload, &stored); err != nil {
+		return EventEnvelope{}, err
+	}
+	value := any(stored.Value)
+	if decoder := decoders[stored.Type]; decoder != nil {
+		decoded, err := decoder(stored.Value)
+		if err != nil {
+			return EventEnvelope{}, err
+		}
+		value = decoded
+	}
+	return EventEnvelope{Category: stored.Category, Type: stored.Type, Value: value}, nil
 }
 
 // Outbox stores command-emitted events for durable delivery. Implementations

--- a/runtime/contracts/fileoutbox/fileoutbox.go
+++ b/runtime/contracts/fileoutbox/fileoutbox.go
@@ -11,7 +11,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"reflect"
 	"sync"
 	"time"
 
@@ -22,7 +21,7 @@ const defaultBatchSize = 100
 
 // Decoder converts one persisted JSON payload back into the typed Go event
 // value expected by runtime/contracts subscribers.
-type Decoder func(json.RawMessage) (any, error)
+type Decoder = contracts.EventDecoder
 
 // Record is one durable outbox row stored as a JSON Lines object.
 type Record struct {
@@ -89,19 +88,13 @@ func WithDecoder(eventType string, decoder Decoder) Option {
 
 // WithJSONDecoder registers a JSON decoder for one stored event type.
 func WithJSONDecoder[T any](eventType string) Option {
-	return WithDecoder(eventType, func(raw json.RawMessage) (any, error) {
-		var value T
-		if err := json.Unmarshal(raw, &value); err != nil {
-			return nil, err
-		}
-		return value, nil
-	})
+	return WithDecoder(eventType, contracts.JSONEventDecoder[T]())
 }
 
 // WithJSONTypeDecoder registers a JSON decoder using the same Go type name
 // stored by runtime/contracts when T is emitted.
 func WithJSONTypeDecoder[T any]() Option {
-	return WithJSONDecoder[T](typeName[T]())
+	return WithJSONDecoder[T](contracts.ContractName[T]())
 }
 
 // New creates a file-backed outbox at path.
@@ -242,14 +235,6 @@ func (store *Store) ReceiveEventBatch(ctx context.Context) (contracts.EventBatch
 func (store *Store) nextID() string {
 	store.seq++
 	return fmt.Sprintf("%d-%d", store.now().UTC().UnixNano(), store.seq)
-}
-
-func typeName[T any]() string {
-	t := reflect.TypeOf((*T)(nil)).Elem()
-	if t.PkgPath() == "" || t.Name() == "" {
-		return t.String()
-	}
-	return t.PkgPath() + "." + t.Name()
 }
 
 // decodeRecordsLocked decodes records into typed envelopes. Records that have

--- a/runtime/contracts/fileoutbox/fileoutbox_test.go
+++ b/runtime/contracts/fileoutbox/fileoutbox_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/cssbruno/gowdk/runtime/contracts"
 )
 
-var patientCreatedType = typeName[patientCreated]()
+var patientCreatedType = contracts.ContractName[patientCreated]()
 
 type patientCreated struct {
 	ID string `json:"id"`

--- a/runtime/contracts/natsbroker/natsbroker.go
+++ b/runtime/contracts/natsbroker/natsbroker.go
@@ -3,7 +3,6 @@ package natsbroker
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"time"
 
@@ -28,7 +27,7 @@ type Broker struct {
 
 // Decoder converts one JSON event value into the typed value expected by
 // runtime/contracts subscribers.
-type Decoder func(json.RawMessage) (any, error)
+type Decoder = contracts.EventDecoder
 
 // Option configures a Broker.
 type Option func(*Broker)
@@ -69,13 +68,13 @@ func WithDecoder(eventType string, decoder Decoder) Option {
 
 // WithJSONDecoder registers a JSON decoder for one event type.
 func WithJSONDecoder[T any](eventType string) Option {
-	return WithDecoder(eventType, func(raw json.RawMessage) (any, error) {
-		var value T
-		if err := json.Unmarshal(raw, &value); err != nil {
-			return nil, err
-		}
-		return value, nil
-	})
+	return WithDecoder(eventType, contracts.JSONEventDecoder[T]())
+}
+
+// WithJSONTypeDecoder registers a JSON decoder using the same Go type name
+// stored by runtime/contracts when T is emitted.
+func WithJSONTypeDecoder[T any]() Option {
+	return WithJSONDecoder[T](contracts.ContractName[T]())
 }
 
 // New creates a NATS broker adapter.
@@ -200,35 +199,9 @@ func (broker *Broker) decodeMessage(message *nats.Msg) (contracts.EventEnvelope,
 }
 
 func (broker *Broker) decodePayload(payload []byte) (contracts.EventEnvelope, error) {
-	var stored storedEnvelope
-	if err := json.Unmarshal(payload, &stored); err != nil {
-		return contracts.EventEnvelope{}, err
-	}
-	value := any(stored.Value)
-	if decoder := broker.decoders[stored.Type]; decoder != nil {
-		decoded, err := decoder(stored.Value)
-		if err != nil {
-			return contracts.EventEnvelope{}, err
-		}
-		value = decoded
-	}
-	return contracts.EventEnvelope{Category: stored.Category, Type: stored.Type, Value: value}, nil
-}
-
-type storedEnvelope struct {
-	Category contracts.EventCategory `json:"category"`
-	Type     string                  `json:"type"`
-	Value    json.RawMessage         `json:"value"`
+	return contracts.DecodeEventEnvelopeJSON(payload, broker.decoders)
 }
 
 func marshalEnvelope(event contracts.EventEnvelope) ([]byte, error) {
-	value, err := json.Marshal(event.Value)
-	if err != nil {
-		return nil, err
-	}
-	payload, err := json.Marshal(storedEnvelope{Category: event.Category, Type: event.Type, Value: value})
-	if err != nil {
-		return nil, err
-	}
-	return payload, nil
+	return contracts.MarshalEventEnvelopeJSON(event)
 }

--- a/runtime/contracts/natsbroker/natsbroker_test.go
+++ b/runtime/contracts/natsbroker/natsbroker_test.go
@@ -34,7 +34,7 @@ func TestDecodePayloadWithRegisteredDecoder(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	payload, err := json.Marshal(storedEnvelope{
+	payload, err := json.Marshal(contracts.StoredEventEnvelope{
 		Category: contracts.IntegrationEvent,
 		Type:     "PatientCreated",
 		Value:    value,

--- a/runtime/contracts/redisstream/redisstream.go
+++ b/runtime/contracts/redisstream/redisstream.go
@@ -3,7 +3,6 @@ package redisstream
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -40,7 +39,7 @@ type Store struct {
 
 // Decoder converts one JSON event value into the typed value expected by
 // runtime/contracts subscribers.
-type Decoder func(json.RawMessage) (any, error)
+type Decoder = contracts.EventDecoder
 
 // Option configures a Store.
 type Option func(*Store)
@@ -74,13 +73,13 @@ func WithDecoder(eventType string, decoder Decoder) Option {
 
 // WithJSONDecoder registers a JSON decoder for one event type.
 func WithJSONDecoder[T any](eventType string) Option {
-	return WithDecoder(eventType, func(raw json.RawMessage) (any, error) {
-		var value T
-		if err := json.Unmarshal(raw, &value); err != nil {
-			return nil, err
-		}
-		return value, nil
-	})
+	return WithDecoder(eventType, contracts.JSONEventDecoder[T]())
+}
+
+// WithJSONTypeDecoder registers a JSON decoder using the same Go type name
+// stored by runtime/contracts when T is emitted.
+func WithJSONTypeDecoder[T any]() Option {
+	return WithJSONDecoder[T](contracts.ContractName[T]())
 }
 
 // New creates a Redis Streams store.
@@ -260,34 +259,12 @@ func (store *Store) decodeMessage(message redis.XMessage) (contracts.EventEnvelo
 	return store.decodeStored(message.ID, source)
 }
 
-func (store *Store) decodeStored(id string, source string) (contracts.EventEnvelope, error) {
-	var stored storedEnvelope
-	if err := json.Unmarshal([]byte(source), &stored); err != nil {
-		return contracts.EventEnvelope{}, err
-	}
-	value := any(stored.Value)
-	if decoder := store.decoders[stored.Type]; decoder != nil {
-		decoded, err := decoder(stored.Value)
-		if err != nil {
-			return contracts.EventEnvelope{}, err
-		}
-		value = decoded
-	}
-	return contracts.EventEnvelope{Category: stored.Category, Type: stored.Type, Value: value}, nil
-}
-
-type storedEnvelope struct {
-	Category contracts.EventCategory `json:"category"`
-	Type     string                  `json:"type"`
-	Value    json.RawMessage         `json:"value"`
+func (store *Store) decodeStored(_ string, source string) (contracts.EventEnvelope, error) {
+	return contracts.DecodeEventEnvelopeJSON([]byte(source), store.decoders)
 }
 
 func marshalEnvelope(event contracts.EventEnvelope) (string, error) {
-	value, err := json.Marshal(event.Value)
-	if err != nil {
-		return "", err
-	}
-	payload, err := json.Marshal(storedEnvelope{Category: event.Category, Type: event.Type, Value: value})
+	payload, err := contracts.MarshalEventEnvelopeJSON(event)
 	if err != nil {
 		return "", err
 	}

--- a/runtime/contracts/redisstream/redisstream_test.go
+++ b/runtime/contracts/redisstream/redisstream_test.go
@@ -33,7 +33,7 @@ func TestDecodeMessageWithRegisteredDecoder(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	payload, err := json.Marshal(storedEnvelope{
+	payload, err := json.Marshal(contracts.StoredEventEnvelope{
 		Category: contracts.DomainEvent,
 		Type:     "PatientCreated",
 		Value:    value,


### PR DESCRIPTION
## Summary

- extend the diagnostic registry with severity and fix metadata, expose it through `gowdk explain`, `check --json`, and registry-driven LSP code actions
- add `gowdk fix` with dry-run/code filtering and safe single-file rewrites for old endpoint syntax and missing `use` declarations
- add `check --warnings-as-errors`
- remove drifting duplicate helpers in build option parsing, backend binding, island component lookup, generated identifier naming, and contract event envelope adapters

## Verification

- `git diff --check`
- `go test ./...`
- `go build ./cmd/gowdk`
- `scripts/test-go-modules.sh`

Closes #178
Closes #163