### PR TITLE
M2 #306: recover Go-typed contracts via go/parser

### DIFF
--- a/docs/engineering/decisions/0010-tokenizer-recursive-descent-parser.md
+++ b/docs/engineering/decisions/0010-tokenizer-recursive-descent-parser.md
@@ -58,6 +58,20 @@ Concretely:
   `gwdkast.File` with explicit declaration, block, and view productions instead
   of line-pattern matching. The brace scanner's string/comment/template state
   becomes ordinary lexer state rather than a separate counter.
+- **Custom grammar for `.gwdk`, the real Go parser for embedded Go.** The
+  recursive-descent parser owns only the framework grammar — package, imports,
+  uses, metadata, blocks, view markup, contracts, and endpoints. Wherever a
+  construct embeds Go — `go {}`/`client {}` block bodies and the `pkg.Type` /
+  `pkg.NewFn()` references in `store`/`props`/`state` contracts — the parser
+  delegates to `go/parser` (`go/ast`) on the extracted source span rather than
+  re-implementing Go lexing or parsing. The framework tokenizer only locates the
+  boundaries (e.g. the `=` separating a contract type from its initializer); the
+  Go operands are handed to the Go parser, which is then constrained to the
+  shapes the language accepts (a single `pkg.Name` selector, a zero-argument
+  constructor call). This keeps one definition of Go syntax — the Go toolchain's
+  — and means generics, multi-segment selectors, and call arguments are
+  recognized and accepted or rejected by Go's own grammar, not a hand-rolled
+  approximation.
 - **Error recovery.** The parser synchronizes at top-level declaration
   boundaries and block braces so one syntax error does not hide the rest of the
   file. It accumulates diagnostics instead of returning on the first error.
@@ -121,6 +135,11 @@ holds, then the line-oriented path and `lexLine` are removed.
 - **Incremental/streaming parser from day one.** Useful for an editor, but
   premature. The AST seam lets an incremental layer be added later without
   another front-end decision.
+- **Hand-roll Go lexing/parsing for embedded Go.** Re-implementing qualified
+  identifiers, call expressions, and (eventually) type expressions inside the
+  `.gwdk` tokenizer would duplicate a moving target and drift from `go/build`
+  semantics. Rejected: `go/parser` already parses Go exactly, so embedded Go is
+  delegated to it and only the framework-level boundaries are tokenized here.
 
 ## Follow-Up
 

--- a/internal/lang/declparse.go
+++ b/internal/lang/declparse.go
@@ -1,24 +1,34 @@
 package lang
 
 import (
+	"go/ast"
+	goparser "go/parser"
+	"go/token"
 	"strings"
 	"unicode"
 
 	"github.com/cssbruno/gowdk/internal/gwdkast"
+	"github.com/cssbruno/gowdk/internal/source"
 )
 
 // TopLevel holds the top-level declaration nodes a recursive-descent parse
