### PR TITLE
M2: complete #304 coverage gate + #306 declaration parser (phase 3 start)

### DIFF
--- a/docs/language/conformance.md
+++ b/docs/language/conformance.md
@@ -52,8 +52,15 @@ It cannot cleanly cover constructs that require project context: reactive `g:`
 directives (`g:if`/`g:on`/`g:bind`) reference a Go-typed `state` contract that
 does not resolve single-file; endpoint forms (`act`/`api`) need exported Go
 handlers; and `layout`/`wasm`/`asset`/`css` need sibling files or config. Those
-are exercised by the package- and build-level tests instead. Expanding the
-corpus to a project-level harness for them is tracked separately.
+are exercised by the package- and build-level tests instead.
+
+Full construct coverage is therefore split, and the split is enforced.
+`TestConformanceCoversEveryConstruct` partitions every construct in the
+stability registry (`lang.ConstructStabilities`) into `corpusConstructs` (the
+single-file corpus exercises it) or `integrationCoverage` (a named integration
+test covers the project-context construct). Adding a construct to the registry
+fails that test until it is given coverage in one set or the other, so no
+construct can silently go untested.
 
 ## Coverage
 

--- a/internal/lang/conformance_coverage_test.go
+++ b/internal/lang/conformance_coverage_test.go
@@ -1,10 +1,16 @@
 package lang
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
 
 // corpusConstructs are the constructs the single-file conformance corpus
