### PR TITLE
fix(compiler): preserve view diagnostic spans

### DIFF
--- a/internal/compiler/validate_component_view.go
+++ b/internal/compiler/validate_component_view.go
@@ -11,21 +11,29 @@ import (
 type reactiveAttrExpr struct {
 	Name       string
 	Expression string
+	Start      int
+	End        int
 }
 
 type eventExpr struct {
 	Name       string
 	Expression string
+	Start      int
+	End        int
 }
 
 type classToggleExpr struct {
 	Name       string
 	Expression string
+	Start      int
+	End        int
 }
 
 type styleBindingExpr struct {
 	Name       string
 	Expression string
+	Start      int
+	End        int
 }
 
 type valueBindExpr struct {
@@ -33,18 +41,33 @@ type valueBindExpr struct {
 	Element    string
 	InputType  string
 	InputValue string
+	Start      int
+	End        int
+}
+
+type fieldRef struct {
+	Name  string
+	Start int
+	End   int
+}
+
+type stringRef struct {
+	Value string
+	Start int
+	End   int
 }
 
 type componentViewRefs struct {
 	Fields        map[string]bool
+	FieldRefs     []fieldRef
 	Events        []eventExpr
-	Bools         []string
+	Bools         []stringRef
 	Attrs         []reactiveAttrExpr
 	ClassToggles  []classToggleExpr
 	StyleBindings []styleBindingExpr
 	ValueBinds    []valueBindExpr
-	CheckedBinds  []string
-	RefBinds      []string
+	CheckedBinds  []fieldRef
+	RefBinds      []fieldRef
 }
 
 func componentViewReferences(source string) (componentViewRefs, error) {
@@ -53,7 +76,7 @@ func componentViewReferences(source string) (componentViewRefs, error) {
 		return componentViewRefs{}, err
 	}
 	refs := componentViewRefs{Fields: map[string]bool{}}
-	collectComponentViewReferences(nodes, &refs)
+	collectComponentViewReferences(source, nodes, &refs)
 	return refs, nil
 }
 
@@ -131,66 +154,75 @@ func elementKeyExpression(element view.Element) (string, bool) {
 	return "", false
 }
 
-func collectComponentViewReferences(nodes []view.Node, refs *componentViewRefs) {
+func collectComponentViewReferences(source string, nodes []view.Node, refs *componentViewRefs) {
 	for _, node := range nodes {
 		switch typed := node.(type) {
 		case view.Text:
-			collectSimpleInterpolations(typed.Value, refs.Fields)
+			collectSimpleInterpolationRefs(typed.Value, typed.Start, refs)
 		case view.Element:
 			if loop, ok := elementForDirective(typed); ok {
 				if parsed, err := view.ParseForDirective(loop.Value); err == nil {
 					for _, field := range expressionFields(parsed.Collection) {
-						refs.Fields[field] = true
+						addFieldRef(refs, field, loop.Start, loop.End)
 					}
 				}
 				continue
 			}
 			for _, attr := range typed.Attrs {
 				if strings.HasPrefix(attr.Name, "g:on:") {
-					refs.Events = append(refs.Events, eventExpr{Name: attr.Name, Expression: strings.TrimSpace(attr.Value)})
+					exprStart, exprEnd := attrValueOffset(source, attr, strings.TrimSpace(attr.Value))
+					refs.Events = append(refs.Events, eventExpr{Name: attr.Name, Expression: strings.TrimSpace(attr.Value), Start: exprStart, End: exprEnd})
 					for _, field := range view.IslandExpressionFields(attr.Value) {
 						if isDOMEventScopeField(field) {
 							continue
 						}
-						refs.Fields[field] = true
+						addFieldRef(refs, field, exprStart, exprEnd)
 					}
 					continue
 				}
 				if attr.Name == "g:if" {
 					expr := strings.TrimSpace(attr.Value)
-					refs.Bools = append(refs.Bools, expr)
+					exprStart, exprEnd := attrValueOffset(source, attr, expr)
+					refs.Bools = append(refs.Bools, stringRef{Value: expr, Start: exprStart, End: exprEnd})
 					for _, field := range expressionFields(expr) {
-						refs.Fields[field] = true
+						addFieldRef(refs, field, exprStart, exprEnd)
 					}
 					continue
 				}
 				if attr.Name == "g:else-if" {
 					expr := strings.TrimSpace(attr.Value)
-					refs.Bools = append(refs.Bools, expr)
+					exprStart, exprEnd := attrValueOffset(source, attr, expr)
+					refs.Bools = append(refs.Bools, stringRef{Value: expr, Start: exprStart, End: exprEnd})
 					for _, field := range expressionFields(expr) {
-						refs.Fields[field] = true
+						addFieldRef(refs, field, exprStart, exprEnd)
 					}
 					continue
 				}
 				if attr.Name == "g:bind:value" {
 					field := strings.TrimSpace(attr.Value)
+					fieldStart, fieldEnd := attrValueOffset(source, attr, field)
 					refs.ValueBinds = append(refs.ValueBinds, valueBindExpr{
 						Field:      field,
 						Element:    typed.Name,
 						InputType:  literalAttrValue(typed.Attrs, "type"),
 						InputValue: literalAttrValue(typed.Attrs, "value"),
+						Start:      fieldStart,
+						End:        fieldEnd,
 					})
-					refs.Fields[field] = true
+					addFieldRef(refs, field, fieldStart, fieldEnd)
 					continue
 				}
 				if attr.Name == "g:bind:checked" {
 					field := strings.TrimSpace(attr.Value)
-					refs.CheckedBinds = append(refs.CheckedBinds, field)
-					refs.Fields[field] = true
+					fieldStart, fieldEnd := attrValueOffset(source, attr, field)
+					refs.CheckedBinds = append(refs.CheckedBinds, fieldRef{Name: field, Start: fieldStart, End: fieldEnd})
+					addFieldRef(refs, field, fieldStart, fieldEnd)
 					continue
 				}
 				if attr.Name == "g:ref" {
-					refs.RefBinds = append(refs.RefBinds, strings.TrimSpace(attr.Value))
+					refName := strings.TrimSpace(attr.Value)
+					refStart, refEnd := attrValueOffset(source, attr, refName)
+					refs.RefBinds = append(refs.RefBinds, fieldRef{Name: refName, Start: refStart, End: refEnd})
 					continue
 				}
 				if strings.HasPrefix(attr.Name, "g:") {
@@ -198,41 +230,71 @@ func collectComponentViewReferences(nodes []view.Node, refs *componentViewRefs) 
 				}
 				if strings.HasPrefix(attr.Name, "class:") {
 					expr := expressionAttrSource(attr.Value)
-					refs.ClassToggles = append(refs.ClassToggles, classToggleExpr{Name: attr.Name, Expression: expr})
+					exprStart, exprEnd := attrValueOffset(source, attr, expr)
+					refs.ClassToggles = append(refs.ClassToggles, classToggleExpr{Name: attr.Name, Expression: expr, Start: exprStart, End: exprEnd})
 					for _, field := range expressionFields(expr) {
-						refs.Fields[field] = true
+						addFieldRef(refs, field, exprStart, exprEnd)
 					}
 					continue
 				}
 				if strings.HasPrefix(attr.Name, "style:") {
 					expr := expressionAttrSource(attr.Value)
-					refs.StyleBindings = append(refs.StyleBindings, styleBindingExpr{Name: attr.Name, Expression: expr})
+					exprStart, exprEnd := attrValueOffset(source, attr, expr)
+					refs.StyleBindings = append(refs.StyleBindings, styleBindingExpr{Name: attr.Name, Expression: expr, Start: exprStart, End: exprEnd})
 					for _, field := range expressionFields(expr) {
-						refs.Fields[field] = true
+						addFieldRef(refs, field, exprStart, exprEnd)
 					}
 					continue
 				}
 				if attr.Expression {
 					expr := expressionAttrSource(attr.Value)
-					refs.Attrs = append(refs.Attrs, reactiveAttrExpr{Name: attr.Name, Expression: expr})
+					exprStart, exprEnd := attrValueOffset(source, attr, expr)
+					refs.Attrs = append(refs.Attrs, reactiveAttrExpr{Name: attr.Name, Expression: expr, Start: exprStart, End: exprEnd})
 					for _, field := range expressionFields(expr) {
-						refs.Fields[field] = true
+						addFieldRef(refs, field, exprStart, exprEnd)
 					}
 					continue
 				}
-				collectSimpleInterpolations(attr.Value, refs.Fields)
+				collectSimpleAttrInterpolationRefs(source, attr, refs)
 			}
-			collectComponentViewReferences(typed.Children, refs)
+			collectComponentViewReferences(source, typed.Children, refs)
 		case view.ComponentCall:
 			for _, attr := range typed.Attrs {
 				if strings.HasPrefix(attr.Name, "g:") {
 					continue
 				}
-				collectSimpleInterpolations(attr.Value, refs.Fields)
+				collectSimpleAttrInterpolationRefs(source, attr, refs)
 			}
-			collectComponentViewReferences(typed.Children, refs)
+			collectComponentViewReferences(source, typed.Children, refs)
 		}
 	}
+}
+
+func addFieldRef(refs *componentViewRefs, name string, start int, end int) {
+	refs.Fields[name] = true
+	refs.FieldRefs = append(refs.FieldRefs, fieldRef{Name: name, Start: start, End: end})
+}
+
+func attrValueOffset(source string, attr view.Attr, value string) (int, int) {
+	if value == "" {
+		return attr.Start, attr.End
+	}
+	runes := []rune(source)
+	if attr.Start < 0 || attr.End > len(runes) || attr.Start >= attr.End {
+		return attr.Start, attr.End
+	}
+	raw := string(runes[attr.Start:attr.End])
+	index := strings.Index(raw, value)
+	if index < 0 {
+		return attr.Start, attr.End
+	}
+	start := attr.Start + len([]rune(raw[:index]))
+	return start, start + len([]rune(value))
+}
+
+func collectSimpleAttrInterpolationRefs(source string, attr view.Attr, refs *componentViewRefs) {
+	start, _ := attrValueOffset(source, attr, attr.Value)
+	collectSimpleInterpolationRefs(attr.Value, start, refs)
 }
 
 func isDOMEventScopeField(field string) bool {
@@ -274,6 +336,11 @@ func literalAttrValue(attrs []view.Attr, name string) string {
 }
 
 func collectSimpleInterpolations(value string, fields map[string]bool) {
+	refs := componentViewRefs{Fields: fields}
+	collectSimpleInterpolationRefs(value, 0, &refs)
+}
+
+func collectSimpleInterpolationRefs(value string, base int, refs *componentViewRefs) {
 	for index := 0; index < len(value); index++ {
 		if value[index] != '{' {
 			continue
@@ -285,7 +352,7 @@ func collectSimpleInterpolations(value string, fields map[string]bool) {
 		end += index + 1
 		name := value[index+1 : end]
 		if isSimpleInterpolationName(name) {
-			fields[name] = true
+			addFieldRef(refs, name, base+index+1, base+end)
 		}
 		index = end
 	}

--- a/internal/compiler/validate_component_view_contract.go
+++ b/internal/compiler/validate_component_view_contract.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/cssbruno/gowdk/internal/clientlang"
 	"github.com/cssbruno/gowdk/internal/gwdkir"
+	"github.com/cssbruno/gowdk/internal/source"
 	"github.com/cssbruno/gowdk/internal/view"
 )
 
@@ -37,19 +38,24 @@ func validateComponentViewContract(component gwdkir.Component, ctx componentVali
 
 func validateUnknownViewFields(component gwdkir.Component, ctx componentValidationContext, viewRefs componentViewRefs) []ValidationError {
 	var diagnostics []ValidationError
-	for field := range viewRefs.Fields {
-		if ctx.Props[field] || ctx.State[field] {
+	seen := map[string]bool{}
+	for _, field := range viewRefs.FieldRefs {
+		if seen[field.Name] {
 			continue
 		}
-		if _, ok := ctx.ComputedTypes[field]; ok {
+		seen[field.Name] = true
+		if ctx.Props[field.Name] || ctx.State[field.Name] {
+			continue
+		}
+		if _, ok := ctx.ComputedTypes[field.Name]; ok {
 			continue
 		}
 		diagnostics = append(diagnostics, ValidationError{
 			Code:          "component_field_error",
 			ComponentName: component.Name,
 			Source:        component.Source,
-			Span:          viewBodyNeedleSpan(component, field),
-			Message:       fmt.Sprintf("component %s view references unknown field %q", component.Name, field),
+			Span:          componentViewBodyOffsetSpan(component, field.Start, field.End),
+			Message:       fmt.Sprintf("component %s view references unknown field %q", component.Name, field.Name),
 		})
 	}
 	return diagnostics
@@ -63,7 +69,7 @@ func validateViewEventExpressions(component gwdkir.Component, ctx componentValid
 				Code:          "component_field_error",
 				ComponentName: component.Name,
 				Source:        component.Source,
-				Span:          viewBodyNeedleSpan(component, eventExpr.Name),
+				Span:          componentViewBodyOffsetSpan(component, eventExpr.Start, eventExpr.End),
 				Message:       fmt.Sprintf("component %s event directive %q is invalid: %v", component.Name, eventExpr.Name, err),
 			})
 			continue
@@ -74,7 +80,7 @@ func validateViewEventExpressions(component gwdkir.Component, ctx componentValid
 				Code:          "component_field_error",
 				ComponentName: component.Name,
 				Source:        component.Source,
-				Span:          viewBodyNeedleSpan(component, eventExpr.Expression),
+				Span:          componentViewBodyOffsetSpan(component, eventExpr.Start, eventExpr.End),
 				Message:       fmt.Sprintf("component %s event expression %q is invalid: %v", component.Name, eventExpr.Expression, err),
 			})
 		}
@@ -96,13 +102,13 @@ func mergeClientSymbols(left, right map[string]clientlang.ValueType) map[string]
 func validateViewBooleanExpressions(component gwdkir.Component, ctx componentValidationContext, viewRefs componentViewRefs) []ValidationError {
 	var diagnostics []ValidationError
 	for _, expr := range viewRefs.Bools {
-		if err := view.ValidateIslandBoolExpressionTyped(expr, ctx.SymbolTypes); err != nil {
+		if err := view.ValidateIslandBoolExpressionTyped(expr.Value, ctx.SymbolTypes); err != nil {
 			diagnostics = append(diagnostics, ValidationError{
 				Code:          "component_field_error",
 				ComponentName: component.Name,
 				Source:        component.Source,
-				Span:          firstSpan(component.Blocks.Spans.View, component.Span),
-				Message:       fmt.Sprintf("component %s bool expression %q is invalid: %v", component.Name, expr, err),
+				Span:          componentViewBodyOffsetSpan(component, expr.Start, expr.End),
+				Message:       fmt.Sprintf("component %s bool expression %q is invalid: %v", component.Name, expr.Value, err),
 			})
 		}
 	}
@@ -117,7 +123,7 @@ func validateViewAttributeExpressions(component gwdkir.Component, ctx componentV
 				Code:          "component_field_error",
 				ComponentName: component.Name,
 				Source:        component.Source,
-				Span:          firstSpan(component.Blocks.Spans.View, component.Span),
+				Span:          componentViewBodyOffsetSpan(component, attrExpr.Start, attrExpr.End),
 				Message:       fmt.Sprintf("component %s reactive attribute %s=%q is invalid: %v", component.Name, attrExpr.Name, attrExpr.Expression, err),
 			})
 		}
@@ -128,7 +134,7 @@ func validateViewAttributeExpressions(component gwdkir.Component, ctx componentV
 				Code:          "component_field_error",
 				ComponentName: component.Name,
 				Source:        component.Source,
-				Span:          firstSpan(component.Blocks.Spans.View, component.Span),
+				Span:          componentViewBodyOffsetSpan(component, toggle.Start, toggle.End),
 				Message:       fmt.Sprintf("component %s class toggle %s=%q is invalid: %v", component.Name, toggle.Name, toggle.Expression, err),
 			})
 		}
@@ -139,7 +145,7 @@ func validateViewAttributeExpressions(component gwdkir.Component, ctx componentV
 				Code:          "component_field_error",
 				ComponentName: component.Name,
 				Source:        component.Source,
-				Span:          firstSpan(component.Blocks.Spans.View, component.Span),
+				Span:          componentViewBodyOffsetSpan(component, binding.Start, binding.End),
 				Message:       fmt.Sprintf("component %s style binding %s=%q is invalid: %v", component.Name, binding.Name, binding.Expression, err),
 			})
 		}
@@ -158,13 +164,13 @@ func validateViewValueBinds(component gwdkir.Component, ctx componentValidationC
 func validateViewValueBind(component gwdkir.Component, ctx componentValidationContext, field valueBindExpr) []ValidationError {
 	typ, ok := ctx.StateTypes[field.Field]
 	if !ok {
-		return []ValidationError{componentFieldError(component, fmt.Sprintf("component %s g:bind:value target %q must be a state field", component.Name, field.Field))}
+		return []ValidationError{componentFieldErrorAt(component, componentViewBodyOffsetSpan(component, field.Start, field.End), fmt.Sprintf("component %s g:bind:value target %q must be a state field", component.Name, field.Field))}
 	}
 	if !isValueBindableElement(field.Element) {
-		return []ValidationError{componentFieldError(component, fmt.Sprintf("component %s g:bind:value target %q is on unsupported <%s>", component.Name, field.Field, field.Element))}
+		return []ValidationError{componentFieldErrorAt(component, componentViewBodyOffsetSpan(component, field.Start, field.End), fmt.Sprintf("component %s g:bind:value target %q is on unsupported <%s>", component.Name, field.Field, field.Element))}
 	}
 	if field.Element == "input" && strings.EqualFold(field.InputType, "radio") && field.InputValue == "" {
-		return []ValidationError{componentFieldError(component, fmt.Sprintf("component %s g:bind:value radio target %q requires a literal value attribute", component.Name, field.Field))}
+		return []ValidationError{componentFieldErrorAt(component, componentViewBodyOffsetSpan(component, field.Start, field.End), fmt.Sprintf("component %s g:bind:value radio target %q requires a literal value attribute", component.Name, field.Field))}
 	}
 	if typ == clientlang.TypeString || typ == clientlang.TypeUnknown {
 		return nil
@@ -173,21 +179,22 @@ func validateViewValueBind(component gwdkir.Component, ctx componentValidationCo
 		if field.Element == "input" && strings.EqualFold(field.InputType, "number") {
 			return nil
 		}
-		return []ValidationError{componentFieldError(component, fmt.Sprintf("component %s g:bind:value numeric target %q requires <input type=\"number\">", component.Name, field.Field))}
+		return []ValidationError{componentFieldErrorAt(component, componentViewBodyOffsetSpan(component, field.Start, field.End), fmt.Sprintf("component %s g:bind:value numeric target %q requires <input type=\"number\">", component.Name, field.Field))}
 	}
-	return []ValidationError{componentFieldError(component, fmt.Sprintf("component %s g:bind:value target %q must be string or numeric, got %s", component.Name, field.Field, typ))}
+	return []ValidationError{componentFieldErrorAt(component, componentViewBodyOffsetSpan(component, field.Start, field.End), fmt.Sprintf("component %s g:bind:value target %q must be string or numeric, got %s", component.Name, field.Field, typ))}
 }
 
 func validateViewCheckedBinds(component gwdkir.Component, ctx componentValidationContext, viewRefs componentViewRefs) []ValidationError {
 	var diagnostics []ValidationError
 	for _, field := range viewRefs.CheckedBinds {
-		typ, ok := ctx.StateTypes[field]
+		span := componentViewBodyOffsetSpan(component, field.Start, field.End)
+		typ, ok := ctx.StateTypes[field.Name]
 		if !ok {
-			diagnostics = append(diagnostics, componentFieldError(component, fmt.Sprintf("component %s g:bind:checked target %q must be a state field", component.Name, field)))
+			diagnostics = append(diagnostics, componentFieldErrorAt(component, span, fmt.Sprintf("component %s g:bind:checked target %q must be a state field", component.Name, field.Name)))
 			continue
 		}
 		if typ != clientlang.TypeBool && typ != clientlang.TypeUnknown {
-			diagnostics = append(diagnostics, componentFieldError(component, fmt.Sprintf("component %s g:bind:checked target %q must be bool, got %s", component.Name, field, typ)))
+			diagnostics = append(diagnostics, componentFieldErrorAt(component, span, fmt.Sprintf("component %s g:bind:checked target %q must be bool, got %s", component.Name, field.Name, typ)))
 		}
 	}
 	return diagnostics
@@ -197,19 +204,20 @@ func validateViewRefBinds(component gwdkir.Component, ctx componentValidationCon
 	boundRefs := map[string]bool{}
 	var diagnostics []ValidationError
 	for _, refName := range viewRefs.RefBinds {
+		span := componentViewBodyOffsetSpan(component, refName.Start, refName.End)
 		if ctx.Refs == nil {
-			diagnostics = append(diagnostics, componentFieldError(component, fmt.Sprintf("component %s g:ref target %q is not declared", component.Name, refName)))
+			diagnostics = append(diagnostics, componentFieldErrorAt(component, span, fmt.Sprintf("component %s g:ref target %q is not declared", component.Name, refName.Name)))
 			continue
 		}
-		if _, ok := ctx.Refs[refName]; !ok {
-			diagnostics = append(diagnostics, componentFieldError(component, fmt.Sprintf("component %s g:ref target %q is not declared", component.Name, refName)))
+		if _, ok := ctx.Refs[refName.Name]; !ok {
+			diagnostics = append(diagnostics, componentFieldErrorAt(component, span, fmt.Sprintf("component %s g:ref target %q is not declared", component.Name, refName.Name)))
 			continue
 		}
-		if boundRefs[refName] {
-			diagnostics = append(diagnostics, componentFieldError(component, fmt.Sprintf("component %s g:ref target %q is bound more than once", component.Name, refName)))
+		if boundRefs[refName.Name] {
+			diagnostics = append(diagnostics, componentFieldErrorAt(component, span, fmt.Sprintf("component %s g:ref target %q is bound more than once", component.Name, refName.Name)))
 			continue
 		}
-		boundRefs[refName] = true
+		boundRefs[refName.Name] = true
 	}
 	for refName := range ctx.UsedRefs {
 		if !boundRefs[refName] {
@@ -226,11 +234,15 @@ func validateViewRefBinds(component gwdkir.Component, ctx componentValidationCon
 }
 
 func componentFieldError(component gwdkir.Component, message string) ValidationError {
+	return componentFieldErrorAt(component, firstSpan(component.Blocks.Spans.View, component.Span), message)
+}
+
+func componentFieldErrorAt(component gwdkir.Component, span source.SourceSpan, message string) ValidationError {
 	return ValidationError{
 		Code:          "component_field_error",
 		ComponentName: component.Name,
 		Source:        component.Source,
-		Span:          firstSpan(component.Blocks.Spans.View, component.Span),
+		Span:          span,
 		Message:       message,
 	}
 }

--- a/internal/compiler/validate_source_uses.go
+++ b/internal/compiler/validate_source_uses.go
@@ -135,7 +135,7 @@ func validatePageQualifiedComponentRefs(page gwdkir.Page, usesByAlias map[string
 	if !page.Blocks.View || strings.TrimSpace(page.Blocks.ViewBody) == "" {
 		return nil
 	}
-	refs, err := view.ComponentReferences(page.Blocks.ViewBody)
+	refs, err := view.ComponentReferenceSpans(page.Blocks.ViewBody)
 	if err != nil {
 		return []ValidationError{{
 			Code:    "view_parse_error",
@@ -147,21 +147,22 @@ func validatePageQualifiedComponentRefs(page gwdkir.Page, usesByAlias map[string
 	}
 	var diagnostics []ValidationError
 	for _, ref := range refs {
-		alias, name, ok := strings.Cut(ref, ".")
+		alias, name, ok := strings.Cut(ref.Name, ".")
 		if !ok {
 			continue
 		}
+		span := pageViewBodyOffsetSpan(page, ref.Start, ref.End)
 		use, exists := usesByAlias[alias]
 		if !exists {
 			diagnostics = append(diagnostics, ValidationError{
 				Code:   "unknown_gowdk_use_alias",
 				PageID: page.ID,
 				Source: page.Source,
-				Span:   firstSpan(page.Blocks.Spans.View, page.Spans.Page),
+				Span:   span,
 				Message: fmt.Sprintf(
 					"%s references component <%s />, but alias %q is not declared. Add `use %s \"<package>\"` before the view block",
 					page.ID,
-					ref,
+					ref.Name,
 					alias,
 					alias,
 				),
@@ -177,11 +178,11 @@ func validatePageQualifiedComponentRefs(page gwdkir.Page, usesByAlias map[string
 					Code:   "unknown_gowdk_component",
 					PageID: page.ID,
 					Source: page.Source,
-					Span:   firstSpan(page.Blocks.Spans.View, page.Spans.Page),
+					Span:   span,
 					Message: fmt.Sprintf(
 						"%s references component <%s />, but package %s does not declare components",
 						page.ID,
-						ref,
+						ref.Name,
 						use.Package,
 					),
 				})
@@ -195,11 +196,11 @@ func validatePageQualifiedComponentRefs(page gwdkir.Page, usesByAlias map[string
 			Code:   "unknown_gowdk_component",
 			PageID: page.ID,
 			Source: page.Source,
-			Span:   firstSpan(page.Blocks.Spans.View, page.Spans.Page),
+			Span:   span,
 			Message: fmt.Sprintf(
 				"%s references component <%s />, but package %s does not declare component %s",
 				page.ID,
-				ref,
+				ref.Name,
 				use.Package,
 				name,
 			),
@@ -212,7 +213,7 @@ func validateComponentQualifiedComponentRefs(component gwdkir.Component, usesByA
 	if !component.Blocks.View || strings.TrimSpace(component.Blocks.ViewBody) == "" {
 		return nil
 	}
-	refs, err := view.ComponentReferences(component.Blocks.ViewBody)
+	refs, err := view.ComponentReferenceSpans(component.Blocks.ViewBody)
 	if err != nil {
 		return []ValidationError{{
 			Code:          "view_parse_error",
@@ -224,21 +225,22 @@ func validateComponentQualifiedComponentRefs(component gwdkir.Component, usesByA
 	}
 	var diagnostics []ValidationError
 	for _, ref := range refs {
-		alias, name, ok := strings.Cut(ref, ".")
+		alias, name, ok := strings.Cut(ref.Name, ".")
 		if !ok {
 			continue
 		}
+		span := componentViewBodyOffsetSpan(component, ref.Start, ref.End)
 		use, exists := usesByAlias[alias]
 		if !exists {
 			diagnostics = append(diagnostics, ValidationError{
 				Code:          "unknown_gowdk_use_alias",
 				ComponentName: component.Name,
 				Source:        component.Source,
-				Span:          firstSpan(component.Blocks.Spans.View, component.Span),
+				Span:          span,
 				Message: fmt.Sprintf(
 					"component %s references component <%s />, but alias %q is not declared. Add `use %s \"<package>\"` before the view block",
 					component.Name,
-					ref,
+					ref.Name,
 					alias,
 					alias,
 				),
@@ -254,11 +256,11 @@ func validateComponentQualifiedComponentRefs(component gwdkir.Component, usesByA
 					Code:          "unknown_gowdk_component",
 					ComponentName: component.Name,
 					Source:        component.Source,
-					Span:          firstSpan(component.Blocks.Spans.View, component.Span),
+					Span:          span,
 					Message: fmt.Sprintf(
 						"component %s references component <%s />, but package %s does not declare components",
 						component.Name,
-						ref,
+						ref.Name,
 						use.Package,
 					),
 				})
@@ -272,11 +274,11 @@ func validateComponentQualifiedComponentRefs(component gwdkir.Component, usesByA
 			Code:          "unknown_gowdk_component",
 			ComponentName: component.Name,
 			Source:        component.Source,
-			Span:          firstSpan(component.Blocks.Spans.View, component.Span),
+			Span:          span,
 			Message: fmt.Sprintf(
 				"component %s references component <%s />, but package %s does not declare component %s",
 				component.Name,
-				ref,
+				ref.Name,
 				use.Package,
 				name,
 			),

--- a/internal/compiler/validate_spans.go
+++ b/internal/compiler/validate_spans.go
@@ -45,6 +45,67 @@ func viewBodyNeedleSpan(component gwdkir.Component, needle string) source.Source
 	}
 }
 
+func pageViewBodyOffsetSpan(page gwdkir.Page, start int, end int) source.SourceSpan {
+	return viewBodyOffsetSpan(
+		page.Blocks.ViewBody,
+		page.Blocks.Spans.ViewBodyStart,
+		page.Blocks.Spans.View,
+		page.Spans.Page,
+		start,
+		end,
+	)
+}
+
+func componentViewBodyOffsetSpan(component gwdkir.Component, start int, end int) source.SourceSpan {
+	return viewBodyOffsetSpan(
+		component.Blocks.ViewBody,
+		component.Blocks.Spans.ViewBodyStart,
+		component.Blocks.Spans.View,
+		component.Span,
+		start,
+		end,
+	)
+}
+
+func viewBodyOffsetSpan(body string, bodyStart source.SourcePosition, viewSpan source.SourceSpan, fallback source.SourceSpan, start int, end int) source.SourceSpan {
+	if start < 0 || end <= start || start >= len([]rune(body)) {
+		return firstSpan(viewSpan, fallback)
+	}
+	startPos := bodyOffsetPosition(body, bodyStart, viewSpan, start)
+	endPos := bodyOffsetPosition(body, bodyStart, viewSpan, end)
+	if startPos.Line == 0 || endPos.Line == 0 {
+		return firstSpan(viewSpan, fallback)
+	}
+	return source.SourceSpan{Start: startPos, End: endPos}
+}
+
+func bodyOffsetPosition(body string, bodyStart source.SourcePosition, viewSpan source.SourceSpan, offset int) source.SourcePosition {
+	line := bodyStart.Line
+	column := bodyStart.Column
+	if line == 0 || column == 0 {
+		line = viewSpan.Start.Line + 1
+		column = 1
+	}
+	if line == 0 || column == 0 {
+		return source.SourcePosition{}
+	}
+	for index, char := range []rune(body) {
+		if index == offset {
+			return source.SourcePosition{Line: line, Column: column}
+		}
+		if char == '\n' {
+			line++
+			column = 1
+			continue
+		}
+		column++
+	}
+	if offset == len([]rune(body)) {
+		return source.SourcePosition{Line: line, Column: column}
+	}
+	return source.SourcePosition{}
+}
+
 func firstNamedSpan(spans []source.NamedSpan, fallback source.SourceSpan) source.SourceSpan {
 	for _, item := range spans {
 		if hasSpan(item.Span) {

--- a/internal/compiler/validate_test.go
+++ b/internal/compiler/validate_test.go
@@ -477,6 +477,35 @@ func TestValidateManifestRejectsUnknownGOWDKUseAlias(t *testing.T) {
 	}
 }
 
+func TestValidateManifestUnknownGOWDKUseAliasPointsToComponentTag(t *testing.T) {
+	app := appFixture{
+		Pages: []gwdkir.Page{{
+			Package: "pages",
+			ID:      "home",
+			Route:   "/",
+			Blocks: gwdkir.Blocks{
+				View:     true,
+				ViewBody: "<main>\n  <ui.Hero />\n</main>",
+				Spans: gwdkir.BlockSpans{
+					View:          source.SourceSpan{Start: source.SourcePosition{Line: 8, Column: 1}, End: source.SourcePosition{Line: 8, Column: 7}},
+					ViewBodyStart: source.SourcePosition{Line: 9, Column: 1},
+				},
+			},
+		}},
+		Components: []gwdkir.Component{{Package: "components", Name: "Hero"}},
+	}
+
+	err := validateManifest(gowdk.Config{}, app)
+	if err == nil {
+		t.Fatal("expected unknown use alias diagnostic")
+	}
+	diagnostic := firstDiagnostic(err.(ValidationErrors), "unknown_gowdk_use_alias")
+	if diagnostic == nil {
+		t.Fatalf("missing unknown alias diagnostic: %#v", err)
+	}
+	assertSourceSpan(t, diagnostic.Span, 10, 3, 10, 14)
+}
+
 func TestValidateManifestRejectsUnknownQualifiedComponent(t *testing.T) {
 	app := appFixture{
 		Pages: []gwdkir.Page{{
@@ -497,6 +526,36 @@ func TestValidateManifestRejectsUnknownQualifiedComponent(t *testing.T) {
 	if !hasDiagnosticCode(diagnostics, "unknown_gowdk_component") {
 		t.Fatalf("missing unknown component diagnostic: %#v", diagnostics)
 	}
+}
+
+func TestValidateManifestUnknownQualifiedComponentPointsToComponentTag(t *testing.T) {
+	app := appFixture{
+		Pages: []gwdkir.Page{{
+			Package: "pages",
+			ID:      "home",
+			Route:   "/",
+			Uses:    []gwdkir.Use{{Alias: "ui", Package: "components"}},
+			Blocks: gwdkir.Blocks{
+				View:     true,
+				ViewBody: "<main>\n  <ui.Missing />\n</main>",
+				Spans: gwdkir.BlockSpans{
+					View:          source.SourceSpan{Start: source.SourcePosition{Line: 12, Column: 1}, End: source.SourcePosition{Line: 12, Column: 7}},
+					ViewBodyStart: source.SourcePosition{Line: 13, Column: 1},
+				},
+			},
+		}},
+		Components: []gwdkir.Component{{Package: "components", Name: "Hero"}},
+	}
+
+	err := validateManifest(gowdk.Config{}, app)
+	if err == nil {
+		t.Fatal("expected unknown component diagnostic")
+	}
+	diagnostic := firstDiagnostic(err.(ValidationErrors), "unknown_gowdk_component")
+	if diagnostic == nil {
+		t.Fatalf("missing unknown component diagnostic: %#v", err)
+	}
+	assertSourceSpan(t, diagnostic.Span, 14, 3, 14, 17)
 }
 
 func TestValidateManifestRejectsComponentRefToLayoutOnlyUsePackage(t *testing.T) {
@@ -2472,6 +2531,36 @@ func TestValidateManifestUnknownViewFieldDiagnosticPointsToIdentifier(t *testing
 	assertSourceSpan(t, diagnostic.Span, 5, 10, 5, 17)
 }
 
+func TestValidateManifestRepeatedViewExpressionDiagnosticPointsToOccurrence(t *testing.T) {
+	app := appFixture{Components: []gwdkir.Component{{
+		Name:    "Counter",
+		Source:  "components/counter.cmp.gwdk",
+		Imports: []gwdkir.Import{{Alias: "ui", Path: "github.com/cssbruno/gowdk/testfixture/islands"}},
+		State: gwdkir.StateContract{
+			Type: gwdkir.GoRef{Alias: "ui", Name: "CounterState"},
+			Init: gwdkir.GoRef{Alias: "ui", Name: "NewCounterState"},
+		},
+		Blocks: gwdkir.Blocks{
+			View: true,
+			ViewBody: `<p>{Count}</p>
+<button class:active={Count}>Increment</button>`,
+			Spans: gwdkir.BlockSpans{
+				View: source.SourceSpan{Start: source.SourcePosition{Line: 4, Column: 1}, End: source.SourcePosition{Line: 4, Column: 7}},
+			},
+		},
+	}}}
+
+	err := validateManifest(gowdk.Config{}, app)
+	if err == nil {
+		t.Fatal("expected class toggle diagnostic")
+	}
+	diagnostic := firstDiagnostic(err.(ValidationErrors), "component_field_error")
+	if diagnostic == nil || !strings.Contains(diagnostic.Message, "class toggle") {
+		t.Fatalf("Missing class toggle diagnostic: %#v", err)
+	}
+	assertSourceSpan(t, diagnostic.Span, 6, 23, 6, 28)
+}
+
 func TestValidateManifestBadGForDiagnosticPointsToDirectiveValue(t *testing.T) {
 	app := appFixture{Components: []gwdkir.Component{{
 		Name:   "Nested",
@@ -3015,6 +3104,9 @@ func TestValidateManifestRejectsNonBoolReactiveBooleanAttribute(t *testing.T) {
 		Blocks: gwdkir.Blocks{
 			View:     true,
 			ViewBody: `<button disabled={Count}>{Count}</button>`,
+			Spans: gwdkir.BlockSpans{
+				View: source.SourceSpan{Start: source.SourcePosition{Line: 30, Column: 1}, End: source.SourcePosition{Line: 30, Column: 7}},
+			},
 		},
 	}}}
 
@@ -3026,6 +3118,8 @@ func TestValidateManifestRejectsNonBoolReactiveBooleanAttribute(t *testing.T) {
 	if !hasDiagnosticCode(diagnostics, "component_field_error") {
 		t.Fatalf("Missing component_field_error diagnostic: %#v", diagnostics)
 	}
+	diagnostic := firstDiagnostic(diagnostics, "component_field_error")
+	assertSourceSpan(t, diagnostic.Span, 31, 19, 31, 24)
 }
 
 func TestValidateManifestRejectsUnsafeReactiveURLAttribute(t *testing.T) {
@@ -3085,6 +3179,9 @@ func TestValidateManifestRejectsNonBoolClassToggle(t *testing.T) {
 		Blocks: gwdkir.Blocks{
 			View:     true,
 			ViewBody: `<button class:active={Count}>{Count}</button>`,
+			Spans: gwdkir.BlockSpans{
+				View: source.SourceSpan{Start: source.SourcePosition{Line: 40, Column: 1}, End: source.SourcePosition{Line: 40, Column: 7}},
+			},
 		},
 	}}}
 
@@ -3096,6 +3193,8 @@ func TestValidateManifestRejectsNonBoolClassToggle(t *testing.T) {
 	if !hasDiagnosticCode(diagnostics, "component_field_error") {
 		t.Fatalf("Missing component_field_error diagnostic: %#v", diagnostics)
 	}
+	diagnostic := firstDiagnostic(diagnostics, "component_field_error")
+	assertSourceSpan(t, diagnostic.Span, 41, 23, 41, 28)
 }
 
 func TestValidateManifestAllowsStyleBinding(t *testing.T) {
@@ -3130,6 +3229,9 @@ func TestValidateManifestRejectsBoolStyleBinding(t *testing.T) {
 		Blocks: gwdkir.Blocks{
 			View:     true,
 			ViewBody: `<div style:height.px={Open}>{Count}</div>`,
+			Spans: gwdkir.BlockSpans{
+				View: source.SourceSpan{Start: source.SourcePosition{Line: 50, Column: 1}, End: source.SourcePosition{Line: 50, Column: 7}},
+			},
 		},
 	}}}
 
@@ -3141,6 +3243,8 @@ func TestValidateManifestRejectsBoolStyleBinding(t *testing.T) {
 	if !hasDiagnosticCode(diagnostics, "component_field_error") {
 		t.Fatalf("Missing component_field_error diagnostic: %#v", diagnostics)
 	}
+	diagnostic := firstDiagnostic(diagnostics, "component_field_error")
+	assertSourceSpan(t, diagnostic.Span, 51, 23, 51, 27)
 }
 
 func TestValidateManifestRejectsRelativeGoTypedImportPath(t *testing.T) {

--- a/internal/view/api.go
+++ b/internal/view/api.go
@@ -125,6 +125,13 @@ type ComponentCallUsage struct {
 	ReactiveProps bool
 }
 
+// ComponentReference records one component call with source offsets.
+type ComponentReference struct {
+	Name  string
+	Start int
+	End   int
+}
+
 // ContractReference records one template-local backend contract intent.
 type ContractReference struct {
 	Kind   ContractReferenceKind
@@ -242,20 +249,37 @@ func ActionFormSchema(source string) (map[string][]ActionFormField, error) {
 // ComponentReferences returns unique component names directly referenced by a
 // view markup fragment.
 func ComponentReferences(source string) ([]string, error) {
+	refs, err := ComponentReferenceSpans(source)
+	if err != nil {
+		return nil, err
+	}
+	if len(refs) == 0 {
+		return nil, nil
+	}
+	names := map[string]bool{}
+	for _, ref := range refs {
+		names[ref.Name] = true
+	}
+	out := make([]string, 0, len(names))
+	for name := range names {
+		out = append(out, name)
+	}
+	sort.Strings(out)
+	return out, nil
+}
+
+// ComponentReferenceSpans returns component calls directly referenced by a view
+// markup fragment, preserving source offsets for diagnostics.
+func ComponentReferenceSpans(source string) ([]ComponentReference, error) {
 	nodes, err := Parse(source)
 	if err != nil {
 		return nil, err
 	}
-	names := map[string]bool{}
-	collectComponentReferences(nodes, names)
-	if len(names) == 0 {
+	var refs []ComponentReference
+	collectComponentReferences(nodes, &refs)
+	if len(refs) == 0 {
 		return nil, nil
 	}
-	refs := make([]string, 0, len(names))
-	for name := range names {
-		refs = append(refs, name)
-	}
-	sort.Strings(refs)
 	return refs, nil
 }
 

--- a/internal/view/component.go
+++ b/internal/view/component.go
@@ -14,6 +14,8 @@ type ComponentCall struct {
 	Name     string
 	Attrs    []Attr
 	Children []Node
+	Start    int
+	End      int
 }
 
 type slotContent struct {

--- a/internal/view/component_references.go
+++ b/internal/view/component_references.go
@@ -2,14 +2,14 @@ package view
 
 import "strings"
 
-func collectComponentReferences(nodes []Node, names map[string]bool) {
+func collectComponentReferences(nodes []Node, refs *[]ComponentReference) {
 	for _, node := range nodes {
 		switch typed := node.(type) {
 		case ComponentCall:
-			names[typed.Name] = true
-			collectComponentReferences(typed.Children, names)
+			*refs = append(*refs, ComponentReference{Name: typed.Name, Start: typed.Start, End: typed.End})
+			collectComponentReferences(typed.Children, refs)
 		case Element:
-			collectComponentReferences(typed.Children, names)
+			collectComponentReferences(typed.Children, refs)
 		}
 	}
 }

--- a/internal/view/node_loop.go
+++ b/internal/view/node_loop.go
@@ -16,6 +16,8 @@ type Node interface {
 // Text is escaped text content.
 type Text struct {
 	Value string
+	Start int
+	End   int
 }
 
 func (node Text) render(ctx *renderContext, out *renderOutput) error {

--- a/internal/view/parser.go
+++ b/internal/view/parser.go
@@ -48,7 +48,7 @@ func (parser *parser) nodes(until string) ([]Node, error) {
 				parser.index = start + offset
 				return nil, parser.errorf("%s", message)
 			}
-			nodes = append(nodes, Text{Value: text})
+			nodes = append(nodes, Text{Value: text, Start: start, End: parser.index})
 		}
 	}
 }
@@ -93,7 +93,7 @@ func (parser *parser) element() (Node, error) {
 		return nil, err
 	}
 	if isComponentName(name) {
-		return parser.componentCall(name)
+		return parser.componentCall(name, start)
 	}
 	if !isLowerHTMLName(name) {
 		return nil, parser.errorf("unsupported element <%s>; this build slice supports lowercase HTML tags only", name)
@@ -146,19 +146,19 @@ func (parser *parser) element() (Node, error) {
 	}
 }
 
-func (parser *parser) componentCall(name string) (ComponentCall, error) {
+func (parser *parser) componentCall(name string, start int) (ComponentCall, error) {
 	var attrs []Attr
 	for {
 		parser.skipSpace()
 		switch {
 		case parser.consume("/>"):
-			return ComponentCall{Name: name, Attrs: attrs}, nil
+			return ComponentCall{Name: name, Attrs: attrs, Start: start, End: parser.index}, nil
 		case parser.consume(">"):
 			children, err := parser.nodes(name)
 			if err != nil {
 				return ComponentCall{}, err
 			}
-			return ComponentCall{Name: name, Attrs: attrs, Children: children}, nil
+			return ComponentCall{Name: name, Attrs: attrs, Children: children, Start: start, End: parser.index}, nil
 		case parser.done():
 			return ComponentCall{}, parser.errorf("unterminated <%s> component tag", name)
 		default:

--- a/internal/view/view_test.go
+++ b/internal/view/view_test.go
@@ -1298,6 +1298,22 @@ func TestCommandReferencesFindsGCommandForms(t *testing.T) {
 	}
 }
 
+func TestComponentReferenceSpansPreservesCallOffsets(t *testing.T) {
+	refs, err := ComponentReferenceSpans(`<main><ui.Hero /><section><Card></Card></section></main>`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 2 {
+		t.Fatalf("expected two component refs, got %#v", refs)
+	}
+	if refs[0].Name != "ui.Hero" || refs[0].Start != 6 || refs[0].End != 17 {
+		t.Fatalf("unexpected qualified component ref span: %#v", refs[0])
+	}
+	if refs[1].Name != "Card" || refs[1].Start != 26 || refs[1].End != 39 {
+		t.Fatalf("unexpected component ref span: %#v", refs[1])
+	}
+}
+
 func TestContractReferencesFindsCommandsAndQueries(t *testing.T) {
 	refs, err := ContractReferences(`<main><section g:query="patients.GetPatientPage"></section><form method="post" action="/patients" g:command={patients.CreatePatient}></form></main>`)
 	if err != nil {


### PR DESCRIPTION
## Summary

- Adds parsed source offsets for component calls and text nodes so diagnostics can point at the specific view reference instead of the full `view {}` block.
- Preserves exact spans for qualified component alias/name failures and component contract checks for fields, events, bools, attrs, class/style bindings, `g:bind`, and `g:ref`.
- Keeps diagnostic codes and message shapes stable while adding regression coverage for repeated expressions and exact attr/class/style/component-tag spans.

## Issue Closure

Closes #262

## Verification

- [x] I ran the relevant tests, lint, and build commands.
- [ ] I ran `scripts/test-go-modules.sh` when Go code or compiler behavior changed.
- [ ] I ran `go build ./cmd/gowdk` when CLI, compiler, runtime, addon, or release behavior changed.
- [ ] I ran `node --check editors/vscode/extension.js` when editor files changed.
- [ ] I updated docs for behavior, setup, or architecture changes.
- [x] I added or updated tests for changed behavior.

Commands run:

```bash
git diff --check
go test ./internal/view ./internal/compiler ./internal/lang
```

## LLM Assistance

- LLM session summary: Implemented offset-backed view/component diagnostic spans for issue #262 and added focused compiler/view regression tests.
- Human-reviewed assumptions: This is diagnostic metadata only; no public syntax, diagnostic code, or generated output shape changes are intended.
- Follow-up work: None known.