-// recovers from .gwdk source. It is the first slice of the ADR 0010 parser
-// producing real gwdkast nodes (rather than the tooling outline): the package
-// declaration, Go imports and GOWDK uses, and the top-level metadata
-// declarations — all of which map one-to-one to the line-oriented parser's
-// output and are exercised by an equivalence test against
-// internal/parser.ParseSyntax. Metadata is recovered both as the raw
-// declaration list (Metadata, mirroring SyntaxFile.Metadata) and routed into the
-// validation-free typed fields the line parser assigns unconditionally (Page,
-// Component, Cache). Metadata that needs validation to reach a typed field
-// (route, revalidate, error, layout, guard, css, asset), block bodies, view
-// markup, and endpoints remain on the line-oriented parser until later phases.
+// recovers from .gwdk source. It is the ADR 0010 parser producing real gwdkast
+// nodes (rather than the tooling outline), built behind an equivalence test
+// against internal/parser.ParseSyntax. It currently recovers:
+//
+//   - the package declaration, Go imports, and GOWDK uses;
+//   - the top-level metadata declarations, both as the raw list (Metadata,
+//     mirroring SyntaxFile.Metadata) and routed into the validation-free typed
+//     fields the line parser assigns unconditionally (Page, Component, Cache,
+//     WASM);
+//   - the Go-typed contracts (Stores, PropsType, State), whose pkg.Type and
+//     pkg.NewFn() references are parsed by go/parser per ADR 0010's split —
+//     custom grammar for .gwdk, the real Go parser for embedded Go — then
+//     constrained to the shapes the line parser accepts.
+//
+// Metadata that needs validation to reach a typed field (route, revalidate,
+// error, layout, guard, css, asset), block bodies, view markup, and endpoints
+// remain on the line-oriented parser until later phases.
 type TopLevel struct {
 	Package   *gwdkast.Package
 	Imports   []gwdkast.Import
@@ -27,6 +37,10 @@ type TopLevel struct {
 	Page      *gwdkast.PageDecl
 	Component *gwdkast.ComponentDecl
 	Cache     *gwdkast.CacheDecl
+	Stores    []gwdkast.Store
+	PropsType *gwdkast.GoTypeRef
+	State     *gwdkast.StateContract
+	WASM      *gwdkast.WASMContract
 }
 
 // ParseTopLevel parses the package, import, and use declarations of .gwdk source
@@ -75,6 +89,18 @@ func ParseTopLevel(src string) TopLevel {
 				if use, ok := parseUseTokens(line); ok {
 					result.Uses = append(result.Uses, use)
 				}
+			case "store":
+				if store, ok := parseStoreTokens(src, line, tokens[lineEnd]); ok {
+					result.Stores = append(result.Stores, store)
+				}
+			case "props":
+				if ref, ok := parsePropsTokens(src, line, tokens[lineEnd]); ok {
+					result.PropsType = &ref
+				}
+			case "state":
+				if state, ok := parseStateTokens(src, line, tokens[lineEnd]); ok {
+					result.State = &state
+				}
 			}
 		case first.Kind == TokenMetadata:
 			result.applyMetadata(first, line, metadataValue(src, first, tokens[lineEnd]))
@@ -116,7 +142,141 @@ func (top *TopLevel) applyMetadata(keyword Token, line []Token, value string) {
 		top.Component = &gwdkast.ComponentDecl{Name: value, Span: span}
 	case "cache":
 		top.Cache = &gwdkast.CacheDecl{Policy: unquote(value), Span: span}
+	case "wasm":
+		// The SyntaxFile path keeps the raw quoted value (it does not trimQuotes),
+		// so match it for equivalence rather than unquoting.
+		top.WASM = &gwdkast.WASMContract{Package: value, Span: span}
 	}
+}
+
+// parseStoreTokens recovers a `store <name> <pkg.Type> = <pkg.NewFn()>` line. The
+// name is a strict identifier; the type and initializer are Go expressions
+// delegated to go/parser per ADR 0010 (custom .gwdk grammar, reused Go parser for
+// embedded Go), then constrained to the single-selector / zero-arg-call shapes
+// the line parser's qualifiedIdent accepts so recovery stays equivalent.
+func parseStoreTokens(src string, line []Token, end Token) (gwdkast.Store, bool) {
+	if len(line) < 2 || line[1].Kind != TokenIdentifier || !isStrictIdent(line[1].Lexeme) {
+		return gwdkast.Store{}, false
+	}
+	assign := assignIndex(line)
+	if assign < 2 {
+		return gwdkast.Store{}, false
+	}
+	span := spanOf(line[0], line[len(line)-1])
+	typeRef, ok := goTypeRef(sourceBetween(src, tokenEnd(line[1]), line[assign].Offset), span)
+	if !ok {
+		return gwdkast.Store{}, false
+	}
+	initRef, ok := goFuncRef(sourceBetween(src, tokenEnd(line[assign]), end.Offset), span)
+	if !ok {
+		return gwdkast.Store{}, false
+	}
+	return gwdkast.Store{Name: line[1].Lexeme, Type: typeRef, Init: initRef, Span: span}, true
+}
+
+// parsePropsTokens recovers a `props <pkg.Type>` contract: a type reference with
+// no initializer (an `=` makes it a malformed props line the line parser
+// rejects, so it is skipped rather than emitted).
+func parsePropsTokens(src string, line []Token, end Token) (gwdkast.GoTypeRef, bool) {
+	if assignIndex(line) != -1 {
+		return gwdkast.GoTypeRef{}, false
+	}
+	span := spanOf(line[0], line[len(line)-1])
+	return goTypeRef(sourceBetween(src, tokenEnd(line[0]), end.Offset), span)
+}
+
+// parseStateTokens recovers a `state <pkg.Type> = <pkg.NewFn()>` contract. Unlike
+// props, the initializer is required, so a missing `=` is rejected.
+func parseStateTokens(src string, line []Token, end Token) (gwdkast.StateContract, bool) {
+	assign := assignIndex(line)
+	if assign < 1 {
+		return gwdkast.StateContract{}, false
+	}
+	span := spanOf(line[0], line[len(line)-1])
+	typeRef, ok := goTypeRef(sourceBetween(src, tokenEnd(line[0]), line[assign].Offset), span)
+	if !ok {
+		return gwdkast.StateContract{}, false
+	}
+	initRef, ok := goFuncRef(sourceBetween(src, tokenEnd(line[assign]), end.Offset), span)
+	if !ok {
+		return gwdkast.StateContract{}, false
+	}
+	return gwdkast.StateContract{Type: typeRef, Init: initRef, Span: span}, true
+}
+
+// goTypeRef parses a Go type reference (pkg.Type) and accepts only a single
+// selector of two strict identifiers — the line parser's qualifiedIdent rule, so
+// generics (pkg.Type[T]) and multi-segment paths (a.b.c) are rejected.
+func goTypeRef(expr string, span source.SourceSpan) (gwdkast.GoTypeRef, bool) {
+	parsed, err := goparser.ParseExpr(strings.TrimSpace(expr))
+	if err != nil {
+		return gwdkast.GoTypeRef{}, false
+	}
+	alias, name, ok := selectorParts(parsed)
+	if !ok {
+		return gwdkast.GoTypeRef{}, false
+	}
+	return gwdkast.GoTypeRef{Alias: alias, Name: name, Span: span}, true
+}
+
+// goFuncRef parses a Go constructor reference (pkg.NewFn()) — a call of a
+// pkg.Fn selector with no arguments, matching the line parser's `()` requirement.
+func goFuncRef(expr string, span source.SourceSpan) (gwdkast.GoFuncRef, bool) {
+	parsed, err := goparser.ParseExpr(strings.TrimSpace(expr))
+	if err != nil {
+		return gwdkast.GoFuncRef{}, false
+	}
+	call, ok := parsed.(*ast.CallExpr)
+	if !ok || len(call.Args) != 0 || call.Ellipsis != token.NoPos {
+		return gwdkast.GoFuncRef{}, false
+	}
+	alias, name, ok := selectorParts(call.Fun)
+	if !ok {
+		return gwdkast.GoFuncRef{}, false
+	}
+	return gwdkast.GoFuncRef{Alias: alias, Name: name, Span: span}, true
+}
+
+// selectorParts splits a pkg.Name selector into its two strict identifiers.
+func selectorParts(node ast.Expr) (string, string, bool) {
+	selector, ok := node.(*ast.SelectorExpr)
+	if !ok {
+		return "", "", false
+	}
+	pkg, ok := selector.X.(*ast.Ident)
+	if !ok {
+		return "", "", false
+	}
+	if !isStrictIdent(pkg.Name) || !isStrictIdent(selector.Sel.Name) {
+		return "", "", false
+	}
+	return pkg.Name, selector.Sel.Name, true
+}
+
+// assignIndex returns the position of the first framework-level `=` token in the
+// line, or -1. The shared tokenizer emits `=>` as an arrow, so this never matches
+// inside a paths block's arrow.
+func assignIndex(line []Token) int {
+	for index, token := range line {
+		if token.Kind == TokenAssign {
+			return index
+		}
+	}
+	return -1
+}
+
+// tokenEnd returns the byte offset just past a token.
+func tokenEnd(token Token) int {
+	return token.Offset + len(token.Lexeme)
+}
+
+// sourceBetween returns the source slice for a byte range, clamped to valid
+// bounds (an empty string for an inverted or out-of-range span).
+func sourceBetween(src string, start, stop int) string {
+	if start < 0 || stop > len(src) || start > stop {
+		return ""
+	}
+	return src[start:stop]
 }
 
 // parsePackageName accepts exactly `package <strict-ident>` with no trailing