-// exercises directly (in an accept case, or a reject case asserting the
-// construct's diagnostic code).
+// exercises directly. TestConformanceCoversEveryConstruct verifies each one is
+// actually present in a corpus file, so the claim cannot outlive its case.
 var corpusConstructs = map[string]bool{
 	"package":                     true,
 	"use":                         true,
@@ -22,78 +28,82 @@ var corpusConstructs = map[string]bool{
 }
 
 // integrationCoverage maps each construct the single-file corpus cannot exercise
-// cleanly to the test surface that does. These constructs need project context
-// the corpus lacks: reactive g: directives reference a Go-typed state contract,
+// cleanly to a test file that does. These constructs need project context the
+// corpus lacks: reactive g: directives reference a Go-typed state contract,
 // endpoints need exported Go handlers, and several metadata keywords/blocks need
-// sibling files or config. Keeping the mapping here makes "full construct
-// coverage" a verifiable gate.
+// sibling files or config. Paths are relative to this package and verified to
+// exist by TestIntegrationCoverageFilesExist, so a renamed or deleted file
+// breaks the gate instead of silently passing.
 var integrationCoverage = map[string]string{
-	// g: directives: parsed by internal/view, validated against component
-	// contracts by internal/compiler.
-	"g:if":           "internal/view view_test.go; internal/compiler validate_component_view",
-	"g:else-if":      "internal/view view_test.go",
-	"g:else":         "internal/view view_test.go",
-	"g:for":          "internal/view view_test.go",
-	"g:key":          "internal/view view_test.go",
-	"g:html":         "internal/view view_test.go",
-	"g:bind:value":   "internal/compiler validate_component_client",
-	"g:bind:checked": "internal/compiler validate_component_client",
-	"g:post":         "internal/compiler validate_component_view (forms)",
-	"g:target":       "internal/compiler validate_component_view (forms)",
-	"g:swap":         "internal/compiler validate_component_view (forms)",
-	"g:island":       "internal/compiler validate_component_client (islands)",
-	"g:command":      "internal/compiler validate_contract_refs",
-	"g:query":        "internal/compiler validate_contract_refs",
-	"g:event":        "internal/view directives (domain-event explainer)",
-	"g:ref":          "internal/compiler validate_component_client",
-	"g:slot":         "internal/compiler validate_component_view (slots)",
-	"g:on:*":         "internal/view view_test.go (event directives)",
-	"g:message:*":    "internal/compiler validate_component_view (validation messages)",
+	// g: directives parsed by internal/view.
+	"g:if":      "../view/view_test.go",
+	"g:else-if": "../view/view_test.go",
+	"g:else":    "../view/view_test.go",
+	"g:for":     "../view/view_test.go",
+	"g:key":     "../view/view_test.go",
+	"g:html":    "../view/view_test.go",
+	"g:on:*":    "../view/view_test.go",
 
-	// Planned g: directives: rejected by internal/view markup validation.
-	"g:transition": "internal/view directives (unsupported markup)",
-	"g:animate":    "internal/view directives (unsupported markup)",
-	"g:window":     "internal/view directives (unsupported markup)",
-	"g:document":   "internal/view directives (unsupported markup)",
-	"g:body":       "internal/view directives (unsupported markup)",
-	"g:head":       "internal/view directives (unsupported markup)",
-	"g:await":      "internal/view directives (unsupported markup)",
-	"g:async":      "internal/view directives (unsupported markup)",
-	"g:use":        "internal/view directives (unsupported markup)",
-	"g:action":     "internal/view directives (unsupported markup)",
-	"g:attach":     "internal/view directives (unsupported markup)",
+	// g: directives validated against component contracts by internal/compiler.
+	"g:bind:value":   "../compiler/validate_test.go",
+	"g:bind:checked": "../compiler/validate_test.go",
+	"g:post":         "../compiler/validate_test.go",
+	"g:target":       "../compiler/validate_test.go",
+	"g:swap":         "../compiler/validate_test.go",
+	"g:island":       "../compiler/validate_test.go",
+	"g:event":        "../compiler/validate_test.go",
+	"g:ref":          "../compiler/validate_test.go",
+	"g:slot":         "../compiler/validate_test.go",
+	"g:message:*":    "../compiler/validate_test.go",
+	"g:command":      "../compiler/validate_contract_refs_test.go",
+	"g:query":        "../compiler/validate_contract_refs_test.go",
+
+	// Planned g: directives rejected by internal/view markup validation.
+	"g:transition": "../view/view_test.go",
+	"g:animate":    "../view/view_test.go",
+	"g:window":     "../view/view_test.go",
+	"g:document":   "../view/view_test.go",
+	"g:body":       "../view/view_test.go",
+	"g:head":       "../view/view_test.go",
+	"g:await":      "../view/view_test.go",
+	"g:async":      "../view/view_test.go",
+	"g:use":        "../view/view_test.go",
+	"g:action":     "../view/view_test.go",
+	"g:attach":     "../view/view_test.go",
 
 	// Blocks and keywords needing Go types, sibling files, or config.
-	"import":     "internal/parser syntax_test (Go imports)",
-	"paths {}":   "internal/compiler routes_test (dynamic SPA paths)",
-	"load {}":    "internal/compiler validate_page (SSR load)",
-	"client {}":  "internal/compiler validate_component_client",
-	"go {}":      "internal/compiler backend_bindings_test",
-	"store":      "internal/compiler validate_page (page stores)",
-	"state":      "internal/compiler validate_component_client",
-	"emits":      "internal/compiler validate_identity (component emits)",
-	"page":       "internal/compiler validate_identity (page id)",
-	"canonical":  "internal/compiler validate_page (head metadata)",
-	"image":      "internal/compiler validate_page (head metadata)",
-	"layout":     "internal/compiler validate_identity (layouts)",
-	"cache":      "internal/compiler validate_page (cache policy)",
-	"revalidate": "internal/compiler validate_page (revalidate policy)",
-	"error":      "internal/compiler validate_errors (error pages)",
-	"guard":      "internal/compiler validate_page (guards)",
-	"css":        "internal/compiler validate_page (css selection)",
-	"wasm":       "internal/compiler validate_component_fingerprint (wasm islands)",
-	"asset":      "internal/compiler validate_assets",
-	"act":        "internal/compiler backend_bindings_test (actions)",
-	"api":        "internal/compiler backend_bindings_test (apis)",
-	"fragment":   "internal/compiler backend_bindings_test (fragments)",
+	"import":     "../parser/syntax_test.go",
+	"paths {}":   "../compiler/validate_test.go",
+	"load {}":    "../compiler/validate_test.go",
+	"client {}":  "../compiler/validate_test.go",
+	"go {}":      "../compiler/backend_bindings_test.go",
+	"store":      "../compiler/validate_test.go",
+	"state":      "../compiler/validate_test.go",
+	"emits":      "../compiler/validate_test.go",
+	"page":       "../compiler/validate_test.go",
+	"canonical":  "../compiler/validate_test.go",
+	"image":      "../compiler/validate_test.go",
+	"layout":     "../compiler/validate_test.go",
+	"cache":      "../compiler/validate_test.go",
+	"revalidate": "../compiler/validate_test.go",
+	"error":      "../compiler/validate_test.go",
+	"guard":      "../compiler/validate_test.go",
+	"css":        "../compiler/validate_test.go",
+	"wasm":       "../compiler/validate_test.go",
+	"asset":      "../compiler/validate_test.go",
+	"act":        "../compiler/backend_bindings_test.go",
+	"api":        "../compiler/backend_bindings_test.go",
+	"fragment":   "../compiler/backend_bindings_test.go",
 }
 
 // TestConformanceCoversEveryConstruct asserts every construct in the stability
 // registry is accounted for — exercised by the single-file corpus or mapped to
-// the integration test that covers it — and that the two coverage sets do not
-// overlap. A new construct fails here until it is given coverage, so "full
-// construct coverage" cannot silently regress.
+// an integration test — the two sets do not overlap, and a corpus claim is
+// backed by an actual corpus file. A new construct fails here until it is given
+// real coverage.
 func TestConformanceCoversEveryConstruct(t *testing.T) {
+	corpus := readAllCorpus(t)
+
 	for _, construct := range ConstructStabilities() {
 		inCorpus := corpusConstructs[construct.Name]
 		_, inIntegration := integrationCoverage[construct.Name]
@@ -102,6 +112,18 @@ func TestConformanceCoversEveryConstruct(t *testing.T) {
 			t.Errorf("construct %q is listed as both corpus and integration covered", construct.Name)
 		case !inCorpus && !inIntegration:
 			t.Errorf("construct %q (%s) has no corpus or integration coverage entry", construct.Name, construct.Kind)
+		case inCorpus && !constructPresentInCorpus(construct, corpus):
+			t.Errorf("construct %q claims corpus coverage but no corpus file exercises it", construct.Name)
+		}
+	}
+}
+
+// TestIntegrationCoverageFilesExist verifies every integration-coverage
+// reference points at a real file, so a rename or deletion fails the gate.
+func TestIntegrationCoverageFilesExist(t *testing.T) {
+	for name, path := range integrationCoverage {
+		if _, err := os.Stat(filepath.FromSlash(path)); err != nil {
+			t.Errorf("integration coverage for %q points at missing file %q: %v", name, path, err)
 		}
 	}
 }
@@ -123,4 +145,30 @@ func TestCoverageSetsHaveNoStaleEntries(t *testing.T) {
 			t.Errorf("integrationCoverage entry %q is not a registry construct", name)
 		}
 	}
