### PR TITLE
M2 #306: recover act/api endpoints in the declaration parser

### DIFF
--- a/internal/lang/declparse.go
+++ b/internal/lang/declparse.go
@@ -24,11 +24,15 @@ import (
 //   - the Go-typed contracts (Stores, PropsType, State), whose pkg.Type and
 //     pkg.NewFn() references are parsed by go/parser per ADR 0010's split —
 //     custom grammar for .gwdk, the real Go parser for embedded Go — then
-//     constrained to the shapes the line parser accepts.
+//     constrained to the shapes the line parser accepts;
+//   - the exact act/api endpoint declarations (Actions, APIs), with the line
+//     parser's post-match validation (exported handler name, allowed method,
+//     resolvable error page).
 //
 // Metadata that needs validation to reach a typed field (route, revalidate,
-// error, layout, guard, css, asset), block bodies, view markup, and endpoints
-// remain on the line-oriented parser until later phases.
+// error, layout, guard, css, asset), block bodies, view markup, and the
+// block-bodied fragment endpoint remain on the line-oriented parser until later
+// phases.
 type TopLevel struct {
 	Package   *gwdkast.Package
 	Imports   []gwdkast.Import
@@ -41,6 +45,8 @@ type TopLevel struct {
 	PropsType *gwdkast.GoTypeRef
 	State     *gwdkast.StateContract
 	WASM      *gwdkast.WASMContract
+	Actions   []gwdkast.Endpoint
+	APIs      []gwdkast.Endpoint
 }
 
 // ParseTopLevel parses the package, import, and use declarations of .gwdk source
@@ -100,6 +106,14 @@ func ParseTopLevel(src string) TopLevel {
 			case "state":
 				if state, ok := parseStateTokens(src, line, tokens[lineEnd]); ok {
 					result.State = &state
+				}
+			case "act":
+				if endpoint, ok := parseEndpointTokens("act", line); ok {
+					result.Actions = append(result.Actions, endpoint)
+				}
+			case "api":
+				if endpoint, ok := parseEndpointTokens("api", line); ok {
+					result.APIs = append(result.APIs, endpoint)
 				}
 			}
 		case first.Kind == TokenMetadata:
@@ -331,6 +345,93 @@ func parseUseTokens(line []Token) (gwdkast.Use, bool) {
 		return gwdkast.Use{}, false
 	}
 	return gwdkast.Use{Alias: line[1].Lexeme, Package: pkg, Span: spanOf(line[0], line[len(line)-1])}, true
+}
+
+// parseEndpointTokens recovers an exact endpoint declaration:
+//
+//	act <Name> POST "<route>" [error "<page>"]
+//	api <Name> <METHOD> "<route>" [error "<page>"]
+//
+// matching parseActionEndpointLine / parseAPIEndpointLine plus the validation the
+// line parser applies after the pattern: the handler name must be an exported Go
+// identifier, the method must be an uppercase token (POST for actions; one of the
+// REST verbs for APIs), and an optional error page must resolve. Lines that fail
+// any check are skipped so recovery never emits an endpoint the line parser would
+// reject.
+func parseEndpointTokens(kind string, line []Token) (gwdkast.Endpoint, bool) {
+	if len(line) != 4 && len(line) != 6 {
+		return gwdkast.Endpoint{}, false
+	}
+	name := line[1]
+	if name.Kind != TokenIdentifier || !isExportedIdent(name.Lexeme) {
+		return gwdkast.Endpoint{}, false
+	}
+	method := line[2]
+	if method.Kind != TokenIdentifier || !isUpperMethod(method.Lexeme) || !methodAllowed(kind, method.Lexeme) {
+		return gwdkast.Endpoint{}, false
+	}
+	if line[3].Kind != TokenString {
+		return gwdkast.Endpoint{}, false
+	}
+	span := spanOf(line[0], line[len(line)-1])
+	endpoint := gwdkast.Endpoint{
+		Kind:   kind,
+		Name:   name.Lexeme,
+		Method: method.Lexeme,
+		Route:  unquote(line[3].Lexeme),
+		Span:   span,
+	}
+	if len(line) == 6 {
+		if line[4].Kind != TokenIdentifier || line[4].Lexeme != "error" || line[5].Kind != TokenString {
+			return gwdkast.Endpoint{}, false
+		}
+		errorPage, err := source.ErrorPagePath(unquote(line[5].Lexeme))
+		if err != nil {
+			return gwdkast.Endpoint{}, false
+		}
+		endpoint.ErrorPage = errorPage
+		endpoint.ErrorPageSpan = span
+	}
+	return endpoint, true
+}
+
+// isExportedIdent reports whether value is a strict identifier whose first rune
+// is an ASCII capital, matching the line parser's isExportedIdentifier.
+func isExportedIdent(value string) bool {
+	if !isStrictIdent(value) {
+		return false
+	}
+	first := []rune(value)[0]
+	return first >= 'A' && first <= 'Z'
+}
+
+// isUpperMethod reports whether value is a non-empty run of ASCII capitals,
+// matching the line parser's method() rule.
+func isUpperMethod(value string) bool {
+	if value == "" {
+		return false
+	}
+	for _, r := range value {
+		if r < 'A' || r > 'Z' {
+			return false
+		}
+	}
+	return true
+}
+
+// methodAllowed enforces the per-kind method constraint: actions require POST;
+// APIs accept the REST verb set.
+func methodAllowed(kind, method string) bool {
+	switch kind {
+	case "act":
+		return method == "POST"
+	case "api":
+		switch method {
+		case "GET", "POST", "PUT", "PATCH", "DELETE":
+			return true
+		}
+	}
+	return false
 }
 
 // isStrictIdent mirrors the line parser's identifier rule: a leading letter or

--- a/internal/lang/declparse_test.go
+++ b/internal/lang/declparse_test.go
@@ -124,6 +124,12 @@ func TestParseTopLevelMatchesPackageOnCorpus(t *testing.T) {
 			if got, want := metadataPairs(top.Metadata), metadataPairs(syntaxFile.Metadata); !equalOrdered(got, want) {
 				t.Fatalf("metadata mismatch for %s:\n got %v\nwant %v", name, got, want)
 			}
+			if got, want := endpointKeys(top.Actions), endpointKeys(syntaxFile.Actions); !equalKeys(got, want) {
+				t.Fatalf("action mismatch for %s:\n got %v\nwant %v", name, got, want)
+			}
+			if got, want := endpointKeys(top.APIs), endpointKeys(syntaxFile.APIs); !equalKeys(got, want) {
+				t.Fatalf("api mismatch for %s:\n got %v\nwant %v", name, got, want)
+			}
 		})
 	}
 }
