### PR TITLE
fix(compiler): reject dynamic default contract routes

### DIFF
--- a/internal/compiler/validate_test.go
+++ b/internal/compiler/validate_test.go
@@ -3621,6 +3621,31 @@ func TestValidateManifestRejectsInvalidContractReferenceRoutes(t *testing.T) {
 	}
 }
 
+func TestValidateManifestRejectsDefaultContractRouteOnDynamicPage(t *testing.T) {
+	app := appFixture{
+		Pages: []gwdkir.Page{{
+			Package: "pages",
+			ID:      "blog.show",
+			Route:   "/blog/{slug}",
+			Source:  "pages/blog-show.page.gwdk",
+			Blocks: gwdkir.Blocks{
+				Paths:    true,
+				View:     true,
+				ViewBody: `<form g:command="posts.CreateComment"></form>`,
+			},
+		}},
+	}
+
+	err := validateManifest(gowdk.Config{}, app)
+	if err == nil {
+		t.Fatal("expected invalid dynamic default contract route diagnostic")
+	}
+	diagnostics := err.(ValidationErrors)
+	if !hasDiagnosticMessage(diagnostics, "contract_route_invalid", "dynamic page route", "/blog/{slug}") {
+		t.Fatalf("Missing dynamic default contract_route_invalid diagnostic: %#v", diagnostics)
+	}
+}
+
 func TestValidateManifestRejectsDefaultQueryRouteWithDynamicParams(t *testing.T) {
 	app := appFixture{
 		Pages: []gwdkir.Page{{
@@ -3643,7 +3668,7 @@ func TestValidateManifestRejectsDefaultQueryRouteWithDynamicParams(t *testing.T)
 	if !hasDiagnosticCode(diagnostics, "contract_route_invalid") {
 		t.Fatalf("Missing contract_route_invalid diagnostic: %#v", diagnostics)
 	}
-	if !strings.Contains(diagnostics[0].Message, "without query, fragment, or params") {
+	if !strings.Contains(diagnostics[0].Message, "dynamic page route") {
 		t.Fatalf("unexpected diagnostic message: %s", diagnostics[0].Message)
 	}
 }
@@ -3817,6 +3842,29 @@ func TestValidateManifestRejectsRouteMethodConflicts(t *testing.T) {
 		diagnostics := err.(ValidationErrors)
 		if !hasDiagnosticMessage(diagnostics, "route_method_conflict", "POST", "/patients", "command contract patients.CreatePatient", "action patients.CreatePatient") {
 			t.Fatalf("Missing command/action route_method_conflict diagnostic: %#v", diagnostics)
+		}
+	})
+
+	t.Run("default command route conflicts with inherited action route", func(t *testing.T) {
+		app := appFixture{
+			Pages: []gwdkir.Page{{
+				ID:    "patients",
+				Route: "/patients",
+				Blocks: gwdkir.Blocks{
+					View:     true,
+					ViewBody: `<main><form g:command="patients.CreatePatient"></form></main>`,
+					Actions:  []gwdkir.Action{{Name: "Save"}},
+				},
+			}},
+		}
+
+		err := validateManifest(gowdk.Config{}, app)
+		if err == nil {
+			t.Fatal("expected default command/action route method conflict")
+		}
+		diagnostics := err.(ValidationErrors)
+		if !hasDiagnosticMessage(diagnostics, "route_method_conflict", "POST", "/patients", "command contract patients.CreatePatient", "action patients.Save") {
+			t.Fatalf("Missing default command/action route_method_conflict diagnostic: %#v", diagnostics)
 		}
 	})
 

--- a/internal/gwdkanalysis/ir_contracts.go
+++ b/internal/gwdkanalysis/ir_contracts.go
@@ -24,12 +24,22 @@ func appendContractReferences(program *gwdkir.Program, template gwdkir.Template)
 		method := source.BackendRouteMethod(ref.Method)
 		path := ref.Path
 		if path == "" && template.Route != "" {
-			if ref.Kind == view.ContractReferenceQuery {
+			routeIsDynamic := routeHasDynamicParams(template.Route)
+			if routeIsDynamic {
+				program.Diagnostics = append(program.Diagnostics, gwdkir.Diagnostic{
+					Code:    "contract_route_invalid",
+					Source:  template.Source,
+					Span:    templateOffsetSpan(template, ref.Start, ref.End),
+					Message: fmt.Sprintf("%s %s must declare an explicit route on dynamic page route %q", irContractReferenceKind(ref.Kind), ref.Name, template.Route),
+				})
+			} else if ref.Kind == view.ContractReferenceQuery {
 				method = "GET"
 			} else if method == "" {
 				method = "POST"
 			}
-			path = template.Route
+			if !routeIsDynamic {
+				path = template.Route
+			}
 		}
 		importAlias, contractType := splitContractReferenceName(ref.Name)
 		importPath := contractReferenceImportPath(template.Imports, importAlias)
@@ -49,6 +59,10 @@ func appendContractReferences(program *gwdkir.Program, template gwdkir.Template)
 			Span:        templateOffsetSpan(template, ref.Start, ref.End),
 		})
 	}
+}
+
+func routeHasDynamicParams(route string) bool {
+	return strings.Contains(route, "{")
 }
 
 func splitContractReferenceName(name string) (string, string) {

--- a/internal/gwdkanalysis/ir_contracts_test.go
+++ b/internal/gwdkanalysis/ir_contracts_test.go
@@ -34,6 +34,38 @@ func TestBuildProgramDerivesPageOwnedContractRoutes(t *testing.T) {
 	}
 }
 
