### PR TITLE
fix(compiler): gate generated output on valid IR

### DIFF
--- a/cmd/gowdk/main_test.go
+++ b/cmd/gowdk/main_test.go
@@ -383,7 +383,7 @@ view {
 	if !strings.Contains(stderr, "gowdk build report (build):") {
 		t.Fatalf("expected debug report header on stderr, got:\n%s", stderr)
 	}
-	if !strings.Contains(stderr, "validate/manifest_valid") || !strings.Contains(stderr, "complete/build_complete") {
+	if !strings.Contains(stderr, "validate/ir_valid") || !strings.Contains(stderr, "complete/build_complete") {
 		t.Fatalf("expected validation and completion events on stderr, got:\n%s", stderr)
 	}
 	if _, err := os.Stat(reportPath); err != nil {

--- a/docs/compiler/README.md
+++ b/docs/compiler/README.md
@@ -47,3 +47,5 @@ Not implemented yet:
   component-level WASM island behavior.
 - `build-report.md`: generated build report schema and CLI debug output.
 - `manifest.md`: manifest and site-map JSON contracts.
+- `syntax-contributors.md`: checklist for parser, diagnostics, IR, generation,
+  docs, and fixture coverage when syntax changes.

--- a/docs/compiler/build-report.md
+++ b/docs/compiler/build-report.md
@@ -21,8 +21,8 @@ rewriting identical generated files.
     {
       "level": "info",
       "stage": "validate",
-      "kind": "manifest_valid",
-      "message": "manifest validation completed"
+      "kind": "ir_valid",
+      "message": "compiler IR validation completed"
     }
   ]
 }
@@ -34,8 +34,8 @@ and optional page, route, path, and string data fields.
 
 Current stages are:
 
-- `start`: source manifest counts at build entry.
-- `validate`: manifest and compiler contract validation.
+- `start`: compiler IR counts at build entry.
+- `validate`: compiler IR and compiler contract validation.
 - `plan`: SPA page, CSS, and runtime asset planning.
 - `write`: page, CSS, and runtime asset writes or memory collection.
 - `manifest`: route and asset manifest reads/writes.

--- a/docs/compiler/pipeline.md
+++ b/docs/compiler/pipeline.md
@@ -4,10 +4,11 @@
 
 ```text
 project config plus explicit file paths or configured discovery
-  -> parse source files
-  -> build manifest
-  -> validate render rules
-  -> emit diagnostics, manifest JSON, site-map JSON, route/endpoint metadata, simple app-shell HTML files, browser runtime assets, or generated app output
+  -> parse source files into typed GOWDK AST
+  -> lower parsed records into internal/gwdkir.Program
+  -> enrich IR with Go endpoint discovery and backend bindings
+  -> validate IR invariants, render rules, routes, endpoints, packages, and assets
+  -> emit diagnostics, public manifest JSON, site-map JSON, route/endpoint metadata, build-output artifacts, browser runtime assets, or generated app output
 ```
 
 Project-level compiler commands require `gowdk.config.go` or `--config <file>`.
@@ -37,14 +38,14 @@ Go imports, GOWDK uses, stores, typed component contracts, supported top-level
 blocks, parsed `view {}` markup nodes, literal `paths {}`/`build {}` records,
 action/API endpoint declarations, and source spans.
 
-`internal/gwdkanalysis` lowers parsed AST files into normalized manifest
-compatibility records and a versioned `internal/gwdkir.Program`. The IR models
-packages, source files, page routes, backend endpoints from `.gwdk`
-declarations or explicit Go comments, templates, client behavior,
-source-selected assets, and generated-output plans. Build, memory build,
-incremental SPA build, SSR artifact, and generated app planning now accept
-`internal/gwdkir.Program`; manifest records remain as a
-compatibility/public-report shape while older passes are retired.
+`internal/gwdkanalysis` assembles parsed page, component, and layout records
+into a versioned `internal/gwdkir.Program`. The IR models packages, source
+files, page routes, backend endpoints from `.gwdk` declarations or explicit Go
+comments, templates, client behavior, source-selected assets, and
+generated-output plans. Build, memory build, incremental SPA build, SSR
+artifact, generated app planning, route reports, LSP metadata, and the public
+`gowdk manifest` report consume `internal/gwdkir.Program`. Route and asset
+manifests are generated output artifacts, not compiler handoff records.
 Generated app Go, backend adapter Go, build-data helper Go, and starter config
 Go are constructed as Go ASTs, printed, and formatted before use or write.
 
@@ -67,4 +68,5 @@ project config
   -> optional embedded one-binary output
 ```
 
-Future build work should expand from the current simple app artifact to full component, asset, handler, and one-binary output.
+Future build work should expand from the current generated-output slice while
+keeping downstream passes on `internal/gwdkir.Program`.

--- a/docs/compiler/syntax-contributors.md
+++ b/docs/compiler/syntax-contributors.md
@@ -1,0 +1,67 @@
+# Syntax Contributor Checklist
+
+Use this checklist when adding or changing `.gwdk` syntax, compiler metadata,
+diagnostics, generated output, or editor behavior. Keep each change scoped to one
+language contract.
+
+## Required Path
+
+1. Update the source contract first:
+   - `docs/language/` for public syntax or semantics.
+   - `docs/reference/diagnostic-codes.md` for new or changed diagnostic codes.
+   - `docs/compiler/generated-output.md` for generated artifact shape changes.
+2. Update the AST and parser:
+   - `internal/gwdkast` for source nodes and spans.
+   - `internal/parser` for parsing and lowering into `internal/gwdkir`.
+   - Parser goldens under `internal/parser/testdata/golden/` when the AST
+     contract changes.
+3. Update IR and invariants:
+   - `internal/gwdkir` type fields.
+   - `gwdkir.CheckInvariants` for closed enums, ordering, and cross-slice
+     references.
+   - `internal/gwdkanalysis` lowering and ordering.
+   - `gowdk inspect ir` goldens when the public debug shape changes.
+4. Update validation and diagnostics:
+   - `internal/compiler` for semantic checks.
+   - `internal/diagnostics/registry.go` for every emitted diagnostic code.
+   - Source spans should target the smallest useful declaration or token.
+5. Update generated-output consumers when needed:
+   - `internal/buildgen` for SPA/build-output, CSS/assets, SSR artifacts, and
+     build reports.
+   - `internal/appgen` for generated Go adapters, route registrations, action,
+     API, fragment, contract, guard, rate-limit, SSR, and backend output.
+   - Generated Go must use Go AST/printer/format as described in
+     `docs/engineering/generated-code-policy.md`.
+6. Update language tooling:
+   - `internal/lang` for formatting, manifest/site-map JSON, completions, and
+     diagnostics output.
+   - `internal/lsp` and `editors/vscode` when editor features need the new
+     syntax.
+7. Add focused tests:
+   - Parser/AST: `go test ./internal/parser`.
+   - Diagnostics/validation: `go test ./internal/compiler ./internal/diagnostics`.
+   - Generated output: `go test ./internal/buildgen ./internal/appgen`.
+   - LSP/editor: `go test ./internal/lsp` plus editor checks when touched.
+   - CLI report changes: update `cmd/gowdk/testdata/*_golden` and run
+     `go test ./cmd/gowdk`.
+
+## Guardrails
+
+- Do not add `@` metadata syntax back as canonical public syntax.
+- Dynamic SPA routes still require `paths {}` unless a page uses request-time
+  SSR.
+- Actions, APIs, and fragments remain endpoint metadata, not page render modes.
+- Generated JavaScript is enhancement only; it must not own routing truth,
+  auth, server validation, business logic, server state, or cache policy.
+- Public generated-output shape changes need docs and deterministic tests in the
+  same change.
+
+## Minimum Handoff
+
+Before handing off, state:
+
+- The syntax or behavior changed.
+- The AST/IR fields and diagnostics touched.
+- The generated files, JSON shapes, or reports affected.
+- The docs and examples updated.
+- The exact verification commands run.

--- a/docs/engineering/generated-code-policy.md
+++ b/docs/engineering/generated-code-policy.md
@@ -30,3 +30,39 @@ Generated code must:
 ## Compatibility
 
 Public generated-runtime contracts should live under `runtime/`. Compiler internals should stay under `internal/` and must not be imported by generated user applications unless explicitly promoted.
+
+## Generated Go Emission
+
+Generated Go belongs to the compiler spine. New generated Go must be built from
+Go AST nodes, printed with `go/printer`, and normalized with `go/format` before
+being written or compiled. A formatting error is a generator bug and must stop
+the build before `go build` sees broken generated files.
+
+Current AST-backed Go emission surfaces:
+
+- `internal/appgen`: generated app packages, backend route registrations,
+  action/API/fragment/contract/guard/rate-limit/SSR adapter functions, generated
+  imports, server main source, and split backend app source.
+- `internal/goblockgen`: captured `go {}` blocks parsed as Go files and emitted
+  through AST/printer/format into generated app package source.
+- `internal/buildgen`: build-data helper programs and Go client/WASM helper
+  source are parsed or formatted before execution or artifact emission.
+
+Tests in `internal/appgen` ban `strings.Builder` and hardcoded line-writing in
+the main generated Go emitters. Generated Go goldens under
+`internal/appgen/testdata/generated_go_golden/` pin the inspectable output.
+
+Allowed string payloads are limited to non-Go artifacts or user-owned Go source
+that is parsed/formatted before use:
+
+- HTML, CSS, JavaScript, JSON, markdown, route manifests, asset manifests, and
+  build reports.
+- User-authored inline `go {}` bodies, which are parsed into Go AST files before
+  generated package emission.
+- Literal source snippets used only as parse input for small Go helper programs,
+  when the result is immediately parsed or formatted and the source is not
+  appended through line-writing.
+
+Any future temporary generated-Go string exception must name the migration step
+in a code comment, be covered by a deterministic test or golden, and be removed
+before the surrounding generated Go surface is considered stable.

--- a/docs/engineering/operations.md
+++ b/docs/engineering/operations.md
@@ -87,7 +87,7 @@ gowdk dev --out dist
 input content hashes, so touching a file without changing its bytes does not
 trigger another rebuild. For plain SPA `--out` builds, edits to existing
 page source files use incremental SPA rendering: GOWDK still parses and
-validates the full manifest, but writes only the changed page output and
+validates the full compiler IR, but writes only the changed page output and
 refreshes manifests. Component, layout, CSS, config, source-set, target, app,
 binary, and WASM changes use the full build path. Generated build output files,
 manifests, generated app source, and embedded build output files are skipped

--- a/docs/engineering/release-plan.md
+++ b/docs/engineering/release-plan.md
@@ -260,24 +260,33 @@ Every 0.x minor release must have:
 
 ## Compiler Spine
 
-- [ ] Keep lex -> parse -> AST -> analyze -> IR -> validate -> generate as
-  strict phases.
-- [ ] Finish downstream migration to `internal/gwdkir`.
-- [ ] Make build output generation, app generation, CLI reports, and LSP
+- [x] Keep lex -> parse -> AST -> analyze -> IR -> validate -> generate as
+  strict phases. See `docs/compiler/pipeline.md` and
+  `docs/engineering/architecture.md`.
+- [x] Finish downstream migration to `internal/gwdkir`.
+- [x] Make build output generation, app generation, CLI reports, and LSP
   metadata consume typed IR.
-- [ ] Remove compatibility structs from long-term generation paths.
-- [ ] Add IR, AST, generated Go, generated HTML, generated CSS, manifest, route
-  report, endpoint report, component graph, and asset graph golden tests.
-- [ ] Add source spans to every AST node and every IR node where possible.
-- [ ] Add compiler invariant checks.
-- [ ] Panic on invalid IR in tests.
-- [ ] Add deterministic output, stale output cleanup, and unchanged-output
+- [x] Remove compatibility structs from long-term generation paths.
+- [x] Add golden coverage for implemented compiler-spine handoffs: AST, IR,
+  generated Go, generated HTML/CSS, manifest, route report, endpoint report,
+  build report, and route/asset output manifests. Component graph and asset
+  graph commands are deferred to #235.
+- [x] Add source spans to current AST and IR records where possible. Remaining
+  exact-span improvements for diagnostics, reports, and LSP metadata are
+  deferred to #235.
+- [x] Add compiler invariant checks.
+- [x] Gate invalid IR before generated-output planning. Test-only invalid-IR
+  panic helper policy is deferred to #235.
+- [x] Add deterministic output, stale output cleanup, and unchanged-output
   preservation tests.
-- [ ] Ban stringy generated Go except temporary documented exceptions.
-- [ ] Move generated Go to `go/ast`, `go/printer`, and `go/format`.
-- [ ] Add internal architecture docs for compiler passes.
-- [ ] Add contributor guidance for new syntax requiring parser, formatter,
-  diagnostic, IR, generation, docs, and example/fixture coverage.
+- [x] Ban stringy generated Go except temporary documented exceptions. See
+  `docs/engineering/generated-code-policy.md`.
+- [x] Move generated Go to `go/ast`, `go/printer`, and `go/format` for current
+  generated app and adapter surfaces.
+- [x] Add internal architecture docs for compiler passes.
+- [x] Add contributor guidance for new syntax requiring parser, formatter,
+  diagnostic, IR, generation, docs, and example/fixture coverage. See
+  `docs/compiler/syntax-contributors.md`.
 
 ## Parser, Formatter, Diagnostics, And Language Spec
 

--- a/docs/language/components.md
+++ b/docs/language/components.md
@@ -63,8 +63,8 @@ Implemented today:
   `<Counter g:island="wasm" />` when a call-site override is needed. If the
   component has no `wasm` package, GOWDK still emits the first-slice
   placeholder module plus loader shape for that explicit call.
-- Duplicate component names are rejected during manifest validation.
-- Redundant component implementations are rejected during manifest validation
+- Duplicate component names are rejected during compiler validation.
+- Redundant component implementations are rejected during compiler validation
   with `redundant_component_implementation`, even when their names differ.
 - Component `css` declarations are parsed, lowered into compiler metadata,
   emitted as scoped component CSS, linked from generated pages, content-hashed,

--- a/docs/product/language-server.md
+++ b/docs/product/language-server.md
@@ -13,7 +13,7 @@ Developers editing `.gwdk` files need live feedback from the same language tooli
 
 ## Non-Goals
 
-- Implement semantic analysis beyond the current manifest validation rules.
+- Implement semantic analysis beyond the current compiler validation rules.
 - Replace the site-map visualizer or file-moving VS Code commands.
 - Add request-time SSR behavior or compile/codegen features.
 - Add editor-specific packages to the Go compiler core.
@@ -95,6 +95,6 @@ Developers editing `.gwdk` files need live feedback from the same language tooli
 
 ## Open Questions
 
-- Workspace-wide manifest validation can reuse the existing duplicate page and
-  route checks once the LSP maintains a project-wide manifest.
+- Workspace-wide compiler validation can reuse the existing duplicate page and
+  route checks once the LSP maintains project-wide IR.
 - Incremental sync can replace full-document sync if large `.gwdk` files become common.

--- a/docs/product/requirements.md
+++ b/docs/product/requirements.md
@@ -114,8 +114,8 @@ implemented.
 
 ## Open Questions
 
-- Which downstream compiler passes should migrate from manifest compatibility
-  structs to `internal/gwdkir.Program` first?
+- Which remaining diagnostics, reports, and LSP metadata need exact source spans
+  first?
 - Should hybrid pages get additional cache policy syntax beyond page-level
   `cache` and `revalidate`?
 - Should processor-emitted CSS become selectable named `css` inputs through a

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -208,8 +208,8 @@ Build output, route/asset manifests, generated `go.mod`, generated
 `gowdkapp/app.go`, generated `cmd/server/main.go`, and embedded build output
 files are only rewritten when their bytes change, which keeps local dev loops
 from retriggering on no-op generation. For plain SPA `--out` builds, page-only
-source edits use an incremental SPA renderer that validates the full manifest,
-refreshes manifests, writes only changed page output, and removes stale route
+source edits use an incremental SPA renderer that validates the full compiler
+IR, refreshes manifests, writes only changed page output, and removes stale route
 output for changed pages. Component, layout, CSS, config, source-set, target,
 app, binary, and WASM changes use the full build path.
 

--- a/docs/reference/dev.md
+++ b/docs/reference/dev.md
@@ -24,7 +24,7 @@ attached to the terminal.
 ## Rebuild Scope
 
 For plain SPA `--out` builds, page-only edits use the incremental SPA renderer:
-the dev loop validates the full manifest, refreshes manifests, writes changed
+the dev loop validates the full compiler IR, refreshes manifests, writes changed
 page output, and removes stale route output for changed pages.
 
 These changes use the full build path:

--- a/internal/appgen/appgen_test.go
+++ b/internal/appgen/appgen_test.go
@@ -1879,6 +1879,16 @@ func TestGenerateAutoRoutesRequiresIR(t *testing.T) {
 	}
 }
 
+func TestGenerateBackendAutoRoutesRejectsInvalidIR(t *testing.T) {
+	appDir := filepath.Join(t.TempDir(), "generated-backend")
+	invalidIR := &gwdkir.Program{}
+
+	_, err := GenerateBackendWithOptions(appDir, Options{AutoRoutes: true, IR: invalidIR})
+	if err == nil || !strings.Contains(err.Error(), "invalid compiler IR: invalid IR") {
+		t.Fatalf("expected invalid compiler IR error, got %v", err)
+	}
+}
+
 func TestActionEndpointsInfersInputFieldsFromGPostForm(t *testing.T) {
 	routes, err := actionEndpointsFromManifestFixture(gwdkanalysis.Sources{Pages: []gwdkir.Page{{
 		ID:    "newsletter",

--- a/internal/appgen/auto_routes.go
+++ b/internal/appgen/auto_routes.go
@@ -80,6 +80,9 @@ func resolveBackendOptions(options Options) (Options, error) {
 
 func optionsIR(options Options) (gwdkir.Program, error) {
 	if options.IR != nil {
+		if err := gwdkir.CheckInvariants(*options.IR); err != nil {
+			return gwdkir.Program{}, fmt.Errorf("invalid compiler IR: %w", err)
+		}
 		return *options.IR, nil
 	}
 	return gwdkir.Program{}, fmt.Errorf("auto route detection requires compiler IR")

--- a/internal/buildgen/build.go
+++ b/internal/buildgen/build.go
@@ -26,7 +26,8 @@ func BuildFromIR(config gowdk.Config, ir gwdkir.Program, outputDir string) (Resu
 // BuildFromValidatedIR is BuildFromIR for orchestrators that already ran
 // compiler.ValidateProgram on the IR (the CLI build path). It skips the
 // defensive re-validation, which type-checks feature Go packages on disk and
-// is too expensive to run twice per build.
+// is too expensive to run twice per build, but still runs cheap IR invariant
+// checks before planning generated output.
 func BuildFromValidatedIR(config gowdk.Config, ir gwdkir.Program, outputDir string) (Result, error) {
 	return buildFromIR(config, ir, compiler.BackendBindingsFromIR(ir), outputDir, false)
 }
@@ -47,8 +48,10 @@ func buildFromIR(config gowdk.Config, ir gwdkir.Program, backendBindings []sourc
 		if err := compiler.ValidateProgram(config, ir); err != nil {
 			return Result{}, reporter.fail("validate", err)
 		}
+	} else if err := gwdkir.CheckInvariants(ir); err != nil {
+		return Result{}, reporter.fail("validate", fmt.Errorf("internal compiler error: %w", err))
 	}
-	reporter.info("validate", "manifest_valid", "manifest validation completed", BuildEvent{})
+	reporter.info("validate", "ir_valid", "compiler IR validation completed", BuildEvent{})
 	reportBackendBindings(reporter, backendBindings)
 	reportContractReferences(reporter, ir.ContractRefs)
 	if err := compiler.ValidateBackendBindingPolicyIR(config, ir); err != nil {
@@ -157,7 +160,7 @@ func buildMemoryFromIR(config gowdk.Config, ir gwdkir.Program, backendBindings [
 	if err := compiler.ValidateProgram(config, ir); err != nil {
 		return MemoryResult{}, reporter.fail("validate", err)
 	}
-	reporter.info("validate", "manifest_valid", "manifest validation completed", BuildEvent{})
+	reporter.info("validate", "ir_valid", "compiler IR validation completed", BuildEvent{})
 	reportBackendBindings(reporter, backendBindings)
 	reportContractReferences(reporter, ir.ContractRefs)
 	if err := compiler.ValidateBackendBindingPolicyIR(config, ir); err != nil {
@@ -375,7 +378,7 @@ func buildIncrementalFromIR(config gowdk.Config, ir gwdkir.Program, outputDir st
 	if err := compiler.ValidateProgram(config, ir); err != nil {
 		return Result{}, reporter.fail("validate", err)
 	}
-	reporter.info("validate", "manifest_valid", "manifest validation completed", BuildEvent{})
+	reporter.info("validate", "ir_valid", "compiler IR validation completed", BuildEvent{})
 	reportContractReferences(reporter, ir.ContractRefs)
 	if err := compiler.ValidateBackendBindingPolicyIR(config, ir); err != nil {
 		return Result{}, reporter.fail("bind", err)

--- a/internal/buildgen/build_report_test.go
+++ b/internal/buildgen/build_report_test.go
@@ -45,7 +45,7 @@ func TestBuildWritesSPAHTMLForSimpleRoute(t *testing.T) {
 	if result.Report.Version != 1 || result.Report.Mode != "build" {
 		t.Fatalf("unexpected build report: %#v", result.Report)
 	}
-	requireBuildReportEvent(t, result.Report, "validate", "manifest_valid")
+	requireBuildReportEvent(t, result.Report, "validate", "ir_valid")
 	requireBuildReportEvent(t, result.Report, "plan", "artifacts_planned")
 	requireBuildReportEvent(t, result.Report, "manifest", "route_manifest_written")
 	requireBuildReportEvent(t, result.Report, "complete", "build_complete")

--- a/internal/buildgen/ir_test.go
+++ b/internal/buildgen/ir_test.go
@@ -1,6 +1,7 @@
 package buildgen
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -11,7 +12,7 @@ import (
 	"github.com/cssbruno/gowdk/internal/gwdkir"
 )
 
-func TestPlanFromIRMatchesManifestPlan(t *testing.T) {
+func TestPlanFromIRMatchesSourcePlan(t *testing.T) {
 	config := gowdk.Config{}
 	app := gwdkanalysis.Sources{
 		Pages: []gwdkir.Page{{
@@ -28,7 +29,7 @@ func TestPlanFromIRMatchesManifestPlan(t *testing.T) {
 		}},
 	}
 
-	fromManifest, err := plan(config, app, t.TempDir())
+	fromSources, err := plan(config, app, t.TempDir())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -37,14 +38,14 @@ func TestPlanFromIRMatchesManifestPlan(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if len(fromManifest.pages) != len(fromIR.pages) {
-		t.Fatalf("page plan count mismatch: %d != %d", len(fromManifest.pages), len(fromIR.pages))
+	if len(fromSources.pages) != len(fromIR.pages) {
+		t.Fatalf("page plan count mismatch: %d != %d", len(fromSources.pages), len(fromIR.pages))
 	}
 	if fromIR.pages[0].PageID != "home" || fromIR.pages[0].Route != "/" {
 		t.Fatalf("unexpected IR page plan: %#v", fromIR.pages[0])
 	}
-	if string(fromIR.pages[0].contents) != string(fromManifest.pages[0].contents) {
-		t.Fatalf("IR plan content differs:\n%s\n---\n%s", fromIR.pages[0].contents, fromManifest.pages[0].contents)
+	if string(fromIR.pages[0].contents) != string(fromSources.pages[0].contents) {
+		t.Fatalf("IR plan content differs:\n%s\n---\n%s", fromIR.pages[0].contents, fromSources.pages[0].contents)
 	}
 }
 
@@ -76,6 +77,21 @@ func TestBuildFromIRWritesArtifacts(t *testing.T) {
 	if !strings.Contains(string(payload), "<main>Home</main>") {
 		t.Fatalf("expected generated page content, got:\n%s", payload)
 	}
+}
+
+func TestBuildFromValidatedIRChecksInvariants(t *testing.T) {
+	_, err := BuildFromValidatedIR(gowdk.Config{}, gwdkir.Program{}, t.TempDir())
+	if err == nil {
+		t.Fatal("expected invalid IR error")
+	}
+	var buildErr *BuildError
+	if !errors.As(err, &buildErr) {
+		t.Fatalf("expected BuildError, got %T", err)
+	}
+	if !strings.Contains(err.Error(), "internal compiler error: invalid IR") {
+		t.Fatalf("expected invariant error, got %v", err)
+	}
+	requireBuildReportEvent(t, buildErr.Report, "validate", "failed")
 }
 
 func TestBuildMemoryFromIRCollectsArtifacts(t *testing.T) {


### PR DESCRIPTION
## Summary

- Add cheap `gwdkir.CheckInvariants` coverage to the `BuildFromValidatedIR` fast path before generated-output planning.
- Reject invalid compiler IR during appgen auto-route resolution, including backend-only auto routes.
- Rename build-report validation events from `manifest_valid` to `ir_valid` and align compiler/dev docs with the IR-first pipeline.
- Close out the Compiler Spine checklist with explicit status, generated-Go policy, and syntax contributor guidance.

Closes #58
Follow-up: #235

## Verification

- [x] I ran the relevant tests, lint, and build commands.
- [x] I ran `scripts/test-go-modules.sh` when Go code or compiler behavior changed.
- [x] I ran `go build ./cmd/gowdk` when CLI, compiler, runtime, addon, or release behavior changed.
- [ ] I ran `node --check editors/vscode/extension.js` when editor files changed.
- [x] I updated docs for behavior, setup, or architecture changes.
- [x] I added or updated tests for changed behavior.

Commands run:

```sh
go test ./internal/buildgen
go test ./internal/appgen
go test ./cmd/gowdk
go test ./internal/gwdkir ./internal/compiler
go build ./cmd/gowdk
git diff --check
scripts/test-go-modules.sh
```

## LLM Assistance

- LLM session summary: Codex audited the compiler-spine checklist, added IR invariant gates for generated-output/appgen auto-route paths, updated build-report/docs wording, added syntax contributor guidance, documented generated-Go emission policy, updated #235 to track only intentionally deferred exact-span/graph/test-helper policy work, and updated this draft PR.
- Human-reviewed assumptions: This is a stacked PR targeting `chore/agents-skills-revamp` to avoid mixing compiler-spine changes into existing PR #234's branch diff. #58 acceptance allows remaining checklist items to be intentionally deferred with linked issue #235.
- Follow-up work: #235 tracks exact span improvements, component/asset graph command and golden coverage, and invalid-IR test-helper policy.