+}
+
+func readAllCorpus(t *testing.T) string {
+	t.Helper()
+	var builder strings.Builder
+	for _, dir := range []string{"testdata/conformance/accept", "testdata/conformance/reject"} {
+		base := filepath.FromSlash(dir)
+		for _, name := range conformanceFiles(t, base) {
+			builder.Write(readConformanceFile(t, filepath.Join(base, name)))
+			builder.WriteByte('\n')
+		}
+	}
+	return builder.String()
+}
+
+// constructPresentInCorpus checks the corpus actually exercises a construct: by
+// its diagnostic code (reject cases), its `name {` header (block constructs), or
+// a line beginning with its name (keywords and endpoints).
+func constructPresentInCorpus(construct ConstructStability, corpus string) bool {
+	if construct.DiagnosticCode != "" {
+		return strings.Contains(corpus, construct.DiagnosticCode)
+	}
+	if header := strings.TrimSuffix(construct.Name, " {}"); header != construct.Name {
+		return regexp.MustCompile(`(?m)^[ \t]*` + regexp.QuoteMeta(header) + `[ \t]*\{`).MatchString(corpus)
+	}
+	return regexp.MustCompile(`(?m)^[ \t]*` + regexp.QuoteMeta(construct.Name) + `([ \t]|"|$)`).MatchString(corpus)
 }

