### PR TITLE
docs: make README reflect the actual codebase surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,17 +9,21 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/cssbruno/gowdk)](https://goreportcard.com/report/github.com/cssbruno/gowdk)
 [![Go Reference](https://pkg.go.dev/badge/github.com/cssbruno/gowdk.svg)](https://pkg.go.dev/github.com/cssbruno/gowdk)
 
-Write pages in `.gwdk`, ship one Go binary.
+GoWDK ships Go web apps through two coordinated layers: the **GOWDK
+Compiler** and the **GOWDK Runtime**.
 
-GoWDK compiles pages and components into static HTML and plain Go at build
-time. No template engine or reflection at request time — the generated
-`net/http` handlers, form decoders, and guards are code you can read, backed
-by a thin runtime library.
+The Compiler owns `.gwdk` — pages, components, layouts, routes — and turns
+them at build time into static HTML, assets, and plain Go adapters you can
+read: `net/http` routes, typed form decoders, guards. The Runtime owns
+request time: serving, actions, APIs, fragments, SSR, CSRF, and typed
+contracts (commands, queries, events, jobs). Together they ship as one Go
+binary. No reflection, no template engine at request time.
 
-- **Build-time first** — pages render at build time; request-time SSR is a
-  per-page opt-in.
-- **Type-checked against your Go** — `.gwdk` files live next to your packages
-  and bind to real functions and types.
+- **Build-time first** — full pages default to static output; request-time
+  SSR is a per-page opt-in.
+- **Your logic stays in Go** — `.gwdk` files live next to your packages and
+  bind to real functions and types; generated Go is adapter glue, not
+  application logic.
 - **Inspectable** — `gowdk inspect ir`, `gowdk explain <code>`, and
   `gowdk doctor` expose every compiler stage; unsupported source fails with a
   diagnostic instead of clever output.

--- a/README.md
+++ b/README.md
@@ -9,24 +9,12 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/cssbruno/gowdk)](https://goreportcard.com/report/github.com/cssbruno/gowdk)
 [![Go Reference](https://pkg.go.dev/badge/github.com/cssbruno/gowdk.svg)](https://pkg.go.dev/github.com/cssbruno/gowdk)
 
-GoWDK ships Go web apps through two coordinated layers: the **GOWDK
-Compiler** and the **GOWDK Runtime**.
+GoWDK is a Go-first full web app platform: write pages and components in
+`.gwdk` files that live next to your Go packages, and ship the whole app —
+static pages, backend endpoints, SSR, typed contracts — as one Go binary.
 
-The Compiler owns `.gwdk` — pages, components, layouts, routes — and turns
-them at build time into static HTML, assets, and plain Go adapters you can
-read: `net/http` routes, typed form decoders, guards. The Runtime owns
-request time: serving, actions, APIs, fragments, SSR, CSRF, and typed
-contracts (commands, queries, events, jobs). Together they ship as one Go
-binary. No reflection, no template engine at request time.
-
-- **Build-time first** — full pages default to static output; request-time
-  SSR is a per-page opt-in.
-- **Your logic stays in Go** — `.gwdk` files live next to your packages and
-  bind to real functions and types; generated Go is adapter glue, not
-  application logic.
-- **Inspectable** — `gowdk inspect ir`, `gowdk explain <code>`, and
-  `gowdk doctor` expose every compiler stage; unsupported source fails with a
-  diagnostic instead of clever output.
+No JavaScript application stack required. No reflection or template engine at
+request time. Your logic stays in Go.
 
 <!-- TODO: short GIF of `gowdk dev` rebuilding + live-reloading goes here. -->
 

--- a/README.md
+++ b/README.md
@@ -9,20 +9,20 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/cssbruno/gowdk)](https://goreportcard.com/report/github.com/cssbruno/gowdk)
 [![Go Reference](https://pkg.go.dev/badge/github.com/cssbruno/gowdk.svg)](https://pkg.go.dev/github.com/cssbruno/gowdk)
 
-GoWDK is a compiler, not a runtime framework. You write pages and components
-in `.gwdk` — a small declarative language that sits next to your normal Go
-packages and is type-checked against them — and `gowdk build` turns the whole
-app into artifacts you can read line by line: static HTML, `net/http`
-handlers, typed form decoders, guards, browser islands (JS or Go WASM),
-packaged into one binary.
+Write pages in `.gwdk`, ship one Go binary.
 
-Nothing interprets your templates at request time. Pages render at build time
-by default; request-time SSR is a per-page opt-in. Every compiler stage is
-observable from the CLI — `gowdk inspect ir` prints the typed intermediate
-representation, `gowdk explain ambiguous_dynamic_route` documents any
-diagnostic — and unsupported source fails with a diagnostic instead of
-generating something clever. No reflection, no request-time magic: the
-deployed artifact is plain Go you could have written yourself.
+GoWDK compiles pages and components into static HTML and plain Go at build
+time. No template engine or reflection at request time — the generated
+`net/http` handlers, form decoders, and guards are code you can read, backed
+by a thin runtime library.
+
+- **Build-time first** — pages render at build time; request-time SSR is a
+  per-page opt-in.
+- **Type-checked against your Go** — `.gwdk` files live next to your packages
+  and bind to real functions and types.
+- **Inspectable** — `gowdk inspect ir`, `gowdk explain <code>`, and
+  `gowdk doctor` expose every compiler stage; unsupported source fails with a
+  diagnostic instead of clever output.
 
 <!-- TODO: short GIF of `gowdk dev` rebuilding + live-reloading goes here. -->
 

--- a/README.md
+++ b/README.md
@@ -138,7 +138,52 @@ view {
 
 Replace `github.com/acme/hello-gowdk/ui` with your app module path.
 
+## CLI at a Glance
+
+"Inspectable" is not just a slogan — the CLI exposes every stage of the
+pipeline. Run `gowdk` with no arguments for full flags.
+
+### Build and run
+
+| Command | What it does |
+| --- | --- |
+| `gowdk init` | Scaffold a starter project (`--template site\|minimal`, `--tests`) |
+| `gowdk build` | Compile `.gwdk` into static output, a generated Go app, or a single binary (`--out`, `--app`, `--bin`, `--wasm`, backend variants) |
+| `gowdk dev` | Build, serve, rebuild on change, live-reload browsers, show an error overlay |
+| `gowdk preview` | Build and serve a local deploy preview |
+| `gowdk serve` | Serve already-generated build output |
+
+### Inspect and debug
+
+| Command | What it does |
+| --- | --- |
+| `gowdk check` | Parse and validate, with `--json` and `--warnings-as-errors` |
+| `gowdk fix` | Apply registered safe fixes for diagnostics (`--dry-run`, `--code`) |
+| `gowdk explain <code>` | Explain a diagnostic code and its next steps |
+| `gowdk doctor` | Check local environment and project health |
+| `gowdk inspect ir` | Print the validated compiler IR as JSON |
+| `gowdk manifest` / `routes` / `sitemap` | Print validated manifest, route/endpoint metadata, or editor site-map JSON |
+| `gowdk tokens` | Print raw language tokens for a file |
+| `gowdk fmt` | Format `.gwdk` sources (`--write`) |
+
+### Contracts and tooling
+
+| Command | What it does |
+| --- | --- |
+| `gowdk contracts` / `graph` / `trace` / `list` | Print contract registration metadata, the command/event graph, a single contract trace, or filtered lists of commands/queries/events/jobs |
+| `gowdk add <addon>` | Wire an optional addon into `gowdk.config.go` (`add --list` to see all) |
+| `gowdk lsp` | Start the language server over stdio |
+
 ## Design
+
+`.gwdk` sources move through an explicit pipeline: parse → AST → validation →
+a typed intermediate representation → code generation. Every stage is
+observable from the CLI (`tokens`, `check`, `inspect ir`, `manifest`), and the
+generators emit three kinds of output from the same IR: static HTML/CSS/asset
+bundles, generated Go adapters (`net/http` routes, form decoders, guards), and
+browser islands (JS and Go `js/wasm`, with source maps). Diagnostics come from
+a central registry with stable codes — `gowdk explain <code>` documents each
+one, and error output redacts secrets quoted from source.
 
 How responsibility is split, and the opinions behind it:
 
@@ -165,27 +210,31 @@ How responsibility is split, and the opinions behind it:
 
 ## What Works Today
 
-This table describes the current demoable 0.x slice. "Partial" means the listed
-path works, but the public contract is not stable and the remaining limit is
-still tracked in the hardening backlog.
+This table describes the current demoable 0.x slice. Status levels:
+
+- **Works** — the listed path works end-to-end today.
+- **Works, contract unstable** — the listed path works end-to-end, but the
+  public contract is still pre-1.0 and the remaining limits are tracked in the
+  hardening backlog.
+- **Early** — a real but narrower slice works; expect missing cases.
 
 | Surface | Status | Works Today | Current Limit | Docs | Example |
 | --- | --- | --- | --- | --- | --- |
-| Static build output | Implemented | `gowdk build --out` emits HTML, route metadata, and asset metadata for simple build-time pages. | Generated output is still pre-1.0. | [CLI](docs/reference/cli.md) | [Pages](examples/pages/home.page.gwdk) |
-| Dynamic SPA paths | Partial | Dynamic SPA routes can be expanded from the first supported literal `paths {}` subset. | Dynamic SPA routes need `paths {}` unless the page uses request-time rendering. | [Routing](docs/reference/routing.md) | [Blog](examples/pages/blog-post.page.gwdk) |
-| Build-time Go data | Partial | Literal build records and supported no-argument Go build functions can feed SPA rendering. | Arbitrary build-time Go statements and broader data lifecycles are not stable. | [Data](docs/language/data.md) | [Go interop](examples/go-interop/README.md) |
-| Actions | Partial | Generated apps can serve typed POST action handlers, decode supported form inputs, validate request shape, return redirects/fragments, and opt into CSRF. | File uploads, multipart generated forms, and domain validation stay in user-owned Go handlers. | [Actions](docs/language/actions.md) | [Login](examples/login/README.md) |
-| APIs | Partial | Feature-bound API handlers can be generated for supported signatures. | Typed body/query helpers and broader error/status contracts remain planned. | [API](docs/language/api.md) | [API](examples/api/status.page.gwdk) |
-| Fragments | Partial | Partial form submissions and standalone fragment routes can return server fragments and remount local islands. | Richer fragment rendering and broader local client behavior are still hardening work. | [Partials](docs/language/partials.md) | [Fragments](examples/partials/patients-fragment.page.gwdk) |
-| SSR | Partial | Pages with `load {}` or `go ssr {}` can build request-time handlers when the SSR addon is enabled. | Typed route-param accessors, lifecycle docs, and error/cache contracts need more hardening. | [SSR](docs/language/ssr.md) | [SSR](examples/ssr/simple-ssr.page.gwdk) |
-| Hybrid | Partial | Hybrid request-time route metadata and generated request-time pages exist for the supported slice. | The public hybrid source contract, streaming, and data refresh policy are not stable. | [Hybrid](docs/language/hybrid.md) | [Hybrid](examples/ssr/hybrid-static.page.gwdk) |
-| Components | Partial | Components support imported contracts, slots, scoped CSS/assets, first local client behavior, and generated island assets. | Non-string props, richer slots/events, real `g:if`/`g:for`, lifecycle cleanup, and dependency diagnostics are planned. | [Components](docs/language/components.md) | [Components](examples/components/base/base-components.page.gwdk) |
-| WASM islands | Partial | Component-level `wasm` and page-level `go client {}` can emit Go `js/wasm` browser assets for supported fixtures. | ABI docs, size reporting, runtime validation, and browser behavior coverage need hardening. | [Components](docs/language/components.md) | [Test fixture](testfixture/islands/islands.go) |
-| CSS/assets | Partial | CSS processors, page CSS, scoped component CSS, component assets, asset manifests, content-hashed filenames, and optional Tailwind wrapper exist. | CSS processor contracts and optional dependency boundaries need hardening. | [CSS](docs/reference/css.md) | [CSS](examples/css/styled.page.gwdk) |
-| One-binary output | Partial | `gowdk build --app --bin` can generate and compile an embedded Go server for supported SPA/backend/SSR slices. | Runtime operations, split/backend-only deploys, and artifact smoke coverage are still expanding. | [Deployment](docs/reference/deployment.md) | [Embed](examples/embed/site.page.gwdk) |
-| Contracts | Partial | Runtime contracts support typed queries, commands, events, jobs, role filtering, local dispatch, file outbox, broker/fanout adapters, contract graph/trace/list commands, and generated `g:command`/`g:query` web adapters. | Split worker/cron generation, retry policy, managed deployment recipes, and editor-first contract visualization remain planned. | [Contracts](docs/reference/contracts.md) | [Runtime contracts](runtime/contracts) |
-| Dev server | Partial | `gowdk dev` polls inputs, skips no-op rebuilds, serves or runs generated output, live-reloads browsers, shows a browser overlay for rebuild failures, and keeps serving the last successful output. | Overlay diagnostics need codes, source spans, changed-file context, and better generated-app runtime attribution. Component HMR is intentionally deferred. | [Dev](docs/reference/dev.md) | [Getting started](docs/getting-started.md) |
-| Editor/LSP | Implemented | The VS Code extension and dependency-free LSP provide diagnostics, formatting, completions, hover, outline, semantic tokens, definitions, references, site-map visualization, and project-aware navigation for supported paths. | Exact source ranges, richer quick fixes, route/endpoint/contract maps, and `g:command`/`g:query` status in the editor are planned. | [Language server](docs/product/language-server.md) | [VS Code](editors/vscode) |
+| Static build output | Works | `gowdk build --out` emits HTML, route metadata, and asset metadata for simple build-time pages. | Generated output is still pre-1.0. | [CLI](docs/reference/cli.md) | [Pages](examples/pages/home.page.gwdk) |
+| Dynamic SPA paths | Early | Dynamic SPA routes can be expanded from the first supported literal `paths {}` subset. | Dynamic SPA routes need `paths {}` unless the page uses request-time rendering. | [Routing](docs/reference/routing.md) | [Blog](examples/pages/blog-post.page.gwdk) |
+| Build-time Go data | Early | Literal build records and supported no-argument Go build functions can feed SPA rendering. | Arbitrary build-time Go statements and broader data lifecycles are not stable. | [Data](docs/language/data.md) | [Go interop](examples/go-interop/README.md) |
+| Actions | Works, contract unstable | Generated apps can serve typed POST action handlers, decode supported form inputs, validate request shape, return redirects/fragments, and opt into CSRF. | File uploads, multipart generated forms, and domain validation stay in user-owned Go handlers. | [Actions](docs/language/actions.md) | [Login](examples/login/README.md) |
+| APIs | Works, contract unstable | Feature-bound API handlers can be generated for supported signatures. | Typed body/query helpers and broader error/status contracts remain planned. | [API](docs/language/api.md) | [API](examples/api/status.page.gwdk) |
+| Fragments | Works, contract unstable | Partial form submissions and standalone fragment routes can return server fragments and remount local islands. | Richer fragment rendering and broader local client behavior are still hardening work. | [Partials](docs/language/partials.md) | [Fragments](examples/partials/patients-fragment.page.gwdk) |
+| SSR | Works, contract unstable | Pages with `load {}` or `go ssr {}` can build request-time handlers when the SSR addon is enabled. | Typed route-param accessors, lifecycle docs, and error/cache contracts need more hardening. | [SSR](docs/language/ssr.md) | [SSR](examples/ssr/simple-ssr.page.gwdk) |
+| Hybrid | Early | Hybrid request-time route metadata and generated request-time pages exist for the supported slice. | The public hybrid source contract, streaming, and data refresh policy are not stable. | [Hybrid](docs/language/hybrid.md) | [Hybrid](examples/ssr/hybrid-static.page.gwdk) |
+| Components | Works, contract unstable | Components support imported contracts, slots, scoped CSS/assets, first local client behavior, and generated island assets. | Non-string props, richer slots/events, real `g:if`/`g:for`, lifecycle cleanup, and dependency diagnostics are planned. | [Components](docs/language/components.md) | [Components](examples/components/base/base-components.page.gwdk) |
+| WASM islands | Early | Component-level `wasm` and page-level `go client {}` can emit Go `js/wasm` browser assets for supported fixtures. | ABI docs, size reporting, runtime validation, and browser behavior coverage need hardening. | [Components](docs/language/components.md) | [Test fixture](testfixture/islands/islands.go) |
+| CSS/assets | Works, contract unstable | CSS processors, page CSS, scoped component CSS, component assets, asset manifests, content-hashed filenames, and optional Tailwind wrapper exist. | CSS processor contracts and optional dependency boundaries need hardening. | [CSS](docs/reference/css.md) | [CSS](examples/css/styled.page.gwdk) |
+| One-binary output | Works, contract unstable | `gowdk build --app --bin` can generate and compile an embedded Go server for supported SPA/backend/SSR slices. | Runtime operations, split/backend-only deploys, and artifact smoke coverage are still expanding. | [Deployment](docs/reference/deployment.md) | [Embed](examples/embed/site.page.gwdk) |
+| Contracts | Works, contract unstable | Runtime contracts support typed queries, commands, events, jobs, role filtering, local dispatch, file outbox, broker/fanout adapters, contract graph/trace/list commands, and generated `g:command`/`g:query` web adapters. | Split worker/cron generation, retry policy, managed deployment recipes, and editor-first contract visualization remain planned. | [Contracts](docs/reference/contracts.md) | [Runtime contracts](runtime/contracts) |
+| Dev server | Works | `gowdk dev` polls inputs, skips no-op rebuilds, serves or runs generated output, live-reloads browsers, shows a browser overlay for rebuild failures, and keeps serving the last successful output. | Overlay diagnostics need codes, source spans, changed-file context, and better generated-app runtime attribution. Component HMR is intentionally deferred. | [Dev](docs/reference/dev.md) | [Getting started](docs/getting-started.md) |
+| Editor/LSP | Works | The VS Code extension and dependency-free LSP provide diagnostics, formatting, completions, hover, outline, semantic tokens, definitions, references, site-map visualization, and project-aware navigation for supported paths. | Exact source ranges, richer quick fixes, route/endpoint/contract maps, and `g:command`/`g:query` status in the editor are planned. | [Language server](docs/product/language-server.md) | [VS Code](editors/vscode) |
 
 Security note: request-time features are still 0.x, but the core request-time
 hardening is now in place. Generated handlers apply body-size limits (actions
@@ -201,6 +250,27 @@ Known gaps and release hardening work live in
 [the 0.x improvement checklist](docs/engineering/release-plan.md), with public
 tracking in the
 [0.x Hardening project](https://github.com/users/cssbruno/projects/2).
+
+## Addons
+
+The runtime core stays dependency-light; everything optional is an addon you
+wire in with `gowdk add <addon>` (see `gowdk add --list`):
+
+| Addon | What it adds |
+| --- | --- |
+| `actions` | Backend form/action handlers |
+| `api` | Request-time API endpoints |
+| `auth` | Batteries-included auth: PBKDF2, signed sessions, RBAC guards (no external deps) |
+| `contracts` | Contract-driven command/event metadata |
+| `css` | Build-time CSS processing |
+| `db` | sqlc + `database/sql` plumbing helper (no domain, no driver dep) |
+| `embed` | Embed build output into the binary |
+| `partial` | Fragment/partial responses |
+| `ratelimit` | Request-time rate limiting |
+| `ssr` | Server-side rendering |
+
+Heavier integrations (Tailwind, Redis, NATS, WebSocket fanout) live in nested
+optional modules so the root module's dependency graph stays small.
 
 ## Development
 
@@ -222,6 +292,11 @@ Run the all-module vulnerability gate before release-style dependency changes:
 ```sh
 scripts/vulncheck-go-modules.sh
 ```
+
+Generated output is golden-tested: the compiler's HTML, generated Go adapters,
+island JS/WASM assets, IR, and CLI behavior are all snapshot-checked against
+committed fixtures, so any change to generated artifacts shows up as a
+reviewable test diff rather than a silent behavior change.
 
 ## Docs
 

--- a/README.md
+++ b/README.md
@@ -9,10 +9,20 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/cssbruno/gowdk)](https://goreportcard.com/report/github.com/cssbruno/gowdk)
 [![Go Reference](https://pkg.go.dev/badge/github.com/cssbruno/gowdk.svg)](https://pkg.go.dev/github.com/cssbruno/gowdk)
 
-GoWDK compiles `.gwdk` pages ahead of time into plain, inspectable Go —
-`net/http` routes, form decoders, guards — and packages the whole app into one
-binary. Build-time rendering is the default; request-time SSR is opt-in per
-page. No reflection, no request-time magic.
+GoWDK is a compiler, not a runtime framework. You write pages and components
+in `.gwdk` — a small declarative language that sits next to your normal Go
+packages and is type-checked against them — and `gowdk build` turns the whole
+app into artifacts you can read line by line: static HTML, `net/http`
+handlers, typed form decoders, guards, browser islands (JS or Go WASM),
+packaged into one binary.
+
+Nothing interprets your templates at request time. Pages render at build time
+by default; request-time SSR is a per-page opt-in. Every compiler stage is
+observable from the CLI — `gowdk inspect ir` prints the typed intermediate
+representation, `gowdk explain ambiguous_dynamic_route` documents any
+diagnostic — and unsupported source fails with a diagnostic instead of
+generating something clever. No reflection, no request-time magic: the
+deployed artifact is plain Go you could have written yourself.
 
 <!-- TODO: short GIF of `gowdk dev` rebuilding + live-reloading goes here. -->
 


### PR DESCRIPTION
The README under-sold the codebase: it mentioned only 3 of ~22 CLI subcommands, described the compiler in prose without the actual pipeline, flattened 12 working surfaces into a single "Partial" label, never mentioned the golden-test infrastructure, and buried the addon ecosystem in one bullet.

## Changes

- **New "CLI at a Glance" section** — all subcommands in three groups (build/run, inspect/debug, contracts/tooling), including the inspectability story: `inspect ir`, `explain`, `doctor`, `fix`, `tokens`, `manifest`/`routes`/`sitemap`, `fmt`, `lsp`. Verified against live `gowdk` help output.
- **Design section now opens with the real pipeline** — parse → AST → validation → typed IR → generators (static HTML/assets, Go adapters, browser islands with source maps), plus the central diagnostics registry with stable, explainable codes.
- **Feature table statuses reworked** into three levels with a legend: *Works*, *Works, contract unstable*, and *Early* — so working end-to-end surfaces no longer read the same as narrow slices.
- **New "Addons" section** mirroring `gowdk add --list` output.
- **Testing paragraph under Development** documenting that generated HTML, Go adapters, island assets, IR, and CLI behavior are golden-tested against committed fixtures.

Docs-only change; no code touched.