### PR TITLE
fix(appgen): gate partial imports to emitted action fragments

### DIFF
--- a/internal/appgen/appgen_test.go
+++ b/internal/appgen/appgen_test.go
@@ -860,6 +860,9 @@ func TestGenerateWritesTypedBoundActionHandlers(t *testing.T) {
 	if strings.Contains(source, `gowdkresponse.RedirectTo("/dashboard")`) || strings.Contains(source, `<p>ignored</p>`) {
 		t.Fatalf("bound action must keep redirect and fragment policy in the user Go response:\n%s", source)
 	}
+	if strings.Contains(source, `gowdkpartial "github.com/cssbruno/gowdk/addons/partial"`) {
+		t.Fatalf("bound action fragments must not import partial helpers when generated partial branches are not emitted:\n%s", source)
+	}
 }
 
 func TestGenerateDoesNotImportMissingOrUnsupportedBackendPackages(t *testing.T) {
@@ -873,6 +876,7 @@ func TestGenerateDoesNotImportMissingOrUnsupportedBackendPackages(t *testing.T) 
 			PageID:     "home",
 			ActionName: "Submit",
 			Route:      "/",
+			Fragments:  []ActionFragment{{Target: "#home", HTML: "<p>ignored</p>"}},
 			Binding: source.BackendBinding{
 				Status:       source.BackendBindingMissing,
 				ImportPath:   "example.com/app/missing",
@@ -906,8 +910,10 @@ func TestGenerateDoesNotImportMissingOrUnsupportedBackendPackages(t *testing.T) 
 	for _, forbidden := range []string{
 		`"example.com/app/missing"`,
 		`"example.com/app/status"`,
+		`gowdkpartial "github.com/cssbruno/gowdk/addons/partial"`,
 		`missing.Submit(`,
 		`status.Status(`,
+		`<p>ignored</p>`,
 	} {
 		if strings.Contains(source, forbidden) {
 			t.Fatalf("did not expect generated missing-handler source to contain %q:\n%s", forbidden, source)

--- a/internal/appgen/source_actions.go
+++ b/internal/appgen/source_actions.go
@@ -76,11 +76,15 @@ func actionsUseForm(actions []ActionEndpoint) bool {
 
 func actionsUseFragments(actions []ActionEndpoint) bool {
 	for _, action := range actions {
-		if len(action.Fragments) > 0 {
+		if actionUsesPartialAddon(action) {
 			return true
 		}
 	}
 	return false
+}
+
+func actionUsesPartialAddon(action ActionEndpoint) bool {
+	return action.Binding.Status == "" && len(action.Fragments) > 0
 }
 
 func actionsParseForm(actions []ActionEndpoint) bool {


### PR DESCRIPTION
### Motivation

- Generated apps were importing the `gowdkpartial` addon whenever any action carried fragment metadata, even if that action was backend-bound, missing, or used an unsupported signature and therefore never emitted the partial response branch.
- This produced unused imports and caused `go build` failures for valid backends that retained fragment metadata but did not generate partial branches.

### Description

- Change the import predicate to only consider actions that can actually emit generated partial responses by adding `actionUsesPartialAddon` and using it from `actionsUseFragments` in `internal/appgen/source_actions.go`.
- `actionUsesPartialAddon` requires the action to be unbound (no backend binding) and to have fragment metadata, so backend-bound/missing/unsupported actions no longer trigger the partial helper import.
- Add regression assertions in `internal/appgen/appgen_test.go` to ensure bound and missing backend actions that retain fragment metadata do not cause the `gowdkpartial` import or include ignored fragment HTML in generated source.
- Update tests to cover the missing-backend + fragment case so the behavior is guarded against regressions.

### Testing

- Ran `go test ./internal/appgen` and the package tests passed.
- Ran `go test ./...` across the repository and all tests succeeded.
