### PR TITLE
[codex] Remove stale layout identity examples

### DIFF
--- a/docs/language/syntax.md
+++ b/docs/language/syntax.md
@@ -270,11 +270,10 @@ direct `view {}` markup subset. Current `g:swap` modes are `innerHTML` and
 `outerHTML`. SPA builds emit the partial client runtime only for pages that
 use partial form metadata with a fragment-producing action.
 
-Layout files can declare a layout ID and `view {}` body:
+Layout files take their ID from the `.layout.gwdk` file name and declare a
+`view {}` body:
 
 ```gwdk
-layout root
-
 view {
   <slot />
 }

--- a/internal/lang/tools_test.go
+++ b/internal/lang/tools_test.go
@@ -395,7 +395,7 @@ func TestClassifySourceUsesCurrentFileKindRules(t *testing.T) {
 		{"hero.gwdk", "component Hero", FileKindComponent},
 		{"home.page.gwdk", "// Mention component in docs\npage home", FileKindPage},
 		{"root.gwdk", "layout root", FileKindLayout},
-		{"root.layout.gwdk", "layout root", FileKindLayout},
+		{"root.layout.gwdk", "view {\n  <slot />\n}", FileKindLayout},
 		{"images.asset.gwdk", "asset images", FileKindAsset},
 		{"tailwind.plugin.gwdk", "plugin tailwind", FileKindPlugin},
 	}
@@ -424,8 +424,6 @@ view {
 }
 `)
 	writeGWDK(t, layout, `package app
-
-layout root
 
 view {
   <slot />

--- a/internal/lsp/server_test.go
+++ b/internal/lsp/server_test.go
@@ -165,7 +165,7 @@ func TestServerReturnsProjectAwareCompletions(t *testing.T) {
 	pageURI := "file:///tmp/home.page.gwdk"
 	input := framed(`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}`) +
 		framed(`{"jsonrpc":"2.0","method":"textDocument/didOpen","params":{"textDocument":{"uri":"`+componentURI+`","languageId":"gwdk","version":1,"text":"package app\n\ncomponent ProductCard\n\nprops {\n  title string\n}\n\nclient {\n  fn Increment() {\n    Count++\n  }\n}\n\nview {\n  <article>{title}{Count}</article>\n}\n"}}}`) +
-		framed(`{"jsonrpc":"2.0","method":"textDocument/didOpen","params":{"textDocument":{"uri":"`+layoutURI+`","languageId":"gwdk","version":1,"text":"package app\n\nlayout root\n\nview {\n  <slot />\n}\n"}}}`) +
+		framed(`{"jsonrpc":"2.0","method":"textDocument/didOpen","params":{"textDocument":{"uri":"`+layoutURI+`","languageId":"gwdk","version":1,"text":"package app\n\nview {\n  <slot />\n}\n"}}}`) +
 		framed(`{"jsonrpc":"2.0","method":"textDocument/didOpen","params":{"textDocument":{"uri":"`+pageURI+`","languageId":"gwdk","version":1,"text":"package app\nimport ui \"github.com/cssbruno/gowdk/testfixture/islands\"\n\npage home\nroute \"/products\"\nlayout root\nguard RequireUser\n\nstore cart ui.CounterState = ui.NewCounterState()\n\nview {\n  <main></main>\n}\n"}}}`) +
 		framed(`{"jsonrpc":"2.0","id":2,"method":"textDocument/completion","params":{"textDocument":{"uri":"`+pageURI+`"},"position":{"line":6,"character":8}}}`) +
 		framed(`{"jsonrpc":"2.0","id":3,"method":"textDocument/completion","params":{"textDocument":{"uri":"`+componentURI+`"},"position":{"line":8,"character":13}}}`) +

--- a/internal/parser/page_test.go
+++ b/internal/parser/page_test.go
@@ -1193,8 +1193,6 @@ view {
 
 func TestParseLayoutReadsGoBlock(t *testing.T) {
 	layout, err := ParseLayout("root.layout.gwdk", []byte(`
-layout root
-
 go ssr {
 func LayoutData() string {
 	return "root"
@@ -1324,7 +1322,6 @@ view {
 
 func TestParseLayoutRejectsPageMetadata(t *testing.T) {
 	_, err := ParseLayout("root.layout.gwdk", []byte(`
-layout root
 page home
 
 view {
@@ -1333,7 +1330,7 @@ view {
 	if err == nil {
 		t.Fatal("expected unsupported metadata error")
 	}
-	if err.Error() != `line 3: unsupported metadata page` {
+	if err.Error() != `line 2: unsupported metadata page` {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary
- update layout syntax docs so layout files take identity from .layout.gwdk filenames
- remove stale self-identity layout declarations from parser/lang/LSP fixtures

## Validation
- go test ./internal/parser ./internal/lang ./internal/lsp
- go test ./...

Follow-up to #274 after the branch was merged while this cleanup was in progress.