### PR TITLE
[codex] require PR closing keywords

### DIFF
--- a/.agents/skills/gowdk-pr-body/SKILL.md
+++ b/.agents/skills/gowdk-pr-body/SKILL.md
@@ -22,6 +22,10 @@ Explain the net change and why it belongs in GOWDK.
 - Verification commands worth citing are the CI gates: focused `go test`
   packages, `scripts/test-go-modules.sh`, `go build ./cmd/gowdk`, and `gowdk
   check/build` smokes over `examples/`.
+- Issue closure syntax is exact: use GitHub closing keywords (`Closes #123`,
+  `Fixes #123`, or `Resolves #123`) only for issues the PR fully resolves.
+  Put each fully resolved issue on its own line in the PR body. Use `Related:
+  #123` for partial or tracking-only links.
 
 ## Core Workflow
 
@@ -35,10 +39,19 @@ gh pr view --json title,body,url 2>/dev/null
 
 2. Read the diff and preserve any important existing PR body content.
 3. Write the body around the net change, not abandoned attempts.
-4. Fill the template sections; add Migration / Compatibility, Docs / Examples,
+4. Add an Issue Closure section when the PR fully resolves any issue:
+
+```markdown
+## Issue Closure
+
+Closes #123
+Closes #456
+```
+
+5. Fill the template sections; add Migration / Compatibility, Docs / Examples,
    or Known Gaps sections only when they carry real content.
-5. For bug fixes, include the root cause.
-6. For language or generated-output changes, name the public contract impact:
+6. For bug fixes, include the root cause.
+7. For language or generated-output changes, name the public contract impact:
    syntax/diagnostic codes changed, generated files or manifest JSON shapes
    affected, docs/examples updated.
 
@@ -47,5 +60,9 @@ gh pr view --json title,body,url 2>/dev/null
 - Do not reference absolute local paths.
 - Do not mention private prompts, hidden reasoning, credentials, or internal
   context.
-- Use `Closes #123` only when the PR fully resolves the issue.
+- Do not write `Completes #123`, `Completed #123`, or `Done #123` expecting
+  GitHub to auto-close an issue. GitHub does not close issues from those words.
 - List commands actually run; do not imply CI passed locally.
+- If a PR was already merged without closing keywords, verify the linked issue
+  state and close completed issues manually with a comment pointing to the
+  merged PR.

--- a/.agents/templates/pr-description.md
+++ b/.agents/templates/pr-description.md
@@ -2,6 +2,10 @@
 
 - 
 
+# Issue Closure
+
+<!-- Use `Closes #123` when fully resolved; use `Related: #123` for partial links. -->
+
 # Why
 
 - 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,6 +2,12 @@
 
 - 
 
+## Issue Closure
+
+<!-- Use Closes/Fixes/Resolves only when this PR fully resolves the issue.
+Use Related for partial or tracking-only links. GitHub does not auto-close
+issues from words like "Completes". -->
+
 ## Verification
 
 - [ ] I ran the relevant tests, lint, and build commands.


### PR DESCRIPTION
## Summary

- Make the GOWDK PR-body skill require GitHub closing keywords for fully resolved issues.
- Add an Issue Closure section to the PR templates with guidance to use `Closes`/`Fixes`/`Resolves` instead of non-closing words like `Completes`.
- Keep partial/tracking links distinct with `Related: #123` guidance.

## Verification

- [x] Markdown/template-only change; inspected diff with `git diff --check`.

## LLM Assistance

- LLM session summary: Added a reusable PR issue-closing pattern after merged PR #248 did not auto-close linked issues.
- Human-reviewed assumptions: GitHub only auto-closes issues from recognized closing keywords when the PR is merged.
- Follow-up work: None.