### PR TITLE
[codex] Validate generated contract route conflicts

### DIFF
--- a/internal/compiler/routes.go
+++ b/internal/compiler/routes.go
@@ -53,7 +53,7 @@ func duplicateRouteMessage(route, firstID, firstSource, duplicateID, duplicateSo
 func validateAmbiguousDynamicPageRoutes(pages []gwdkir.Page, endpoints []gwdkir.GoEndpoint) []ValidationError {
 	var registered []routeRegistration
 	var diagnostics []ValidationError
-	for _, current := range routeRegistrations(pages, endpoints) {
+	for _, current := range routeRegistrations(pages, endpoints, nil) {
 		for _, previous := range registered {
 			if current.Pattern == previous.Pattern {
 				// Exact duplicates are reported by the duplicate-route and
@@ -171,32 +171,33 @@ func routePatternSegments(pattern string) []string {
 	return strings.Split(trimmed, "/")
 }
 
-func validateRouteMethodConflicts(pages []gwdkir.Page, endpoints []gwdkir.GoEndpoint) []ValidationError {
-	seen := map[string]routeRegistration{}
+func validateRouteMethodConflicts(pages []gwdkir.Page, endpoints []gwdkir.GoEndpoint, refs []gwdkir.ContractReference) []ValidationError {
+	seen := map[string][]routeRegistration{}
 	var diagnostics []ValidationError
-	for _, registration := range routeRegistrations(pages, endpoints) {
+	for _, registration := range routeRegistrations(pages, endpoints, refs) {
 		key := registration.Method + " " + registration.Pattern
-		first, exists := seen[key]
-		if !exists {
-			seen[key] = registration
-			continue
+		for _, previous := range seen[key] {
+			if previous.Kind == "page" && registration.Kind == "page" {
+				continue
+			}
+			if allowedPageOwnedQueryRouteConflict(previous, registration) {
+				continue
+			}
+			diagnostics = append(diagnostics, ValidationError{
+				Code:   "route_method_conflict",
+				PageID: registration.PageID,
+				Source: registration.Source,
+				Span:   registration.Span,
+				Message: fmt.Sprintf(
+					"%s %s for %s conflicts with %s",
+					registration.Method,
+					registration.Route,
+					registration.Owner,
+					previous.Owner,
+				),
+			})
 		}
-		if first.Kind == "page" && registration.Kind == "page" {
-			continue
-		}
-		diagnostics = append(diagnostics, ValidationError{
-			Code:   "route_method_conflict",
-			PageID: registration.PageID,
-			Source: registration.Source,
-			Span:   registration.Span,
-			Message: fmt.Sprintf(
-				"%s %s for %s conflicts with %s",
-				registration.Method,
-				registration.Route,
-				registration.Owner,
-				first.Owner,
-			),
-		})
+		seen[key] = append(seen[key], registration)
 	}
 	return diagnostics
 }
@@ -212,7 +213,7 @@ type routeRegistration struct {
 	Span    source.SourceSpan
 }
 
-func routeRegistrations(pages []gwdkir.Page, endpoints []gwdkir.GoEndpoint) []routeRegistration {
+func routeRegistrations(pages []gwdkir.Page, endpoints []gwdkir.GoEndpoint, refs []gwdkir.ContractReference) []routeRegistration {
 	var registrations []routeRegistration
 	for _, page := range pages {
 		pageInfo, pageIssues := parseRoute(page.Route)
@@ -323,7 +324,42 @@ func routeRegistrations(pages []gwdkir.Page, endpoints []gwdkir.GoEndpoint) []ro
 			Span:    firstSpan(endpoint.RouteSpan, endpoint.Span),
 		})
 	}
+	for _, ref := range refs {
+		if strings.TrimSpace(ref.Method) == "" || strings.TrimSpace(ref.Path) == "" {
+			continue
+		}
+		info, issues := parseRoute(ref.Path)
+		if len(issues) > 0 {
+			continue
+		}
+		kind := "command"
+		if ref.Kind == gwdkir.ContractQuery {
+			kind = "query"
+		}
+		method := strings.ToUpper(strings.TrimSpace(ref.Method))
+		registrations = append(registrations, routeRegistration{
+			Kind:    "contract_" + kind,
+			Owner:   fmt.Sprintf("%s contract %s", kind, ref.Name),
+			Method:  method,
+			Route:   ref.Path,
+			Pattern: info.Pattern,
+			PageID:  ref.OwnerID,
+			Source:  ref.Source,
+			Span:    ref.Span,
+		})
+	}
 	return registrations
+}
+
+func allowedPageOwnedQueryRouteConflict(first routeRegistration, current routeRegistration) bool {
+	return pageOwnedQueryRouteConflict(first, current) || pageOwnedQueryRouteConflict(current, first)
+}
+
+func pageOwnedQueryRouteConflict(page routeRegistration, query routeRegistration) bool {
+	return page.Kind == "page" &&
+		query.Kind == "contract_query" &&
+		query.PageID == page.PageID &&
+		query.Route == page.Route
 }
 
 func validateStandaloneEndpoints(endpoints []gwdkir.GoEndpoint) []ValidationError {

--- a/internal/compiler/validate.go
+++ b/internal/compiler/validate.go
@@ -95,7 +95,7 @@ func validateProgram(config gowdk.Config, ir gwdkir.Program, crossFile bool) Val
 	diagnostics = append(diagnostics, validateGoBlocks(config, ir)...)
 	diagnostics = append(diagnostics, validateUniquePageRoutes(ir.Pages)...)
 	diagnostics = append(diagnostics, validateAmbiguousDynamicPageRoutes(ir.Pages, ir.GoEndpoints)...)
-	diagnostics = append(diagnostics, validateRouteMethodConflicts(ir.Pages, ir.GoEndpoints)...)
+	diagnostics = append(diagnostics, validateRouteMethodConflicts(ir.Pages, ir.GoEndpoints, ir.ContractRefs)...)
 	diagnostics = append(diagnostics, validateStandaloneEndpoints(ir.GoEndpoints)...)
 	for _, page := range ir.Pages {
 		diagnostics = append(diagnostics, ValidatePage(config, page)...)

--- a/internal/compiler/validate_test.go
+++ b/internal/compiler/validate_test.go
@@ -3549,6 +3549,102 @@ func TestValidateManifestRejectsRouteMethodConflicts(t *testing.T) {
 			t.Fatalf("Missing route_method_conflict diagnostic: %#v", diagnostics)
 		}
 	})
+
+	t.Run("command route conflicts with action", func(t *testing.T) {
+		app := appFixture{
+			Pages: []gwdkir.Page{{
+				ID:    "patients",
+				Route: "/patients",
+				Blocks: gwdkir.Blocks{
+					View:     true,
+					ViewBody: `<main><form method="post" action="/patients" g:command="patients.CreatePatient"></form></main>`,
+					Actions:  []gwdkir.Action{{Name: "CreatePatient"}},
+				},
+			}},
+		}
+
+		err := validateManifest(gowdk.Config{}, app)
+		if err == nil {
+			t.Fatal("expected command/action route method conflict")
+		}
+		diagnostics := err.(ValidationErrors)
+		if !hasDiagnosticMessage(diagnostics, "route_method_conflict", "POST", "/patients", "command contract patients.CreatePatient", "action patients.CreatePatient") {
+			t.Fatalf("Missing command/action route_method_conflict diagnostic: %#v", diagnostics)
+		}
+	})
+
+	t.Run("duplicate command routes conflict", func(t *testing.T) {
+		app := appFixture{
+			Pages: []gwdkir.Page{{
+				ID:    "patients",
+				Route: "/patients",
+				Blocks: gwdkir.Blocks{
+					View: true,
+					ViewBody: `<main>
+  <form method="post" action="/patients" g:command="patients.CreatePatient"></form>
+  <form method="post" action="/patients" g:command="patients.UpdatePatient"></form>
+</main>`,
+				},
+			}},
+		}
+
+		err := validateManifest(gowdk.Config{}, app)
+		if err == nil {
+			t.Fatal("expected duplicate command route method conflict")
+		}
+		diagnostics := err.(ValidationErrors)
+		if !hasDiagnosticMessage(diagnostics, "route_method_conflict", "POST", "/patients", "command contract patients.UpdatePatient", "command contract patients.CreatePatient") {
+			t.Fatalf("Missing duplicate command route_method_conflict diagnostic: %#v", diagnostics)
+		}
+	})
+
+	t.Run("query route conflicts with api", func(t *testing.T) {
+		app := appFixture{
+			Pages: []gwdkir.Page{{
+				ID:    "patients",
+				Route: "/patients",
+				Blocks: gwdkir.Blocks{
+					View:     true,
+					ViewBody: `<main><section g:query="patients.ListPatients"></section></main>`,
+					APIs:     []gwdkir.API{{Name: "ListPatients"}},
+				},
+			}},
+		}
+
+		err := validateManifest(gowdk.Config{}, app)
+		if err == nil {
+			t.Fatal("expected query/api route method conflict")
+		}
+		diagnostics := err.(ValidationErrors)
+		if !hasDiagnosticMessage(diagnostics, "route_method_conflict", "GET", "/patients", "query contract patients.ListPatients", "api patients.ListPatients") {
+			t.Fatalf("Missing query/api route_method_conflict diagnostic: %#v", diagnostics)
+		}
+	})
+
+	t.Run("duplicate query routes conflict", func(t *testing.T) {
+		app := appFixture{
+			Pages: []gwdkir.Page{{
+				ID:    "patients",
+				Route: "/patients",
+				Blocks: gwdkir.Blocks{
+					View: true,
+					ViewBody: `<main>
+  <section g:query="patients.ListPatients"></section>
+  <section g:query="patients.SearchPatients"></section>
+</main>`,
+				},
+			}},
+		}
+
+		err := validateManifest(gowdk.Config{}, app)
+		if err == nil {
+			t.Fatal("expected duplicate query route method conflict")
+		}
+		diagnostics := err.(ValidationErrors)
+		if !hasDiagnosticMessage(diagnostics, "route_method_conflict", "GET", "/patients", "query contract patients.SearchPatients", "query contract patients.ListPatients") {
+			t.Fatalf("Missing duplicate query route_method_conflict diagnostic: %#v", diagnostics)
+		}
+	})
 }
 
 func TestValidateManifestAllowsSameRouteWithDifferentMethods(t *testing.T) {
@@ -3565,6 +3661,23 @@ func TestValidateManifestAllowsSameRouteWithDifferentMethods(t *testing.T) {
 
 	if err := validateManifest(gowdk.Config{}, app); err != nil {
 		t.Fatalf("expected GET page plus POST action to be valid, got %v", err)
+	}
+}
+
+func TestValidateManifestAllowsPageOwnedQueryOnPageRoute(t *testing.T) {
+	app := appFixture{
+		Pages: []gwdkir.Page{{
+			ID:    "patients",
+			Route: "/patients",
+			Blocks: gwdkir.Blocks{
+				View:     true,
+				ViewBody: `<main><section g:query="patients.GetPatientPage"></section></main>`,
+			},
+		}},
+	}
+
+	if err := validateManifest(gowdk.Config{}, app); err != nil {
+		t.Fatalf("expected page-owned query to share the page GET route, got %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

Closes #270.

- Include routable `g:command` and `g:query` contract references in compiler route-method conflict validation.
- Compare each route registration against all prior registrations for the same normalized method/path so the page-owned query exception does not hide API or contract collisions.
- Preserve the intentional exception for a page-owned query sharing its page `GET` route.
- Add compiler coverage for command/action conflicts, duplicate command routes, query/API conflicts, duplicate query routes, and the allowed page-query case.

## Verification

- `go test ./internal/compiler`
- `go test ./internal/compiler ./internal/gwdkanalysis ./internal/appgen`