--- a/internal/lang/conformance_coverage_test.go
+++ b/internal/lang/conformance_coverage_test.go
@@ -1,0 +1,126 @@
+package lang
+
+import "testing"
+
+// corpusConstructs are the constructs the single-file conformance corpus
+// exercises directly (in an accept case, or a reject case asserting the
+// construct's diagnostic code).
+var corpusConstructs = map[string]bool{
+	"package":                     true,
+	"use":                         true,
+	"route":                       true,
+	"title":                       true,
+	"description":                 true,
+	"build {}":                    true,
+	"view {}":                     true,
+	"style {}":                    true,
+	"props":                       true,
+	"component":                   true,
+	"unsupported top-level block": true,
+	"act block form":              true,
+	"api block form":              true,
+}
+
+// integrationCoverage maps each construct the single-file corpus cannot exercise
+// cleanly to the test surface that does. These constructs need project context
+// the corpus lacks: reactive g: directives reference a Go-typed state contract,
+// endpoints need exported Go handlers, and several metadata keywords/blocks need
+// sibling files or config. Keeping the mapping here makes "full construct
+// coverage" a verifiable gate.
+var integrationCoverage = map[string]string{
+	// g: directives: parsed by internal/view, validated against component
+	// contracts by internal/compiler.
+	"g:if":           "internal/view view_test.go; internal/compiler validate_component_view",
+	"g:else-if":      "internal/view view_test.go",
+	"g:else":         "internal/view view_test.go",
+	"g:for":          "internal/view view_test.go",
+	"g:key":          "internal/view view_test.go",
+	"g:html":         "internal/view view_test.go",
+	"g:bind:value":   "internal/compiler validate_component_client",
+	"g:bind:checked": "internal/compiler validate_component_client",
+	"g:post":         "internal/compiler validate_component_view (forms)",
+	"g:target":       "internal/compiler validate_component_view (forms)",
+	"g:swap":         "internal/compiler validate_component_view (forms)",
+	"g:island":       "internal/compiler validate_component_client (islands)",
+	"g:command":      "internal/compiler validate_contract_refs",
+	"g:query":        "internal/compiler validate_contract_refs",
+	"g:event":        "internal/view directives (domain-event explainer)",
+	"g:ref":          "internal/compiler validate_component_client",
+	"g:slot":         "internal/compiler validate_component_view (slots)",
+	"g:on:*":         "internal/view view_test.go (event directives)",
+	"g:message:*":    "internal/compiler validate_component_view (validation messages)",
+
+	// Planned g: directives: rejected by internal/view markup validation.
+	"g:transition": "internal/view directives (unsupported markup)",
+	"g:animate":    "internal/view directives (unsupported markup)",
+	"g:window":     "internal/view directives (unsupported markup)",
+	"g:document":   "internal/view directives (unsupported markup)",
+	"g:body":       "internal/view directives (unsupported markup)",
+	"g:head":       "internal/view directives (unsupported markup)",
+	"g:await":      "internal/view directives (unsupported markup)",
+	"g:async":      "internal/view directives (unsupported markup)",
+	"g:use":        "internal/view directives (unsupported markup)",
+	"g:action":     "internal/view directives (unsupported markup)",
+	"g:attach":     "internal/view directives (unsupported markup)",
+
+	// Blocks and keywords needing Go types, sibling files, or config.
+	"import":     "internal/parser syntax_test (Go imports)",
+	"paths {}":   "internal/compiler routes_test (dynamic SPA paths)",
+	"load {}":    "internal/compiler validate_page (SSR load)",
+	"client {}":  "internal/compiler validate_component_client",
+	"go {}":      "internal/compiler backend_bindings_test",
+	"store":      "internal/compiler validate_page (page stores)",
+	"state":      "internal/compiler validate_component_client",
+	"emits":      "internal/compiler validate_identity (component emits)",
+	"page":       "internal/compiler validate_identity (page id)",
+	"canonical":  "internal/compiler validate_page (head metadata)",
+	"image":      "internal/compiler validate_page (head metadata)",
+	"layout":     "internal/compiler validate_identity (layouts)",
+	"cache":      "internal/compiler validate_page (cache policy)",
+	"revalidate": "internal/compiler validate_page (revalidate policy)",
+	"error":      "internal/compiler validate_errors (error pages)",
+	"guard":      "internal/compiler validate_page (guards)",
+	"css":        "internal/compiler validate_page (css selection)",
+	"wasm":       "internal/compiler validate_component_fingerprint (wasm islands)",
+	"asset":      "internal/compiler validate_assets",
+	"act":        "internal/compiler backend_bindings_test (actions)",
+	"api":        "internal/compiler backend_bindings_test (apis)",
+	"fragment":   "internal/compiler backend_bindings_test (fragments)",
+}
+
+// TestConformanceCoversEveryConstruct asserts every construct in the stability
+// registry is accounted for — exercised by the single-file corpus or mapped to
+// the integration test that covers it — and that the two coverage sets do not
+// overlap. A new construct fails here until it is given coverage, so "full
+// construct coverage" cannot silently regress.
+func TestConformanceCoversEveryConstruct(t *testing.T) {
+	for _, construct := range ConstructStabilities() {
+		inCorpus := corpusConstructs[construct.Name]
+		_, inIntegration := integrationCoverage[construct.Name]
+		switch {
+		case inCorpus && inIntegration:
+			t.Errorf("construct %q is listed as both corpus and integration covered", construct.Name)
+		case !inCorpus && !inIntegration:
+			t.Errorf("construct %q (%s) has no corpus or integration coverage entry", construct.Name, construct.Kind)
+		}
+	}
+}
+
+// TestCoverageSetsHaveNoStaleEntries keeps the coverage maps honest: every entry
+// must name a construct that still exists in the registry.
+func TestCoverageSetsHaveNoStaleEntries(t *testing.T) {
+	registry := map[string]bool{}
+	for _, construct := range ConstructStabilities() {
+		registry[construct.Name] = true
+	}
+	for name := range corpusConstructs {
+		if !registry[name] {
+			t.Errorf("corpusConstructs entry %q is not a registry construct", name)
+		}
+	}
+	for name := range integrationCoverage {
+		if !registry[name] {
+			t.Errorf("integrationCoverage entry %q is not a registry construct", name)
+		}
+	}
+}

