### PR TITLE
fix(compiler): skip invalid contract routes in conflict checks

### DIFF
--- a/internal/compiler/routes.go
+++ b/internal/compiler/routes.go
@@ -328,6 +328,12 @@ func routeRegistrations(pages []gwdkir.Page, endpoints []gwdkir.GoEndpoint, refs
 		if strings.TrimSpace(ref.Method) == "" || strings.TrimSpace(ref.Path) == "" {
 			continue
 		}
+		if source.BackendRouteMethod(ref.Method) != contractReferenceRouteMethod(ref.Kind) {
+			continue
+		}
+		if err := source.ValidateBackendRoutePath(ref.Path); err != nil {
+			continue
+		}
 		info, issues := parseRoute(ref.Path)
 		if len(issues) > 0 {
 			continue


### PR DESCRIPTION
## Summary

- Prevent invalid generated contract routes from also entering route conflict validation.
- Keeps the specific `contract_route_invalid` diagnostic ahead of broader `route_method_conflict` noise when a contract method/path is invalid.
- Fixes the final combined `go test ./...` regression after the M2 compiler PR merge chain.

## Verification

- `go test ./internal/compiler`
- `go test ./...`
- `go build ./cmd/gowdk`

## LLM Assistance

- Implemented by Codex after the final M2 merge audit exposed the integration failure.