### PR TITLE
[codex] Add go/packages-backed endpoint binding inspection

### DIFF
--- a/docs/compiler/endpoint-binding-inspection-plan.md
+++ b/docs/compiler/endpoint-binding-inspection-plan.md
@@ -1,0 +1,65 @@
+# Implementation Plan: go/packages Endpoint Binding Inspection
+
+## Context
+
+- Spec: `docs/compiler/endpoint-binding-inspection.md`
+- Issue: `https://github.com/cssbruno/GoWDK/issues/257`
+
+## Assumptions
+
+- This is an internal compiler capability; it does not change public `.gwdk`
+  syntax.
+- Inline `go {}` blocks keep the existing AST inspection path until extraction
+  materializes them as normal package files.
+
+## Proposed Changes
+
+- Replace real same-directory backend handler inspection with `packages.Load`.
+- Classify supported handlers from `types.Signature` and Go type identity.
+- Derive typed action input fields from `types.Struct` metadata.
+- Keep current binding metadata fields stable in `gwdkir` and reports.
+- Add focused tests for renamed imports/type aliases, build tags, non-exported
+  handlers, package load errors, and existing typed inputs.
+
+## Files Expected To Change
+
+- `internal/compiler/backend_bindings.go`
+- `internal/compiler/backend_bindings_test.go`
+- `go.mod`
+- `go.sum`
+- Compiler/product docs that mention the old AST-based binding implementation.
+
+## Data And API Impact
+
+- Public binding report fields remain unchanged.
+- The compiler root module now depends on `golang.org/x/tools/go/packages` for
+  Go package loading.
+
+## Tests
+
+- Unit: endpoint binding signature classification and metadata tests in
+  `internal/compiler`.
+- Integration: generated app tests in `internal/appgen`.
+- End-to-end: root module test suite.
+- Manual: not required for this internal slice.
+
+## Verification Commands
+
+```sh
+go test ./internal/compiler
+go test ./internal/compiler ./internal/appgen
+go test ./...
+```
+
+## Rollback Plan
+
+- Revert the `go/packages` inspection path and dependency updates together.
+- Keep binding metadata contracts stable so generated app consumers do not need
+  migration.
+
+## Risks
+
+- `packages.Load` may surface package load errors that the previous AST scan
+  ignored. The implementation reports those as missing-binding metadata so
+  development builds can still emit 501 stubs while strict production builds
+  fail through the existing policy.

--- a/docs/compiler/endpoint-binding-inspection.md
+++ b/docs/compiler/endpoint-binding-inspection.md
@@ -1,0 +1,71 @@
+# Feature Spec: go/packages Endpoint Binding Inspection
+
+## Problem
+
+Endpoint binding used to parse sibling `.go` files directly and match AST
+shapes. That could drift from ordinary Go semantics for build tags, renamed
+imports, type aliases, package load failures, and exact exported package-scope
+symbols.
+
+## Goals
+
+- Inspect real same-directory Go packages through `golang.org/x/tools/go/packages`.
+- Resolve endpoint handlers from package type information instead of import-name
+  AST matching.
+- Preserve the current supported action, API, fragment, and SSR load
+  signatures.
+- Keep missing and unsupported bindings explicit for generated HTTP 501 stubs
+  and strict production diagnostics.
+
+## Non-Goals
+
+- Add new endpoint signatures.
+- Change `.gwdk` endpoint syntax.
+- Change inline `go {}` extraction. Inline generated Go blocks still use the
+  existing synthetic AST path because they are not real packages on disk yet.
+
+## Requirements
+
+### Functional
+
+- Owning source directories are loaded as Go packages with `packages.Load`.
+- Exported package-scope handler symbols are inspected through `types.Info`,
+  `types.Signature`, and package scope/type metadata.
+- Build-tag-excluded files do not bind handlers unless their tags are active in
+  the build environment.
+- Renamed imports and response type aliases resolve according to Go type
+  identity.
+- Package load errors become clear missing-binding metadata.
+- Typed action input fields are derived from compiled `types.Struct` metadata
+  and preserve existing form tag and supported-field-type behavior.
+
+### Non-Functional
+
+- Performance: only owning endpoint package directories are loaded, and each
+  directory is cached for the current binding pass.
+- Reliability: unsupported signatures continue to be reported without importing
+  or referencing invalid handlers in generated output.
+- Security/privacy: diagnostics and binding messages do not include submitted
+  form values or runtime secrets.
+- Observability: public route/build metadata keeps the existing binding status,
+  message, import path, package, function, signature, and input field fields.
+
+## Acceptance Criteria
+
+- [x] Handler binding uses type-checked Go package information for real Go
+      packages.
+- [x] Build-tag-excluded handlers remain missing by default.
+- [x] Renamed imports and response type aliases resolve correctly.
+- [x] Non-exported handlers remain missing.
+- [x] Package load errors produce clear binding metadata.
+- [x] Unsupported signatures still fail strict production builds unless missing
+      backend stubs are explicitly allowed.
+- [x] Existing generated app behavior remains compatible for supported
+      signatures.
+
+## Dependencies
+
+- Internal: `internal/compiler`, `internal/gwdkir`, generated app consumers of
+  backend binding metadata.
+- External: `golang.org/x/tools/go/packages`, used only by the compiler to load
+  owning Go packages with standard Go semantics.

--- a/docs/compiler/generated-output.md
+++ b/docs/compiler/generated-output.md
@@ -136,6 +136,9 @@ Implemented today:
   fallback.
 - Generated app action endpoint extraction rejects direct file inputs and
   multipart `g:post` forms. Uploads belong in user-owned API/server handlers.
+- `internal/compiler` resolves same-package action, API, fragment, and SSR load
+  handlers through `go/packages` and `go/types`, so build tags, renamed imports,
+  type aliases, and package load errors follow ordinary Go package semantics.
 - `internal/gotypes` resolves component prop/state structs through Go module
   import paths using `go list`, `go/parser`, and `go/types`.
 - `addons/partial` exposes generated fragment and swap helpers. The underlying

--- a/docs/engineering/architecture.md
+++ b/docs/engineering/architecture.md
@@ -85,16 +85,16 @@ Target `.gwdk` compilation:
 Target Go package validation:
 
 ```text
-.go files
-  -> standard go/parser
-  -> standard go/ast
-  -> standard go/types
+.go package directory
+  -> go/packages load
+  -> standard Go syntax and type information
   -> validate exported handlers/types
 ```
 
 The GOWDK AST models `.gwdk` language constructs. Normal Go files and generated
-Go source use the standard Go AST and type checker. Analyzer output connects
-the lanes through package, route, type, component, and handler binding metadata.
+Go source use the standard Go syntax and type information. Analyzer output
+connects the lanes through package, route, type, component, and handler binding
+metadata.
 
 ## Compatibility Records
 
@@ -152,7 +152,7 @@ manifest report (`internal/lang/testdata/manifest_golden`).
 | `internal/lang` | Language tooling for lexing, diagnostics, formatting, checking, and the IR-derived manifest JSON report. | Tools | Initial CLI-backed tools implemented. |
 | `internal/lsp` | Language Server Protocol bridge for diagnostics, formatting, completions, and hover. | Tools | Dependency-free stdio server implemented with baseline and open-project completions plus hover for known language tokens and open-project symbols. |
 | `internal/project` | Load project-level config, module source groups, build targets, and future source roots. | Compiler | SPA `gowdk.config.go` subset implemented for build discovery, output, and `Build.Targets`; project-level CLI commands require this config or an explicit `--config` file before compiling `.gwdk` code. |
-| `internal/compiler` | Validate manifests and coordinate compilation metadata. | Compiler | Render-mode, duplicate identity, redundant component implementation, component Go contract, saved default `go {}` package type-checking with sibling Go files, route shape, duplicate route param, duplicate route pattern, route-method, required page-view validation, default `go {}` backend endpoint binding fallback, and backend binding implemented. CLI route/endpoint reports now convert through `internal/gwdkir.Program`. |
+| `internal/compiler` | Validate manifests and coordinate compilation metadata. | Compiler | Render-mode, duplicate identity, redundant component implementation, component Go contract, saved default `go {}` package type-checking with sibling Go files, route shape, duplicate route param, duplicate route pattern, route-method, required page-view validation, default `go {}` backend endpoint binding fallback, and `go/packages`-backed backend binding implemented. CLI route/endpoint reports now convert through `internal/gwdkir.Program`. |
 | `internal/buildgen` | Emit route-derived spa HTML files for build-time pages and SSR render artifacts. | Compiler | Disk builds, memory builds, incremental SPA builds, and SSR artifact planning consume `internal/gwdkir.Program`. Initial simple page, literal build data, imported Go build data calls, literal dynamic path expansion, component expansion, partial runtime asset emission, default JS island asset emission, component-level non-CSS asset emission, component-level WASM island asset emission, page-level `go client {}` WASM mount asset emission, concrete and dynamic SSR page rendering with declared `load {}` placeholders, route manifest emission, asset manifest emission, mandatory build report emission, identical-output write skipping, and incremental changed-page spa rendering implemented. |
 | `internal/appgen` | Emit generated Go app source for embedded spa output and request-time routes. | Compiler | Auto route planning consumes `internal/gwdkir.Program`, backend adapter planning uses typed appgen IR, and generated app Go files are assembled with `go/ast`/`go/printer` before `go/format`. Generates `go.mod`, `main.go`, copied spa assets, thin `runtime/app` server wiring, `runtime/app.BackendRouter` registrations for feature-bound action/API routes, 501 stubs for missing/unsupported handlers, POST redirect and partial fragment action handlers backed by `runtime/form`, `runtime/response`, `runtime/validation`, and `addons/partial`, form input decoders, concrete and dynamic SSR route handlers backed by `runtime/route`, declared SSR load path calls with redirect/error-page handling through `addons/ssr`, shared request-time guard checks through `runtime/guard`, generated `gowdk_go/` packages for default `go {}` and `go ssr {}` blocks, addon `GoBlockConsumer` Go files, split backend apps, command/query contract exposure metadata in adapter IR including runtime roles, identical-output write skipping, stale embedded spa cleanup, and can invoke `go build` for local binaries or Go `js/wasm` artifacts. |
 | `internal/clientrt` | Emit client runtime for partial updates and static-first SPA navigation. | Runtime | First partial form enhancement runtime emits lifecycle hooks, target/swap request headers, swaps, focus restoration, loading state metadata, island remounts, and page-level `go client {}` remounts after SPA navigation. |