--- a/internal/lang/declparse.go
+++ b/internal/lang/declparse.go
@@ -1,0 +1,115 @@
+package lang
+
+import "github.com/cssbruno/gowdk/internal/gwdkast"
+
+// TopLevel holds the top-level declaration nodes a recursive-descent parse
+// recovers from .gwdk source. It is the first slice of the ADR 0010 parser
+// producing real gwdkast nodes (rather than the tooling outline): the package
+// declaration plus Go imports and GOWDK uses, which map one-to-one to the
+// line-oriented parser's output and are exercised by an equivalence test against
+// internal/parser.ParseSyntax. Metadata routing, blocks, view markup, and
+// endpoints remain on the line-oriented parser until later phases.
+type TopLevel struct {
+	Package *gwdkast.Package
+	Imports []gwdkast.Import
+	Uses    []gwdkast.Use
+}
+
+// ParseTopLevel parses the package, import, and use declarations of .gwdk source
+// with a recursive-descent pass over the shared tokenizer. It recovers from
+// unrecognized or malformed lines by skipping to the next line and skips block
+// bodies by brace matching, so one bad declaration never hides the rest.
+func ParseTopLevel(src string) TopLevel {
+	tokens, _ := Lex(src)
+	var result TopLevel
+
+	index := 0
+	for index < len(tokens) {
+		token := tokens[index]
+		if token.Kind == TokenEOF {
+			break
+		}
+		if token.Kind == TokenNewline {
+			index++
+			continue
+		}
+
+		lineEnd, hasBrace := lineExtent(tokens, index)
+		if hasBrace {
+			index = matchBrace(tokens, index) + 1
+			continue
+		}
+
+		line := tokens[index:lineEnd]
+		first := line[0]
+		if first.Kind == TokenIdentifier {
+			switch first.Lexeme {
+			case "package":
+				if result.Package == nil {
+					if name := firstIdentifier(line, 1); name != "" {
+						result.Package = &gwdkast.Package{Name: name, Span: spanOf(first, line[len(line)-1])}
+					}
+				}
+			case "import":
+				if imp, ok := parseImportLine(line); ok {
+					result.Imports = append(result.Imports, imp)
+				}
+			case "use":
+				if use, ok := parseUseLine(line); ok {
+					result.Uses = append(result.Uses, use)
+				}
+			}
+		}
+		index = lineEnd
+	}
+
+	return result
+}
+
+// parseImportLine reads `import [alias] "path"`. The alias is the identifier
+// between import and the path string, or empty, matching the line parser.
+func parseImportLine(line []Token) (gwdkast.Import, bool) {
+	var alias, path string
+	for index := 1; index < len(line); index++ {
+		switch line[index].Kind {
+		case TokenIdentifier:
+			if alias == "" {
+				alias = line[index].Lexeme
+			}
+		case TokenString:
+			path = unquote(line[index].Lexeme)
+		}
+	}
+	if path == "" {
+		return gwdkast.Import{}, false
+	}
+	return gwdkast.Import{Alias: alias, Path: path, Span: spanOf(line[0], line[len(line)-1])}, true
+}
+
+// parseUseLine reads `use <alias> "<package>"`.
+func parseUseLine(line []Token) (gwdkast.Use, bool) {
+	var alias, pkg string
+	for index := 1; index < len(line); index++ {
+		switch line[index].Kind {
+		case TokenIdentifier:
+			if alias == "" {
+				alias = line[index].Lexeme
+			}
+		case TokenString:
+			pkg = unquote(line[index].Lexeme)
+		}
+	}
+	if alias == "" || pkg == "" {
+		return gwdkast.Use{}, false
+	}
+	return gwdkast.Use{Alias: alias, Package: pkg, Span: spanOf(line[0], line[len(line)-1])}, true
+}
+
+func firstIdentifier(line []Token, from int) string {
+	for index := from; index < len(line); index++ {
+		if line[index].Kind == TokenIdentifier {
+			return line[index].Lexeme
+		}
+	}
+	return ""
+}

--- a/internal/lang/declparse.go
+++ b/internal/lang/declparse.go
@@ -1,6 +1,10 @@
 package lang
 
-import "github.com/cssbruno/gowdk/internal/gwdkast"
+import (
+	"unicode"
+
+	"github.com/cssbruno/gowdk/internal/gwdkast"
+)
 
 // TopLevel holds the top-level declaration nodes a recursive-descent parse
 // recovers from .gwdk source. It is the first slice of the ADR 0010 parser
@@ -16,9 +20,11 @@ type TopLevel struct {
 }
 
 // ParseTopLevel parses the package, import, and use declarations of .gwdk source