--- a/internal/lang/declparse_test.go
+++ b/internal/lang/declparse_test.go
@@ -235,6 +235,91 @@ func TestParseTopLevelRoutesTypedMetadata(t *testing.T) {
 	}
 }
 
+// TestParseTopLevelMatchesContractsOnComponent anchors the Go-typed contract
+// recovery (store/props/state/wasm) against the line parser, including the
+// go/parser-backed pkg.Type and pkg.NewFn() references.
+func TestParseTopLevelMatchesContractsOnComponent(t *testing.T) {
+	src := `package widgets
+
+use cart "cart"
+
+component Cart
+
+state cart.State = cart.NewState()
+props cart.Props
+
+store Items cart.Items = cart.NewItems()
+
+wasm "github.com/acme/cart/wasm"
+
+view {
+  <main></main>
+}
+`
+	syntaxFile, err := parser.ParseSyntax([]byte(src))
+	if err != nil {
+		t.Fatalf("line parser failed: %v", err)
+	}
+	top := ParseTopLevel(src)
+
+	if syntaxFile.State == nil || top.State == nil {
+		t.Fatalf("state contract missing: got %v, line parser %v", top.State, syntaxFile.State)
+	}
+	if top.State.Type.Alias != syntaxFile.State.Type.Alias || top.State.Type.Name != syntaxFile.State.Type.Name {
+		t.Fatalf("state type mismatch: got %+v, line parser %+v", top.State.Type, syntaxFile.State.Type)
+	}
+	if top.State.Init.Alias != syntaxFile.State.Init.Alias || top.State.Init.Name != syntaxFile.State.Init.Name {
+		t.Fatalf("state init mismatch: got %+v, line parser %+v", top.State.Init, syntaxFile.State.Init)
+	}
+	if syntaxFile.PropsType == nil || top.PropsType == nil ||
+		top.PropsType.Alias != syntaxFile.PropsType.Alias || top.PropsType.Name != syntaxFile.PropsType.Name {
+		t.Fatalf("props type mismatch: got %v, line parser %v", top.PropsType, syntaxFile.PropsType)
+	}
+	if len(top.Stores) != len(syntaxFile.Stores) || len(top.Stores) != 1 {
+		t.Fatalf("store count mismatch: got %d, line parser %d", len(top.Stores), len(syntaxFile.Stores))
+	}
+	if top.Stores[0].Name != syntaxFile.Stores[0].Name ||
+		top.Stores[0].Type.Name != syntaxFile.Stores[0].Type.Name ||
+		top.Stores[0].Init.Name != syntaxFile.Stores[0].Init.Name {
+		t.Fatalf("store mismatch: got %+v, line parser %+v", top.Stores[0], syntaxFile.Stores[0])
+	}
+	if syntaxFile.WASM == nil || top.WASM == nil || top.WASM.Package != syntaxFile.WASM.Package {
+		t.Fatalf("wasm mismatch: got %v, line parser %v", top.WASM, syntaxFile.WASM)
+	}
+}
+
+// TestParseTopLevelRejectsMalformedContracts checks the go/parser-constrained
+// recovery does not emit nodes for contract references the line parser does not
+// accept: multi-segment selectors, generics, a constructor with arguments, props
+// with an initializer, and state without one. The line parser handles these two
+// ways — some it errors on (props-with-init, state-without-init), others its
+// pattern simply ignores (multi-dot, generics, args) — so the equivalence is
+// that neither parser emits a contract node, not that the line parser errors.
+func TestParseTopLevelRejectsMalformedContracts(t *testing.T) {
+	cases := map[string]string{
+		"store init with args":   "package p\nstore X a.T = a.New(1)\n",
+		"store multi-dot type":   "package p\nstore X a.b.C = a.New()\n",
+		"props with initializer": "package p\nprops a.T = a.New()\n",
+		"state without init":     "package p\nstate a.T\n",
+		"generic type":           "package p\nstate a.T[int] = a.New()\n",
+	}
+	for name, src := range cases {
+		t.Run(name, func(t *testing.T) {
+			top := ParseTopLevel(src)
+			if len(top.Stores) != 0 || top.PropsType != nil || top.State != nil {
+				t.Fatalf("emitted a contract node for malformed source: stores=%v props=%v state=%v", top.Stores, top.PropsType, top.State)
+			}
+			// Equivalence: where the line parser succeeds, it emits no such
+			// contract either (where it errors, it definitionally has none).
+			if syntaxFile, err := parser.ParseSyntax([]byte(src)); err == nil {
+				if len(syntaxFile.Stores) != 0 || syntaxFile.PropsType != nil || syntaxFile.State != nil {
+					t.Fatalf("line parser emitted a contract for %q", src)
+				}
+			}
+		})
+	}
+}
+
 func equalKeys(a, b map[string]bool) bool {
 	if len(a) != len(b) {
 		return false

--- a/internal/lang/lexer.go
+++ b/internal/lang/lexer.go
@@ -90,6 +90,9 @@ func (scanner *scanner) scan() ([]Token, Diagnostics) {
 			scanner.advance()
 			scanner.advance()
 			tokens = append(tokens, Token{Kind: TokenArrow, Lexeme: "=>", Pos: pos, Offset: offset})
+		case ch == '=':
+			scanner.advance()
+			tokens = append(tokens, Token{Kind: TokenAssign, Lexeme: "=", Pos: pos, Offset: offset})
 		default:
 			tokens = append(tokens, scanner.text())
 		}

--- a/internal/lang/lexer_test.go
+++ b/internal/lang/lexer_test.go
@@ -36,6 +36,33 @@ view {
 	}
 }
 
+func TestLexEmitsAssignToken(t *testing.T) {
+	// A bare `=` is the framework-level separator in store/state contracts; `=>`
+	// must still win as an arrow.
+	tokens, diagnostics := Lex("store Cart cart.Cart = cart.NewCart()\npaths {\n=> {}\n}\n")
+	if diagnostics.HasErrors() {
+		t.Fatal(diagnostics)
+	}
+	var assigns, arrows int
+	for _, token := range tokens {
+		switch token.Kind {
+		case TokenAssign:
+			assigns++
+			if token.Lexeme != "=" {
+				t.Fatalf("assign lexeme = %q, want =", token.Lexeme)
+			}
+		case TokenArrow:
+			arrows++
+		}
+	}
+	if assigns != 1 {
+		t.Fatalf("got %d assign tokens, want 1", assigns)
+	}
+	if arrows != 1 {
+		t.Fatalf("got %d arrow tokens, want 1 (=> must not split into assign)", arrows)
+	}
+}
+
 func TestLexReportsUnterminatedString(t *testing.T) {
 	_, diagnostics := Lex("route \"unterminated\n")
 	if !diagnostics.HasErrors() {

--- a/internal/lang/testdata/grammar_golden/tokens.golden.txt
+++ b/internal/lang/testdata/grammar_golden/tokens.golden.txt
@@ -57,7 +57,7 @@
 18:11	identifier	"g"
 18:12	colon	":"
 18:13	identifier	"post"
-18:17	text	"="
+18:17	assign	"="
 18:18	lbrace	"{"
 18:19	identifier	"Submit"
 18:25	rbrace	"}"

--- a/internal/lang/token.go
+++ b/internal/lang/token.go
@@ -14,6 +14,7 @@ const (
 	TokenRBrace     TokenKind = "rbrace"
 	TokenComma      TokenKind = "comma"
 	TokenColon      TokenKind = "colon"
+	TokenAssign     TokenKind = "assign"
 	TokenQuestion   TokenKind = "question"
 	TokenArrow      TokenKind = "arrow"
 	TokenText       TokenKind = "text"

--- a/internal/lsp/semantic_tokens.go
+++ b/internal/lsp/semantic_tokens.go
@@ -10,7 +10,7 @@ func semanticTokenType(kind lang.TokenKind) (string, bool) {
 		return "variable", true
 	case lang.TokenString:
 		return "string", true
-	case lang.TokenLBrace, lang.TokenRBrace, lang.TokenComma, lang.TokenColon, lang.TokenQuestion, lang.TokenArrow:
+	case lang.TokenLBrace, lang.TokenRBrace, lang.TokenComma, lang.TokenColon, lang.TokenAssign, lang.TokenQuestion, lang.TokenArrow:
 		return "operator", true
 	default:
 		return "", false


### PR DESCRIPTION
Advances #306 (ADR 0010). This slice acts on the directive **custom parser for `.gwdk`, reuse the Go parser for all Go code** — now recorded in ADR 0010.

## What

`ParseTopLevel` now recovers the top-level **Go-typed contracts** alongside package/import/use/metadata:

- `store <name> <pkg.Type> = <pkg.NewFn()>` → `TopLevel.Stores`
- `props <pkg.Type>` → `TopLevel.PropsType`
- `state <pkg.Type> = <pkg.NewFn()>` → `TopLevel.State`
- `wasm "<pkg>"` → `TopLevel.WASM`

## Embedded Go goes to `go/parser`

The recursive-descent parser owns only the **framework** grammar. The `pkg.Type` and `pkg.NewFn()` references inside these contracts are Go — so they're handed to `go/parser.ParseExpr` (`go/ast`), not re-tokenized. The framework tokenizer only locates the `=` boundary between a contract's type and its initializer; the Go operands are parsed by Go's own grammar, then constrained to what the language accepts:

- type ref must be a single `pkg.Name` selector of two strict idents — so `a.b.c` (multi-segment) and `pkg.T[K]` (generics) are rejected;
- init ref must be a zero-argument call of a `pkg.Fn` selector — so `pkg.New(1)` is rejected.

This keeps **one** definition of Go syntax (the toolchain's) and means recovery stays equivalent to the line parser's `qualifiedIdent`/paren rules without duplicating them.

## Tokenizer change (contained)

Added a first-class `=` token (`TokenAssign`); it was previously folded into greedy text runs. `=>` still wins as an arrow (no split). Blast radius is one golden-fixture line (regenerated) and a highlighting nicety (`=` is now an operator, not a variable). No paren tokens were added — `go/parser` owns the call's parens.

## Equivalence stays anchored

- `TestParseTopLevelMatchesContractsOnComponent` — store/props/state/wasm agree with `parser.ParseSyntax`, including the parsed Go references.
- `TestParseTopLevelRejectsMalformedContracts` — for multi-dot/generics/args/props-with-init/state-without-init, **neither** parser emits a contract node. (The line parser handles these two ways — errors on some, silently ignores others — so the asserted equivalence is "no node emitted," not "line parser errors.")
- `TestLexEmitsAssignToken` — locks the new token and that `=>` does not split.

Two behaviors of the line parser this surfaced and now matches exactly: `WASM.Package` keeps its quotes on the SyntaxFile path (no `trimQuotes`), and unmatched `store` lines are ignored rather than errored.

Non-breaking (new `TopLevel` fields; nothing else consumes it yet). Full `go test ./internal/... ./cmd/...` green, gofmt/vet clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)