### PR TITLE
[codex] Rename annotation terminology to metadata

### DIFF
--- a/docs/language/guards.md
+++ b/docs/language/guards.md
@@ -69,7 +69,7 @@ are still planned — see [docs/engineering/security.md](../engineering/security
 
 ## Related
 
-- [spec.md](spec.md) — full page annotation contract.
+- [spec.md](spec.md) — full page keyword and metadata declaration contract.
 - [docs/reference/routing.md](../reference/routing.md) — route validation and plans.
 - [ssr.md](ssr.md) — request-time render mode and `load {}`.
 - [diagnostics.md](diagnostics.md) — `missing_page_guard`, `public_guard_exclusive`.

--- a/editors/vscode/extension-core.js
+++ b/editors/vscode/extension-core.js
@@ -1164,9 +1164,9 @@ function documentOutlineItems(source) {
     if (!trimmed || trimmed.startsWith('//')) {
       continue;
     }
-    const annotation = outlineAnnotation(text, line);
-    if (annotation) {
-      items.push(annotation);
+    const metadata = outlineMetadata(text, line);
+    if (metadata) {
+      items.push(metadata);
       continue;
     }
     const block = outlineBlock(text, line, lines);
@@ -1183,7 +1183,7 @@ function documentOutlineItems(source) {
   return items;
 }
 
-function outlineAnnotation(text, line) {
+function outlineMetadata(text, line) {
   const match = text.match(/^(\s*)(page|component|layout|route|title|description|canonical|image|guard|css|render|cache|revalidate|error|wasm|asset)\b\s*(.*)$/);
   if (!match) {
     return undefined;
@@ -1193,7 +1193,7 @@ function outlineAnnotation(text, line) {
   return outlineItem({
     name: detail ? `${name} ${detail}` : name,
     detail,
-    kind: annotationOutlineKind(match[2]),
+    kind: metadataOutlineKind(match[2]),
     line,
     column: match[1].length,
     length: text.trimEnd().length - match[1].length
@@ -1296,7 +1296,7 @@ function outlineItem({ name, detail, kind, line, column, length }) {
   };
 }
 
-function annotationOutlineKind(name) {
+function metadataOutlineKind(name) {
   if (name === 'page' || name === 'layout') {
     return 'namespace';
   }

--- a/internal/diagnosticfix/fix.go
+++ b/internal/diagnosticfix/fix.go
@@ -116,6 +116,7 @@ func pageRoute(source string) (string, bool) {
 		text := strings.TrimSpace(line)
 		routeText, ok := strings.CutPrefix(text, "route ")
 		if !ok {
+			// Keep safe fixes useful for files that still contain legacy metadata.
 			routeText, ok = strings.CutPrefix(text, "@route ")
 		}
 		if !ok {

--- a/internal/gwdkast/ast.go
+++ b/internal/gwdkast/ast.go
@@ -8,30 +8,30 @@ import (
 
 // File is the typed AST for the currently supported .gwdk syntax subset.
 type File struct {
-	Package     *Package
-	Annotations []Annotation
-	Page        *PageDecl
-	Route       *RouteDecl
-	Cache       *CacheDecl
-	Revalidate  *RevalidateDecl
-	ErrorPage   *ErrorPageDecl
-	Layouts     []LayoutRef
-	Guards      []GuardRef
-	CSS         []AssetRef
-	JS          []AssetRef
-	Assets      []AssetRef
-	Component   *ComponentDecl
-	Layout      *LayoutDecl
-	Imports     []Import
-	Uses        []Use
-	Stores      []Store
-	PropsType   *GoTypeRef
-	State       *StateContract
-	WASM        *WASMContract
-	Blocks      []Block
-	Actions     []Endpoint
-	APIs        []Endpoint
-	Fragments   []FragmentEndpoint
+	Package    *Package
+	Metadata   []MetadataDecl
+	Page       *PageDecl
+	Route      *RouteDecl
+	Cache      *CacheDecl
+	Revalidate *RevalidateDecl
+	ErrorPage  *ErrorPageDecl
+	Layouts    []LayoutRef
+	Guards     []GuardRef
+	CSS        []AssetRef
+	JS         []AssetRef
+	Assets     []AssetRef
+	Component  *ComponentDecl
+	Layout     *LayoutDecl
+	Imports    []Import
+	Uses       []Use
+	Stores     []Store
+	PropsType  *GoTypeRef
+	State      *StateContract
+	WASM       *WASMContract
+	Blocks     []Block
+	Actions    []Endpoint
+	APIs       []Endpoint
+	Fragments  []FragmentEndpoint
 }
 
 // Package is the top-level Go package declaration.
@@ -40,8 +40,8 @@ type Package struct {
 	Span source.SourceSpan
 }
 
-// Annotation is one top-level metadata declaration.
-type Annotation struct {
+// MetadataDecl is one top-level keyword metadata declaration.
+type MetadataDecl struct {
 	Name  string
 	Value string
 	Span  source.SourceSpan

--- a/internal/parser/component.go
+++ b/internal/parser/component.go
@@ -246,7 +246,7 @@ func ParseComponent(src []byte) (gwdkir.Component, error) {
 		}
 
 		if match := metadataPattern.FindStringSubmatch(line); match != nil {
-			if err := applyComponentAnnotation(&component, match[1], match[2], lineNumber, rawLine); err != nil {
+			if err := applyComponentMetadata(&component, match[1], match[2], lineNumber, rawLine); err != nil {
 				return gwdkir.Component{}, fmt.Errorf("line %d: %w", lineNumber, err)
 			}
 			continue

--- a/internal/parser/layout.go
+++ b/internal/parser/layout.go
@@ -19,7 +19,7 @@ func layoutIDFromPath(path string) string {
 
 // ParseLayout extracts layout metadata and top-level block declarations.
 // Layout identity is derived from the file name (`root.layout.gwdk` -> `root`);
-// any `layout` annotation declares parent layouts this layout nests within.
+// any `layout` metadata declaration declares parent layouts this layout nests within.
 func ParseLayout(path string, src []byte) (gwdkir.Layout, error) {
 	var layout gwdkir.Layout
 	layout.ID = layoutIDFromPath(path)
@@ -117,7 +117,7 @@ func ParseLayout(path string, src []byte) (gwdkir.Layout, error) {
 		seenDeclaration = true
 
 		if match := metadataPattern.FindStringSubmatch(line); match != nil {
-			if err := applyLayoutAnnotation(&layout, match[1], match[2], lineNumber, rawLine); err != nil {
+			if err := applyLayoutMetadata(&layout, match[1], match[2], lineNumber, rawLine); err != nil {
 				return gwdkir.Layout{}, fmt.Errorf("line %d: %w", lineNumber, err)
 			}
 			continue

--- a/internal/parser/metadata.go
+++ b/internal/parser/metadata.go
@@ -10,7 +10,7 @@ import (
 	"github.com/cssbruno/gowdk/internal/source"
 )
 
-func applyAnnotation(page *gwdkir.Page, name, rawValue string, lineNumber int, rawLine string) error {
+func applyMetadata(page *gwdkir.Page, name, rawValue string, lineNumber int, rawLine string) error {
 	value := strings.TrimSpace(rawValue)
 	span := sourceLineSpan(lineNumber, rawLine)
 	switch name {
@@ -60,28 +60,28 @@ func applyAnnotation(page *gwdkir.Page, name, rawValue string, lineNumber int, r
 		page.ErrorPage = errorPage
 		page.Spans.ErrorPage = span
 	case "title":
-		title, err := annotationText(name, value)
+		title, err := metadataText(name, value)
 		if err != nil {
 			return err
 		}
 		page.Metadata.Title = title
 		page.Spans.Title = span
 	case "description":
-		description, err := annotationText(name, value)
+		description, err := metadataText(name, value)
 		if err != nil {
 			return err
 		}
 		page.Metadata.Description = description
 		page.Spans.Description = span
 	case "canonical":
-		canonical, err := annotationText(name, value)
+		canonical, err := metadataText(name, value)
 		if err != nil {
 			return err
 		}
 		page.Metadata.Canonical = canonical
 		page.Spans.Canonical = span
 	case "image":
-		image, err := annotationText(name, value)
+		image, err := metadataText(name, value)
 		if err != nil {
 			return err
 		}
@@ -105,7 +105,7 @@ func applyAnnotation(page *gwdkir.Page, name, rawValue string, lineNumber int, r
 	return nil
 }
 
-func annotationText(name, value string) (string, error) {
+func metadataText(name, value string) (string, error) {
 	if value == "" {
 		return "", fmt.Errorf("%s requires a value", name)
 	}
@@ -169,7 +169,7 @@ func revalidateSecondsValue(value string) (string, error) {
 	return strconv.FormatInt(int64(duration/time.Second), 10), nil
 }
 
-func applyLayoutAnnotation(layout *gwdkir.Layout, name, rawValue string, lineNumber int, rawLine string) error {
+func applyLayoutMetadata(layout *gwdkir.Layout, name, rawValue string, lineNumber int, rawLine string) error {
 	value := strings.TrimSpace(rawValue)
 	switch name {
 	case "layout":
@@ -188,7 +188,7 @@ func applyLayoutAnnotation(layout *gwdkir.Layout, name, rawValue string, lineNum
 	return nil
 }
 
-func applyComponentAnnotation(component *gwdkir.Component, name, rawValue string, lineNumber int, rawLine string) error {
+func applyComponentMetadata(component *gwdkir.Component, name, rawValue string, lineNumber int, rawLine string) error {
 	value := strings.TrimSpace(rawValue)
 	switch name {
 	case "component":

--- a/internal/parser/page_lower.go
+++ b/internal/parser/page_lower.go
@@ -18,7 +18,7 @@ func lowerPageSyntax(src []byte, ast gwdkast.File, defaultID string) (gwdkir.Pag
 	page.Imports = lowerSyntaxImports(ast.Imports)
 	page.Uses = lowerSyntaxUses(ast.Uses)
 	page.Stores = lowerSyntaxStores(ast.Stores)
-	if err := lowerPageSyntaxAnnotations(src, ast, &page); err != nil {
+	if err := lowerPageSyntaxMetadata(src, ast, &page); err != nil {
 		return gwdkir.Page{}, err
 	}
 	for _, block := range ast.Blocks {
@@ -80,7 +80,7 @@ func lowerPageSyntax(src []byte, ast gwdkast.File, defaultID string) (gwdkir.Pag
 	return page, nil
 }
 
-func lowerPageSyntaxAnnotations(src []byte, ast gwdkast.File, page *gwdkir.Page) error {
+func lowerPageSyntaxMetadata(src []byte, ast gwdkast.File, page *gwdkir.Page) error {
 	if ast.Page != nil {
 		if ast.Page.ID == "" {
 			return fmt.Errorf("line %d: page requires a value", ast.Page.Span.Start.Line)
@@ -131,20 +131,20 @@ func lowerPageSyntaxAnnotations(src []byte, ast gwdkast.File, page *gwdkir.Page)
 		page.InlineJS = append(page.InlineJS, source.InlineScript{Name: name, Body: script.Inline, Span: script.Span})
 		page.Spans.InlineJS = append(page.Spans.InlineJS, source.NamedSpan{Name: name, Span: script.Span})
 	}
-	for _, annotation := range ast.Annotations {
-		if pageAnnotationLoweredFromAST(ast, annotation.Name) {
+	for _, metadata := range ast.Metadata {
+		if pageMetadataLoweredFromAST(ast, metadata.Name) {
 			continue
 		}
-		lineNumber := annotation.Span.Start.Line
+		lineNumber := metadata.Span.Start.Line
 		rawLine := sourceLineText(src, lineNumber)
-		if err := applyAnnotation(page, annotation.Name, annotation.Value, lineNumber, rawLine); err != nil {
+		if err := applyMetadata(page, metadata.Name, metadata.Value, lineNumber, rawLine); err != nil {
 			return fmt.Errorf("line %d: %w", lineNumber, err)
 		}
 	}
 	return nil
 }
 
-func pageAnnotationLoweredFromAST(ast gwdkast.File, name string) bool {
+func pageMetadataLoweredFromAST(ast gwdkast.File, name string) bool {
 	switch name {
 	case "page":
 		return ast.Page != nil

--- a/internal/parser/syntax.go
+++ b/internal/parser/syntax.go
@@ -14,7 +14,7 @@ import (
 
 type SyntaxFile = gwdkast.File
 type SyntaxPackage = gwdkast.Package
-type SyntaxAnnotation = gwdkast.Annotation
+type SyntaxMetadata = gwdkast.MetadataDecl
 type SyntaxImport = gwdkast.Import
 type SyntaxUse = gwdkast.Use
 type SyntaxBlock = gwdkast.Block
@@ -137,12 +137,12 @@ func ParseSyntax(src []byte) (SyntaxFile, error) {
 		}
 		seenDeclaration = true
 		if match := metadataPattern.FindStringSubmatch(line); match != nil {
-			annotation := SyntaxAnnotation{
+			metadata := SyntaxMetadata{
 				Name:  match[1],
 				Value: strings.TrimSpace(match[2]),
 				Span:  sourceLineSpan(lineNumber, rawLine),
 			}
-			if err := applySyntaxAnnotation(&file, annotation, lineNumber, rawLine); err != nil {
+			if err := applySyntaxMetadata(&file, metadata, lineNumber, rawLine); err != nil {
 				return SyntaxFile{}, fmt.Errorf("line %d: %w", lineNumber, err)
 			}
 			if match[1] == "wasm" {
@@ -151,7 +151,7 @@ func ParseSyntax(src []byte) (SyntaxFile, error) {
 					Span:    sourceLineSpan(lineNumber, rawLine),
 				}
 			}
-			file.Annotations = append(file.Annotations, annotation)
+			file.Metadata = append(file.Metadata, metadata)
 			continue
 		}
 		if strings.HasPrefix(line, "@") {
@@ -356,17 +356,17 @@ func attachSyntaxAssetScopes(file *SyntaxFile) {
 	}
 }
 
-func applySyntaxAnnotation(file *SyntaxFile, annotation SyntaxAnnotation, lineNumber int, rawLine string) error {
-	value := strings.TrimSpace(annotation.Value)
-	switch annotation.Name {
+func applySyntaxMetadata(file *SyntaxFile, metadata SyntaxMetadata, lineNumber int, rawLine string) error {
+	value := strings.TrimSpace(metadata.Value)
+	switch metadata.Name {
 	case "page":
-		file.Page = &gwdkast.PageDecl{ID: value, Span: annotation.Span}
+		file.Page = &gwdkast.PageDecl{ID: value, Span: metadata.Span}
 	case "component":
-		file.Component = &gwdkast.ComponentDecl{Name: value, Span: annotation.Span}
+		file.Component = &gwdkast.ComponentDecl{Name: value, Span: metadata.Span}
 	case "layout":
 		values := splitList(value)
 		if len(values) == 1 {
-			file.Layout = &gwdkast.LayoutDecl{ID: values[0], Span: annotation.Span}
+			file.Layout = &gwdkast.LayoutDecl{ID: values[0], Span: metadata.Span}
 		}
 		for _, span := range namedValueSpans(values, lineNumber, rawLine) {
 			file.Layouts = append(file.Layouts, gwdkast.LayoutRef{ID: span.Name, Span: span.Span})
@@ -380,21 +380,21 @@ func applySyntaxAnnotation(file *SyntaxFile, annotation SyntaxAnnotation, lineNu
 		for _, param := range params {
 			routeParams = append(routeParams, gwdkast.RouteParam{Name: param.Name, Type: param.Type, Span: param.Span})
 		}
-		file.Route = &gwdkast.RouteDecl{Path: path, Params: routeParams, Span: annotation.Span}
+		file.Route = &gwdkast.RouteDecl{Path: path, Params: routeParams, Span: metadata.Span}
 	case "cache":
-		file.Cache = &gwdkast.CacheDecl{Policy: trimQuotes(value), Span: annotation.Span}
+		file.Cache = &gwdkast.CacheDecl{Policy: trimQuotes(value), Span: metadata.Span}
 	case "revalidate":
 		seconds, err := revalidateSecondsValue(value)
 		if err != nil {
 			return err
 		}
-		file.Revalidate = &gwdkast.RevalidateDecl{Seconds: seconds, Span: annotation.Span}
+		file.Revalidate = &gwdkast.RevalidateDecl{Seconds: seconds, Span: metadata.Span}
 	case "error":
 		errorPage, err := source.ErrorPagePath(trimQuotes(value))
 		if err != nil {
 			return err
 		}
-		file.ErrorPage = &gwdkast.ErrorPageDecl{Path: errorPage, Span: annotation.Span}
+		file.ErrorPage = &gwdkast.ErrorPageDecl{Path: errorPage, Span: metadata.Span}
 	case "guard":
 		for _, span := range namedValueSpans(splitList(value), lineNumber, rawLine) {
 			file.Guards = append(file.Guards, gwdkast.GuardRef{Name: span.Name, Span: span.Span})

--- a/internal/parser/syntax_test.go
+++ b/internal/parser/syntax_test.go
@@ -46,8 +46,8 @@ view {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(file.Annotations) != 4 || file.Annotations[1].Name != "route" || file.Annotations[1].Span.Start.Line != 3 {
-		t.Fatalf("unexpected annotations: %#v", file.Annotations)
+	if len(file.Metadata) != 4 || file.Metadata[1].Name != "route" || file.Metadata[1].Span.Start.Line != 3 {
+		t.Fatalf("unexpected metadata: %#v", file.Metadata)
 	}
 	if file.ErrorPage == nil || file.ErrorPage.Path != "errors/newsletter.html" {
 		t.Fatalf("unexpected error page declaration: %#v", file.ErrorPage)


### PR DESCRIPTION
## Summary

Closes #260.

- Rename the internal GOWDK AST/parser metadata collection from `Annotation`/`Annotations` to `MetadataDecl`/`Metadata`.
- Rename parser lowerer helpers and VS Code outline helper internals from annotation wording to metadata wording.
- Update the guard docs link to describe keyword and metadata declarations instead of a page annotation contract.
- Keep the diagnostic safe-fix fallback for legacy `@route` source explicitly scoped as compatibility.

## Audit

- `rg -n "@page|@route|@guard|@layout|@cache|@revalidate|@error|annotation|Annotation" README.md docs examples editors internal/parser internal/gwdkast internal/diagnosticfix`
  - Remaining hit: `internal/diagnosticfix/fix.go` legacy `@route` compatibility fallback only.

## Verification

- `go test ./internal/parser ./internal/lang`
- `node --test editors/vscode/*.test.js`