### PR TITLE
[codex] Validate contract backend route metadata

### DIFF
--- a/cmd/gowdk/main_test.go
+++ b/cmd/gowdk/main_test.go
@@ -657,6 +657,42 @@ view {
 	}
 }
 
+func TestCheckJSONReportsInvalidContractRoute(t *testing.T) {
+	root := t.TempDir()
+	config := writeMinimalCLIConfig(t, root)
+	pageSource := `package pages
+
+page patients
+route "/patients"
+
+view {
+  <main>
+    <form method="post" action="https://example.com/pay" g:command="patients.CreatePatient">
+      <input name="name" />
+    </form>
+  </main>
+}
+`
+	page := filepath.Join(root, "pages", "patients.page.gwdk")
+	writeCLIFile(t, page, pageSource)
+
+	var output string
+	var err error
+	withWorkingDir(t, root, func() {
+		output, err = captureCLIStdout(t, func() error {
+			return run([]string{"check", "--config", config, "--json", page})
+		})
+	})
+	if err == nil {
+		t.Fatal("expected invalid contract route to fail check")
+	}
+	if !strings.Contains(output, `"code": "contract_route_invalid"`) ||
+		!strings.Contains(output, `endpoint path \"https://example.com/pay\" must be a local absolute path`) ||
+		!strings.Contains(output, `"line": 9`) {
+		t.Fatalf("expected invalid contract route diagnostic with source span, got:\n%s", output)
+	}
+}
+
 func TestCheckJSONReportsInvalidGoContractRegistration(t *testing.T) {
 	root := t.TempDir()
 	config := writeMinimalCLIConfig(t, root)

--- a/docs/reference/diagnostic-codes.md
+++ b/docs/reference/diagnostic-codes.md
@@ -140,7 +140,8 @@ gets more specific stable codes.
   `contract_type_invalid`, `contract_result_invalid`,
   `contract_input_invalid`, `contract_event_name_invalid`,
   `contract_event_category_invalid`, `duplicate_command_owner`,
-  `contract_reference_missing`, `contract_reference_invalid`,
+  `contract_route_invalid`, `contract_reference_missing`,
+  `contract_reference_invalid`,
   `contract_reference_role_not_allowed`.
 - WASM and browser Go: `unsupported_wasm_import`,
   `wasm_package_build_error`, `wasm_package_entrypoint_error`,

--- a/internal/appgen/adapter_ir.go
+++ b/internal/appgen/adapter_ir.go
@@ -179,7 +179,7 @@ func backendAdapterIR(options Options) BackendAdapterIR {
 		for _, ref := range sortedContractReferences(options.IR.ContractRefs) {
 			endpoint := BackendEndpointRegistration{
 				Kind:    backendContractEndpointKind(ref.Kind),
-				Method:  ref.Method,
+				Method:  source.BackendRouteMethod(ref.Method),
 				Path:    ref.Path,
 				Handler: string(ref.Kind),
 				PageID:  ref.OwnerID,

--- a/internal/appgen/appgen.go
+++ b/internal/appgen/appgen.go
@@ -56,6 +56,9 @@ func GenerateWithOptions(outputDir, appDir string, options Options) (Result, err
 	if err := validateFragmentEndpoints(options.Fragments); err != nil {
 		return Result{}, err
 	}
+	if err := validateContractRoutes(options.IR); err != nil {
+		return Result{}, err
+	}
 	if err := validateSSRRoutes(options.SSR); err != nil {
 		return Result{}, err
 	}
@@ -145,6 +148,9 @@ func GenerateBackendWithOptions(appDir string, options Options) (Result, error) 
 		return Result{}, err
 	}
 	if err := validateFragmentEndpoints(options.Fragments); err != nil {
+		return Result{}, err
+	}
+	if err := validateContractRoutes(options.IR); err != nil {
 		return Result{}, err
 	}
 	if err := os.MkdirAll(absApp, 0o755); err != nil {

--- a/internal/appgen/appgen_test.go
+++ b/internal/appgen/appgen_test.go
@@ -2167,6 +2167,53 @@ func TestGenerateRejectsDynamicActionEndpoint(t *testing.T) {
 	}
 }
 
+func TestGenerateRejectsInvalidContractRoutes(t *testing.T) {
+	tests := []struct {
+		name string
+		ref  gwdkir.ContractReference
+		want string
+	}{
+		{
+			name: "external command path",
+			ref: gwdkir.ContractReference{
+				Kind:   gwdkir.ContractCommand,
+				Name:   "patients.CreatePatient",
+				Method: "POST",
+				Path:   "https://example.com/pay",
+			},
+			want: `endpoint path "https://example.com/pay" must be a local absolute path`,
+		},
+		{
+			name: "unsupported query method",
+			ref: gwdkir.ContractReference{
+				Kind:   gwdkir.ContractQuery,
+				Name:   "patients.GetPatientPage",
+				Method: "POST",
+				Path:   "/patients",
+			},
+			want: "query contract routes require GET",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			root := t.TempDir()
+			outputDir := filepath.Join(root, "dist")
+			appDir := filepath.Join(root, "generated-app")
+			writeTestFile(t, filepath.Join(outputDir, "index.html"), "<main>Home</main>")
+
+			_, err := GenerateWithOptions(outputDir, appDir, Options{
+				IR: &gwdkir.Program{ContractRefs: []gwdkir.ContractReference{test.ref}},
+			})
+			if err == nil {
+				t.Fatal("expected invalid contract route error")
+			}
+			if !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("expected error to contain %q, got %v", test.want, err)
+			}
+		})
+	}
+}
+
 func TestGenerateRejectsSSRReplacementForUndeclaredParam(t *testing.T) {
 	root := t.TempDir()
 	outputDir := filepath.Join(root, "dist")

--- a/internal/appgen/validate_actions.go
+++ b/internal/appgen/validate_actions.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/cssbruno/gowdk/internal/gwdkir"
 	"github.com/cssbruno/gowdk/internal/source"
 	"github.com/cssbruno/gowdk/runtime/validation"
 )
@@ -57,6 +58,9 @@ func validateAPIEndpoints(endpoints []APIEndpoint) error {
 		if strings.TrimSpace(endpoint.APIName) == "" {
 			return fmt.Errorf("generated API endpoint for page %q is missing API name", endpoint.PageID)
 		}
+		if err := validateActionEndpointPath(endpoint.Route); err != nil {
+			return fmt.Errorf("generated API %s.%s: %w", endpoint.PageID, endpoint.APIName, err)
+		}
 		if endpoint.ErrorPage != "" {
 			errorPage, err := source.ErrorPagePath(endpoint.ErrorPage)
 			if err != nil {
@@ -106,6 +110,31 @@ func validateFragmentEndpoints(endpoints []FragmentEndpoint) error {
 		seen[key] = endpoint
 	}
 	return nil
+}
+
+func validateContractRoutes(ir *gwdkir.Program) error {
+	if ir == nil {
+		return nil
+	}
+	for _, ref := range ir.ContractRefs {
+		method := source.BackendRouteMethod(ref.Method)
+		if strings.TrimSpace(ref.Method) != "" && method != contractRouteMethod(ref.Kind) {
+			return fmt.Errorf("generated %s contract %s route method %q is invalid; %s contract routes require %s", ref.Kind, ref.Name, ref.Method, ref.Kind, contractRouteMethod(ref.Kind))
+		}
+		if strings.TrimSpace(ref.Path) != "" {
+			if err := source.ValidateBackendRoutePath(ref.Path); err != nil {
+				return fmt.Errorf("generated %s contract %s route path is invalid: %w", ref.Kind, ref.Name, err)
+			}
+		}
+	}
+	return nil
+}
+
+func contractRouteMethod(kind gwdkir.ContractKind) string {
+	if kind == gwdkir.ContractQuery {
+		return "GET"
+	}
+	return "POST"
 }
 
 func validateFragmentTargetValue(value string) error {
@@ -196,13 +225,7 @@ func validateValidationRules(endpoint ActionEndpoint) error {
 }
 
 func validateActionEndpointPath(value string) error {
-	if !strings.HasPrefix(value, "/") {
-		return fmt.Errorf("endpoint path %q must be an absolute path", value)
-	}
-	if strings.ContainsAny(value, "?#{}") {
-		return fmt.Errorf("endpoint path %q must be a concrete path without query, fragment, or params", value)
-	}
-	return nil
+	return source.ValidateBackendRoutePath(value)
 }
 
 func validateActionRedirect(value string) error {

--- a/internal/compiler/validate.go
+++ b/internal/compiler/validate.go
@@ -97,6 +97,7 @@ func validateProgram(config gowdk.Config, ir gwdkir.Program, crossFile bool) Val
 	diagnostics = append(diagnostics, validateAmbiguousDynamicPageRoutes(ir.Pages, ir.GoEndpoints)...)
 	diagnostics = append(diagnostics, validateRouteMethodConflicts(ir.Pages, ir.GoEndpoints)...)
 	diagnostics = append(diagnostics, validateStandaloneEndpoints(ir.GoEndpoints)...)
+	diagnostics = append(diagnostics, validateContractReferenceRoutes(ir.ContractRefs)...)
 	for _, page := range ir.Pages {
 		diagnostics = append(diagnostics, ValidatePage(config, page)...)
 	}

--- a/internal/compiler/validate_contract_refs.go
+++ b/internal/compiler/validate_contract_refs.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/cssbruno/gowdk/internal/gwdkir"
+	"github.com/cssbruno/gowdk/internal/source"
 )
 
 // ValidateContractReferences converts linked contract-reference metadata into
@@ -39,6 +40,35 @@ func contractReferenceAllowsWeb(ref gwdkir.ContractReference) bool {
 		}
 	}
 	return false
+}
+
+func validateContractReferenceRoutes(refs []gwdkir.ContractReference) []ValidationError {
+	var diagnostics []ValidationError
+	for _, ref := range refs {
+		method := source.BackendRouteMethod(ref.Method)
+		if strings.TrimSpace(ref.Method) != "" && method != contractReferenceRouteMethod(ref.Kind) {
+			diagnostics = append(diagnostics, contractReferenceRouteDiagnostic(ref, fmt.Sprintf("%s %s route method %q is invalid; %s contract routes require %s", ref.Kind, ref.Name, ref.Method, ref.Kind, contractReferenceRouteMethod(ref.Kind))))
+		}
+		if strings.TrimSpace(ref.Path) != "" {
+			if err := source.ValidateBackendRoutePath(ref.Path); err != nil {
+				diagnostics = append(diagnostics, contractReferenceRouteDiagnostic(ref, fmt.Sprintf("%s %s route path is invalid: %v", ref.Kind, ref.Name, err)))
+			}
+		}
+	}
+	return diagnostics
+}
+
+func contractReferenceRouteMethod(kind gwdkir.ContractKind) string {
+	if kind == gwdkir.ContractQuery {
+		return "GET"
+	}
+	return "POST"
+}
+
+func contractReferenceRouteDiagnostic(ref gwdkir.ContractReference, message string) ValidationError {
+	diagnostic := contractReferenceDiagnostic(ref, "contract_route_invalid")
+	diagnostic.Message = message
+	return diagnostic
 }
 
 func contractReferenceRoleDiagnostic(ref gwdkir.ContractReference) ValidationError {

--- a/internal/compiler/validate_test.go
+++ b/internal/compiler/validate_test.go
@@ -3401,6 +3401,88 @@ func TestValidateManifestReportsContractReferenceParseErrors(t *testing.T) {
 	}
 }
 
+func TestValidateManifestRejectsInvalidContractReferenceRoutes(t *testing.T) {
+	tests := []struct {
+		name     string
+		viewBody string
+		message  string
+	}{
+		{
+			name:     "external command action",
+			viewBody: `<form method="post" action="https://example.com/pay" g:command="patients.CreatePatient"></form>`,
+			message:  "must be a local absolute path",
+		},
+		{
+			name:     "dynamic command action",
+			viewBody: `<form method="post" action="/patients/{id}" g:command="patients.CreatePatient"></form>`,
+			message:  "without query, fragment, or params",
+		},
+		{
+			name:     "unsupported command method",
+			viewBody: `<form method="get" action="/patients" g:command="patients.CreatePatient"></form>`,
+			message:  "command contract routes require POST",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			app := appFixture{
+				Pages: []gwdkir.Page{{
+					Package: "pages",
+					ID:      "patients",
+					Route:   "/patients",
+					Source:  "pages/patients.page.gwdk",
+					Blocks: gwdkir.Blocks{
+						View:     true,
+						ViewBody: test.viewBody,
+					},
+				}},
+			}
+
+			err := validateManifest(gowdk.Config{}, app)
+			if err == nil {
+				t.Fatal("expected invalid contract route diagnostic")
+			}
+			diagnostics := err.(ValidationErrors)
+			if !hasDiagnosticCode(diagnostics, "contract_route_invalid") {
+				t.Fatalf("Missing contract_route_invalid diagnostic: %#v", diagnostics)
+			}
+			if !strings.Contains(diagnostics[0].Message, test.message) {
+				t.Fatalf("expected diagnostic message to contain %q, got %q", test.message, diagnostics[0].Message)
+			}
+			if diagnostics[0].Source != "pages/patients.page.gwdk" || diagnostics[0].Span.Start.Line == 0 {
+				t.Fatalf("expected source span on contract route diagnostic, got %#v", diagnostics[0])
+			}
+		})
+	}
+}
+
+func TestValidateManifestRejectsDefaultQueryRouteWithDynamicParams(t *testing.T) {
+	app := appFixture{
+		Pages: []gwdkir.Page{{
+			Package: "pages",
+			ID:      "patients.show",
+			Route:   "/patients/{id}",
+			Source:  "pages/patients-show.page.gwdk",
+			Blocks: gwdkir.Blocks{
+				View:     true,
+				ViewBody: `<section g:query="patients.GetPatient"></section>`,
+			},
+		}},
+	}
+
+	err := validateManifest(gowdk.Config{}, app)
+	if err == nil {
+		t.Fatal("expected invalid contract query route diagnostic")
+	}
+	diagnostics := err.(ValidationErrors)
+	if !hasDiagnosticCode(diagnostics, "contract_route_invalid") {
+		t.Fatalf("Missing contract_route_invalid diagnostic: %#v", diagnostics)
+	}
+	if !strings.Contains(diagnostics[0].Message, "without query, fragment, or params") {
+		t.Fatalf("unexpected diagnostic message: %s", diagnostics[0].Message)
+	}
+}
+
 func TestValidateManifestRejectsLayoutWithoutSlot(t *testing.T) {
 	app := appFixture{
 		Layouts: []gwdkir.Layout{

--- a/internal/diagnostics/registry.go
+++ b/internal/diagnostics/registry.go
@@ -78,6 +78,7 @@ var Registry = []Code{
 	{Code: "contract_reference_parse_error", Area: "contracts", Stability: StabilityExperimental, Severity: SeverityError, Summary: "view contract reference directives could not be parsed"},
 	{Code: "contract_reference_role_not_allowed", Area: "contracts", Stability: StabilityExperimental, Severity: SeverityError, Summary: "contract reference targets a registration that is not available to the web role"},
 	{Code: "contract_result_invalid", Area: "contracts", Stability: StabilityExperimental, Severity: SeverityError, Summary: "contract result type is invalid"},
+	{Code: "contract_route_invalid", Area: "contracts", Stability: StabilityExperimental, Severity: SeverityError, Summary: "contract reference route method or path is invalid"},
 	{Code: "contract_type_invalid", Area: "contracts", Stability: StabilityExperimental, Severity: SeverityError, Summary: "contract type is invalid"},
 	{Code: "cyclic_layout_reference", Area: "layouts", Stability: StabilityStable, Severity: SeverityError, Summary: "layout layout inheritance forms a cycle"},
 	{Code: "duplicate_command_owner", Area: "contracts", Stability: StabilityExperimental, Severity: SeverityError, Summary: "command has more than one owner registration"},

--- a/internal/gwdkanalysis/ir_contracts.go
+++ b/internal/gwdkanalysis/ir_contracts.go
@@ -21,7 +21,7 @@ func appendContractReferences(program *gwdkir.Program, template gwdkir.Template)
 		return
 	}
 	for _, ref := range refs {
-		method := ref.Method
+		method := source.BackendRouteMethod(ref.Method)
 		path := ref.Path
 		if ref.Kind == view.ContractReferenceQuery && path == "" && template.Route != "" {
 			method = "GET"

--- a/internal/source/source.go
+++ b/internal/source/source.go
@@ -61,6 +61,45 @@ func InlineScriptName(index int) string {
 	return fmt.Sprintf("inline-%d-gowdk.js", index+1)
 }
 
+// BackendRouteMethod returns the normalized HTTP method spelling used by
+// generated backend route metadata.
+func BackendRouteMethod(value string) string {
+	return strings.ToUpper(strings.TrimSpace(value))
+}
+
+// ValidateBackendRoutePath rejects paths that would be unsafe or ambiguous when
+// registered as generated backend routes.
+func ValidateBackendRoutePath(value string) error {
+	if strings.TrimSpace(value) != value {
+		return fmt.Errorf("endpoint path %q must not contain surrounding whitespace", value)
+	}
+	if value == "" {
+		return fmt.Errorf("endpoint path must not be empty")
+	}
+	if !strings.HasPrefix(value, "/") {
+		return fmt.Errorf("endpoint path %q must be a local absolute path", value)
+	}
+	if strings.HasPrefix(value, "//") {
+		return fmt.Errorf("endpoint path %q must not be protocol-relative", value)
+	}
+	if strings.Contains(value, "\\") {
+		return fmt.Errorf("endpoint path %q must not contain backslashes", value)
+	}
+	if strings.ContainsAny(value, "?#{}") {
+		return fmt.Errorf("endpoint path %q must be a concrete path without query, fragment, or params", value)
+	}
+	for _, char := range value {
+		if char < 0x20 || char == 0x7f {
+			return fmt.Errorf("endpoint path %q must not contain control characters", value)
+		}
+	}
+	cleaned := path.Clean(value)
+	if cleaned != value {
+		return fmt.Errorf("endpoint path %q must be a clean absolute path without dot segments, duplicate slashes, or trailing slash", value)
+	}
+	return nil
+}
+
 // BackendBindingStatus describes whether a .gwdk backend block has a matching
 // same-package Go handler.
 type BackendBindingStatus string

--- a/internal/source/source_test.go
+++ b/internal/source/source_test.go
@@ -1,0 +1,45 @@
+package source
+
+import "testing"
+
+func TestValidateBackendRoutePath(t *testing.T) {
+	valid := []string{
+		"/",
+		"/patients",
+		"/patients/list",
+	}
+	for _, path := range valid {
+		if err := ValidateBackendRoutePath(path); err != nil {
+			t.Fatalf("expected %q to be valid, got %v", path, err)
+		}
+	}
+
+	invalid := []string{
+		"",
+		"patients",
+		"//example.com/pay",
+		"https://example.com/pay",
+		"/https://example.com/pay",
+		"/patients?filter=active",
+		"/patients#form",
+		"/patients/{id}",
+		"/patients\nadmin",
+		"/patients\\admin",
+		"/patients/../admin",
+		"/patients//active",
+		"/patients/./active",
+		"/patients/",
+		" /patients",
+	}
+	for _, path := range invalid {
+		if err := ValidateBackendRoutePath(path); err == nil {
+			t.Fatalf("expected %q to be invalid", path)
+		}
+	}
+}
+
+func TestBackendRouteMethod(t *testing.T) {
+	if got := BackendRouteMethod(" post "); got != "POST" {
+		t.Fatalf("expected normalized method POST, got %q", got)
+	}
+}


### PR DESCRIPTION
## Summary

Closes #271.

- Add shared backend route method/path validation for generated backend routes.
- Emit `contract_route_invalid` diagnostics for invalid command/query route method or path metadata before appgen runs.
- Reject invalid contract routes in appgen for direct IR callers, and reuse the route-path helper for generated API/action/fragment path checks.
- Cover invalid external paths, dynamic params, unsupported contract methods, default query routes on dynamic pages, appgen direct IR, and CLI JSON source spans.

## Verification

- `go test ./internal/source ./internal/gwdkanalysis ./internal/compiler ./internal/appgen ./internal/diagnostics ./cmd/gowdk`