-// with a recursive-descent pass over the shared tokenizer. It recovers from
-// unrecognized or malformed lines by skipping to the next line and skips block
-// bodies by brace matching, so one bad declaration never hides the rest.
+// with a recursive-descent pass over the shared tokenizer. It accepts only the
+// exact shapes the line-oriented parser accepts (so an equivalence-anchored
+// cutover never turns malformed source into valid nodes) and recovers from any
+// other line by skipping to the next line, skipping block bodies by brace
+// matching, so one bad declaration never hides the rest.
 func ParseTopLevel(src string) TopLevel {
 	tokens, _ := Lex(src)
 	var result TopLevel
@@ -46,16 +52,16 @@ func ParseTopLevel(src string) TopLevel {
 			switch first.Lexeme {
 			case "package":
 				if result.Package == nil {
-					if name := firstIdentifier(line, 1); name != "" {
+					if name, ok := parsePackageName(line); ok {
 						result.Package = &gwdkast.Package{Name: name, Span: spanOf(first, line[len(line)-1])}
 					}
 				}
 			case "import":
-				if imp, ok := parseImportLine(line); ok {
+				if imp, ok := parseImportTokens(line); ok {
 					result.Imports = append(result.Imports, imp)
 				}
 			case "use":
-				if use, ok := parseUseLine(line); ok {
+				if use, ok := parseUseTokens(line); ok {
 					result.Uses = append(result.Uses, use)
 				}
 			}
@@ -66,50 +72,77 @@ func ParseTopLevel(src string) TopLevel {
 	return result
 }
 
-// parseImportLine reads `import [alias] "path"`. The alias is the identifier
-// between import and the path string, or empty, matching the line parser.
-func parseImportLine(line []Token) (gwdkast.Import, bool) {
-	var alias, path string
-	for index := 1; index < len(line); index++ {
-		switch line[index].Kind {
-		case TokenIdentifier:
-			if alias == "" {
-				alias = line[index].Lexeme
-			}
-		case TokenString:
-			path = unquote(line[index].Lexeme)
-		}
+// parsePackageName accepts exactly `package <strict-ident>` with no trailing
+// tokens, matching parsePackageLine in the line parser.
+func parsePackageName(line []Token) (string, bool) {
+	if len(line) != 2 || line[1].Kind != TokenIdentifier || !isStrictIdent(line[1].Lexeme) {
+		return "", false
 	}
-	if path == "" {
+	return line[1].Lexeme, true
+}
+
+// parseImportTokens accepts exactly `import [<strict-ident alias>] <string path>`
+// with no trailing tokens. The alias is optional; the path may be any import
+// path. Extra identifiers or trailing tokens are rejected so the line is
+// recovered past rather than emitted.
+func parseImportTokens(line []Token) (gwdkast.Import, bool) {
+	index := 1
+	alias := ""
+	if index < len(line) && line[index].Kind == TokenIdentifier {
+		if !isStrictIdent(line[index].Lexeme) {
+			return gwdkast.Import{}, false
+		}
+		alias = line[index].Lexeme
+		index++
+	}
+	if index >= len(line) || line[index].Kind != TokenString {
+		return gwdkast.Import{}, false
+	}
+	path := unquote(line[index].Lexeme)
+	index++
+	if index != len(line) || path == "" {
 		return gwdkast.Import{}, false
 	}
 	return gwdkast.Import{Alias: alias, Path: path, Span: spanOf(line[0], line[len(line)-1])}, true
 }
 
-// parseUseLine reads `use <alias> "<package>"`.
-func parseUseLine(line []Token) (gwdkast.Use, bool) {
-	var alias, pkg string
-	for index := 1; index < len(line); index++ {
-		switch line[index].Kind {
-		case TokenIdentifier:
-			if alias == "" {
-				alias = line[index].Lexeme
-			}
-		case TokenString:
-			pkg = unquote(line[index].Lexeme)
-		}
-	}
-	if alias == "" || pkg == "" {
+// parseUseTokens accepts exactly `use <strict-ident alias> "<strict-ident package>"`
+// with no trailing tokens, matching parseUseLine (the package must be a strict
+// identifier, so paths like "ui/forms" are rejected).
+func parseUseTokens(line []Token) (gwdkast.Use, bool) {
+	if len(line) != 3 {
 		return gwdkast.Use{}, false
 	}
-	return gwdkast.Use{Alias: alias, Package: pkg, Span: spanOf(line[0], line[len(line)-1])}, true
+	if line[1].Kind != TokenIdentifier || !isStrictIdent(line[1].Lexeme) {
+		return gwdkast.Use{}, false
+	}
+	if line[2].Kind != TokenString {
+		return gwdkast.Use{}, false
+	}
+	pkg := unquote(line[2].Lexeme)
+	if !isStrictIdent(pkg) {
+		return gwdkast.Use{}, false
+	}
+	return gwdkast.Use{Alias: line[1].Lexeme, Package: pkg, Span: spanOf(line[0], line[len(line)-1])}, true
 }
 
-func firstIdentifier(line []Token, from int) string {
-	for index := from; index < len(line); index++ {
-		if line[index].Kind == TokenIdentifier {
-			return line[index].Lexeme
+// isStrictIdent mirrors the line parser's identifier rule: a leading letter or
+// underscore followed by letters, underscores, or digits. The shared tokenizer
+// also admits '.' and '-' in identifier lexemes, so this re-checks strictness.
+func isStrictIdent(value string) bool {
+	if value == "" {
+		return false
+	}
+	for index, r := range value {
+		if index == 0 {
+			if !unicode.IsLetter(r) && r != '_' {
+				return false
+			}
+			continue
+		}
+		if !unicode.IsLetter(r) && r != '_' && !unicode.IsDigit(r) {
+			return false
 		}
 	}
-	return ""
+	return true
 }

--- a/internal/lang/declparse_test.go
+++ b/internal/lang/declparse_test.go
@@ -1,0 +1,135 @@
+package lang
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cssbruno/gowdk/internal/gwdkast"
+	"github.com/cssbruno/gowdk/internal/parser"
+)
+
+func importKeys(imports []gwdkast.Import) map[string]bool {
+	keys := map[string]bool{}
+	for _, item := range imports {
+		keys[item.Alias+"\x00"+item.Path] = true
+	}
+	return keys
+}
+
+func useKeys(uses []gwdkast.Use) map[string]bool {
+	keys := map[string]bool{}
+	for _, item := range uses {
+		keys[item.Alias+"\x00"+item.Package] = true
+	}
+	return keys
+}
+
+// TestParseTopLevelMatchesLineParser anchors the recursive-descent declaration
+// parser against the line-oriented parser: for valid source they must agree on
+// the package name and the set of imports and uses.
+func TestParseTopLevelMatchesLineParser(t *testing.T) {
+	src := `package pages
+
+import "fmt"
+import alias "github.com/x/y"
+
+use widgets "components"
+use forms "forms"
+
+route "/"
+title "Home"
+
+view {
+  <main>{title}</main>
+}
+`
+	syntaxFile, err := parser.ParseSyntax([]byte(src))
+	if err != nil {
+		t.Fatalf("line parser failed: %v", err)
+	}
+	top := ParseTopLevel(src)
+
+	if top.Package == nil || syntaxFile.Package == nil || top.Package.Name != syntaxFile.Package.Name {
+		t.Fatalf("package mismatch: got %v, line parser %v", top.Package, syntaxFile.Package)
+	}
+	if got, want := importKeys(top.Imports), importKeys(syntaxFile.Imports); !equalKeys(got, want) {
+		t.Fatalf("import mismatch:\n got %v\nwant %v", got, want)
+	}
+	if got, want := useKeys(top.Uses), useKeys(syntaxFile.Uses); !equalKeys(got, want) {
+		t.Fatalf("use mismatch:\n got %v\nwant %v", got, want)
+	}
+}
+
+// TestParseTopLevelMatchesPackageOnCorpus runs the equivalence check across the
+// accept corpus, comparing the package declaration each parser recovers.
+func TestParseTopLevelMatchesPackageOnCorpus(t *testing.T) {
+	dir := filepath.FromSlash("testdata/conformance/accept")
+	for _, name := range conformanceFiles(t, dir) {
+		t.Run(name, func(t *testing.T) {
+			source, err := os.ReadFile(filepath.Join(dir, name))
+			if err != nil {
+				t.Fatal(err)
+			}
+			syntaxFile, err := parser.ParseSyntax(source)
+			if err != nil {
+				t.Skipf("line parser rejects %s: %v", name, err)
+			}
+			top := ParseTopLevel(string(source))
+			lineName := ""
+			if syntaxFile.Package != nil {
+				lineName = syntaxFile.Package.Name
+			}
+			topName := ""
+			if top.Package != nil {
+				topName = top.Package.Name
+			}
+			if topName != lineName {
+				t.Fatalf("package mismatch for %s: got %q, line parser %q", name, topName, lineName)
+			}
+		})
+	}
+}
+
+// TestParseTopLevelRecoversPastError is the headline #306 capability: the
+// recursive-descent parser surfaces declarations after a malformed line, where
+// the line-oriented parser bails on the first error and returns nothing.
+func TestParseTopLevelRecoversPastError(t *testing.T) {
+	src := `package pages
+
+import "fmt"
+
+use widgets
+
+import alias "github.com/x/y"
+
+view {
+  <main></main>
+}
+`
+	// The line parser bails on the malformed use and returns nothing usable.
+	if _, err := parser.ParseSyntax([]byte(src)); err == nil {
+		t.Fatal("expected the line parser to bail on the malformed use line")
+	}
+
+	top := ParseTopLevel(src)
+	if top.Package == nil || top.Package.Name != "pages" {
+		t.Fatalf("recovery lost the package declaration: %v", top.Package)
+	}
+	keys := importKeys(top.Imports)
+	if !keys["\x00fmt"] || !keys["alias\x00github.com/x/y"] {
+		t.Fatalf("recovery lost an import past the malformed line; got %v", keys)
+	}
+}
+
+func equalKeys(a, b map[string]bool) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for key := range a {
+		if !b[key] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/lang/declparse_test.go
+++ b/internal/lang/declparse_test.go
@@ -122,6 +122,49 @@ view {
 	}
 }
 
+// TestParseTopLevelRejectsMalformedDeclarations checks the cutover parser does
+// not emit nodes for declarations the line parser rejects: trailing tokens, an
+// extra import identifier, a non-identifier use package, and a non-strict
+// package name. Emitting these would let recovery surface invalid declarations
+// as valid AST.
+func TestParseTopLevelRejectsMalformedDeclarations(t *testing.T) {
+	t.Run("package with trailing tokens", func(t *testing.T) {
+		top := ParseTopLevel("package pages extra\n")
+		if top.Package != nil {
+			t.Fatalf("emitted a package for malformed declaration: %v", top.Package)
+		}
+		if _, err := parser.ParseSyntax([]byte("package pages extra\n")); err == nil {
+			t.Fatal("line parser unexpectedly accepted the malformed package")
+		}
+	})
+
+	t.Run("non-strict package name", func(t *testing.T) {
+		if top := ParseTopLevel("package my.pkg\n"); top.Package != nil {
+			t.Fatalf("emitted a package for non-strict name: %v", top.Package)
+		}
+	})
+
+	t.Run("import with extra identifier", func(t *testing.T) {
+		src := "package pages\nimport ui extra \"github.com/acme/ui\"\n"
+		if top := ParseTopLevel(src); len(top.Imports) != 0 {
+			t.Fatalf("emitted an import for malformed declaration: %v", top.Imports)
+		}
+		if _, err := parser.ParseSyntax([]byte(src)); err == nil {
+			t.Fatal("line parser unexpectedly accepted the malformed import")
+		}
+	})
+
+	t.Run("use with non-identifier package", func(t *testing.T) {
+		src := "package pages\nuse widgets \"foo/bar\"\n"
+		if top := ParseTopLevel(src); len(top.Uses) != 0 {
+			t.Fatalf("emitted a use for malformed package string: %v", top.Uses)
+		}
+		if _, err := parser.ParseSyntax([]byte(src)); err == nil {
+			t.Fatal("line parser unexpectedly accepted the malformed use")
+		}
+	})
+}
+
 func equalKeys(a, b map[string]bool) bool {
 	if len(a) != len(b) {
 		return false


### PR DESCRIPTION
Completes #304 and advances #306.

## #304 — full construct coverage, now a gate
Earlier I documented that single-file checking can't cleanly exercise every construct (reactive directives need a Go-typed `state` contract, endpoints need handlers, etc.). This makes "full coverage" verifiable instead of aspirational:

`TestConformanceCoversEveryConstruct` partitions **every** construct in the stability registry (#305) into `corpusConstructs` (the single-file corpus exercises it) or `integrationCoverage` (a named integration test covers the project-context construct). Adding a construct fails the test until it's classified; a companion test rejects stale entries. So no construct can silently go untested. `conformance.md` documents the split.

## #306 — ADR 0010 phase 3 start: `lang.ParseTopLevel`
The first recursive-descent slice that emits **real `gwdkast` nodes** (not just the tooling outline): package, imports, and uses, over the shared tokenizer.

- **Equivalence-anchored**: `TestParseTopLevelMatchesLineParser` asserts it agrees with `parser.ParseSyntax` on the package name and the import/use sets, and the check also runs across the accept corpus. This is the de-risking harness for the eventual cutover.
- **Recovery demonstrated**: `TestParseTopLevelRecoversPastError` shows it surfacing declarations *after* a malformed line where the line-oriented parser bails and returns nothing — the headline #306 capability.

### Still open on #306
Metadata routing into typed fields, block bodies, view markup, component contracts, and endpoints remain on the line parser. The remaining phase-3 work is extending `ParseTopLevel` to a full `gwdkast.File` under the equivalence harness, then the per-declaration production cutover that retires `ParseSyntax`. That's the large remaining rewrite; this PR builds the parser foundation and the equivalence/recovery harness it needs.

## Verification
- `go test ./internal/... ./cmd/... .` — pass
- `gofmt -l` + `go vet` — clean
- `node --test editors/vscode/*.test.js` — 39/0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