+func TestBuildProgramRejectsDynamicPageOwnedDefaultContractRoutes(t *testing.T) {
+	program := BuildProgram(gowdk.Config{}, Sources{Pages: []gwdkir.Page{{
+		Package: "pages",
+		ID:      "blog.show",
+		Route:   "/blog/{slug}",
+		Blocks: gwdkir.Blocks{
+			Paths: true,
+			View:  true,
+			ViewBody: `<main>
+  <form g:command="posts.CreateComment"></form>
+  <section g:query="posts.GetComments"></section>
+</main>`,
+		},
+	}}})
+
+	refs := contractRefsByName(program.ContractRefs)
+	if ref := refs["posts.CreateComment"]; ref.Method != "POST" || ref.Path != "" {
+		t.Fatalf("dynamic default command method/path = %s %s, want POST with empty non-routable path", ref.Method, ref.Path)
+	}
+	if ref := refs["posts.GetComments"]; ref.Method != "" || ref.Path != "" {
+		t.Fatalf("dynamic default query method/path = %s %s, want empty non-routable metadata", ref.Method, ref.Path)
+	}
+	if len(program.Diagnostics) != 2 {
+		t.Fatalf("expected two dynamic default contract route diagnostics, got %#v", program.Diagnostics)
+	}
+	for _, diagnostic := range program.Diagnostics {
+		if diagnostic.Code != "contract_route_invalid" {
+			t.Fatalf("expected contract_route_invalid diagnostic, got %#v", diagnostic)
+		}
+	}
+}
+
 func TestBuildProgramKeepsComponentQueryNonRoutable(t *testing.T) {
 	program := BuildProgram(gowdk.Config{}, Sources{Components: []gwdkir.Component{{
 		Package: "components",


### PR DESCRIPTION
## Summary

- Stop deriving generated contract route paths from dynamic page route patterns when `g:command` or `g:query` omits an explicit action/path.
- Emit `contract_route_invalid` for omitted contract routes on dynamic pages so the route report cannot advertise unreachable `/path/{param}` backend routes.
- Add a regression for default command routes colliding with inherited page action routes so appgen duplicate backend registrations stay compile-time diagnostics.

## Review Feedback

Addresses Codex review comments:

- Avoid registering template route patterns for default commands.
- Detect collisions with page-owned backend endpoints.

## Verification

- `go test ./internal/gwdkanalysis ./internal/compiler`
- `go test ./internal/appgen ./internal/buildgen`
- `go test ./...`
- `go build ./cmd/gowdk`

## LLM Assistance

- Implemented by Codex from automated review feedback.