### PR TITLE
[codex] Preserve effective request-time render metadata

### DIFF
--- a/cmd/gowdk/main_test.go
+++ b/cmd/gowdk/main_test.go
@@ -3252,6 +3252,51 @@ view {
 	})
 }
 
+func TestRoutesCommandPrintsDefaultHybridRouteKind(t *testing.T) {
+	root := t.TempDir()
+	page := filepath.Join(root, "dashboard.page.gwdk")
+	config := filepath.Join(root, "gowdk.config.go")
+	writeCLIFile(t, config, `package app
+
+import "github.com/cssbruno/gowdk"
+
+var Config = gowdk.Config{
+	Render: gowdk.RenderConfig{Default: gowdk.Hybrid},
+}
+`)
+	writeCLIFile(t, page, `package app
+
+page dashboard
+route "/dashboard"
+
+view {
+  <main>Dashboard</main>
+}
+`)
+
+	output, stderr, err := captureCLIOutput(t, func() error {
+		return run([]string{"routes", "--ssr", "--config", config, page})
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(stderr, "spa_disabled") || strings.Contains(stderr, "ssr_disabled") {
+		t.Fatalf("expected no disabled route info for default hybrid route, got:\n%s", stderr)
+	}
+
+	var report routeMetadataReport
+	if err := json.Unmarshal([]byte(output), &report); err != nil {
+		t.Fatalf("invalid routes JSON: %v\n%s", err, output)
+	}
+	assertRouteBinding(t, report.Routes, routeBindingJSON{
+		Kind:    "hybrid",
+		Method:  "GET",
+		Route:   "/dashboard",
+		PageID:  "dashboard",
+		Handler: "hybrid.RenderDashboard",
+	})
+}
+
 func TestRoutesCommandDiscoversSelectedModuleOnly(t *testing.T) {
 	root := t.TempDir()
 	writeCLIFile(t, filepath.Join(root, "gowdk.config.go"), `package app

--- a/internal/appgen/appgen_test.go
+++ b/internal/appgen/appgen_test.go
@@ -1720,6 +1720,51 @@ func TestGenerateAutoDetectsActionAndSSRRoutes(t *testing.T) {
 	}
 }
 
+func TestGenerateAutoRoutesUseDefaultHybridRenderMetadata(t *testing.T) {
+	root := t.TempDir()
+	outputDir := filepath.Join(root, "dist")
+	appDir := filepath.Join(root, "generated-app")
+	if err := os.MkdirAll(outputDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	app := gwdkanalysis.Sources{Pages: []gwdkir.Page{{
+		ID:     "dashboard",
+		Route:  "/dashboard",
+		Guards: []string{"public"},
+		Blocks: gwdkir.Blocks{
+			View:     true,
+			ViewBody: `<main><h1>Dashboard</h1></main>`,
+		},
+	}}}
+
+	config := gowdk.Config{
+		Render: gowdk.RenderConfig{Default: gowdk.Hybrid},
+		Addons: []gowdk.Addon{gowdk.NewAddon("ssr", gowdk.FeatureSSR)},
+	}
+	ir := gwdkanalysis.BuildProgram(config, app)
+	result, err := GenerateWithOptions(outputDir, appDir, Options{
+		AutoRoutes: true,
+		Config:     config,
+		IR:         &ir,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload, err := os.ReadFile(result.PackagePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	source := string(payload)
+	expected := `gowdkruntime.RouteMetadata{Kind: "ssr", PageID: "dashboard", Method: "GET", Path: "/dashboard", Render: "hybrid", Guards: []string{"public"}}`
+	if !strings.Contains(source, expected) {
+		t.Fatalf("expected default-hybrid generated app source to contain %q:\n%s", expected, source)
+	}
+	if strings.Contains(source, `PageID: "dashboard", Method: "GET", Path: "/dashboard", Render: "ssr"`) {
+		t.Fatalf("expected default-hybrid metadata not to report ssr:\n%s", source)
+	}
+}
+
 func TestGenerateWritesGuardRegistryAndGuardChecks(t *testing.T) {
 	root := t.TempDir()
 	outputDir := filepath.Join(root, "dist")

--- a/internal/buildgen/ssr.go
+++ b/internal/buildgen/ssr.go
@@ -81,6 +81,7 @@ func SSRArtifactsFromIR(config gowdk.Config, ir gwdkir.Program, outputDir string
 }
 
 func ssrArtifact(config gowdk.Config, page gwdkir.Page, components map[string]view.Component, layouts map[string]gwdkir.Layout, stylesheets []gowdk.Stylesheet) (SSRArtifact, error) {
+	render := page.RenderMode(config.Render.DefaultMode())
 	routeData, replacements := ssrRouteData(page)
 	buildData, err := parseBuildData(page.Blocks.BuildBody, routeData, page.Imports, page.Blocks.GoBlocks, page.Source)
 	if err != nil {
@@ -104,7 +105,7 @@ func ssrArtifact(config gowdk.Config, page gwdkir.Page, components map[string]vi
 	return SSRArtifact{
 		PageID:           page.ID,
 		Route:            page.Route,
-		Render:           page.Render,
+		Render:           render,
 		Cache:            page.CachePolicy(),
 		ErrorPage:        page.ErrorPage,
 		DynamicParams:    page.DynamicParams(),

--- a/internal/buildgen/ssr_test.go
+++ b/internal/buildgen/ssr_test.go
@@ -175,6 +175,39 @@ func TestSSRArtifactsRenderHybridPageWithoutLoad(t *testing.T) {
 	}
 }
 
+func TestSSRArtifactsStoreDefaultHybridRenderMode(t *testing.T) {
+	outputDir := t.TempDir()
+	config := gowdk.Config{
+		Render: gowdk.RenderConfig{Default: gowdk.Hybrid},
+		Addons: []gowdk.Addon{gowdk.NewAddon("ssr", gowdk.FeatureSSR)},
+	}
+	app := gwdkanalysis.Sources{
+		Pages: []gwdkir.Page{{
+			ID:    "dashboard",
+			Route: "/dashboard",
+			Blocks: gwdkir.Blocks{
+				View:     true,
+				ViewBody: `<main><h1>Dashboard</h1></main>`,
+			},
+		}},
+	}
+
+	artifacts, err := SSRArtifacts(config, app, outputDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(artifacts) != 1 {
+		t.Fatalf("expected one default-hybrid artifact, got %#v", artifacts)
+	}
+	artifact := artifacts[0]
+	if artifact.Render != gowdk.Hybrid {
+		t.Fatalf("expected effective hybrid render mode, got %#v", artifact)
+	}
+	if !strings.Contains(artifact.HTML, "<h1>Dashboard</h1>") {
+		t.Fatalf("expected rendered default-hybrid HTML, got %s", artifact.HTML)
+	}
+}
+
 func TestSSRArtifactsFromIRRenderConcreteSSRPage(t *testing.T) {
 	outputDir := t.TempDir()
 	config := gowdk.Config{Addons: []gowdk.Addon{gowdk.NewAddon("ssr", gowdk.FeatureSSR)}}


### PR DESCRIPTION
## Summary

Closes #267.

- Store the effective render mode on generated SSR artifacts instead of the raw page render field.
- Preserve default-hybrid pages as `Render: "hybrid"` in generated runtime route metadata.
- Add regressions for SSR artifacts, generated app route metadata, and `gowdk routes` default-hybrid reporting.

## Verification

- `go test ./internal/buildgen ./internal/appgen ./internal/compiler ./cmd/gowdk`