### PR TITLE
[codex] Diagnose malformed Go endpoint comments

### DIFF
--- a/cmd/gowdk/main_test.go
+++ b/cmd/gowdk/main_test.go
@@ -706,6 +706,51 @@ func HandleCreatePatient(ctx context.Context, command string) (CreatePatientResu
 	}
 }
 
+func TestCheckJSONReportsMalformedGoEndpointComment(t *testing.T) {
+	root := t.TempDir()
+	config := writeMinimalCLIConfig(t, root)
+	page := filepath.Join(root, "pages", "home.page.gwdk")
+	writeCLIFile(t, page, `package pages
+
+page home
+route "/"
+
+view {
+  <main>Home</main>
+}
+`)
+	writeCLIFile(t, filepath.Join(root, "pages", "handlers.go"), `package pages
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/cssbruno/gowdk/runtime/response"
+)
+
+//gowdk:route GET /api/health
+func Health(context.Context, *http.Request) (response.Response, error) {
+	return response.Response{}, nil
+}
+`)
+
+	var output string
+	var err error
+	withWorkingDir(t, root, func() {
+		output, err = captureCLIStdout(t, func() error {
+			return run([]string{"check", "--config", config, "--json", page})
+		})
+	})
+	if err == nil {
+		t.Fatal("expected malformed Go endpoint comment to fail check")
+	}
+	if !strings.Contains(output, `"code": "malformed_go_endpoint_comment"`) ||
+		!strings.Contains(output, "supported endpoint kinds are act and api") ||
+		!strings.Contains(output, `"line": 10`) {
+		t.Fatalf("expected malformed Go endpoint diagnostic with source span, got:\n%s", output)
+	}
+}
+
 func TestBuildFailsForMissingContractReference(t *testing.T) {
 	root := t.TempDir()
 	config := writeMinimalCLIConfig(t, root)

--- a/docs/reference/diagnostic-codes.md
+++ b/docs/reference/diagnostic-codes.md
@@ -117,9 +117,9 @@ gets more specific stable codes.
   `missing_page_guard`, `public_guard_exclusive`, and
   `guard_requires_request_render`.
 - Backend endpoints: `invalid_backend_handler_name`,
-  `invalid_go_endpoint_handler`, `go_endpoint_parse_error`,
-  `duplicate_go_endpoint_comment`, `unsupported_action_method`,
-  `backend_binding_required`.
+  `invalid_go_endpoint_handler`, `malformed_go_endpoint_comment`,
+  `go_endpoint_parse_error`, `duplicate_go_endpoint_comment`,
+  `unsupported_action_method`, `backend_binding_required`.
 - Layouts, CSS, and cache: `duplicate_layout_id`, `unknown_layout_id`,
   `invalid_css_selection`, `duplicate_css_selection`,
   `revalidate_requires_cache`, `duplicate_revalidate_policy`.

--- a/docs/reference/routing.md
+++ b/docs/reference/routing.md
@@ -248,6 +248,8 @@ Go comment action endpoints are standalone backend endpoints. They use the same
 binding and generated adapter pipeline as `.gwdk` action declarations, but they
 do not infer page-local form schemas, fragments, or guards from `.gwdk` page
 markup.
+Malformed `//gowdk:` comments, unknown endpoint kinds, and missing method or
+path fields fail with `malformed_go_endpoint_comment`.
 
 When `Build.CSRF.Enabled` is set, generated action handlers validate CSRF
 tokens before generated decoding or user handlers run. Missing or invalid

--- a/internal/compiler/backend_bindings_test.go
+++ b/internal/compiler/backend_bindings_test.go
@@ -461,6 +461,113 @@ func Session(context.Context, *http.Request) (response.Response, error) {
 	assertBinding(t, bindings["Session"], source.BackendBindingBound, source.BackendSignatureAPI, "", false)
 }
 
+func TestDiscoverGoEndpointCommentsRejectsMalformedComments(t *testing.T) {
+	tests := []struct {
+		name    string
+		comment string
+		want    string
+	}{
+		{
+			name:    "missing method",
+			comment: "//gowdk:api /api/health",
+			want:    "expected //gowdk:act METHOD /path or //gowdk:api METHOD /path",
+		},
+		{
+			name:    "missing path",
+			comment: "//gowdk:api GET",
+			want:    "expected //gowdk:act METHOD /path or //gowdk:api METHOD /path",
+		},
+		{
+			name:    "unknown kind",
+			comment: "//gowdk:route GET /api/health",
+			want:    "supported endpoint kinds are act and api",
+		},
+		{
+			name:    "invalid method",
+			comment: "//gowdk:api G3T /api/health",
+			want:    "method must contain only ASCII letters",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			root := t.TempDir()
+			writeCompilerTestModule(t, root)
+			writeCompilerTestFile(t, filepath.Join(root, "handlers.go"), `package api
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/cssbruno/gowdk/runtime/response"
+)
+
+`+test.comment+`
+func Session(context.Context, *http.Request) (response.Response, error) {
+	return response.Response{}, nil
+}
+`)
+			app := appFixture{Pages: []gwdkir.Page{{
+				ID:     "home",
+				Source: filepath.Join(root, "home.page.gwdk"),
+				Route:  "/",
+				Guards: []string{"public"},
+				Blocks: gwdkir.Blocks{View: true, ViewBody: "<main>Home</main>"},
+			}}}
+
+			ir := app.program(gowdk.Config{})
+			err := DiscoverGoEndpoints(&ir)
+			if err == nil {
+				t.Fatal("expected malformed endpoint comment diagnostic")
+			}
+			diagnostics := err.(ValidationErrors)
+			if len(diagnostics) != 1 || diagnostics[0].Code != "malformed_go_endpoint_comment" {
+				t.Fatalf("unexpected diagnostics: %#v", diagnostics)
+			}
+			if !strings.Contains(diagnostics[0].Message, test.want) {
+				t.Fatalf("expected diagnostic to contain %q, got %q", test.want, diagnostics[0].Message)
+			}
+			if diagnostics[0].Source != filepath.Join(root, "handlers.go") || diagnostics[0].Span.Start.Line == 0 {
+				t.Fatalf("expected source span on malformed endpoint comment, got %#v", diagnostics[0])
+			}
+		})
+	}
+}
+
+func TestDiscoverGoEndpointCommentsIgnoresUnrelatedComments(t *testing.T) {
+	root := t.TempDir()
+	writeCompilerTestModule(t, root)
+	writeCompilerTestFile(t, filepath.Join(root, "handlers.go"), `package api
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/cssbruno/gowdk/runtime/response"
+)
+
+//gowdkx:api GET /api/ignored
+//gowdk:api GET /api/session
+func Session(context.Context, *http.Request) (response.Response, error) {
+	return response.Response{}, nil
+}
+`)
+	app := appFixture{Pages: []gwdkir.Page{{
+		ID:     "home",
+		Source: filepath.Join(root, "home.page.gwdk"),
+		Route:  "/",
+		Guards: []string{"public"},
+		Blocks: gwdkir.Blocks{View: true, ViewBody: "<main>Home</main>"},
+	}}}
+
+	ir := app.program(gowdk.Config{})
+	if err := DiscoverGoEndpoints(&ir); err != nil {
+		t.Fatal(err)
+	}
+	if len(ir.GoEndpoints) != 1 || ir.GoEndpoints[0].Route != "/api/session" {
+		t.Fatalf("expected only the valid GOWDK endpoint, got %#v", ir.GoEndpoints)
+	}
+}
+
 func TestValidateManifestRejectsGoEndpointConflictWithGOWDKEndpoint(t *testing.T) {
 	root := t.TempDir()
 	sourcePath := filepath.Join(root, "home.page.gwdk")

--- a/internal/compiler/go_endpoints.go
+++ b/internal/compiler/go_endpoints.go
@@ -105,7 +105,8 @@ func discoverGoEndpointsInDir(dir string) ([]gwdkir.GoEndpoint, []ValidationErro
 			if !ok || function.Doc == nil {
 				continue
 			}
-			found := endpointCommentsForFunction(fileSet, path, file.Name.Name, function)
+			found, foundDiagnostics := endpointCommentsForFunction(fileSet, path, file.Name.Name, function)
+			diagnostics = append(diagnostics, foundDiagnostics...)
 			if len(found) > 1 {
 				diagnostics = append(diagnostics, goEndpointDiagnostic(fileSet, path, function, "duplicate_go_endpoint_comment", fmt.Sprintf("Go handler %s has multiple gowdk endpoint comments; declare at most one", function.Name.Name)))
 				continue
@@ -129,19 +130,29 @@ func discoverGoEndpointsInDir(dir string) ([]gwdkir.GoEndpoint, []ValidationErro
 	return endpoints, diagnostics
 }
 
-func endpointCommentsForFunction(fileSet *token.FileSet, path string, packageName string, function *ast.FuncDecl) []gwdkir.GoEndpoint {
+func endpointCommentsForFunction(fileSet *token.FileSet, path string, packageName string, function *ast.FuncDecl) ([]gwdkir.GoEndpoint, []ValidationError) {
 	var endpoints []gwdkir.GoEndpoint
+	var diagnostics []ValidationError
 	for _, comment := range function.Doc.List {
 		text := strings.TrimSpace(strings.TrimPrefix(comment.Text, "//"))
 		text = strings.TrimSpace(strings.TrimPrefix(text, "/*"))
 		text = strings.TrimSpace(strings.TrimSuffix(text, "*/"))
-		kind, methodText, routeText, ok := parseGoEndpointComment(text)
-		if !ok {
+		kind, methodText, routeText, matched, err := parseGoEndpointComment(text)
+		if !matched {
+			continue
+		}
+		span := goTokenSpan(fileSet, comment.Pos(), comment.End())
+		if err != nil {
+			diagnostics = append(diagnostics, ValidationError{
+				Code:    "malformed_go_endpoint_comment",
+				Source:  path,
+				Span:    span,
+				Message: err.Error(),
+			})
 			continue
 		}
 		method := strings.ToUpper(methodText)
 		route := strings.Trim(routeText, `"`)
-		span := goTokenSpan(fileSet, comment.Pos(), comment.End())
 		endpoints = append(endpoints, gwdkir.GoEndpoint{
 			Kind:        kind,
 			SourceKind:  gwdkir.EndpointSourceGo,
@@ -155,26 +166,26 @@ func endpointCommentsForFunction(fileSet *token.FileSet, path string, packageNam
 			RouteParams: routeParamSpansFallback(route, span),
 		})
 	}
-	return endpoints
+	return endpoints, diagnostics
 }
 
-func parseGoEndpointComment(text string) (string, string, string, bool) {
+func parseGoEndpointComment(text string) (string, string, string, bool, error) {
 	rest, ok := strings.CutPrefix(text, "gowdk:")
 	if !ok {
-		return "", "", "", false
+		return "", "", "", false, nil
 	}
 	fields := strings.Fields(rest)
 	if len(fields) != 3 {
-		return "", "", "", false
+		return "", "", "", true, fmt.Errorf("malformed Go endpoint comment %q; expected //gowdk:act METHOD /path or //gowdk:api METHOD /path", text)
 	}
 	kind := fields[0]
 	if kind != "act" && kind != "api" {
-		return "", "", "", false
+		return "", "", "", true, fmt.Errorf("malformed Go endpoint comment %q; supported endpoint kinds are act and api", text)
 	}
 	if !isASCIILetters(fields[1]) {
-		return "", "", "", false
+		return "", "", "", true, fmt.Errorf("malformed Go endpoint comment %q; method must contain only ASCII letters", text)
 	}
-	return kind, fields[1], fields[2], true
+	return kind, fields[1], fields[2], true, nil
 }
 
 func isASCIILetters(value string) bool {

--- a/internal/diagnostics/registry.go
+++ b/internal/diagnostics/registry.go
@@ -111,6 +111,7 @@ var Registry = []Code{
 	{Code: "layout_self_reference", Area: "layouts", Stability: StabilityStable, Severity: SeverityError, Summary: "layout lists itself in layout; a layout cannot inherit from itself"},
 	{Code: "layout_slot_count", Area: "layouts", Stability: StabilityStable, Severity: SeverityError, Summary: "layout must contain exactly one <slot /> placeholder"},
 	{Code: "load_requires_request_render", Area: "rendering", Stability: StabilityStable, Severity: SeverityError, Summary: "load block requires request-time page rendering"},
+	{Code: "malformed_go_endpoint_comment", Area: "backend", Stability: StabilityStable, Severity: SeverityError, Summary: "Go endpoint comment uses an unsupported //gowdk shape"},
 	{Code: "malformed_gowdk_use", Area: "source-imports", Stability: StabilityStable, Severity: SeverityError, Summary: "GOWDK use declaration is malformed"},
 	{Code: "malformed_route", Area: "routing", Stability: StabilityStable, Severity: SeverityError, Summary: "route path violates GOWDK route syntax"},
 	{Code: "missing_img_alt", Area: "accessibility", Stability: StabilityStable, Severity: SeverityWarning, Summary: "image element is missing explicit alt text"},


### PR DESCRIPTION
## Summary

Closes #265.

- Distinguish unrelated comments from malformed `//gowdk:` endpoint comments during standalone Go endpoint discovery.
- Emit `malformed_go_endpoint_comment` with the comment source span for unknown endpoint kinds, missing fields, and invalid method text.
- Preserve valid `//gowdk:act` / `//gowdk:api` discovery, duplicate-comment diagnostics, and invalid-handler diagnostics.
- Document the supported comment shape and diagnostic code.

## Verification

- `go test ./internal/compiler ./internal/lang ./cmd/gowdk`
- `go test ./internal/diagnostics`