### PR TITLE
[codex] Derive page-owned command contract routes

### DIFF
--- a/docs/reference/contracts.md
+++ b/docs/reference/contracts.md
@@ -562,7 +562,10 @@ Current behavior:
   `.gwdk import`, local command type, bound result type, binding status, and
   handler/register function names and runtime roles in IR/build-report
   metadata when known.
-- Records literal form `method` and `action` as command adapter IR method/path.
+- Records literal form `method` and `action` as command adapter IR
+  method/path. If a page-owned `g:command` form omits `action`, the command
+  adapter path is the owning page route, matching the browser's default form
+  submission target.
 - `gowdk build` links command references to scanned Go command registrations
   and adds `contract_reference` events with status and source line/column to
   `gowdk-build-report.json`. Command events include method/path when present.
@@ -723,7 +726,8 @@ Use `g:on:*` for local UI/component events and `g:command` for backend intent.
   not use string line writing.
 - `gowdk routes` includes routable `g:command` and `g:query` references as
   backend endpoint metadata with contract binding details.
-- Command contract adapter IR includes literal form method/path.
+- Command contract adapter IR includes the form method and either the literal
+  form action or, for page-owned forms that omit `action`, the page route.
 - Page-owned query contract adapter IR includes `GET` plus the page route.
 - Page-owned generated query routes use JSON/query request negotiation so they
   do not replace normal static, SPA, or SSR page responses.

--- a/internal/appgen/appgen_test.go
+++ b/internal/appgen/appgen_test.go
@@ -378,6 +378,42 @@ func TestGenerateWritesBoundContractBackendRoutes(t *testing.T) {
 	}
 }
 
