### PR TITLE
[codex] Carry explicit project root through compiler commands

### DIFF
--- a/cmd/gowdk/build.go
+++ b/cmd/gowdk/build.go
@@ -110,7 +110,7 @@ func buildOnce(options cliOptions, request buildRequest) error {
 	options.Config.Build.Output = outputDir
 	paths := append([]string(nil), request.Paths...)
 	if len(paths) == 0 {
-		discovered, err := discoverBuildFiles(options.Config, outputDir, request.Modules)
+		discovered, err := discoverBuildFiles(options.Config, outputDir, request.Modules, options.ProjectRoot)
 		if err != nil {
 			return err
 		}
@@ -144,7 +144,7 @@ func buildOnce(options cliOptions, request buildRequest) error {
 	if report.HasErrors() {
 		return fmt.Errorf("build failed")
 	}
-	if err := linkIRContractReferences(&ir, "."); err != nil {
+	if err := linkIRContractReferences(&ir, options.ProjectRoot); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		return fmt.Errorf("build failed")
 	}

--- a/cmd/gowdk/contracts.go
+++ b/cmd/gowdk/contracts.go
@@ -25,6 +25,9 @@ func contractsReport(args []string) error {
 }
 
 func linkIRContractReferences(ir *gwdkir.Program, root string) error {
+	if strings.TrimSpace(root) == "" {
+		root = "."
+	}
 	report, err := contractscan.Scan(root)
 	if err != nil {
 		return err

--- a/cmd/gowdk/dev_loop.go
+++ b/cmd/gowdk/dev_loop.go
@@ -57,7 +57,7 @@ func buildIncrementalSPA(args []string, change inputChange) (bool, error) {
 	}
 	options.Config.Build.Output = outputDir
 	if len(paths) == 0 {
-		discovered, err := discoverBuildFiles(options.Config, outputDir, plan.ModuleNames)
+		discovered, err := discoverBuildFiles(options.Config, outputDir, plan.ModuleNames, options.ProjectRoot)
 		if err != nil {
 			return true, err
 		}
@@ -359,12 +359,12 @@ func buildInputSnapshot(args []string) (inputSnapshot, error) {
 			return nil, err
 		}
 		for _, target := range targets {
-			discovered, err := discoverBuildFiles(options.Config, target.Output, target.Modules)
+			discovered, err := discoverBuildFiles(options.Config, target.Output, target.Modules, options.ProjectRoot)
 			if err != nil {
 				return nil, err
 			}
 			paths = append(paths, discovered...)
-			css, err := discoverBuildCSSFiles(options.Config, target.Output)
+			css, err := discoverBuildCSSFiles(options.Config, target.Output, options.ProjectRoot)
 			if err != nil {
 				return nil, err
 			}
@@ -373,30 +373,30 @@ func buildInputSnapshot(args []string) (inputSnapshot, error) {
 	} else if outputDir == "" {
 		outputDir = options.Config.Build.Output
 		if len(paths) == 0 {
-			discovered, err := discoverBuildFiles(options.Config, outputDir, plan.ModuleNames)
+			discovered, err := discoverBuildFiles(options.Config, outputDir, plan.ModuleNames, options.ProjectRoot)
 			if err != nil {
 				return nil, err
 			}
 			paths = discovered
 		}
-		css, err := discoverBuildCSSFiles(options.Config, outputDir)
+		css, err := discoverBuildCSSFiles(options.Config, outputDir, options.ProjectRoot)
 		if err != nil {
 			return nil, err
 		}
 		paths = append(paths, css...)
 	} else if len(paths) == 0 {
-		discovered, err := discoverBuildFiles(options.Config, outputDir, plan.ModuleNames)
+		discovered, err := discoverBuildFiles(options.Config, outputDir, plan.ModuleNames, options.ProjectRoot)
 		if err != nil {
 			return nil, err
 		}
 		paths = discovered
-		css, err := discoverBuildCSSFiles(options.Config, outputDir)
+		css, err := discoverBuildCSSFiles(options.Config, outputDir, options.ProjectRoot)
 		if err != nil {
 			return nil, err
 		}
 		paths = append(paths, css...)
 	} else {
-		css, err := discoverBuildCSSFiles(options.Config, outputDir)
+		css, err := discoverBuildCSSFiles(options.Config, outputDir, options.ProjectRoot)
 		if err != nil {
 			return nil, err
 		}
@@ -404,8 +404,11 @@ func buildInputSnapshot(args []string) (inputSnapshot, error) {
 	}
 	if strings.TrimSpace(plan.ConfigPath) != "" {
 		paths = append(paths, plan.ConfigPath)
-	} else if _, err := os.Stat("gowdk.config.go"); err == nil {
-		paths = append(paths, "gowdk.config.go")
+	} else {
+		configPath := filepath.Join(options.ProjectRoot, "gowdk.config.go")
+		if _, err := os.Stat(configPath); err == nil {
+			paths = append(paths, configPath)
+		}
 	}
 	snapshot := inputSnapshot{}
 	for _, item := range paths {
@@ -430,7 +433,7 @@ func buildInputSnapshot(args []string) (inputSnapshot, error) {
 	return snapshot, nil
 }
 
-func discoverBuildCSSFiles(config gowdk.Config, outputDir string) ([]string, error) {
+func discoverBuildCSSFiles(config gowdk.Config, outputDir string, root string) ([]string, error) {
 	includes := appendPatterns(nil, config.CSS.Include)
 	if len(includes) == 1 && includes[0] == buildgen.DisableCSSDiscovery {
 		return nil, nil
@@ -439,9 +442,12 @@ func discoverBuildCSSFiles(config gowdk.Config, outputDir string) ([]string, err
 		includes = []string{"**/*.css"}
 	}
 
-	root, err := os.Getwd()
-	if err != nil {
-		return nil, err
+	if strings.TrimSpace(root) == "" {
+		var err error
+		root, err = os.Getwd()
+		if err != nil {
+			return nil, err
+		}
 	}
 	excludes := []string{".git/**", "**/.git/**", "vendor/**", "**/vendor/**", "node_modules/**", "**/node_modules/**", ".gowdk/**", "**/.gowdk/**", "dist/**", "**/dist/**"}
 	excludes = appendPatterns(excludes, config.CSS.Exclude)

--- a/cmd/gowdk/doctor.go
+++ b/cmd/gowdk/doctor.go
@@ -122,7 +122,7 @@ func runDoctor(args []string) (doctorReport, bool) {
 		report.Environment.ConfigPath = doctorConfigDisplayPath(configPath)
 	}
 
-	resolvedPaths, sourcesOK := report.runSourcesCheck(options.Config, moduleNames, paths)
+	resolvedPaths, sourcesOK := report.runSourcesCheck(options.Config, moduleNames, paths, options.ProjectRoot)
 	if !sourcesOK {
 		report.addSkipped("language_check", "language check skipped because no .gwdk sources were found")
 		report.addSkipped("routes", "route metadata skipped because no .gwdk sources were found")
@@ -131,7 +131,7 @@ func runDoctor(args []string) (doctorReport, bool) {
 		return report, options.JSON
 	}
 
-	app, languageOK := report.runLanguageCheck(options.Config, resolvedPaths)
+	app, languageOK := report.runLanguageCheck(options.Config, resolvedPaths, options.ProjectRoot)
 	if !languageOK {
 		report.addSkipped("routes", "route metadata skipped because language check failed")
 		report.runOptionalToolsCheck(options.Config)
@@ -139,7 +139,7 @@ func runDoctor(args []string) (doctorReport, bool) {
 		return report, options.JSON
 	}
 
-	report.runRoutesCheck(options.Config, app)
+	report.runRoutesCheck(options.Config, app, options.ProjectRoot)
 	report.runOptionalToolsCheck(options.Config)
 	report.finalize()
 	return report, options.JSON
@@ -234,9 +234,9 @@ func (report *doctorReport) runConfigCheck(options *cliOptions, configPath strin
 	return true
 }
 
-func (report *doctorReport) runSourcesCheck(config gowdk.Config, moduleNames, paths []string) ([]string, bool) {
+func (report *doctorReport) runSourcesCheck(config gowdk.Config, moduleNames, paths []string, projectRoot string) ([]string, bool) {
 	if len(paths) == 0 {
-		discovered, err := discoverProjectFiles(config, moduleNames)
+		discovered, err := discoverProjectFiles(config, moduleNames, projectRoot)
 		if err != nil {
 			report.addCheck(doctorCheck{
 				ID:       "sources",
@@ -269,8 +269,8 @@ func (report *doctorReport) runSourcesCheck(config gowdk.Config, moduleNames, pa
 	return paths, true
 }
 
-func (report *doctorReport) runLanguageCheck(config gowdk.Config, paths []string) (lang.CheckResult, bool) {
-	app, diagnostics := lang.CheckFiles(config, paths)
+func (report *doctorReport) runLanguageCheck(config gowdk.Config, paths []string, projectRoot string) (lang.CheckResult, bool) {
+	app, diagnostics := lang.CheckFilesWithOptions(config, paths, lang.CheckOptions{ProjectRoot: projectRoot})
 	if diagnostics.HasErrors() {
 		report.addCheck(doctorCheck{
 			ID:       "language_check",
@@ -304,9 +304,9 @@ func (report *doctorReport) runLanguageCheck(config gowdk.Config, paths []string
 	return app, true
 }
 
-func (report *doctorReport) runRoutesCheck(config gowdk.Config, checked lang.CheckResult) {
+func (report *doctorReport) runRoutesCheck(config gowdk.Config, checked lang.CheckResult, projectRoot string) {
 	ir := checked.IR
-	if err := linkIRContractReferences(&ir, "."); err != nil {
+	if err := linkIRContractReferences(&ir, projectRoot); err != nil {
 		report.addCheck(doctorCheck{
 			ID:       "routes",
 			Status:   "error",

--- a/cmd/gowdk/fix.go
+++ b/cmd/gowdk/fix.go
@@ -26,7 +26,7 @@ func fixCommand(args []string) error {
 	if err != nil {
 		return err
 	}
-	_, foundDiagnostics := lang.CheckFiles(options.Config, paths)
+	_, foundDiagnostics := lang.CheckFilesWithOptions(options.Config, paths, lang.CheckOptions{ProjectRoot: options.ProjectRoot})
 	summary, err := collectFixes(foundDiagnostics, fixOptions.Code)
 	if err != nil {
 		return err

--- a/cmd/gowdk/inspect.go
+++ b/cmd/gowdk/inspect.go
@@ -28,7 +28,7 @@ func inspectIR(args []string) error {
 		return err
 	}
 
-	checked, diagnostics := lang.CheckFiles(options.Config, paths)
+	checked, diagnostics := lang.CheckFilesWithOptions(options.Config, paths, lang.CheckOptions{ProjectRoot: options.ProjectRoot})
 	for _, diagnostic := range diagnostics {
 		fmt.Fprintln(os.Stderr, diagnostic.String())
 	}
@@ -37,7 +37,7 @@ func inspectIR(args []string) error {
 	}
 
 	ir := checked.IR
-	if err := linkIRContractReferences(&ir, "."); err != nil {
+	if err := linkIRContractReferences(&ir, options.ProjectRoot); err != nil {
 		return err
 	}
 	payload, err := json.MarshalIndent(ir, "", "  ")

--- a/cmd/gowdk/lang.go
+++ b/cmd/gowdk/lang.go
@@ -72,7 +72,7 @@ func check(args []string) error {
 	}
 
 	if options.JSON {
-		payload, diagnostics := lang.CheckJSON(options.Config, paths)
+		payload, diagnostics := lang.CheckJSONWithOptions(options.Config, paths, lang.CheckOptions{ProjectRoot: options.ProjectRoot})
 		if len(payload) > 0 {
 			fmt.Print(string(payload))
 		}
@@ -82,7 +82,7 @@ func check(args []string) error {
 		return nil
 	}
 
-	_, diagnostics := lang.CheckFiles(options.Config, paths)
+	_, diagnostics := lang.CheckFilesWithOptions(options.Config, paths, lang.CheckOptions{ProjectRoot: options.ProjectRoot})
 	if len(diagnostics) == 0 {
 		fmt.Println("ok")
 		return nil
@@ -109,7 +109,7 @@ func manifestJSON(args []string) error {
 		return err
 	}
 
-	payload, diagnostics := lang.ManifestJSON(options.Config, paths)
+	payload, diagnostics := lang.ManifestJSONWithOptions(options.Config, paths, lang.CheckOptions{ProjectRoot: options.ProjectRoot})
 	for _, diagnostic := range diagnostics {
 		fmt.Fprintln(os.Stderr, diagnostic.String())
 	}
@@ -126,7 +126,7 @@ func siteMapJSON(args []string) error {
 		return err
 	}
 
-	payload, diagnostics := lang.SiteMapJSON(options.Config, paths)
+	payload, diagnostics := lang.SiteMapJSONWithOptions(options.Config, paths, lang.CheckOptions{ProjectRoot: options.ProjectRoot})
 	for _, diagnostic := range diagnostics {
 		fmt.Fprintln(os.Stderr, diagnostic.String())
 	}
@@ -143,7 +143,7 @@ func routesJSON(args []string) error {
 		return err
 	}
 
-	checked, diagnostics := lang.CheckFiles(options.Config, paths)
+	checked, diagnostics := lang.CheckFilesWithOptions(options.Config, paths, lang.CheckOptions{ProjectRoot: options.ProjectRoot})
 	for _, diagnostic := range diagnostics {
 		fmt.Fprintln(os.Stderr, diagnostic.String())
 	}
@@ -152,7 +152,7 @@ func routesJSON(args []string) error {
 	}
 
 	ir := checked.IR
-	if err := linkIRContractReferences(&ir, "."); err != nil {
+	if err := linkIRContractReferences(&ir, options.ProjectRoot); err != nil {
 		return err
 	}
 	metadata := compiler.BuildRouteMetadataFromIR(options.Config, ir)

--- a/cmd/gowdk/main.go
+++ b/cmd/gowdk/main.go
@@ -133,6 +133,7 @@ func usage() {
 
 type cliOptions struct {
 	Config              gowdk.Config
+	ProjectRoot         string
 	JSON                bool
 	Debug               bool
 	AllowMissingBackend bool

--- a/cmd/gowdk/main_test.go
+++ b/cmd/gowdk/main_test.go
@@ -3682,6 +3682,83 @@ func HandleCreatePatient(ctx context.Context, command CreatePatient) (CreatePati
 	}
 }
 
+func TestRoutesCommandUsesExplicitConfigProjectRootForDiscoveryAndContracts(t *testing.T) {
+	root := t.TempDir()
+	page := filepath.Join(root, "pages", "patients.page.gwdk")
+	config := writeMinimalCLIConfig(t, root)
+	writeCLIFile(t, page, `package pages
+
+page patients
+route "/patients"
+
+view {
+  <main>
+    <form method="post" action="/patients" g:command="patients.CreatePatient">
+      <input name="name" />
+    </form>
+  </main>
+}
+`)
+	writeCLIFile(t, filepath.Join(root, "contracts", "patients.go"), `package patients
+
+import (
+	"context"
+	contracts "github.com/cssbruno/gowdk/runtime/contracts"
+)
+
+type CreatePatient struct {
+	Name string `+"`json:\"name\" form:\"name\"`"+`
+}
+type CreatePatientResult struct{}
+
+func Register(r *contracts.Registry) {
+	contracts.RegisterCommand[CreatePatient, CreatePatientResult](r, HandleCreatePatient, contracts.RoleWeb)
+}
+
+func HandleCreatePatient(ctx context.Context, command CreatePatient) (CreatePatientResult, error) {
+	return CreatePatientResult{}, nil
+}
+`)
+
+	var output string
+	withWorkingDir(t, t.TempDir(), func() {
+		captured, err := captureCLIStdout(t, func() error {
+			return run([]string{"routes", "--config", config})
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		output = captured
+	})
+
+	var report routeMetadataReport
+	if err := json.Unmarshal([]byte(output), &report); err != nil {
+		t.Fatalf("invalid routes JSON: %v\n%s", err, output)
+	}
+	assertEndpointBinding(t, report.Endpoints, endpointBindingJSON{
+		Kind:           "command",
+		EndpointSource: "contract",
+		Source:         page,
+		Package:        "pages",
+		Symbol:         "patients.CreatePatient",
+		Method:         "POST",
+		Route:          "/patients",
+		PageID:         "patients",
+		Handler:        "contracts.command.patients.CreatePatient",
+		Contract: &contractBindingJSON{
+			Name:        "patients.CreatePatient",
+			Kind:        "command",
+			Status:      "bound",
+			ImportAlias: "patients",
+			Type:        "CreatePatient",
+			Result:      "CreatePatientResult",
+			Roles:       []string{"web"},
+			Handler:     "HandleCreatePatient",
+			Register:    "Register",
+		},
+	})
+}
+
 func TestBuildCommandWritesGeneratedEmbeddedApp(t *testing.T) {
 	root := t.TempDir()
 	page := filepath.Join(root, "home.page.gwdk")

--- a/cmd/gowdk/project_inputs.go
+++ b/cmd/gowdk/project_inputs.go
@@ -19,6 +19,10 @@ func loadBuildConfig(options *cliOptions, configPath string) error {
 
 func loadProjectConfig(options *cliOptions, configPath string) error {
 	allowMissingBackend := options.AllowMissingBackend
+	projectRoot, err := resolveProjectRoot(configPath)
+	if err != nil {
+		return err
+	}
 	config, err := project.LoadConfig(configPath)
 	if err != nil {
 		return err
@@ -28,24 +32,38 @@ func loadProjectConfig(options *cliOptions, configPath string) error {
 		config.Build.AllowMissingBackend = true
 	}
 	options.Config = config
+	options.ProjectRoot = projectRoot
 	options.AllowMissingBackend = allowMissingBackend
 	return nil
 }
 
-func discoverBuildFiles(config gowdk.Config, outputDir string, moduleNames []string) ([]string, error) {
-	return discoverConfiguredFiles(config, outputDir, moduleNames)
-}
-
-func discoverProjectFiles(config gowdk.Config, moduleNames []string) ([]string, error) {
-	return discoverConfiguredFiles(config, config.Build.Output, moduleNames)
-}
-
-func discoverConfiguredFiles(config gowdk.Config, outputDir string, moduleNames []string) ([]string, error) {
-	root, err := os.Getwd()
-	if err != nil {
-		return nil, err
+func resolveProjectRoot(configPath string) (string, error) {
+	if strings.TrimSpace(configPath) != "" {
+		absolute, err := filepath.Abs(configPath)
+		if err != nil {
+			return "", err
+		}
+		return filepath.Dir(absolute), nil
 	}
+	return os.Getwd()
+}
 
+func discoverBuildFiles(config gowdk.Config, outputDir string, moduleNames []string, root string) ([]string, error) {
+	return discoverConfiguredFiles(config, outputDir, moduleNames, root)
+}
+
+func discoverProjectFiles(config gowdk.Config, moduleNames []string, root string) ([]string, error) {
+	return discoverConfiguredFiles(config, config.Build.Output, moduleNames, root)
+}
+
+func discoverConfiguredFiles(config gowdk.Config, outputDir string, moduleNames []string, root string) ([]string, error) {
+	if strings.TrimSpace(root) == "" {
+		var err error
+		root, err = os.Getwd()
+		if err != nil {
+			return nil, err
+		}
+	}
 	modules, err := buildModules(config.Modules, moduleNames)
 	if err != nil {
 		return nil, err
@@ -68,7 +86,7 @@ func loadCommandInputs(args []string, command string, allowJSON bool) (cliOption
 		return options, nil, err
 	}
 	if len(paths) == 0 {
-		discovered, err := discoverProjectFiles(options.Config, moduleNames)
+		discovered, err := discoverProjectFiles(options.Config, moduleNames, options.ProjectRoot)
 		if err != nil {
 			return options, nil, err
 		}

--- a/internal/lang/sitemap.go
+++ b/internal/lang/sitemap.go
@@ -102,7 +102,13 @@ func siteMapFromMetadata(pages []SiteMapPage, metadata compiler.RouteMetadata) S
 
 // SiteMapJSON returns the JSON site map for parsed and validated files.
 func SiteMapJSON(config gowdk.Config, paths []string) ([]byte, Diagnostics) {
-	result, diagnostics := CheckFiles(config, paths)
+	return SiteMapJSONWithOptions(config, paths, CheckOptions{})
+}
+
+// SiteMapJSONWithOptions returns the JSON site map with explicit project
+// context.
+func SiteMapJSONWithOptions(config gowdk.Config, paths []string, options CheckOptions) ([]byte, Diagnostics) {
+	result, diagnostics := CheckFilesWithOptions(config, paths, options)
 	if diagnostics.HasErrors() {
 		return nil, diagnostics
 	}

--- a/internal/lang/tools.go
+++ b/internal/lang/tools.go
@@ -276,8 +276,19 @@ type CheckResult struct {
 	Bindings []source.BackendBinding
 }
 
+// CheckOptions controls validation behavior that depends on project context.
+type CheckOptions struct {
+	ProjectRoot string
+}
+
 // CheckFiles parses and validates .gwdk files.
 func CheckFiles(config gowdk.Config, paths []string) (CheckResult, Diagnostics) {
+	return CheckFilesWithOptions(config, paths, CheckOptions{})
+}
+
+// CheckFilesWithOptions parses and validates .gwdk files with explicit project
+// context for checks that need to inspect sibling Go code.
+func CheckFilesWithOptions(config gowdk.Config, paths []string, options CheckOptions) (CheckResult, Diagnostics) {
 	sources, diagnostics := ParseFiles(paths)
 	if diagnostics.HasErrors() {
 		return CheckResult{}, diagnostics
@@ -298,13 +309,16 @@ func CheckFiles(config gowdk.Config, paths []string) (CheckResult, Diagnostics) 
 	diagnostics = append(diagnostics, accessibilityDiagnostics(result.IR)...)
 	if !diagnostics.HasErrors() {
 		result.Bindings = compiler.BindBackendHandlers(&result.IR)
-		diagnostics = append(diagnostics, validateContractReferences(config, result.IR)...)
+		diagnostics = append(diagnostics, validateContractReferences(config, result.IR, options.ProjectRoot)...)
 	}
 	return result, diagnostics
 }
 
-func validateContractReferences(config gowdk.Config, ir gwdkir.Program) Diagnostics {
-	report, err := contractscan.Scan(".")
+func validateContractReferences(config gowdk.Config, ir gwdkir.Program, projectRoot string) Diagnostics {
+	if strings.TrimSpace(projectRoot) == "" {
+		projectRoot = "."
+	}
+	report, err := contractscan.Scan(projectRoot)
 	if err != nil {
 		return Diagnostics{{Severity: "error", Message: fmt.Sprintf("scan Go contracts: %v", err)}}
 	}
@@ -381,7 +395,13 @@ type DiagnosticReport struct {
 
 // CheckJSON returns editor-friendly JSON diagnostics for parsed files.
 func CheckJSON(config gowdk.Config, paths []string) ([]byte, Diagnostics) {
-	_, diagnostics := CheckFiles(config, paths)
+	return CheckJSONWithOptions(config, paths, CheckOptions{})
+}
+
+// CheckJSONWithOptions returns editor-friendly JSON diagnostics for parsed
+// files with explicit project context.
+func CheckJSONWithOptions(config gowdk.Config, paths []string, options CheckOptions) ([]byte, Diagnostics) {
+	_, diagnostics := CheckFilesWithOptions(config, paths, options)
 	payload, err := json.MarshalIndent(DiagnosticReport{Diagnostics: diagnostics}, "", "  ")
 	if err != nil {
 		return nil, Diagnostics{{Severity: "error", Message: err.Error()}}
@@ -392,7 +412,13 @@ func CheckJSON(config gowdk.Config, paths []string) ([]byte, Diagnostics) {
 // ManifestJSON returns the manifest JSON report for parsed and validated
 // files. The report shape is derived from the compiler IR.
 func ManifestJSON(config gowdk.Config, paths []string) ([]byte, Diagnostics) {
-	result, diagnostics := CheckFiles(config, paths)
+	return ManifestJSONWithOptions(config, paths, CheckOptions{})
+}
+
+// ManifestJSONWithOptions returns the manifest JSON report with explicit
+// project context.
+func ManifestJSONWithOptions(config gowdk.Config, paths []string, options CheckOptions) ([]byte, Diagnostics) {
+	result, diagnostics := CheckFilesWithOptions(config, paths, options)
 	if diagnostics.HasErrors() {
 		return nil, diagnostics
 	}


### PR DESCRIPTION
## Summary

Closes #264.

- Resolve and store the project root from `--config` or cwd in CLI options.
- Use that root for configured source/CSS discovery and contract scanning/linking.
- Add lang check/manifest/sitemap options for explicit project context.
- Cover running `routes` from outside the project with `--config <abs path>`, proving discovery and contract binding use the config root.

## Verification

- `go test ./cmd/gowdk ./internal/lang ./internal/contractscan`