@@ -161,7 +161,7 @@ manifest report (`internal/lang/testdata/manifest_golden`).
 | `runtime/html` | HTML escaping, attributes, and class helpers. | Runtime | Initial helpers implemented. |
 | `runtime/auth` | Thin principal and RBAC access-gate helpers. | Runtime | Defines application-owned principal/provider contracts and native `role:`/`permission:` guard ID helpers for defense-in-depth generated route access. It does not own users, sessions, OAuth, tenants, persistence, or backend resource authorization. |
 | `runtime/guard` | Shared request-time guard execution. | Runtime | Defines guard context, registry, ordered execution, and native RBAC guard resolution for generated action, API, fragment, and SSR handlers without depending on the SSR addon. |
-| `runtime/form` | Form value normalization and scalar helpers for generated decoders. | Runtime | Values, first-slice allowlist decoding, and scalar parse helpers implemented; typed struct shape decoding is generated from Go AST instead of runtime reflection. |
+| `runtime/form` | Form value normalization and scalar helpers for generated decoders. | Runtime | Values, first-slice allowlist decoding, and scalar parse helpers implemented; typed struct shape decoding is generated from Go package type metadata instead of runtime reflection. |
 | `runtime/validation` | Validation result and errors for actions. | Runtime | Initial result model implemented. |
 | `runtime/response` | HTML, redirect, fragment, and JSON response envelopes. | Runtime | Initial response model implemented. |
 | `runtime/asset` | Asset manifest resolution. | Runtime | Initial manifest helper implemented. |

--- a/docs/engineering/dependency-policy.md
+++ b/docs/engineering/dependency-policy.md
@@ -42,7 +42,9 @@ readiness.
 
 ## Current Dependency Classification
 
-- Compiler core: standard library plus repository packages under `internal/`.
+- Compiler core: standard library plus repository packages under `internal/`,
+  and `golang.org/x/tools/go/packages` for Go package loading during endpoint
+  binding inspection.
 - Runtime core: standard library plus repository packages under `runtime/`.
 - Optional HTTP adapters: `runtime/adapters/echo`, `runtime/adapters/gin`, and
   `runtime/adapters/fiber`; each adapter is a nested Go module so framework

--- a/docs/language/actions.md
+++ b/docs/language/actions.md
@@ -50,7 +50,7 @@ Current behavior:
 - Generated first-slice action error responses use explicit status mapping for
   invalid CSRF tokens, invalid forms, oversized requests, and validation
   failures, and set `Cache-Control: no-store`.
-- Generated typed action decoders are built from same-package Go AST metadata,
+- Generated typed action decoders are built from same-package Go type metadata,
   then printed as ordinary Go code. They decode exported struct fields using
   `form:"name"` tags first, then Go field names. They ignore `form:"-"`, reject
   unknown user fields through the generated allowlist step, strip generated

--- a/docs/product/roadmap.md
+++ b/docs/product/roadmap.md
@@ -121,8 +121,8 @@ level, the current baseline already includes:
 - component discovery, imported props/state contracts, slots, generated
   JavaScript islands, component-level WASM island assets, and a first-slice client
   language for local component behavior;
-- same-package Go handler binding through `go list`, `go/parser`, `go/ast`, and
-  `go/types`, exact exported handler matching, typed action input decoding,
+- same-package Go handler binding through `go/packages` and `go/types`, exact
+  exported handler matching, typed action input decoding,
   generated `501` responses for missing or unsupported bindings, deterministic
   import aliases, and formatted generated app source;
 - shared backend routing primitives in `runtime/app`, runtime action/API

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,13 @@ module github.com/cssbruno/gowdk
 
 go 1.26.4
 
-require github.com/evanw/esbuild v0.28.0
+require (
+	github.com/evanw/esbuild v0.28.0
+	golang.org/x/tools v0.45.0
+)
 