+func TestGenerateWritesDerivedCommandContractBackendRoute(t *testing.T) {
+	root := t.TempDir()
+	outputDir := filepath.Join(root, "dist")
+	appDir := filepath.Join(root, "generated-app")
+	writeTestFile(t, filepath.Join(outputDir, "patients", "index.html"), "<main>Patients</main>")
+
+	program := gwdkanalysis.BuildProgram(gowdk.Config{}, gwdkanalysis.Sources{Pages: []gwdkir.Page{{
+		Package: "pages",
+		ID:      "patients",
+		Route:   "/patients",
+		Blocks: gwdkir.Blocks{
+			View:     true,
+			ViewBody: `<main><form g:command="patients.CreatePatient"></form></main>`,
+		},
+	}}})
+
+	result, err := GenerateWithOptions(outputDir, appDir, Options{IR: &program})
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload, err := os.ReadFile(result.PackagePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	source := string(payload)
+	for _, expected := range []string{
+		`Kind: "command", Handler: commandPatientsCreatePatientPOSTPatients`,
+		`func commandPatientsCreatePatientPOSTPatients(response http.ResponseWriter, request *http.Request) bool`,
+		`GOWDK command contract is not implemented`,
+	} {
+		if !strings.Contains(source, expected) {
+			t.Fatalf("expected generated derived command route source to contain %q:\n%s", expected, source)
+		}
+	}
+}
+
 func TestGeneratedGoMatchesGoldenFixture(t *testing.T) {
 	root := t.TempDir()
 	outputDir := filepath.Join(root, "dist")

--- a/internal/buildgen/build_report_test.go
+++ b/internal/buildgen/build_report_test.go
@@ -314,6 +314,32 @@ func TestBuildReportIncludesContractReferences(t *testing.T) {
 	}
 }
 
+func TestBuildReportDerivesCommandReferencePathFromPageRoute(t *testing.T) {
+	outputDir := t.TempDir()
+	app := gwdkanalysis.Sources{Pages: []gwdkir.Page{{
+		Source:  "pages/patients.page.gwdk",
+		Package: "pages",
+		ID:      "patients",
+		Route:   "/patients",
+		Blocks: gwdkir.Blocks{
+			View:     true,
+			ViewBody: `<main><form g:command="patients.CreatePatient"><input name="name" /></form></main>`,
+		},
+	}}}
+
+	result, err := Build(gowdk.Config{}, app, outputDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	event := findBuildReportEvent(result.Report, "bind", "contract_reference")
+	if event == nil {
+		t.Fatalf("missing contract_reference event in %#v", result.Report.Events)
+	}
+	if event.Data["kind"] != "command" || event.Data["method"] != "POST" || event.Data["path"] != "/patients" {
+		t.Fatalf("unexpected derived command route metadata: %#v", event.Data)
+	}
+}
+
 func TestBuildReportIncludesQueryContractReferences(t *testing.T) {
 	outputDir := t.TempDir()
 	app := gwdkanalysis.Sources{Pages: []gwdkir.Page{{

--- a/internal/compiler/route_bindings_test.go
+++ b/internal/compiler/route_bindings_test.go
@@ -197,6 +197,24 @@ func TestBuildRouteMetadataFromIR(t *testing.T) {
 	}
 }
 
+func TestBuildRouteMetadataIncludesDerivedCommandEndpointRoute(t *testing.T) {
+	ir := appFixture{Pages: []gwdkir.Page{{
+		Package: "pages",
+		ID:      "patients",
+		Route:   "/patients",
+		Blocks: gwdkir.Blocks{
+			View:     true,
+			ViewBody: `<main><form g:command="patients.CreatePatient"></form></main>`,
+		},
+	}}}.program(gowdk.Config{})
+
+	metadata := BuildRouteMetadataFromIR(gowdk.Config{}, ir)
+	command := findEndpoint(t, metadata.Endpoints, EndpointCommand, "POST", "/patients")
+	if command.Symbol != "patients.CreatePatient" || command.PageID != "patients" {
+		t.Fatalf("unexpected derived command route metadata: %#v", command)
+	}
+}
+
 func assertRoute(t *testing.T, routes []RouteBinding, kind RouteKind, method, route, handler string) {
 	t.Helper()
 	for _, binding := range routes {

--- a/internal/gwdkanalysis/ir_contracts.go
+++ b/internal/gwdkanalysis/ir_contracts.go
@@ -23,8 +23,12 @@ func appendContractReferences(program *gwdkir.Program, template gwdkir.Template)
 	for _, ref := range refs {
 		method := ref.Method
 		path := ref.Path
-		if ref.Kind == view.ContractReferenceQuery && path == "" && template.Route != "" {
-			method = "GET"
+		if path == "" && template.Route != "" {
+			if ref.Kind == view.ContractReferenceQuery {
+				method = "GET"
+			} else if method == "" {
+				method = "POST"
+			}
 			path = template.Route
 		}
 		importAlias, contractType := splitContractReferenceName(ref.Name)

--- a/internal/gwdkanalysis/ir_contracts_test.go
+++ b/internal/gwdkanalysis/ir_contracts_test.go
@@ -1,0 +1,59 @@
+package gwdkanalysis
+
+import (
+	"testing"
+
+	"github.com/cssbruno/gowdk"
+	"github.com/cssbruno/gowdk/internal/gwdkir"
+)
+
+func TestBuildProgramDerivesPageOwnedContractRoutes(t *testing.T) {
+	program := BuildProgram(gowdk.Config{}, Sources{Pages: []gwdkir.Page{{
+		Package: "pages",
+		ID:      "patients",
+		Route:   "/patients",
+		Blocks: gwdkir.Blocks{
+			View: true,
+			ViewBody: `<main>
+  <form method="patch" action="/patients/archive" g:command="patients.ArchivePatients"></form>
+  <form g:command="patients.CreatePatient"></form>
+  <section g:query="patients.GetPatientPage"></section>
+</main>`,
+		},
+	}}})
+
+	refs := contractRefsByName(program.ContractRefs)
+	if ref := refs["patients.ArchivePatients"]; ref.Method != "PATCH" || ref.Path != "/patients/archive" {
+		t.Fatalf("literal command method/path = %s %s, want PATCH /patients/archive", ref.Method, ref.Path)
+	}
+	if ref := refs["patients.CreatePatient"]; ref.Method != "POST" || ref.Path != "/patients" {
+		t.Fatalf("default command method/path = %s %s, want POST /patients", ref.Method, ref.Path)
+	}
+	if ref := refs["patients.GetPatientPage"]; ref.Method != "GET" || ref.Path != "/patients" {
+		t.Fatalf("page query method/path = %s %s, want GET /patients", ref.Method, ref.Path)
+	}
+}
+
+func TestBuildProgramKeepsComponentQueryNonRoutable(t *testing.T) {
+	program := BuildProgram(gowdk.Config{}, Sources{Components: []gwdkir.Component{{
+		Package: "components",
+		Name:    "PatientList",
+		Blocks: gwdkir.Blocks{
+			View:     true,
+			ViewBody: `<section g:query="patients.GetPatientPage"></section>`,
+		},
+	}}})
+
+	refs := contractRefsByName(program.ContractRefs)
+	if ref := refs["patients.GetPatientPage"]; ref.Method != "" || ref.Path != "" {
+		t.Fatalf("component query method/path = %s %s, want empty non-routable metadata", ref.Method, ref.Path)
+	}
+}
+
+func contractRefsByName(refs []gwdkir.ContractReference) map[string]gwdkir.ContractReference {
+	out := make(map[string]gwdkir.ContractReference, len(refs))
+	for _, ref := range refs {
+		out[ref.Name] = ref
+	}
+	return out
+}


### PR DESCRIPTION
## Summary

Closes #266.

- Derive the owning page route for page-owned `g:command` forms that omit a literal `action`, while preserving literal form methods/actions when present.
- Keep page-owned `g:query` route derivation intentional and document component query references as non-routable when they have no page route context.
- Add IR, build-report, route metadata, and appgen coverage so derived command references are visible to reports and generate backend fallback routes instead of being silently skipped.
- Update contract docs with the command form `method`/`action` metadata rule.

## Verification

- `go test ./internal/view ./internal/gwdkanalysis ./internal/compiler ./internal/appgen ./internal/buildgen ./cmd/gowdk`