### PR TITLE
[codex] Align layout-file use contract

### DIFF
--- a/docs/language/layouts.md
+++ b/docs/language/layouts.md
@@ -63,6 +63,8 @@ The quoted `use` target is a discovered `.gwdk` package name, not a Go import
 path. The qualified reference `chrome.root` resolves to the layout `root` (the
 file `root.layout.gwdk`) in package `layouts`. Unqualified cross-package lookup
 is rejected so layout reuse does not depend on global IDs or folder locations.
+Layout files do not support `use` declarations yet; parent layouts declared
+inside a layout file must be same-package references.
 
 When layout files are part of the project manifest, compiler validation resolves
 page `layout` references by package and declared ID and reports unknown or
@@ -85,6 +87,8 @@ Current app-shell layout rules:
   layout nests within.
 - Cross-package layouts use `layout alias.id` with a page-level
   `use alias "package"` declaration.
+- Layout files cannot declare `use`; cross-package parent layouts are deferred
+  until a layout-local import contract is stable.
 - Each layout must contain exactly one `<slot />` placeholder. Layouts with zero
   or multiple slots are rejected at validation time (`layout_slot_count`).
 - A layout may not reference itself or form a cyclic inheritance chain.

--- a/internal/buildgen/render.go
+++ b/internal/buildgen/render.go
@@ -109,13 +109,7 @@ func composeLayoutWithParents(layout gwdkir.Layout, child string, layouts map[st
 }
 
 func resolveLayoutParent(layout gwdkir.Layout, layouts map[string]gwdkir.Layout, ref string) (gwdkir.Layout, bool) {
-	if alias, layoutID, ok := strings.Cut(ref, "."); ok {
-		for _, use := range layout.Uses {
-			if use.Alias == alias {
-				parent, exists := layouts[layoutRegistryKey(use.Package, layoutID)]
-				return parent, exists
-			}
-		}
+	if _, _, ok := strings.Cut(ref, "."); ok {
 		return gwdkir.Layout{}, false
 	}
 	if layout.Package != "" {

--- a/internal/compiler/validate_identity.go
+++ b/internal/compiler/validate_identity.go
@@ -156,15 +156,9 @@ func validateLayoutReferences(layouts []gwdkir.Layout) []ValidationError {
 		}
 	}
 
-	resolve := func(layout gwdkir.Layout, usesByAlias map[string]gwdkir.Use, ref string) (key string, known bool) {
-		if alias, layoutID, ok := strings.Cut(ref, "."); ok {
-			use, exists := usesByAlias[alias]
-			if !exists {
-				return ref, false
-			}
-			key = layoutIdentityKey(use.Package, layoutID)
-			_, known = declared[key]
-			return key, known
+	resolve := func(layout gwdkir.Layout, ref string) (key string, known bool) {
+		if _, _, ok := strings.Cut(ref, "."); ok {
+			return ref, false
 		}
 		if layout.Package != "" {
 			key = layoutIdentityKey(layout.Package, ref)
@@ -181,9 +175,8 @@ func validateLayoutReferences(layouts []gwdkir.Layout) []ValidationError {
 	edges := map[string][]string{}
 	for _, layout := range layouts {
 		selfKey := layoutIdentityKey(layout.Package, layout.ID)
-		usesByAlias := layoutUsesByAlias(layout)
 		for index, ref := range layout.Layouts {
-			key, known := resolve(layout, usesByAlias, ref)
+			key, known := resolve(layout, ref)
 			span := layoutRefSpan(layout, index)
 			if key == selfKey {
 				diagnostics = append(diagnostics, ValidationError{
@@ -198,15 +191,23 @@ func validateLayoutReferences(layouts []gwdkir.Layout) []ValidationError {
 				continue
 			}
 			if !known {
-				diagnostics = append(diagnostics, ValidationError{
-					Code:   "unknown_layout_id",
-					Source: layout.Source,
-					Span:   span,
-					Message: fmt.Sprintf(
-						"layout %s references parent layout %q, but no matching .layout.gwdk file declares it",
+				message := fmt.Sprintf(
+					"layout %s references parent layout %q, but no matching .layout.gwdk file declares it",
+					layoutDisplayName(layout.Package, layout.ID),
+					ref,
+				)
+				if strings.Contains(ref, ".") {
+					message = fmt.Sprintf(
+						"layout %s references qualified parent layout %q, but layout files do not support use aliases yet; parent layouts must be in the same GOWDK package",
 						layoutDisplayName(layout.Package, layout.ID),
 						ref,
-					),
+					)
+				}
+				diagnostics = append(diagnostics, ValidationError{
+					Code:    "unknown_layout_id",
+					Source:  layout.Source,
+					Span:    span,
+					Message: message,
 				})
 				continue
 			}
@@ -316,16 +317,6 @@ func countLayoutSlots(body string) int {
 		}
 	}
 	return count
-}
-
-func layoutUsesByAlias(layout gwdkir.Layout) map[string]gwdkir.Use {
-	usesByAlias := map[string]gwdkir.Use{}
-	for _, use := range layout.Uses {
-		if _, exists := usesByAlias[use.Alias]; !exists {
-			usesByAlias[use.Alias] = use
-		}
-	}
-	return usesByAlias
 }
 
 func layoutRefSpan(layout gwdkir.Layout, index int) source.SourceSpan {

--- a/internal/compiler/validate_source_uses.go
+++ b/internal/compiler/validate_source_uses.go
@@ -46,7 +46,7 @@ func validateGOWDKUses(app gwdkir.Program, crossFile bool) []ValidationError {
 				Source: layout.Source,
 				Span:   use.Span,
 				Message: fmt.Sprintf(
-					"layout %s declares GOWDK use alias %q, but layouts do not support GOWDK use yet; pages and components support qualified component calls",
+					"layout %s declares GOWDK use alias %q, but layout files do not support GOWDK use yet; pages support cross-package layout references with page-level use declarations",
 					layout.ID,
 					use.Alias,
 				),

--- a/internal/compiler/validate_test.go
+++ b/internal/compiler/validate_test.go
@@ -3360,6 +3360,57 @@ func TestValidateManifestAcceptsLayoutInheritanceChain(t *testing.T) {
 	}
 }
 
+func TestValidateManifestRejectsLayoutFileUseAndQualifiedParentLayout(t *testing.T) {
+	useSpan := source.SourceSpan{Start: source.SourcePosition{Line: 2, Column: 1}, End: source.SourcePosition{Line: 2, Column: 20}}
+	parentSpan := source.SourceSpan{Start: source.SourcePosition{Line: 3, Column: 8}, End: source.SourcePosition{Line: 3, Column: 19}}
+	app := appFixture{
+		Layouts: []gwdkir.Layout{
+			{
+				Package:     "pages",
+				ID:          "docs",
+				Source:      "pages/docs.layout.gwdk",
+				Uses:        []gwdkir.Use{{Alias: "chrome", Package: "layouts", Span: useSpan}},
+				Layouts:     []string{"chrome.root"},
+				LayoutSpans: []source.NamedSpan{{Name: "chrome.root", Span: parentSpan}},
+				Blocks:      gwdkir.Blocks{View: true, ViewBody: "<slot />"},
+			},
+			{
+				Package: "layouts",
+				ID:      "root",
+				Source:  "layouts/root.layout.gwdk",
+				Blocks:  gwdkir.Blocks{View: true, ViewBody: "<slot />"},
+			},
+		},
+	}
+
+	err := validateManifest(gowdk.Config{}, app)
+	if err == nil {
+		t.Fatal("expected layout use diagnostics")
+	}
+	diagnostics := err.(ValidationErrors)
+	if !hasDiagnosticCode(diagnostics, "unsupported_gowdk_use_scope") {
+		t.Fatalf("Missing unsupported_gowdk_use_scope diagnostic: %#v", diagnostics)
+	}
+	if !hasDiagnosticCode(diagnostics, "unknown_layout_id") {
+		t.Fatalf("Missing unknown_layout_id diagnostic: %#v", diagnostics)
+	}
+	var sawUseSpan, sawParentSpan bool
+	for _, diagnostic := range diagnostics {
+		switch diagnostic.Code {
+		case "unsupported_gowdk_use_scope":
+			sawUseSpan = diagnostic.Span == useSpan
+		case "unknown_layout_id":
+			sawParentSpan = diagnostic.Span == parentSpan && strings.Contains(diagnostic.Message, "layout files do not support use aliases")
+		}
+	}
+	if !sawUseSpan {
+		t.Fatalf("expected unsupported use diagnostic at use span, got %#v", diagnostics)
+	}
+	if !sawParentSpan {
+		t.Fatalf("expected qualified parent diagnostic at parent layout span, got %#v", diagnostics)
+	}
+}
+
 func TestValidateManifestRejectsUnknownLayoutParent(t *testing.T) {
 	app := appFixture{
 		Layouts: []gwdkir.Layout{

--- a/internal/gwdkanalysis/ir_builder.go
+++ b/internal/gwdkanalysis/ir_builder.go
@@ -308,7 +308,6 @@ func (builder *irBuilder) addLayout(layout gwdkir.Layout) {
 	builder.program.Layouts = append(builder.program.Layouts, layout)
 	pkg := builder.ensurePackage(layout.Package, layout.Source)
 	pkg.Files = append(pkg.Files, gwdkir.SourceFile{Path: layout.Source, Kind: gwdkir.SourceLayout, Package: layout.Package, Name: layout.ID, Span: layout.Span})
-	appendPackageUses(pkg, layout.Uses)
 	if !layout.Blocks.View {
 		return
 	}

--- a/internal/lang/tools.go
+++ b/internal/lang/tools.go
@@ -460,7 +460,7 @@ func diagnosticSuggestion(validation compiler.ValidationError) string {
 	case "unknown_gowdk_component":
 		return "Use a component exported by the imported GOWDK package, or fix the package alias."
 	case "unsupported_gowdk_use_scope":
-		return "Move this use declaration to the page that calls the imported component, or keep the component in the same package."
+		return "Move this use declaration to the page or component that uses the imported GOWDK package."
 	case "missing_ssr_addon":
 		return "Enable ssr.Addon() in gowdk.config.go or remove request-time page behavior."
 	case "spa_dynamic_route_missing_paths":

--- a/internal/parser/page_test.go
+++ b/internal/parser/page_test.go
@@ -1322,6 +1322,27 @@ view {
 	}
 }
 
+func TestParseLayoutPreservesUseForUnsupportedScopeDiagnostic(t *testing.T) {
+	layout, err := ParseLayout("layouts/docs.layout.gwdk", []byte(`
+package layouts
+use chrome "chrome"
+layout root
+
+view {
+  <slot />
+}
+`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(layout.Uses) != 1 || layout.Uses[0].Alias != "chrome" || layout.Uses[0].Package != "chrome" {
+		t.Fatalf("expected layout use to be preserved for validation, got %#v", layout.Uses)
+	}
+	if layout.Uses[0].Span.Start.Line != 3 {
+		t.Fatalf("expected layout use span on line 3, got %#v", layout.Uses[0].Span)
+	}
+}
+
 func TestParseLayoutRejectsPageMetadata(t *testing.T) {
 	_, err := ParseLayout("root.layout.gwdk", []byte(`
 layout root


### PR DESCRIPTION
## Summary

Closes #263.

Decision: layout files do not support `use` declarations yet. Cross-package layout references remain page-level only.

- Stop resolving layout parent references through layout-local `use` aliases in validation and build-time layout composition.
- Keep parsed layout `use` declarations only so validation can report `unsupported_gowdk_use_scope` with the source span.
- Remove layout-local uses from package IR assembly so reports do not imply support.
- Update diagnostics/suggestions and layout docs to state the page-level-only contract.
- Add tests for preserving layout `use` spans for diagnostics and rejecting qualified parent layout aliases with stable spans.

## Verification

- `go test ./internal/parser ./internal/compiler ./internal/lang`
- `go test ./internal/buildgen ./internal/gwdkanalysis`