### PR TITLE
M2 #306: recover top-level metadata in the declaration parser

### DIFF
--- a/internal/lang/declparse.go
+++ b/internal/lang/declparse.go
@@ -1,6 +1,7 @@
 package lang
 
 import (
+	"strings"
 	"unicode"
 
 	"github.com/cssbruno/gowdk/internal/gwdkast"
@@ -9,14 +10,23 @@ import (
 // TopLevel holds the top-level declaration nodes a recursive-descent parse
 // recovers from .gwdk source. It is the first slice of the ADR 0010 parser
 // producing real gwdkast nodes (rather than the tooling outline): the package
-// declaration plus Go imports and GOWDK uses, which map one-to-one to the
-// line-oriented parser's output and are exercised by an equivalence test against
-// internal/parser.ParseSyntax. Metadata routing, blocks, view markup, and
-// endpoints remain on the line-oriented parser until later phases.
+// declaration, Go imports and GOWDK uses, and the top-level metadata
+// declarations — all of which map one-to-one to the line-oriented parser's
+// output and are exercised by an equivalence test against
+// internal/parser.ParseSyntax. Metadata is recovered both as the raw
+// declaration list (Metadata, mirroring SyntaxFile.Metadata) and routed into the
+// validation-free typed fields the line parser assigns unconditionally (Page,
+// Component, Cache). Metadata that needs validation to reach a typed field
+// (route, revalidate, error, layout, guard, css, asset), block bodies, view
+// markup, and endpoints remain on the line-oriented parser until later phases.
 type TopLevel struct {
-	Package *gwdkast.Package
-	Imports []gwdkast.Import
-	Uses    []gwdkast.Use
+	Package   *gwdkast.Package
+	Imports   []gwdkast.Import
+	Uses      []gwdkast.Use
+	Metadata  []gwdkast.MetadataDecl
+	Page      *gwdkast.PageDecl
+	Component *gwdkast.ComponentDecl
+	Cache     *gwdkast.CacheDecl
 }
 
 // ParseTopLevel parses the package, import, and use declarations of .gwdk source
@@ -48,7 +58,8 @@ func ParseTopLevel(src string) TopLevel {
 
 		line := tokens[index:lineEnd]
 		first := line[0]
-		if first.Kind == TokenIdentifier {
+		switch {
+		case first.Kind == TokenIdentifier:
 			switch first.Lexeme {
 			case "package":
 				if result.Package == nil {
@@ -65,11 +76,47 @@ func ParseTopLevel(src string) TopLevel {
 					result.Uses = append(result.Uses, use)
 				}
 			}
+		case first.Kind == TokenMetadata:
+			result.applyMetadata(first, line, metadataValue(src, first, tokens[lineEnd]))
 		}
 		index = lineEnd
 	}
 
 	return result
+}
+
+// metadataValue returns the source text after a line-leading metadata keyword,
+// trimmed, mirroring parseMetadataLine in the line parser (which keeps the raw
+// remainder of the line — quotes and any trailing comment included — and only
+// trims surrounding whitespace). end is the newline or EOF token that closes the
+// line, so its byte offset bounds the value.
+func metadataValue(src string, keyword, end Token) string {
+	start := keyword.Offset + len(keyword.Lexeme)
+	stop := end.Offset
+	if start < 0 || stop > len(src) || start > stop {
+		return ""
+	}
+	return strings.TrimSpace(src[start:stop])
+}
+
+// applyMetadata records one top-level metadata declaration. Every metadata line
+// is appended to Metadata as a raw {Name, Value} pair (matching
+// SyntaxFile.Metadata), and the three keywords the line parser routes into typed
+// fields without validation are mirrored here. The line parser assigns these
+// unconditionally, so the last occurrence wins. Keywords whose typed field needs
+// validation (route, revalidate, error, layout, guard, css, asset) are left to a
+// later phase and survive only in the raw Metadata list for now.
+func (top *TopLevel) applyMetadata(keyword Token, line []Token, value string) {
+	span := spanOf(keyword, line[len(line)-1])
+	top.Metadata = append(top.Metadata, gwdkast.MetadataDecl{Name: keyword.Lexeme, Value: value, Span: span})
+	switch keyword.Lexeme {
+	case "page":
+		top.Page = &gwdkast.PageDecl{ID: value, Span: span}
+	case "component":
+		top.Component = &gwdkast.ComponentDecl{Name: value, Span: span}
+	case "cache":
+		top.Cache = &gwdkast.CacheDecl{Policy: unquote(value), Span: span}
+	}
 }
 
 // parsePackageName accepts exactly `package <strict-ident>` with no trailing

--- a/internal/lang/declparse_test.go
+++ b/internal/lang/declparse_test.go
@@ -25,6 +25,28 @@ func useKeys(uses []gwdkast.Use) map[string]bool {
 	return keys
 }
 
+// metadataPairs reduces metadata declarations to ordered Name=Value strings, the
+// surface both parsers must agree on (spans differ by construction).
+func metadataPairs(decls []gwdkast.MetadataDecl) []string {
+	pairs := make([]string, 0, len(decls))
+	for _, decl := range decls {
+		pairs = append(pairs, decl.Name+"="+decl.Value)
+	}
+	return pairs
+}
+
+func equalOrdered(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for index := range a {
+		if a[index] != b[index] {
+			return false
+		}
+	}
+	return true
+}
+
 // TestParseTopLevelMatchesLineParser anchors the recursive-descent declaration
 // parser against the line-oriented parser: for valid source they must agree on
 // the package name and the set of imports and uses.
@@ -37,8 +59,11 @@ import alias "github.com/x/y"
 use widgets "components"
 use forms "forms"
 
+page home
 route "/"
 title "Home"
+description "Welcome"
+cache "public, max-age=60"
 
 view {
   <main>{title}</main>
@@ -58,6 +83,15 @@ view {
 	}
 	if got, want := useKeys(top.Uses), useKeys(syntaxFile.Uses); !equalKeys(got, want) {
 		t.Fatalf("use mismatch:\n got %v\nwant %v", got, want)
+	}
+	if got, want := metadataPairs(top.Metadata), metadataPairs(syntaxFile.Metadata); !equalOrdered(got, want) {
+		t.Fatalf("metadata mismatch:\n got %v\nwant %v", got, want)
+	}
+	if (top.Page == nil) != (syntaxFile.Page == nil) || (top.Page != nil && top.Page.ID != syntaxFile.Page.ID) {
+		t.Fatalf("page mismatch: got %v, line parser %v", top.Page, syntaxFile.Page)
+	}
+	if (top.Cache == nil) != (syntaxFile.Cache == nil) || (top.Cache != nil && top.Cache.Policy != syntaxFile.Cache.Policy) {
+		t.Fatalf("cache mismatch: got %v, line parser %v", top.Cache, syntaxFile.Cache)
 	}
 }
 
@@ -87,6 +121,9 @@ func TestParseTopLevelMatchesPackageOnCorpus(t *testing.T) {
 			if topName != lineName {
 				t.Fatalf("package mismatch for %s: got %q, line parser %q", name, topName, lineName)
 			}
+			if got, want := metadataPairs(top.Metadata), metadataPairs(syntaxFile.Metadata); !equalOrdered(got, want) {
+				t.Fatalf("metadata mismatch for %s:\n got %v\nwant %v", name, got, want)
+			}
 		})
 	}
 }