-require golang.org/x/sys v0.43.0 // indirect
+require (
+	golang.org/x/mod v0.36.0 // indirect
+	golang.org/x/sync v0.20.0 // indirect
+	golang.org/x/sys v0.44.0 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,13 @@
 github.com/evanw/esbuild v0.28.0 h1:V96ghtc5p5JnNUQIUsc5H3kr+AcFcMqOJll2ZmJW6Lo=
 github.com/evanw/esbuild v0.28.0/go.mod h1:D2vIQZqV/vIf/VRHtViaUtViZmG7o+kKmlBfVQuRi48=
+github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+golang.org/x/mod v0.36.0 h1:JJjpVx6myfUsUdAzZuOSTTmRE0PfZeNWzzvKrP7amb4=
+golang.org/x/mod v0.36.0/go.mod h1:moc6ELqsWcOw5Ef3xVprK5ul/MvtVvkIXLziUOICjUQ=
+golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=
+golang.org/x/sync v0.20.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.43.0 h1:Rlag2XtaFTxp19wS8MXlJwTvoh8ArU6ezoyFsMyCTNI=
-golang.org/x/sys v0.43.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+golang.org/x/sys v0.44.0 h1:ildZl3J4uzeKP07r2F++Op7E9B29JRUy+a27EibtBTQ=
+golang.org/x/sys v0.44.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+golang.org/x/tools v0.45.0 h1:18qN3FAooORvApf5XjCXgsuayZOEtXf6JK18I3+ONa8=
+golang.org/x/tools v0.45.0/go.mod h1:LuUGqqaXcXMEFEruIVJVm5mgDD8vww/z/SR1gQ4uE/0=

--- a/internal/compiler/backend_binding_types.go
+++ b/internal/compiler/backend_binding_types.go
@@ -1,0 +1,94 @@
+package compiler
+
+import (
+	"strings"
+
+	"github.com/cssbruno/gowdk/internal/source"
+)
+
+const (
+	actionHandlerKind   = "action"
+	apiHandlerKind      = "api"
+	fragmentHandlerKind = "fragment"
+	loadHandlerKind     = "load"
+
+	contextImportPath  = "context"
+	formImportPath     = "github.com/cssbruno/gowdk/runtime/form"
+	httpImportPath     = "net/http"
+	guardImportPath    = "github.com/cssbruno/gowdk/runtime/guard"
+	responseImportPath = "github.com/cssbruno/gowdk/runtime/response"
+	ssrImportPath      = "github.com/cssbruno/gowdk/addons/ssr"
+)
+
+type featurePackage struct {
+	Dir        string
+	ImportPath string
+	Name       string
+	Functions  map[string]featureFunction
+	LoadError  string
+}
+
+type featureFunction struct {
+	Name           string
+	Signature      source.BackendSignatureKind
+	InputType      string
+	InputPointer   bool
+	InputFields    []source.BackendInputField
+	SupportMessage string
+}
+
+func (function featureFunction) Action() bool {
+	switch function.Signature {
+	case source.BackendSignatureAction0, source.BackendSignatureActionValues, source.BackendSignatureActionForm, source.BackendSignatureActionFormPtr:
+		return true
+	default:
+		return false
+	}
+}
+
+func (function featureFunction) API() bool {
+	return function.Signature == source.BackendSignatureAPI
+}
+
+func (function featureFunction) Fragment() bool {
+	return function.Signature == source.BackendSignatureAction0 || function.Signature == source.BackendSignatureFragment
+}
+
+func (function featureFunction) Load() bool {
+	return function.Signature == source.BackendSignatureLoad || function.Signature == source.BackendSignatureLoadError
+}
+
+func bindingPackageName(pkgName string, fallback string) string {
+	if strings.TrimSpace(pkgName) != "" {
+		return pkgName
+	}
+	return fallback
+}
+
+func bindingPackageLabel(binding source.BackendBinding, pkg featurePackage) string {
+	if pkg.ImportPath != "" {
+		return pkg.ImportPath
+	}
+	if pkg.Name != "" {
+		return pkg.Name
+	}
+	if binding.PackageName != "" {
+		return binding.PackageName
+	}
+	return "feature"
+}
+
+func packageLabel(pkg featurePackage) string {
+	if pkg.ImportPath != "" {
+		return pkg.ImportPath
+	}
+	if pkg.Name != "" {
+		return pkg.Name
+	}
+	return "feature"
+}
+
+type inputStruct struct {
+	Fields  []source.BackendInputField
+	Message string
+}

--- a/internal/compiler/backend_bindings.go
+++ b/internal/compiler/backend_bindings.go
@@ -1,36 +1,14 @@
 package compiler
 
 import (
-	"encoding/json"
 	"fmt"
-	"go/ast"
-	"go/parser"
-	"go/token"
-	"os"
-	"os/exec"
-	"path"
 	"path/filepath"
 	"sort"
-	"strconv"
 	"strings"
 
-	"github.com/cssbruno/gowdk/internal/goblockgen"
 	"github.com/cssbruno/gowdk/internal/gwdkanalysis"
 	"github.com/cssbruno/gowdk/internal/gwdkir"
 	"github.com/cssbruno/gowdk/internal/source"
-)
-
-const (
-	actionHandlerKind   = "action"
-	apiHandlerKind      = "api"
-	fragmentHandlerKind = "fragment"
-	loadHandlerKind     = "load"
-
-	contextImportPath  = "context"
-	formImportPath     = "github.com/cssbruno/gowdk/runtime/form"
-	httpImportPath     = "net/http"
-	responseImportPath = "github.com/cssbruno/gowdk/runtime/response"
-	ssrImportPath      = "github.com/cssbruno/gowdk/addons/ssr"
 )
 
 // BindBackendHandlers discovers same-package Go handlers for act and api blocks,
@@ -134,7 +112,7 @@ func bindLoad(page gwdkir.Page, pkg featurePackage) source.BackendBinding {
 		binding := baseBackendBinding(page, loadHandlerKind, functionName, "GET", page.Route, pkg)
 		if !function.Load() {
 			binding.Status = source.BackendBindingUnsupportedSignature
-			binding.Message = fmt.Sprintf("GOWDK SSR load handler %s.%s must have signature func(ssr.LoadContext) map[string]any or func(ssr.LoadContext) (map[string]any, error)", packageLabel(pkg), functionName)
+			binding.Message = fmt.Sprintf("GOWDK SSR load handler %s.%s must have signature func(ssr.LoadContext) map[string]any or func(ssr.LoadContext) (map[string]any, error)", bindingPackageLabel(binding, pkg), functionName)
 			return binding
 		}
 		binding.Signature = function.Signature
@@ -146,7 +124,7 @@ func bindLoad(page gwdkir.Page, pkg featurePackage) source.BackendBinding {
 		binding := baseBackendBinding(page, loadHandlerKind, functionName, "GET", page.Route, inlinePkg)
 		if !function.Load() {
 			binding.Status = source.BackendBindingUnsupportedSignature
-			binding.Message = fmt.Sprintf("GOWDK SSR load handler %s.%s must have signature func(ssr.LoadContext) map[string]any or func(ssr.LoadContext) (map[string]any, error)", packageLabel(inlinePkg), functionName)
+			binding.Message = fmt.Sprintf("GOWDK SSR load handler %s.%s must have signature func(ssr.LoadContext) map[string]any or func(ssr.LoadContext) (map[string]any, error)", bindingPackageLabel(binding, inlinePkg), functionName)
 			return binding
 		}
 		binding.Signature = function.Signature
@@ -155,7 +133,11 @@ func bindLoad(page gwdkir.Page, pkg featurePackage) source.BackendBinding {
 	}
 	binding := baseBackendBinding(page, loadHandlerKind, functionName, "GET", page.Route, pkg)
 	binding.Status = source.BackendBindingMissing
-	binding.Message = fmt.Sprintf("GOWDK SSR load handler %s.%s is not implemented", packageLabel(pkg), functionName)
+	if pkg.LoadError != "" {
+		binding.Message = fmt.Sprintf("GOWDK SSR load handler %s.%s could not be inspected: %s", bindingPackageLabel(binding, pkg), functionName, pkg.LoadError)
+	} else {
+		binding.Message = fmt.Sprintf("GOWDK SSR load handler %s.%s is not implemented", bindingPackageLabel(binding, pkg), functionName)
+	}
 	return binding
 }
 
@@ -168,18 +150,23 @@ func bindStandaloneAction(endpoint gwdkir.GoEndpoint, pkg featurePackage) source
 }
 
 func bindActionEndpoint(binding source.BackendBinding, pkg featurePackage) source.BackendBinding {
+	if pkg.LoadError != "" {
+		binding.Status = source.BackendBindingMissing
+		binding.Message = fmt.Sprintf("GOWDK action handler %s.%s could not be inspected: %s", bindingPackageLabel(binding, pkg), binding.FunctionName, pkg.LoadError)
+		return binding
+	}
 	function, ok := pkg.Functions[binding.FunctionName]
 	if !ok {
 		binding.Status = source.BackendBindingMissing
-		binding.Message = fmt.Sprintf("GOWDK action handler %s.%s is not implemented", packageLabel(pkg), binding.FunctionName)
+		binding.Message = fmt.Sprintf("GOWDK action handler %s.%s is not implemented", bindingPackageLabel(binding, pkg), binding.FunctionName)
 		return binding
 	}
 	if !function.Action() {
 		binding.Status = source.BackendBindingUnsupportedSignature
 		if function.SupportMessage != "" {
-			binding.Message = fmt.Sprintf("GOWDK action handler %s.%s is unsupported: %s", packageLabel(pkg), binding.FunctionName, function.SupportMessage)
+			binding.Message = fmt.Sprintf("GOWDK action handler %s.%s is unsupported: %s", bindingPackageLabel(binding, pkg), binding.FunctionName, function.SupportMessage)
 		} else {
-			binding.Message = fmt.Sprintf("GOWDK action handler %s.%s must have signature func(context.Context) (response.Response, error), func(context.Context, Input) (response.Response, error), func(context.Context, *Input) (response.Response, error), or func(context.Context, form.Values) (response.Response, error)", packageLabel(pkg), binding.FunctionName)
+			binding.Message = fmt.Sprintf("GOWDK action handler %s.%s must have signature func(context.Context) (response.Response, error), func(context.Context, Input) (response.Response, error), func(context.Context, *Input) (response.Response, error), or func(context.Context, form.Values) (response.Response, error)", bindingPackageLabel(binding, pkg), binding.FunctionName)
 		}
 		return binding
 	}
@@ -200,15 +187,20 @@ func bindStandaloneAPI(endpoint gwdkir.GoEndpoint, pkg featurePackage) source.Ba
 }
 
 func bindAPIEndpoint(binding source.BackendBinding, pkg featurePackage) source.BackendBinding {
+	if pkg.LoadError != "" {
+		binding.Status = source.BackendBindingMissing
+		binding.Message = fmt.Sprintf("GOWDK API handler %s.%s could not be inspected: %s", bindingPackageLabel(binding, pkg), binding.FunctionName, pkg.LoadError)
+		return binding
+	}
 	function, ok := pkg.Functions[binding.FunctionName]
 	if !ok {
 		binding.Status = source.BackendBindingMissing
-		binding.Message = fmt.Sprintf("GOWDK API handler %s.%s is not implemented", packageLabel(pkg), binding.FunctionName)
+		binding.Message = fmt.Sprintf("GOWDK API handler %s.%s is not implemented", bindingPackageLabel(binding, pkg), binding.FunctionName)
 		return binding
 	}
 	if !function.API() {
 		binding.Status = source.BackendBindingUnsupportedSignature
-		binding.Message = fmt.Sprintf("GOWDK API handler %s.%s must have signature func(context.Context, *http.Request) (response.Response, error)", packageLabel(pkg), binding.FunctionName)
+		binding.Message = fmt.Sprintf("GOWDK API handler %s.%s must have signature func(context.Context, *http.Request) (response.Response, error)", bindingPackageLabel(binding, pkg), binding.FunctionName)
 		return binding
 	}
 	binding.Signature = function.Signature
@@ -252,7 +244,7 @@ func bindFragment(page gwdkir.Page, fragment gwdkir.FragmentEndpoint, pkg featur
 	}
 	if !function.Fragment() {
 		binding.Status = source.BackendBindingUnsupportedSignature
-		binding.Message = fmt.Sprintf("GOWDK fragment handler %s.%s must have signature func(context.Context) (response.Response, error)", packageLabel(pkg), binding.FunctionName)
+		binding.Message = fmt.Sprintf("GOWDK fragment handler %s.%s must have signature func(context.Context) (response.Response, error)", bindingPackageLabel(binding, pkg), binding.FunctionName)
 		return binding, true
 	}
 	binding.Signature = source.BackendSignatureFragment
@@ -269,7 +261,7 @@ func baseBackendBinding(page gwdkir.Page, kind, blockName, method, route string,
 		Method:       method,
 		Route:        route,
 		ImportPath:   pkg.ImportPath,
-		PackageName:  pkg.Name,
+		PackageName:  bindingPackageName(pkg.Name, page.Package),
 		FunctionName: blockName,
 		Status:       source.BackendBindingMissing,
 	}
@@ -284,20 +276,10 @@ func baseStandaloneBackendBinding(endpoint gwdkir.GoEndpoint, kind, method strin
 		Method:       method,
 		Route:        endpoint.Route,
 		ImportPath:   pkg.ImportPath,
-		PackageName:  pkg.Name,
+		PackageName:  bindingPackageName(pkg.Name, endpoint.Package),
 		FunctionName: endpoint.Name,
 		Status:       source.BackendBindingMissing,
 	}
-}
-
-func packageLabel(pkg featurePackage) string {
-	if pkg.ImportPath != "" {
-		return pkg.ImportPath
-	}
-	if pkg.Name != "" {
-		return pkg.Name
-	}
-	return "feature"
 }
 
 func sourceDir(sourcePath string) string {
@@ -307,476 +289,8 @@ func sourceDir(sourcePath string) string {
 	return filepath.Dir(sourcePath)
 }
 
-type featurePackage struct {
-	Dir        string
-	ImportPath string
-	Name       string
-	Functions  map[string]featureFunction
-}
-
-type inputStruct struct {
-	Fields  []source.BackendInputField
-	Message string
-}
-
-type featureFunction struct {
-	Name           string
-	Signature      source.BackendSignatureKind
-	InputType      string
-	InputPointer   bool
-	InputFields    []source.BackendInputField
-	SupportMessage string
-}
-
-func (function featureFunction) Action() bool {
-	switch function.Signature {
-	case source.BackendSignatureAction0, source.BackendSignatureActionValues, source.BackendSignatureActionForm, source.BackendSignatureActionFormPtr:
-		return true
-	default:
-		return false
-	}
-}
-
-func (function featureFunction) API() bool {
-	return function.Signature == source.BackendSignatureAPI
-}
-
-func (function featureFunction) Fragment() bool {
-	return function.Signature == source.BackendSignatureAction0 || function.Signature == source.BackendSignatureFragment
-}
-
-func (function featureFunction) Load() bool {
-	return function.Signature == source.BackendSignatureLoad || function.Signature == source.BackendSignatureLoadError
-}
-
-func inspectFeaturePackage(dir string) featurePackage {
-	absDir, err := filepath.Abs(dir)
-	if err != nil {
-		absDir = dir
-	}
-	pkg := featurePackage{Dir: absDir, Functions: map[string]featureFunction{}}
-	info := goListDir(absDir)
-	pkg.ImportPath = info.ImportPath
-	pkg.Name = info.Name
-
-	entries, err := os.ReadDir(absDir)
-	if err != nil {
-		return pkg
-	}
-	fileSet := token.NewFileSet()
-	var files []*ast.File
-	for _, entry := range entries {
-		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".go") || strings.HasSuffix(entry.Name(), "_test.go") {
-			continue
-		}
-		filePath := filepath.Join(absDir, entry.Name())
-		file, err := parser.ParseFile(fileSet, filePath, nil, 0)
-		if err != nil {
-			continue
-		}
-		if pkg.Name == "" {
-			pkg.Name = file.Name.Name
-		}
-		files = append(files, file)
-	}
-
-	inputStructs := collectInputStructs(files)
-	for _, file := range files {
-		imports := astImportAliases(file)
-		for _, declaration := range file.Decls {
-			fn, ok := declaration.(*ast.FuncDecl)
-			if !ok || fn.Recv != nil || fn.Name == nil || !fn.Name.IsExported() {
-				continue
-			}
-			signature, inputType, inputPointer := backendSignature(fn.Type, imports)
-			var inputFields []source.BackendInputField
-			var supportMessage string
-			if signature == source.BackendSignatureActionForm || signature == source.BackendSignatureActionFormPtr {
-				inputStruct, ok := inputStructs[inputType]
-				if !ok {
-					supportMessage = fmt.Sprintf("typed action input %s must be an exported struct in the same package", inputType)
-					signature = ""
-				} else if inputStruct.Message != "" {
-					supportMessage = inputStruct.Message
-					signature = ""
-				} else {
-					inputFields = append([]source.BackendInputField(nil), inputStruct.Fields...)
-				}
-			}
-			pkg.Functions[fn.Name.Name] = featureFunction{
-				Name:           fn.Name.Name,
-				Signature:      signature,
-				InputType:      inputType,
-				InputPointer:   inputPointer,
-				InputFields:    inputFields,
-				SupportMessage: supportMessage,
-			}
-		}
-	}
-	return pkg
-}
-
-func inspectInlineScriptFeaturePackage(page gwdkir.Page, target string) featurePackage {
-	pkg := featurePackage{
-		ImportPath: goblockgen.GeneratedImportPath(page.Package),
-		Name:       goblockgen.SafePackageName(page.Package),
-		Functions:  map[string]featureFunction{},
-	}
-	var files []*ast.File
-	var importMaps []map[string]string
-	for _, block := range page.Blocks.GoBlocks {
-		if strings.TrimSpace(block.Target) != target {
-			continue
-		}
-		file, err := goblockgen.ParseFile(page.Package, block)
-		if err != nil {
-			continue
-		}
-		files = append(files, file)
-		importMaps = append(importMaps, goblockgen.ImportAliases(file, page.Imports))
-	}
-	if len(files) == 0 {
-		return pkg
-	}
-	inputStructs := collectInputStructs(files)
-	for index, file := range files {
-		imports := importMaps[index]
-		for _, declaration := range file.Decls {
-			fn, ok := declaration.(*ast.FuncDecl)
-			if !ok || fn.Recv != nil || fn.Name == nil || !fn.Name.IsExported() {
-				continue
-			}
-			signature, inputType, inputPointer := backendSignature(fn.Type, imports)
-			var inputFields []source.BackendInputField
-			var supportMessage string
-			if signature == source.BackendSignatureActionForm || signature == source.BackendSignatureActionFormPtr {
-				inputStruct, ok := inputStructs[inputType]
-				if !ok {
-					supportMessage = fmt.Sprintf("typed action input %s must be an exported struct in the same package", inputType)
-					signature = ""
-				} else if inputStruct.Message != "" {
-					supportMessage = inputStruct.Message
-					signature = ""
-				} else {
-					inputFields = append([]source.BackendInputField(nil), inputStruct.Fields...)
-				}
-			}
-			pkg.Functions[fn.Name.Name] = featureFunction{
-				Name:           fn.Name.Name,
-				Signature:      signature,
-				InputType:      inputType,
-				InputPointer:   inputPointer,
-				InputFields:    inputFields,
-				SupportMessage: supportMessage,
-			}
-		}
-	}
-	return pkg
-}
-
-func collectInputStructs(files []*ast.File) map[string]inputStruct {
-	structs := map[string]inputStruct{}
-	for _, file := range files {
-		for _, declaration := range file.Decls {
-			gen, ok := declaration.(*ast.GenDecl)
-			if !ok || gen.Tok != token.TYPE {
-				continue
-			}
-			for _, spec := range gen.Specs {
-				typeSpec, ok := spec.(*ast.TypeSpec)
-				if !ok || typeSpec.Name == nil || !typeSpec.Name.IsExported() {
-					continue
-				}
-				structType, ok := typeSpec.Type.(*ast.StructType)
-				if !ok {
-					continue
-				}
-				structs[typeSpec.Name.Name] = backendInputStruct(typeSpec.Name.Name, structType)
-			}
-		}
-	}
-	return structs
-}
-
-func backendInputStruct(typeName string, structType *ast.StructType) inputStruct {
-	if structType == nil || structType.Fields == nil {
-		return inputStruct{}
-	}
-	seen := map[string]bool{}
-	var fields []source.BackendInputField
-	for _, field := range structType.Fields.List {
-		if len(field.Names) == 0 {
-			return inputStruct{Message: fmt.Sprintf("typed action input %s cannot use embedded fields", typeName)}
-		}
-		formName, skip, explicit, err := formTagName(field)
-		if err != nil {
-			return inputStruct{Message: fmt.Sprintf("typed action input %s has invalid form tag: %v", typeName, err)}
-		}
-		var exportedNames []*ast.Ident
-		for _, name := range field.Names {
-			if name != nil && name.IsExported() {
-				exportedNames = append(exportedNames, name)
-			}
-		}
-		if len(exportedNames) == 0 || skip {
-			continue
-		}
-		if explicit && len(exportedNames) > 1 {
-			return inputStruct{Message: fmt.Sprintf("typed action input %s cannot reuse one explicit form tag across multiple fields", typeName)}
-		}
-		fieldType, ok := backendInputFieldType(field.Type)
-		if !ok {
-			return inputStruct{Message: fmt.Sprintf("typed action input %s uses unsupported field type", typeName)}
-		}
-		for _, name := range exportedNames {
-			nameFormName := formName
-			if nameFormName == "" {
-				nameFormName = name.Name
-			}
-			if seen[nameFormName] {
-				return inputStruct{Message: fmt.Sprintf("typed action input %s maps multiple fields to form field %q", typeName, nameFormName)}
-			}
-			seen[nameFormName] = true
-			fields = append(fields, source.BackendInputField{
-				FieldName: name.Name,
-				FormName:  nameFormName,
-				Type:      fieldType,
-			})
-		}
-	}
-	return inputStruct{Fields: fields}
-}
-
-func formTagName(field *ast.Field) (string, bool, bool, error) {
-	if field == nil || field.Tag == nil {
-		return "", false, false, nil
-	}
-	tag, err := strconv.Unquote(field.Tag.Value)
-	if err != nil {
-		return "", false, false, err
-	}
-	value, ok, err := structTagValue(tag, "form")
-	if err != nil || !ok {
-		return "", false, ok, err
-	}
-	name, _, _ := strings.Cut(value, ",")
-	if name == "-" {
-		return "", true, true, nil
-	}
-	return strings.TrimSpace(name), false, true, nil
-}
-
-func structTagValue(tag string, key string) (string, bool, error) {
-	for tag != "" {
-		tag = strings.TrimLeft(tag, " ")
-		if tag == "" {
-			return "", false, nil
-		}
-		keyEnd := strings.IndexByte(tag, ':')
-		if keyEnd <= 0 {
-			return "", false, fmt.Errorf("malformed struct tag")
-		}
-		name := tag[:keyEnd]
-		rest := tag[keyEnd+1:]
-		if rest == "" || rest[0] != '"' {
-			return "", false, fmt.Errorf("malformed struct tag")
-		}
-		valueEnd := 1
-		for valueEnd < len(rest) {
-			if rest[valueEnd] == '\\' {
-				valueEnd += 2
-				continue
-			}
-			if rest[valueEnd] == '"' {
-				break
-			}
-			valueEnd++
-		}
-		if valueEnd >= len(rest) || rest[valueEnd] != '"' {
-			return "", false, fmt.Errorf("malformed struct tag")
-		}
-		rawValue := rest[:valueEnd+1]
-		value, err := strconv.Unquote(rawValue)
-		if err != nil {
-			return "", false, err
-		}
-		if name == key {
-			return value, true, nil
-		}
-		tag = rest[valueEnd+1:]
-	}
-	return "", false, nil
-}
-
-func backendInputFieldType(expression ast.Expr) (string, bool) {
-	if ident, ok := expression.(*ast.Ident); ok {
-		switch ident.Name {
-		case "string", "bool", "int", "int8", "int16", "int32", "int64", "uint", "uint8", "uint16", "uint32", "uint64":
-			return ident.Name, true
-		default:
-			return "", false
-		}
-	}
-	array, ok := expression.(*ast.ArrayType)
-	if !ok || array.Len != nil {
-		return "", false
-	}
-	ident, ok := array.Elt.(*ast.Ident)
-	if !ok || ident.Name != "string" {
-		return "", false
-	}
-	return "[]string", true
-}
-
-type goListDirInfo struct {
-	ImportPath string
-	Name       string
-}
-
-func goListDir(dir string) goListDirInfo {
-	command := exec.Command("go", "list", "-json", ".")
-	command.Dir = dir
-	output, err := command.Output()
-	if err != nil {
-		return goListDirInfo{}
-	}
-	var info goListDirInfo
-	if err := json.Unmarshal(output, &info); err != nil {
-		return goListDirInfo{}
-	}
-	return info
-}
-
-func astImportAliases(file *ast.File) map[string]string {
-	imports := map[string]string{}
-	for _, spec := range file.Imports {
-		importPath := strings.Trim(spec.Path.Value, `"`)
-		if importPath == "" {
-			continue
-		}
-		name := path.Base(importPath)
-		if spec.Name != nil && spec.Name.Name != "" && spec.Name.Name != "." && spec.Name.Name != "_" {
-			name = spec.Name.Name
-		}
-		imports[name] = importPath
-	}
-	return imports
-}
-
-func backendSignature(function *ast.FuncType, imports map[string]string) (source.BackendSignatureKind, string, bool) {
-	if kind, inputType, inputPointer, ok := actionSignature(function, imports); ok {
-		return kind, inputType, inputPointer
-	}
-	if isAPISignature(function, imports) {
-		return source.BackendSignatureAPI, "", false
-	}
-	if signature, ok := loadSignature(function, imports); ok {
-		return signature, "", false
-	}
-	return "", "", false
-}
-
-func actionSignature(function *ast.FuncType, imports map[string]string) (source.BackendSignatureKind, string, bool, bool) {
-	if function == nil || function.Params == nil || function.Results == nil {
-		return "", "", false, false
-	}
-	if len(function.Results.List) != 2 {
-		return "", "", false, false
-	}
-	if !isSelector(function.Results.List[0].Type, imports, responseImportPath, "Response") ||
-		!isError(function.Results.List[1].Type) {
-		return "", "", false, false
-	}
-	if len(function.Params.List) != 1 && len(function.Params.List) != 2 {
-		return "", "", false, false
-	}
-	if !isSelector(function.Params.List[0].Type, imports, contextImportPath, "Context") {
-		return "", "", false, false
-	}
-	if len(function.Params.List) == 1 {
-		return source.BackendSignatureAction0, "", false, true
-	}
-	second := function.Params.List[1].Type
-	if isSelector(second, imports, formImportPath, "Values") {
-		return source.BackendSignatureActionValues, "", false, true
-	}
-	if ident, ok := second.(*ast.Ident); ok && ident.IsExported() {
-		return source.BackendSignatureActionForm, ident.Name, false, true
-	}
-	if pointer, ok := second.(*ast.StarExpr); ok {
-		if ident, ok := pointer.X.(*ast.Ident); ok && ident.IsExported() {
-			return source.BackendSignatureActionFormPtr, ident.Name, true, true
-		}
-	}
-	return "", "", false, false
-}
-
-func isAPISignature(function *ast.FuncType, imports map[string]string) bool {
-	if function == nil || function.Params == nil || function.Results == nil {
-		return false
-	}
-	if len(function.Params.List) != 2 || len(function.Results.List) != 2 {
-		return false
-	}
-	request, ok := function.Params.List[1].Type.(*ast.StarExpr)
-	return ok &&
-		isSelector(function.Params.List[0].Type, imports, contextImportPath, "Context") &&
-		isSelector(request.X, imports, httpImportPath, "Request") &&
-		isSelector(function.Results.List[0].Type, imports, responseImportPath, "Response") &&
-		isError(function.Results.List[1].Type)
-}
-
-func loadSignature(function *ast.FuncType, imports map[string]string) (source.BackendSignatureKind, bool) {
-	if function == nil || function.Params == nil || function.Results == nil {
-		return "", false
-	}
-	if len(function.Params.List) != 1 || !isSelector(function.Params.List[0].Type, imports, ssrImportPath, "LoadContext") {
-		return "", false
-	}
-	if len(function.Results.List) == 1 && isMapStringAny(function.Results.List[0].Type) {
-		return source.BackendSignatureLoad, true
-	}
-	if len(function.Results.List) == 2 && isMapStringAny(function.Results.List[0].Type) && isError(function.Results.List[1].Type) {
-		return source.BackendSignatureLoadError, true
-	}
-	return "", false
-}
-
-func isMapStringAny(expression ast.Expr) bool {
-	mapType, ok := expression.(*ast.MapType)
-	if !ok {
-		return false
-	}
-	key, ok := mapType.Key.(*ast.Ident)
-	if !ok || key.Name != "string" {
-		return false
-	}
-	if value, ok := mapType.Value.(*ast.Ident); ok && value.Name == "any" {
-		return true
-	}
-	_, ok = mapType.Value.(*ast.InterfaceType)
-	return ok
-}
-
 func loadFunctionName(pageID string) string {
 	return "Load" + source.ExportedIdentifier(pageID, "Page")
-}
-
-func isSelector(expression ast.Expr, imports map[string]string, importPath, name string) bool {
-	selector, ok := expression.(*ast.SelectorExpr)
-	if !ok || selector.Sel == nil || selector.Sel.Name != name {
-		return false
-	}
-	ident, ok := selector.X.(*ast.Ident)
-	if !ok {
-		return false
-	}
-	return imports[ident.Name] == importPath
-}
-
-func isError(expression ast.Expr) bool {
-	ident, ok := expression.(*ast.Ident)
-	return ok && ident.Name == "error"
 }
 
 // BackendBindingsFromIR derives the backend binding records already attached to

--- a/internal/compiler/backend_bindings_test.go
+++ b/internal/compiler/backend_bindings_test.go
@@ -1,6 +1,7 @@
 package compiler
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -14,7 +15,7 @@ import (
 
 func TestBindBackendHandlersClassifiesSupportedActionSignatures(t *testing.T) {
 	root := t.TempDir()
-	writeCompilerTestFile(t, filepath.Join(root, "go.mod"), "module example.com/app\n\ngo 1.26.4\n")
+	writeCompilerTestModule(t, root)
 	writeCompilerTestFile(t, filepath.Join(root, "auth.go"), `package auth
 
 import (
@@ -131,9 +132,124 @@ func BrokenFragment(context.Context, *http.Request) (response.Response, error) {
 	}
 }
 
+func TestBindBackendHandlersUsesTypedGoPackageResolution(t *testing.T) {
+	root := t.TempDir()
+	writeCompilerTestModule(t, root)
+	writeCompilerTestFile(t, filepath.Join(root, "auth.go"), `package auth
+
+import (
+	ctx "context"
+	nethttp "net/http"
+
+	resp "github.com/cssbruno/gowdk/runtime/response"
+)
+
+type ActionResult = resp.Response
+
+type AliasInput struct {
+	Email string `+"`form:\"email\"`"+`
+}
+
+func Login(ctx.Context, AliasInput) (ActionResult, error) {
+	return resp.Response{}, nil
+}
+
+func Session(ctx.Context, *nethttp.Request) (ActionResult, error) {
+	return resp.Response{}, nil
+}
+
+func hidden(ctx.Context) (ActionResult, error) {
+	return resp.Response{}, nil
+}
+`)
+
+	app := bindBackendHandlers(appFixture{Pages: []gwdkir.Page{{
+		ID:     "login",
+		Source: filepath.Join(root, "login.page.gwdk"),
+		Route:  "/login",
+		Blocks: gwdkir.Blocks{
+			Actions: []gwdkir.Action{
+				{Name: "Login"},
+				{Name: "hidden"},
+			},
+			APIs: []gwdkir.API{{
+				Name:   "Session",
+				Method: "GET",
+				Route:  "/api/session",
+			}},
+		},
+	}}})
+
+	bindings := compilerBindingsByBlock(app.BackendBindings)
+	assertBinding(t, bindings["Login"], source.BackendBindingBound, source.BackendSignatureActionForm, "AliasInput", false)
+	assertInputFields(t, bindings["Login"].InputFields, "Email:email:string")
+	assertBinding(t, bindings["Session"], source.BackendBindingBound, source.BackendSignatureAPI, "", false)
+	if got := bindings["hidden"]; got.Status != source.BackendBindingMissing {
+		t.Fatalf("expected unexported handler to remain missing, got %#v", got)
+	}
+}
+
+func TestBindBackendHandlersHonorsBuildTags(t *testing.T) {
+	root := t.TempDir()
+	writeCompilerTestModule(t, root)
+	writeCompilerTestFile(t, filepath.Join(root, "base.go"), `package auth
+`)
+	writeCompilerTestFile(t, filepath.Join(root, "tagged.go"), `//go:build gowdkextra
+
+package auth
+
+import (
+	"context"
+
+	"github.com/cssbruno/gowdk/runtime/response"
+)
+
+func Tagged(context.Context) (response.Response, error) {
+	return response.Response{}, nil
+}
+`)
+
+	app := bindBackendHandlers(appFixture{Pages: []gwdkir.Page{{
+		ID:     "tagged",
+		Source: filepath.Join(root, "tagged.page.gwdk"),
+		Route:  "/tagged",
+		Blocks: gwdkir.Blocks{
+			Actions: []gwdkir.Action{{Name: "Tagged"}},
+		},
+	}}})
+
+	bindings := compilerBindingsByBlock(app.BackendBindings)
+	if got := bindings["Tagged"]; got.Status != source.BackendBindingMissing {
+		t.Fatalf("expected build-tagged handler to be missing without active tag, got %#v", got)
+	}
+}
+
+func TestBindBackendHandlersReportsPackageLoadErrors(t *testing.T) {
+	root := t.TempDir()
+	writeCompilerTestModule(t, root)
+	writeCompilerTestFile(t, filepath.Join(root, "broken.go"), `package broken
+
+func Broken(
+`)
+
+	app := bindBackendHandlers(appFixture{Pages: []gwdkir.Page{{
+		ID:     "broken",
+		Source: filepath.Join(root, "broken.page.gwdk"),
+		Route:  "/broken",
+		Blocks: gwdkir.Blocks{
+			Actions: []gwdkir.Action{{Name: "Broken"}},
+		},
+	}}})
+
+	bindings := compilerBindingsByBlock(app.BackendBindings)
+	if got := bindings["Broken"]; got.Status != source.BackendBindingMissing || !strings.Contains(got.Message, "could not be inspected") {
+		t.Fatalf("expected package load error metadata, got %#v", got)
+	}
+}
+
 func TestBindBackendHandlersClassifiesSSRLoadSignatures(t *testing.T) {
 	root := t.TempDir()
-	writeCompilerTestFile(t, filepath.Join(root, "go.mod"), "module example.com/app\n\ngo 1.26.4\n")
+	writeCompilerTestModule(t, root)
 	writeCompilerTestFile(t, filepath.Join(root, "dashboard.go"), `package dashboard
 
 import "github.com/cssbruno/gowdk/addons/ssr"
@@ -302,7 +418,7 @@ func List(context.Context) (response.Response, error) {
 
 func TestDiscoverGoEndpointCommentsBindsStandaloneEndpoints(t *testing.T) {
 	root := t.TempDir()
-	writeCompilerTestFile(t, filepath.Join(root, "go.mod"), "module example.com/app\n\ngo 1.26.4\n")
+	writeCompilerTestModule(t, root)
 	writeCompilerTestFile(t, filepath.Join(root, "handlers.go"), `package api
 
 import (
@@ -462,6 +578,23 @@ func compilerBindingsByBlock(bindings []source.BackendBinding) map[string]source
 		out[binding.BlockName] = binding
 	}
 	return out
+}
+
+func writeCompilerTestModule(t *testing.T, root string) {
+	t.Helper()
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	repoRoot := filepath.Clean(filepath.Join(wd, "..", ".."))
+	writeCompilerTestFile(t, filepath.Join(root, "go.mod"), fmt.Sprintf(`module example.com/app
+
+go 1.26.4
+
+require github.com/cssbruno/gowdk v0.0.0
+
+replace github.com/cssbruno/gowdk => %s
+`, filepath.ToSlash(repoRoot)))
 }
 
 func writeCompilerTestFile(t *testing.T, path string, content string) {

--- a/internal/compiler/backend_inline_signatures.go
+++ b/internal/compiler/backend_inline_signatures.go
@@ -1,0 +1,181 @@
+package compiler
+
+import (
+	"fmt"
+	"go/ast"
+	"strings"
+
+	"github.com/cssbruno/gowdk/internal/goblockgen"
+	"github.com/cssbruno/gowdk/internal/gwdkir"
+	"github.com/cssbruno/gowdk/internal/source"
+)
+
+func inspectInlineScriptFeaturePackage(page gwdkir.Page, target string) featurePackage {
+	pkg := featurePackage{
+		ImportPath: goblockgen.GeneratedImportPath(page.Package),
+		Name:       goblockgen.SafePackageName(page.Package),
+		Functions:  map[string]featureFunction{},
+	}
+	var files []*ast.File
+	var importMaps []map[string]string
+	for _, block := range page.Blocks.GoBlocks {
+		if strings.TrimSpace(block.Target) != target {
+			continue
+		}
+		file, err := goblockgen.ParseFile(page.Package, block)
+		if err != nil {
+			continue
+		}
+		files = append(files, file)
+		importMaps = append(importMaps, goblockgen.ImportAliases(file, page.Imports))
+	}
+	if len(files) == 0 {
+		return pkg
+	}
+	inputStructs := collectInputStructs(files)
+	for index, file := range files {
+		imports := importMaps[index]
+		for _, declaration := range file.Decls {
+			fn, ok := declaration.(*ast.FuncDecl)
+			if !ok || fn.Recv != nil || fn.Name == nil || !fn.Name.IsExported() {
+				continue
+			}
+			signature, inputType, inputPointer := backendSignature(fn.Type, imports)
+			var inputFields []source.BackendInputField
+			var supportMessage string
+			if signature == source.BackendSignatureActionForm || signature == source.BackendSignatureActionFormPtr {
+				inputStruct, ok := inputStructs[inputType]
+				if !ok {
+					supportMessage = fmt.Sprintf("typed action input %s must be an exported struct in the same package", inputType)
+					signature = ""
+				} else if inputStruct.Message != "" {
+					supportMessage = inputStruct.Message
+					signature = ""
+				} else {
+					inputFields = append([]source.BackendInputField(nil), inputStruct.Fields...)
+				}
+			}
+			pkg.Functions[fn.Name.Name] = featureFunction{
+				Name:           fn.Name.Name,
+				Signature:      signature,
+				InputType:      inputType,
+				InputPointer:   inputPointer,
+				InputFields:    inputFields,
+				SupportMessage: supportMessage,
+			}
+		}
+	}
+	return pkg
+}
+
+func backendSignature(function *ast.FuncType, imports map[string]string) (source.BackendSignatureKind, string, bool) {
+	if kind, inputType, inputPointer, ok := actionSignature(function, imports); ok {
+		return kind, inputType, inputPointer
+	}
+	if isAPISignature(function, imports) {
+		return source.BackendSignatureAPI, "", false
+	}
+	if signature, ok := loadSignature(function, imports); ok {
+		return signature, "", false
+	}
+	return "", "", false
+}
+
+func actionSignature(function *ast.FuncType, imports map[string]string) (source.BackendSignatureKind, string, bool, bool) {
+	if function == nil || function.Params == nil || function.Results == nil {
+		return "", "", false, false
+	}
+	if len(function.Results.List) != 2 {
+		return "", "", false, false
+	}
+	if !isSelector(function.Results.List[0].Type, imports, responseImportPath, "Response") ||
+		!isError(function.Results.List[1].Type) {
+		return "", "", false, false
+	}
+	if len(function.Params.List) != 1 && len(function.Params.List) != 2 {
+		return "", "", false, false
+	}
+	if !isSelector(function.Params.List[0].Type, imports, contextImportPath, "Context") {
+		return "", "", false, false
+	}
+	if len(function.Params.List) == 1 {
+		return source.BackendSignatureAction0, "", false, true
+	}
+	second := function.Params.List[1].Type
+	if isSelector(second, imports, formImportPath, "Values") {
+		return source.BackendSignatureActionValues, "", false, true
+	}
+	if ident, ok := second.(*ast.Ident); ok && ident.IsExported() {
+		return source.BackendSignatureActionForm, ident.Name, false, true
+	}
+	if pointer, ok := second.(*ast.StarExpr); ok {
+		if ident, ok := pointer.X.(*ast.Ident); ok && ident.IsExported() {
+			return source.BackendSignatureActionFormPtr, ident.Name, true, true
+		}
+	}
+	return "", "", false, false
+}
+
+func isAPISignature(function *ast.FuncType, imports map[string]string) bool {
+	if function == nil || function.Params == nil || function.Results == nil {
+		return false
+	}
+	if len(function.Params.List) != 2 || len(function.Results.List) != 2 {
+		return false
+	}
+	request, ok := function.Params.List[1].Type.(*ast.StarExpr)
+	return ok &&
+		isSelector(function.Params.List[0].Type, imports, contextImportPath, "Context") &&
+		isSelector(request.X, imports, httpImportPath, "Request") &&
+		isSelector(function.Results.List[0].Type, imports, responseImportPath, "Response") &&
+		isError(function.Results.List[1].Type)
+}
+
+func loadSignature(function *ast.FuncType, imports map[string]string) (source.BackendSignatureKind, bool) {
+	if function == nil || function.Params == nil || function.Results == nil {
+		return "", false
+	}
+	if len(function.Params.List) != 1 || !isSelector(function.Params.List[0].Type, imports, ssrImportPath, "LoadContext") {
+		return "", false
+	}
+	if len(function.Results.List) == 1 && isMapStringAny(function.Results.List[0].Type) {
+		return source.BackendSignatureLoad, true
+	}
+	if len(function.Results.List) == 2 && isMapStringAny(function.Results.List[0].Type) && isError(function.Results.List[1].Type) {
+		return source.BackendSignatureLoadError, true
+	}
+	return "", false
+}
+
+func isMapStringAny(expression ast.Expr) bool {
+	mapType, ok := expression.(*ast.MapType)
+	if !ok {
+		return false
+	}
+	key, ok := mapType.Key.(*ast.Ident)
+	if !ok || key.Name != "string" {
+		return false
+	}
+	if value, ok := mapType.Value.(*ast.Ident); ok && value.Name == "any" {
+		return true
+	}
+	_, ok = mapType.Value.(*ast.InterfaceType)
+	return ok
+}
+
+func isSelector(expression ast.Expr, imports map[string]string, importPath, name string) bool {
+	selector, ok := expression.(*ast.SelectorExpr)
+	if !ok || selector.Sel == nil || selector.Sel.Name != name {
+		return false
+	}
+	ident, ok := selector.X.(*ast.Ident)
+	if !ok {
+		return false
+	}
+	return imports[ident.Name] == importPath
+}
+
+func isError(expression ast.Expr) bool {
+	ident, ok := expression.(*ast.Ident)
+	return ok && ident.Name == "error"
+}

--- a/internal/compiler/backend_input_fields.go
+++ b/internal/compiler/backend_input_fields.go
@@ -1,0 +1,230 @@
+package compiler
+
+import (
+	"fmt"
+	"go/ast"
+	"go/token"
+	"go/types"
+	"strconv"
+	"strings"
+
+	"github.com/cssbruno/gowdk/internal/source"
+)
+
+func collectInputStructs(files []*ast.File) map[string]inputStruct {
+	structs := map[string]inputStruct{}
+	for _, file := range files {
+		for _, declaration := range file.Decls {
+			gen, ok := declaration.(*ast.GenDecl)
+			if !ok || gen.Tok != token.TYPE {
+				continue
+			}
+			for _, spec := range gen.Specs {
+				typeSpec, ok := spec.(*ast.TypeSpec)
+				if !ok || typeSpec.Name == nil || !typeSpec.Name.IsExported() {
+					continue
+				}
+				structType, ok := typeSpec.Type.(*ast.StructType)
+				if !ok {
+					continue
+				}
+				structs[typeSpec.Name.Name] = backendInputStruct(typeSpec.Name.Name, structType)
+			}
+		}
+	}
+	return structs
+}
+
+func backendInputStruct(typeName string, structType *ast.StructType) inputStruct {
+	if structType == nil || structType.Fields == nil {
+		return inputStruct{}
+	}
+	seen := map[string]bool{}
+	var fields []source.BackendInputField
+	for _, field := range structType.Fields.List {
+		if len(field.Names) == 0 {
+			return inputStruct{Message: fmt.Sprintf("typed action input %s cannot use embedded fields", typeName)}
+		}
+		formName, skip, explicit, err := formTagName(field)
+		if err != nil {
+			return inputStruct{Message: fmt.Sprintf("typed action input %s has invalid form tag: %v", typeName, err)}
+		}
+		var exportedNames []*ast.Ident
+		for _, name := range field.Names {
+			if name != nil && name.IsExported() {
+				exportedNames = append(exportedNames, name)
+			}
+		}
+		if len(exportedNames) == 0 || skip {
+			continue
+		}
+		if explicit && len(exportedNames) > 1 {
+			return inputStruct{Message: fmt.Sprintf("typed action input %s cannot reuse one explicit form tag across multiple fields", typeName)}
+		}
+		fieldType, ok := backendInputFieldType(field.Type)
+		if !ok {
+			return inputStruct{Message: fmt.Sprintf("typed action input %s uses unsupported field type", typeName)}
+		}
+		for _, name := range exportedNames {
+			nameFormName := formName
+			if nameFormName == "" {
+				nameFormName = name.Name
+			}
+			if seen[nameFormName] {
+				return inputStruct{Message: fmt.Sprintf("typed action input %s maps multiple fields to form field %q", typeName, nameFormName)}
+			}
+			seen[nameFormName] = true
+			fields = append(fields, source.BackendInputField{
+				FieldName: name.Name,
+				FormName:  nameFormName,
+				Type:      fieldType,
+			})
+		}
+	}
+	return inputStruct{Fields: fields}
+}
+
+func backendTypedInputStruct(typeName string, typ types.Type) inputStruct {
+	structType, ok := types.Unalias(typ).Underlying().(*types.Struct)
+	if !ok {
+		return inputStruct{Message: fmt.Sprintf("typed action input %s must be an exported struct in the same package", typeName)}
+	}
+	seen := map[string]bool{}
+	var fields []source.BackendInputField
+	for index := 0; index < structType.NumFields(); index++ {
+		field := structType.Field(index)
+		if field.Embedded() {
+			return inputStruct{Message: fmt.Sprintf("typed action input %s cannot use embedded fields", typeName)}
+		}
+		formName, skip, _, err := formTagNameValue(structType.Tag(index))
+		if err != nil {
+			return inputStruct{Message: fmt.Sprintf("typed action input %s has invalid form tag: %v", typeName, err)}
+		}
+		if !field.Exported() || skip {
+			continue
+		}
+		fieldType, ok := backendTypedInputFieldType(field.Type())
+		if !ok {
+			return inputStruct{Message: fmt.Sprintf("typed action input %s uses unsupported field type", typeName)}
+		}
+		if formName == "" {
+			formName = field.Name()
+		}
+		if seen[formName] {
+			return inputStruct{Message: fmt.Sprintf("typed action input %s maps multiple fields to form field %q", typeName, formName)}
+		}
+		seen[formName] = true
+		fields = append(fields, source.BackendInputField{
+			FieldName: field.Name(),
+			FormName:  formName,
+			Type:      fieldType,
+		})
+	}
+	return inputStruct{Fields: fields}
+}
+
+func formTagName(field *ast.Field) (string, bool, bool, error) {
+	if field == nil || field.Tag == nil {
+		return "", false, false, nil
+	}
+	tag, err := strconv.Unquote(field.Tag.Value)
+	if err != nil {
+		return "", false, false, err
+	}
+	return formTagNameValue(tag)
+}
+
+func formTagNameValue(tag string) (string, bool, bool, error) {
+	value, ok, err := structTagValue(tag, "form")
+	if err != nil || !ok {
+		return "", false, ok, err
+	}
+	name, _, _ := strings.Cut(value, ",")
+	if name == "-" {
+		return "", true, true, nil
+	}
+	return strings.TrimSpace(name), false, true, nil
+}
+
+func structTagValue(tag string, key string) (string, bool, error) {
+	for tag != "" {
+		tag = strings.TrimLeft(tag, " ")
+		if tag == "" {
+			return "", false, nil
+		}
+		keyEnd := strings.IndexByte(tag, ':')
+		if keyEnd <= 0 {
+			return "", false, fmt.Errorf("malformed struct tag")
+		}
+		name := tag[:keyEnd]
+		rest := tag[keyEnd+1:]
+		if rest == "" || rest[0] != '"' {
+			return "", false, fmt.Errorf("malformed struct tag")
+		}
+		valueEnd := 1
+		for valueEnd < len(rest) {
+			if rest[valueEnd] == '\\' {
+				valueEnd += 2
+				continue
+			}
+			if rest[valueEnd] == '"' {
+				break
+			}
+			valueEnd++
+		}
+		if valueEnd >= len(rest) || rest[valueEnd] != '"' {
+			return "", false, fmt.Errorf("malformed struct tag")
+		}
+		rawValue := rest[:valueEnd+1]
+		value, err := strconv.Unquote(rawValue)
+		if err != nil {
+			return "", false, err
+		}
+		if name == key {
+			return value, true, nil
+		}
+		tag = rest[valueEnd+1:]
+	}
+	return "", false, nil
+}
+
+func backendInputFieldType(expression ast.Expr) (string, bool) {
+	if ident, ok := expression.(*ast.Ident); ok {
+		switch ident.Name {
+		case "string", "bool", "int", "int8", "int16", "int32", "int64", "uint", "uint8", "uint16", "uint32", "uint64":
+			return ident.Name, true
+		default:
+			return "", false
+		}
+	}
+	array, ok := expression.(*ast.ArrayType)
+	if !ok || array.Len != nil {
+		return "", false
+	}
+	ident, ok := array.Elt.(*ast.Ident)
+	if !ok || ident.Name != "string" {
+		return "", false
+	}
+	return "[]string", true
+}
+
+func backendTypedInputFieldType(typ types.Type) (string, bool) {
+	typ = types.Unalias(typ)
+	if basic, ok := typ.Underlying().(*types.Basic); ok {
+		switch basic.Kind() {
+		case types.String, types.Bool, types.Int, types.Int8, types.Int16, types.Int32, types.Int64, types.Uint, types.Uint8, types.Uint16, types.Uint32, types.Uint64:
+			return basic.Name(), true
+		default:
+			return "", false
+		}
+	}
+	slice, ok := typ.Underlying().(*types.Slice)
+	if !ok {
+		return "", false
+	}
+	basic, ok := types.Unalias(slice.Elem()).Underlying().(*types.Basic)
+	if !ok || basic.Kind() != types.String {
+		return "", false
+	}
+	return "[]string", true
+}

--- a/internal/compiler/backend_package_inspection.go
+++ b/internal/compiler/backend_package_inspection.go
@@ -1,0 +1,139 @@
+package compiler
+
+import (
+	"fmt"
+	"go/ast"
+	"go/types"
+	"path/filepath"
+	"strings"
+
+	"golang.org/x/tools/go/packages"
+)
+
+func inspectFeaturePackage(dir string) featurePackage {
+	absDir, err := filepath.Abs(dir)
+	if err != nil {
+		absDir = dir
+	}
+	pkg := featurePackage{Dir: absDir, Functions: map[string]featureFunction{}}
+	loaded, err := loadFeaturePackage(absDir)
+	if err != nil {
+		pkg.LoadError = err.Error()
+		return pkg
+	}
+	pkg.ImportPath = normalizedPackageImportPath(loaded.PkgPath)
+	if len(loaded.CompiledGoFiles) > 0 || len(loaded.Syntax) > 0 {
+		pkg.Name = loaded.Name
+	}
+	pkg.Functions = typedFeatureFunctions(loaded)
+	return pkg
+}
+
+func loadFeaturePackage(absDir string) (*packages.Package, error) {
+	config := &packages.Config{
+		Dir: absDir,
+		Mode: packages.NeedName |
+			packages.NeedFiles |
+			packages.NeedCompiledGoFiles |
+			packages.NeedSyntax |
+			packages.NeedTypes |
+			packages.NeedTypesInfo,
+		Tests: false,
+	}
+	loaded, err := packages.Load(config, ".")
+	if err != nil {
+		return nil, err
+	}
+	if len(loaded) == 0 {
+		return &packages.Package{}, nil
+	}
+	pkg := loaded[0]
+	if len(pkg.Errors) > 0 {
+		if packageHasNoGoFiles(pkg.Errors) {
+			return pkg, nil
+		}
+		return pkg, fmt.Errorf("%s", pkg.Errors[0].Msg)
+	}
+	if pkg.Types == nil {
+		return pkg, fmt.Errorf("package %s did not provide type information", packageLabel(featurePackage{ImportPath: pkg.PkgPath, Name: pkg.Name}))
+	}
+	return pkg, nil
+}
+
+func normalizedPackageImportPath(importPath string) string {
+	if importPath == "." {
+		return ""
+	}
+	return importPath
+}
+
+func packageHasNoGoFiles(errors []packages.Error) bool {
+	if len(errors) == 0 {
+		return false
+	}
+	for _, err := range errors {
+		message := err.Msg
+		if !strings.Contains(message, "no Go files") &&
+			!strings.Contains(message, "build constraints exclude all Go files") {
+			return false
+		}
+	}
+	return true
+}
+
+func typedFeatureFunctions(pkg *packages.Package) map[string]featureFunction {
+	functions := map[string]featureFunction{}
+	if pkg == nil || pkg.Types == nil {
+		return functions
+	}
+	if pkg.TypesInfo != nil {
+		for _, file := range pkg.Syntax {
+			for _, declaration := range file.Decls {
+				fn, ok := declaration.(*ast.FuncDecl)
+				if !ok || fn.Recv != nil || fn.Name == nil || !fn.Name.IsExported() {
+					continue
+				}
+				obj, ok := pkg.TypesInfo.Defs[fn.Name].(*types.Func)
+				if !ok || obj == nil {
+					continue
+				}
+				if function, ok := typedFeatureFunction(obj, pkg.Types); ok {
+					functions[function.Name] = function
+				}
+			}
+		}
+	}
+	if len(functions) > 0 {
+		return functions
+	}
+	scope := pkg.Types.Scope()
+	if scope == nil {
+		return functions
+	}
+	for _, name := range scope.Names() {
+		obj, ok := scope.Lookup(name).(*types.Func)
+		if !ok || obj == nil || !obj.Exported() {
+			continue
+		}
+		if function, ok := typedFeatureFunction(obj, pkg.Types); ok {
+			functions[function.Name] = function
+		}
+	}
+	return functions
+}
+
+func typedFeatureFunction(obj *types.Func, pkg *types.Package) (featureFunction, bool) {
+	signature, ok := obj.Type().(*types.Signature)
+	if !ok {
+		return featureFunction{}, false
+	}
+	kind, inputType, inputPointer, inputFields, supportMessage := backendTypedSignature(signature, pkg)
+	return featureFunction{
+		Name:           obj.Name(),
+		Signature:      kind,
+		InputType:      inputType,
+		InputPointer:   inputPointer,
+		InputFields:    inputFields,
+		SupportMessage: supportMessage,
+	}, true
+}

--- a/internal/compiler/backend_typed_signatures.go
+++ b/internal/compiler/backend_typed_signatures.go
@@ -1,0 +1,150 @@
+package compiler
+
+import (
+	"go/types"
+
+	"github.com/cssbruno/gowdk/internal/source"
+)
+
+func backendTypedSignature(function *types.Signature, pkg *types.Package) (source.BackendSignatureKind, string, bool, []source.BackendInputField, string) {
+	if kind, inputType, inputPointer, inputFields, supportMessage, ok := typedActionSignature(function, pkg); ok {
+		return kind, inputType, inputPointer, inputFields, supportMessage
+	}
+	if isTypedAPISignature(function) {
+		return source.BackendSignatureAPI, "", false, nil, ""
+	}
+	if signature, ok := typedLoadSignature(function); ok {
+		return signature, "", false, nil, ""
+	}
+	return "", "", false, nil, ""
+}
+
+func typedActionSignature(function *types.Signature, pkg *types.Package) (source.BackendSignatureKind, string, bool, []source.BackendInputField, string, bool) {
+	if function == nil || function.Params() == nil || function.Results() == nil {
+		return "", "", false, nil, "", false
+	}
+	params := function.Params()
+	results := function.Results()
+	if results.Len() != 2 {
+		return "", "", false, nil, "", false
+	}
+	if !isTypedNamed(results.At(0).Type(), responseImportPath, "Response") || !isTypedError(results.At(1).Type()) {
+		return "", "", false, nil, "", false
+	}
+	if params.Len() != 1 && params.Len() != 2 {
+		return "", "", false, nil, "", false
+	}
+	if !isTypedNamed(params.At(0).Type(), contextImportPath, "Context") {
+		return "", "", false, nil, "", false
+	}
+	if params.Len() == 1 {
+		return source.BackendSignatureAction0, "", false, nil, "", true
+	}
+	second := params.At(1).Type()
+	if isTypedNamed(second, formImportPath, "Values") {
+		return source.BackendSignatureActionValues, "", false, nil, "", true
+	}
+	inputName, inputPointer, inputType, ok := typedLocalInputType(second, pkg)
+	if !ok {
+		return "", "", false, nil, "", false
+	}
+	inputStruct := backendTypedInputStruct(inputName, inputType)
+	if inputStruct.Message != "" {
+		return "", inputName, inputPointer, nil, inputStruct.Message, true
+	}
+	kind := source.BackendSignatureActionForm
+	if inputPointer {
+		kind = source.BackendSignatureActionFormPtr
+	}
+	return kind, inputName, inputPointer, append([]source.BackendInputField(nil), inputStruct.Fields...), "", true
+}
+
+func isTypedAPISignature(function *types.Signature) bool {
+	if function == nil || function.Params() == nil || function.Results() == nil {
+		return false
+	}
+	params := function.Params()
+	results := function.Results()
+	if params.Len() != 2 || results.Len() != 2 {
+		return false
+	}
+	return isTypedNamed(params.At(0).Type(), contextImportPath, "Context") &&
+		isTypedPointerToNamed(params.At(1).Type(), httpImportPath, "Request") &&
+		isTypedNamed(results.At(0).Type(), responseImportPath, "Response") &&
+		isTypedError(results.At(1).Type())
+}
+
+func typedLoadSignature(function *types.Signature) (source.BackendSignatureKind, bool) {
+	if function == nil || function.Params() == nil || function.Results() == nil {
+		return "", false
+	}
+	params := function.Params()
+	results := function.Results()
+	if params.Len() != 1 || !isTypedLoadContext(params.At(0).Type()) {
+		return "", false
+	}
+	if results.Len() == 1 && isTypedMapStringAny(results.At(0).Type()) {
+		return source.BackendSignatureLoad, true
+	}
+	if results.Len() == 2 && isTypedMapStringAny(results.At(0).Type()) && isTypedError(results.At(1).Type()) {
+		return source.BackendSignatureLoadError, true
+	}
+	return "", false
+}
+
+func typedLocalInputType(typ types.Type, pkg *types.Package) (string, bool, types.Type, bool) {
+	inputPointer := false
+	typ = types.Unalias(typ)
+	if pointer, ok := typ.(*types.Pointer); ok {
+		inputPointer = true
+		typ = types.Unalias(pointer.Elem())
+	}
+	named, ok := typ.(*types.Named)
+	if !ok || named.Obj() == nil || !named.Obj().Exported() {
+		return "", false, nil, false
+	}
+	if pkg == nil || named.Obj().Pkg() == nil || named.Obj().Pkg().Path() != pkg.Path() {
+		return "", false, nil, false
+	}
+	if _, ok := named.Underlying().(*types.Struct); !ok {
+		return "", false, nil, true
+	}
+	return named.Obj().Name(), inputPointer, named, true
+}
+
+func isTypedNamed(typ types.Type, importPath, name string) bool {
+	named, ok := types.Unalias(typ).(*types.Named)
+	if !ok || named.Obj() == nil || named.Obj().Name() != name {
+		return false
+	}
+	pkg := named.Obj().Pkg()
+	return pkg != nil && pkg.Path() == importPath
+}
+
+func isTypedPointerToNamed(typ types.Type, importPath, name string) bool {
+	pointer, ok := types.Unalias(typ).(*types.Pointer)
+	return ok && isTypedNamed(pointer.Elem(), importPath, name)
+}
+
+func isTypedLoadContext(typ types.Type) bool {
+	return isTypedNamed(typ, ssrImportPath, "LoadContext") ||
+		isTypedNamed(typ, guardImportPath, "Context")
+}
+
+func isTypedError(typ types.Type) bool {
+	errorObj := types.Universe.Lookup("error")
+	return errorObj != nil && types.Identical(types.Unalias(typ), errorObj.Type())
+}
+
+func isTypedMapStringAny(typ types.Type) bool {
+	mapType, ok := types.Unalias(typ).Underlying().(*types.Map)
+	if !ok {
+		return false
+	}
+	key, ok := types.Unalias(mapType.Key()).Underlying().(*types.Basic)
+	if !ok || key.Kind() != types.String {
+		return false
+	}
+	value, ok := types.Unalias(mapType.Elem()).Underlying().(*types.Interface)
+	return ok && value.Empty()
+}

--- a/internal/lang/testdata/manifest_golden/manifest.golden.json
+++ b/internal/lang/testdata/manifest_golden/manifest.golden.json
@@ -61,9 +61,10 @@
       "blockName": "Submit",
       "method": "POST",
       "route": "/",
+      "packageName": "home",
       "functionName": "Submit",
       "status": "missing",
-      "message": "GOWDK action handler feature.Submit is not implemented"
+      "message": "GOWDK action handler home.Submit is not implemented"
     }
   ]
 }

--- a/runtime/contracts/natsbroker/go.mod
+++ b/runtime/contracts/natsbroker/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/nats-io/nkeys v0.4.15 // indirect
 	github.com/nats-io/nuid v1.0.1 // indirect
 	golang.org/x/crypto v0.49.0 // indirect
-	golang.org/x/sys v0.43.0 // indirect
+	golang.org/x/sys v0.44.0 // indirect
 )
 
 replace github.com/cssbruno/gowdk => ../../..

--- a/runtime/contracts/natsbroker/go.sum
+++ b/runtime/contracts/natsbroker/go.sum
@@ -8,5 +8,5 @@ github.com/nats-io/nuid v1.0.1 h1:5iA8DT8V7q8WK2EScv2padNa/rTESc1KdnPw4TC2paw=
 github.com/nats-io/nuid v1.0.1/go.mod h1:19wcPz3Ph3q0Jbyiqsd0kePYG7A95tJPxeL+1OSON2c=
 golang.org/x/crypto v0.49.0 h1:+Ng2ULVvLHnJ/ZFEq4KdcDd/cfjrrjjNSXNzxg0Y4U4=
 golang.org/x/crypto v0.49.0/go.mod h1:ErX4dUh2UM+CFYiXZRTcMpEcN8b/1gxEuv3nODoYtCA=
-golang.org/x/sys v0.43.0 h1:Rlag2XtaFTxp19wS8MXlJwTvoh8ArU6ezoyFsMyCTNI=
-golang.org/x/sys v0.43.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+golang.org/x/sys v0.44.0 h1:ildZl3J4uzeKP07r2F++Op7E9B29JRUy+a27EibtBTQ=
+golang.org/x/sys v0.44.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=


### PR DESCRIPTION
## Summary

- Replace same-package endpoint binding inspection with a `go/packages` + `go/types` path for real Go packages.
- Keep inline `go {}` binding on the existing synthetic AST path and split binding internals into focused files.
- Add tests for renamed imports/type aliases, build-tag exclusion, non-exported handlers, package load errors, and typed action inputs.
- Document the endpoint binding inspection model and the `golang.org/x/tools/go/packages` compiler dependency.

Closes #257.

## Validation

```sh
go test ./internal/compiler
go test ./internal/compiler ./internal/appgen
go test ./...
scripts/test-go-modules.sh
go build ./cmd/gowdk
```

Note: `scripts/test-go-modules.sh` required tidying `runtime/contracts/natsbroker` because its local replace sees the root module dependency graph update.