### PR TITLE
[codex] Expand typed route placeholders in buildgen

### DIFF
--- a/internal/buildgen/build_data_routes_test.go
+++ b/internal/buildgen/build_data_routes_test.go
@@ -597,6 +597,46 @@ func TestBuildExpandsDynamicSPAPaths(t *testing.T) {
 	}
 }
 
+func TestBuildExpandsTypedDynamicSPAPathsAndInheritedActionRoutes(t *testing.T) {
+	outputDir := t.TempDir()
+	app := gwdkanalysis.Sources{Pages: []gwdkir.Page{{
+		ID:     "patients.show",
+		Route:  "/patients/{id:int}",
+		Render: gowdk.Action,
+		Blocks: gwdkir.Blocks{
+			Paths:     true,
+			PathsBody: `=> { id: "123" }`,
+			View:      true,
+			ViewBody:  `<main><p>{id}</p><form g:post={Save}><input name="name" /></form></main>`,
+			Actions: []gwdkir.Action{{
+				Name: "Save",
+			}},
+		},
+	}}}
+
+	result, err := Build(gowdk.Config{}, app, outputDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantPath := filepath.Join(outputDir, "patients", "123", "index.html")
+	if len(result.Artifacts) != 1 || result.Artifacts[0].Route != "/patients/123" || result.Artifacts[0].Path != wantPath {
+		t.Fatalf("unexpected typed dynamic artifact: %#v", result.Artifacts)
+	}
+	html := readFile(t, wantPath)
+	for _, expected := range []string{
+		`<main><p>123</p><form method="post" action="/patients/123"><input name="name"></form></main>`,
+	} {
+		if !strings.Contains(html, expected) {
+			t.Fatalf("expected %q in typed dynamic action page:\n%s", expected, html)
+		}
+	}
+
+	routes := readRouteManifest(t, outputDir)
+	if len(routes.Routes) != 1 || routes.Routes[0].Route != "/patients/123" || routes.Routes[0].Path != "patients/123/index.html" {
+		t.Fatalf("unexpected typed dynamic route manifest: %#v", routes.Routes)
+	}
+}
+
 func TestBuildRejectsUnknownDynamicInterpolationBeforeWriting(t *testing.T) {
 	outputDir := t.TempDir()
 	app := gwdkanalysis.Sources{Pages: []gwdkir.Page{{

--- a/internal/buildgen/render.go
+++ b/internal/buildgen/render.go
@@ -182,9 +182,7 @@ func actionRoutes(page gwdkir.Page, data map[string]string) map[string]string {
 		if route == "" {
 			route = page.Route
 		}
-		for name, value := range data {
-			route = strings.ReplaceAll(route, "{"+name+"}", url.PathEscape(value))
-		}
+		route = expandRouteTemplate(route, data, url.PathEscape)
 		routes[action.Name] = route
 	}
 	return routes

--- a/internal/buildgen/routes.go
+++ b/internal/buildgen/routes.go
@@ -99,10 +99,9 @@ func pageOutputs(page gwdkir.Page) ([]pageOutput, error) {
 			}
 		}
 
-		route := page.Route
-		for name, value := range declaration {
-			route = strings.ReplaceAll(route, "{"+name+"}", value)
-		}
+		route := expandRouteTemplate(page.Route, declaration, func(value string) string {
+			return value
+		})
 		outputs = append(outputs, pageOutput{
 			route: route,
 			data:  cloneStringMap(declaration),
@@ -142,4 +141,48 @@ func outputPath(outputDir, route string) (string, error) {
 	parts := append([]string{outputDir}, segments...)
 	parts = append(parts, "index.html")
 	return filepath.Join(parts...), nil
+}
+
+func expandRouteTemplate(route string, data map[string]string, escape func(string) string) string {
+	if len(data) == 0 || !strings.Contains(route, "{") {
+		return route
+	}
+	var out strings.Builder
+	for index := 0; index < len(route); {
+		if route[index] != '{' {
+			out.WriteByte(route[index])
+			index++
+			continue
+		}
+		end := strings.IndexByte(route[index:], '}')
+		if end < 0 {
+			out.WriteString(route[index:])
+			break
+		}
+		end += index
+		placeholder := route[index : end+1]
+		name, ok := routeTemplateParamName(placeholder)
+		if !ok {
+			out.WriteString(placeholder)
+			index = end + 1
+			continue
+		}
+		value, ok := data[name]
+		if !ok {
+			out.WriteString(placeholder)
+			index = end + 1
+			continue
+		}
+		out.WriteString(escape(value))
+		index = end + 1
+	}
+	return out.String()
+}
+
+func routeTemplateParamName(placeholder string) (string, bool) {
+	params := gwdkir.RouteParamsFromPath(placeholder)
+	if len(params) != 1 {
+		return "", false
+	}
+	return params[0].Name, true
 }


### PR DESCRIPTION
## Summary

Closes #268.

- Add a shared buildgen route-template expander that handles `{name}`, `{name:type}`, and existing route-param placeholders through the IR route parser.
- Use it for concrete SPA output routes and rendered action form routes.
- Add buildgen coverage for typed dynamic SPA output plus inherited `g:post` action routes.

## Verification

- `go test ./internal/buildgen`
- `go test ./internal/buildgen ./internal/gwdkir`