@@ -100,6 +137,9 @@ func TestParseTopLevelRecoversPastError(t *testing.T) {
 import "fmt"
 
 use widgets
+
+route "/"
+title "Home"
 
 import alias "github.com/x/y"
 
@@ -119,6 +159,11 @@ view {
 	keys := importKeys(top.Imports)
 	if !keys["\x00fmt"] || !keys["alias\x00github.com/x/y"] {
 		t.Fatalf("recovery lost an import past the malformed line; got %v", keys)
+	}
+	// Metadata after the malformed line is recovered too, where the line parser
+	// surfaces nothing.
+	if got := metadataPairs(top.Metadata); !equalOrdered(got, []string{`route="/"`, `title="Home"`}) {
+		t.Fatalf("recovery lost metadata past the malformed line; got %v", got)
 	}
 }
 
@@ -163,6 +208,31 @@ func TestParseTopLevelRejectsMalformedDeclarations(t *testing.T) {
 			t.Fatal("line parser unexpectedly accepted the malformed use")
 		}
 	})
+}
+
+// TestParseTopLevelRoutesTypedMetadata locks the three validation-free typed
+// routings against the line parser: page and component carry the raw value as
+// their identifier, cache strips surrounding quotes from its policy.
+func TestParseTopLevelRoutesTypedMetadata(t *testing.T) {
+	src := "package widgets\ncomponent Card\ncache \"no-store\"\n"
+	syntaxFile, err := parser.ParseSyntax([]byte(src))
+	if err != nil {
+		t.Fatalf("line parser failed: %v", err)
+	}
+	top := ParseTopLevel(src)
+
+	if syntaxFile.Component == nil || top.Component == nil || top.Component.Name != syntaxFile.Component.Name {
+		t.Fatalf("component mismatch: got %v, line parser %v", top.Component, syntaxFile.Component)
+	}
+	if top.Component.Name != "Card" {
+		t.Fatalf("component name = %q, want Card", top.Component.Name)
+	}
+	if syntaxFile.Cache == nil || top.Cache == nil || top.Cache.Policy != syntaxFile.Cache.Policy {
+		t.Fatalf("cache mismatch: got %v, line parser %v", top.Cache, syntaxFile.Cache)
+	}
+	if top.Cache.Policy != "no-store" {
+		t.Fatalf("cache policy = %q, want unquoted no-store", top.Cache.Policy)
+	}
 }
 
 func equalKeys(a, b map[string]bool) bool {


### PR DESCRIPTION
Advances #306 (ADR 0010 recursive-descent parser). Next phase-3 slice on top of `lang.ParseTopLevel`: metadata.

## What

`ParseTopLevel` now recovers top-level **metadata declarations** alongside package/import/use:

- **Raw declaration list** — every metadata line becomes a `gwdkast.MetadataDecl{Name, Value, Span}` in `TopLevel.Metadata`, mirroring `SyntaxFile.Metadata` one-to-one.
- **Validation-free typed routing** — the three keywords the line parser assigns into typed fields with no validation are mirrored: `page` → `TopLevel.Page`, `component` → `TopLevel.Component`, `cache` → `TopLevel.Cache` (last occurrence wins, as in `applySyntaxMetadata`).

Metadata values are sliced from the source by byte offset (between the line-leading metadata keyword token and the line's newline/EOF), so they match the line parser's raw remainder exactly — quotes and any trailing comment preserved, surrounding whitespace trimmed.

## What's deferred (honestly)

Keywords whose typed field needs **validation** — `route` (route-decl parse), `revalidate` (duration parse), `error` (error-page path), and the list-splitting `layout`/`guard`/`css`/`asset` — are *not* routed into typed fields here. Emitting those without their validation would let recovery surface malformed values as valid AST (exactly the over-emission Codex flagged on the earlier slice). They survive in the raw `Metadata` list and get typed routing once the parser owns diagnostics.

## Equivalence stays anchored

- `TestParseTopLevelMatchesLineParser` now also asserts the metadata pairs and the `page`/`cache` fields agree with `parser.ParseSyntax`.
- `TestParseTopLevelMatchesPackageOnCorpus` compares the recovered metadata across every accept fixture.
- `TestParseTopLevelRoutesTypedMetadata` locks the `component`/`cache` routing (quote stripping included).
- `TestParseTopLevelRecoversPastError` shows `route`/`title` metadata surfacing **after** a malformed `use` line, where the line-oriented parser bails and returns nothing — the headline #306 recovery capability.

Non-breaking (new fields on `TopLevel`; nothing else consumes it yet). Full `go test ./internal/... ./cmd/...` green, gofmt/vet clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)