@@ -314,6 +320,74 @@ func TestParseTopLevelRejectsMalformedContracts(t *testing.T) {
 			if syntaxFile, err := parser.ParseSyntax([]byte(src)); err == nil {
 				if len(syntaxFile.Stores) != 0 || syntaxFile.PropsType != nil || syntaxFile.State != nil {
 					t.Fatalf("line parser emitted a contract for %q", src)
+				}
+			}
+		})
+	}
+}
+
+func endpointKeys(endpoints []gwdkast.Endpoint) map[string]bool {
+	keys := map[string]bool{}
+	for _, e := range endpoints {
+		keys[e.Kind+"\x00"+e.Name+"\x00"+e.Method+"\x00"+e.Route+"\x00"+e.ErrorPage] = true
+	}
+	return keys
+}
+
+// TestParseTopLevelMatchesEndpoints anchors act/api endpoint recovery against the
+// line parser, including the optional error page.
+func TestParseTopLevelMatchesEndpoints(t *testing.T) {
+	src := `package pages
+
+route "/"
+
+act Submit POST "/submit"
+act Save POST "/save" error "/oops.html"
+api List GET "/api/list"
+api Remove DELETE "/api/remove"
+
+view {
+  <main></main>
+}
+`
+	syntaxFile, err := parser.ParseSyntax([]byte(src))
+	if err != nil {
+		t.Fatalf("line parser failed: %v", err)
+	}
+	top := ParseTopLevel(src)
+
+	if got, want := endpointKeys(top.Actions), endpointKeys(syntaxFile.Actions); !equalKeys(got, want) {
+		t.Fatalf("action mismatch:\n got %v\nwant %v", got, want)
+	}
+	if got, want := endpointKeys(top.APIs), endpointKeys(syntaxFile.APIs); !equalKeys(got, want) {
+		t.Fatalf("api mismatch:\n got %v\nwant %v", got, want)
+	}
+	if len(top.Actions) != 2 || len(top.APIs) != 2 {
+		t.Fatalf("expected 2 actions and 2 apis, got %d and %d", len(top.Actions), len(top.APIs))
+	}
+}
+
+// TestParseTopLevelRejectsMalformedEndpoints checks recovery does not emit
+// endpoints the line parser rejects: a non-exported handler name, an action with
+// a non-POST method, an API with an unknown verb, and a bareword (unquoted)
+// route. None should produce a node.
+func TestParseTopLevelRejectsMalformedEndpoints(t *testing.T) {
+	cases := map[string]string{
+		"non-exported action": "package p\nact submit POST \"/x\"\n",
+		"action non-POST":     "package p\nact Submit GET \"/x\"\n",
+		"api unknown verb":    "package p\napi List FETCH \"/x\"\n",
+		"unquoted route":      "package p\nact Submit POST /x\n",
+		"non-exported api":    "package p\napi list GET \"/x\"\n",
+	}
+	for name, src := range cases {
+		t.Run(name, func(t *testing.T) {
+			top := ParseTopLevel(src)
+			if len(top.Actions) != 0 || len(top.APIs) != 0 {
+				t.Fatalf("emitted an endpoint for malformed source: actions=%v apis=%v", top.Actions, top.APIs)
+			}
+			if syntaxFile, err := parser.ParseSyntax([]byte(src)); err == nil {
+				if len(syntaxFile.Actions) != 0 || len(syntaxFile.APIs) != 0 {
+					t.Fatalf("line parser emitted an endpoint for %q", src)
 				}
 			}
 		})


### PR DESCRIPTION
Advances #306 (ADR 0010). Next slice on `lang.ParseTopLevel`: exact endpoints.

## What

`ParseTopLevel` now recovers the exact endpoint declarations into `TopLevel.Actions` / `TopLevel.APIs`:

```
act <Name> POST "<route>" [error "<page>"]
api <Name> <METHOD> "<route>" [error "<page>"]
```

It mirrors `parseActionEndpointLine` / `parseAPIEndpointLine` **plus** the validation the line parser applies after the pattern matches:

- handler name must be an exported Go identifier;
- method must be an uppercase token — `POST` for actions, one of `GET/POST/PUT/PATCH/DELETE` for APIs;
- an optional `error "<page>"` must resolve through `source.ErrorPagePath` (so it must end in `.html`).

Lines failing any check are skipped, so recovery never emits an endpoint the line parser would reject.

The block-bodied `fragment` endpoint stays on the line parser for now — it belongs with the blocks/view slice (it has a body, so the tokenizer's brace-matching already skips it).

## Equivalence

- `TestParseTopLevelMatchesEndpoints` — act/api recovery agrees with `parser.ParseSyntax`, error page included.
- The accept-corpus equivalence test now also compares endpoints on every fixture.
- `TestParseTopLevelRejectsMalformedEndpoints` — neither parser emits a node for a non-exported name, a non-POST action, an unknown API verb, or a bareword (unquoted) route.

Non-breaking (new `TopLevel` fields). Full `go test ./internal/... ./cmd/...` green, gofmt/vet clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)