### PR TITLE
M2 #306: match the line parser on trailing comments and string escapes

### DIFF
--- a/internal/lang/declparse_test.go
+++ b/internal/lang/declparse_test.go
@@ -405,3 +405,90 @@ func equalKeys(a, b map[string]bool) bool {
 	}
 	return true
 }
+
+// TestParseTopLevelRejectsTrailingComments locks the equivalence fix for the
+// shared tokenizer stripping // comments. The line parser requires eof() after
+// every identifier-led declaration, so a trailing comment makes it emit nothing
+// (it errors on package/import or simply drops the line for act). Recovery must
+// match: the stripped comment must not let a phantom node through. Metadata is
+// exempt because the line parser keeps the raw remainder, comment included.
+func TestParseTopLevelRejectsTrailingComments(t *testing.T) {
+	t.Run("package", func(t *testing.T) {
+		if top := ParseTopLevel("package home // c\n"); top.Package != nil {
+			t.Fatalf("emitted package for trailing-comment line: %#v", top.Package)
+		}
+	})
+	t.Run("import", func(t *testing.T) {
+		if top := ParseTopLevel("package p\nimport \"fmt\" // c\n"); len(top.Imports) != 0 {
+			t.Fatalf("emitted import for trailing-comment line: %#v", top.Imports)
+		}
+	})
+	t.Run("use", func(t *testing.T) {
+		if top := ParseTopLevel("package p\nuse ui \"ui\" // c\n"); len(top.Uses) != 0 {
+			t.Fatalf("emitted use for trailing-comment line: %#v", top.Uses)
+		}
+	})
+	t.Run("store", func(t *testing.T) {
+		// go/parser would silently ignore the comment in the initializer slice;
+		// the guard rejects the line first, matching the line parser's eof().
+		src := "package p\nstore Cart cart.Cart = cart.NewCart() // c\n"
+		if top := ParseTopLevel(src); len(top.Stores) != 0 {
+			t.Fatalf("emitted store for trailing-comment line: %#v", top.Stores)
+		}
+	})
+	t.Run("endpoint anchored to line parser", func(t *testing.T) {
+		// The line parser parses this successfully but emits no action; recovery
+		// must agree rather than report a phantom endpoint.
+		src := "package p\nact Submit POST \"/x\" // c\n"
+		syntaxFile, err := parser.ParseSyntax([]byte(src))
+		if err != nil {
+			t.Fatalf("line parser failed: %v", err)
+		}
+		if len(syntaxFile.Actions) != 0 {
+			t.Fatalf("precondition: line parser emitted an action: %#v", syntaxFile.Actions)
+		}
+		if top := ParseTopLevel(src); len(top.Actions) != 0 {
+			t.Fatalf("emitted endpoint for trailing-comment line: %#v", top.Actions)
+		}
+	})
+	t.Run("metadata keeps the comment in its raw value", func(t *testing.T) {
+		src := "package p\nroute \"/\" // c\n"
+		syntaxFile, err := parser.ParseSyntax([]byte(src))
+		if err != nil {
+			t.Fatalf("line parser failed: %v", err)
+		}
+		top := ParseTopLevel(src)
+		if got, want := metadataPairs(top.Metadata), metadataPairs(syntaxFile.Metadata); !equalOrdered(got, want) {
+			t.Fatalf("metadata mismatch:\n got %v\nwant %v", got, want)
+		}
+	})
+}
+
+// TestParseTopLevelDecodesStringEscapes locks the second equivalence fix: string
+// values the line parser pulls through stringValue()/identString() are decoded
+// (\t, \n, \", \\), so recovery must decode them too rather than keep the raw
+// backslash escapes.
+func TestParseTopLevelDecodesStringEscapes(t *testing.T) {
+	src := "package p\nimport \"a\\tb\"\nact Tab POST \"/x\\ty\"\n"
+	syntaxFile, err := parser.ParseSyntax([]byte(src))
+	if err != nil {
+		t.Fatalf("line parser failed: %v", err)
+	}
+	top := ParseTopLevel(src)
+
+	if len(top.Actions) != 1 {
+		t.Fatalf("expected one action, got %#v", top.Actions)
+	}
+	if top.Actions[0].Route != "/x\ty" {
+		t.Fatalf("route = %q, want %q (a decoded tab)", top.Actions[0].Route, "/x\ty")
+	}
+	if len(syntaxFile.Actions) != 1 || top.Actions[0].Route != syntaxFile.Actions[0].Route {
+		t.Fatalf("route diverged from line parser: got %q want %q", top.Actions[0].Route, syntaxFile.Actions[0].Route)
+	}
+	if len(top.Imports) != 1 || top.Imports[0].Path != "a\tb" {
+		t.Fatalf("import path = %#v, want decoded \"a\\tb\"", top.Imports)
+	}
+	if len(syntaxFile.Imports) != 1 || top.Imports[0].Path != syntaxFile.Imports[0].Path {
+		t.Fatalf("import path diverged from line parser: got %q want %q", top.Imports[0].Path, syntaxFile.Imports[0].Path)
+	}
+}

--- a/internal/syntax/declparse.go
+++ b/internal/syntax/declparse.go
@@ -80,6 +80,15 @@ func ParseTopLevel(src string) TopLevel {
 		first := line[0]
 		switch {
 		case first.Kind == TokenIdentifier:
+			// The line parser requires eof() after every identifier-led
+			// declaration, but the shared tokenizer strips // comments, so a
+			// trailing comment leaves a clean token line here. Reject any line
+			// whose raw tail still holds a dropped comment so recovery never
+			// emits a node ParseSyntax (which sees the comment as a leftover
+			// token and bails) would not.
+			if hasTrailingContent(src, line, tokens[lineEnd]) {
+				break
+			}
 			switch first.Lexeme {
 			case "package":
 				if result.Package == nil {
@@ -293,6 +302,57 @@ func sourceBetween(src string, start, stop int) string {
 	return src[start:stop]
 }
 
+// hasTrailingContent reports whether non-whitespace source remains between the
+// last token of line and the line terminator end — that is, a // comment the
+// shared tokenizer stripped. The line-oriented parser requires eof() after
+// every identifier-led declaration, so a line with a trailing comment is
+// rejected there; this check keeps recovery from emitting a node ParseSyntax
+// would not.
+func hasTrailingContent(src string, line []Token, end Token) bool {
+	last := line[len(line)-1]
+	return strings.TrimSpace(sourceBetween(src, tokenEnd(last), end.Offset)) != ""
+}
+
+// decodeString decodes a "..."-quoted lexeme using the same escape rules as the
+// line parser's lexLineString: \" and \\ collapse, \n and \t become the control
+// characters, any other \x keeps the backslash and the character, and a
+// trailing backslash is kept literally. Recovered string values (routes, error
+// pages, import paths, use packages) must match ParseSyntax byte for byte, and
+// ParseSyntax decodes these escapes, so trimming quotes alone is not enough.
+func decodeString(lexeme string) string {
+	if len(lexeme) < 2 || lexeme[0] != '"' {
+		return Unquote(lexeme)
+	}
+	var builder strings.Builder
+	for index := 1; index < len(lexeme); index++ {
+		ch := lexeme[index]
+		if ch == '"' {
+			break
+		}
+		if ch == '\\' {
+			if index+1 >= len(lexeme) {
+				builder.WriteByte(ch)
+				continue
+			}
+			index++
+			switch lexeme[index] {
+			case '"', '\\':
+				builder.WriteByte(lexeme[index])
+			case 'n':
+				builder.WriteByte('\n')
+			case 't':
+				builder.WriteByte('\t')
+			default:
+				builder.WriteByte('\\')
+				builder.WriteByte(lexeme[index])
+			}
+			continue
+		}
+		builder.WriteByte(ch)
+	}
+	return builder.String()
+}
+
 // parsePackageName accepts exactly `package <strict-ident>` with no trailing
 // tokens, matching parsePackageLine in the line parser.
 func parsePackageName(line []Token) (string, bool) {
@@ -319,7 +379,7 @@ func parseImportTokens(line []Token) (gwdkast.Import, bool) {
 	if index >= len(line) || line[index].Kind != TokenString {
 		return gwdkast.Import{}, false
 	}
-	path := Unquote(line[index].Lexeme)
+	path := decodeString(line[index].Lexeme)
 	index++
 	if index != len(line) || path == "" {
 		return gwdkast.Import{}, false
@@ -340,7 +400,7 @@ func parseUseTokens(line []Token) (gwdkast.Use, bool) {
 	if line[2].Kind != TokenString {
 		return gwdkast.Use{}, false
 	}
-	pkg := Unquote(line[2].Lexeme)
+	pkg := decodeString(line[2].Lexeme)
 	if !isStrictIdent(pkg) {
 		return gwdkast.Use{}, false
 	}
@@ -378,14 +438,14 @@ func parseEndpointTokens(kind string, line []Token) (gwdkast.Endpoint, bool) {
 		Kind:   kind,
 		Name:   name.Lexeme,
 		Method: method.Lexeme,
-		Route:  Unquote(line[3].Lexeme),
+		Route:  decodeString(line[3].Lexeme),
 		Span:   span,
 	}
 	if len(line) == 6 {
 		if line[4].Kind != TokenIdentifier || line[4].Lexeme != "error" || line[5].Kind != TokenString {
 			return gwdkast.Endpoint{}, false
 		}
-		errorPage, err := source.ErrorPagePath(Unquote(line[5].Lexeme))
+		errorPage, err := source.ErrorPagePath(decodeString(line[5].Lexeme))
 		if err != nil {
 			return gwdkast.Endpoint{}, false
 		}


### PR DESCRIPTION
## Why

Codex raised two **P2** equivalence divergences on the now-merged #312 (act/api endpoint recovery). Both stem from the shared tokenizer behaving differently than the line-oriented `ParseSyntax` this recovery layer is anchored to. I fixed them as a **bug class**, not just the two endpoint symptoms — the same divergences affect other declarations.

## Fix 1 — trailing comments (the whole identifier-led class)

The shared tokenizer strips `//` line comments, so `act Submit POST "/x" // c` reached `ParseTopLevel` as a clean 4-token line and emitted a phantom endpoint. The line parser requires `parser.eof()` after **every** identifier-led declaration — `package`, `import`, `use`, `store`, `props`, `state`, `act`, `api` — so it emits nothing for such a line (it *errors* on `package`/`import`, and *drops* the line for `act`).

I verified each parser's `eof()` boundary in `internal/parser/patterns.go` and confirmed the behavior empirically:

| input | `ParseSyntax` |
| --- | --- |
| `package home // c` | error (malformed package) |
| `import "fmt" // c` | error (malformed import) |
| `act Submit POST "/x" // c` | succeeds, **0 actions** |
| `route "/" // c` | metadata value = `route "/" // c` (comment kept) |

So a single `hasTrailingContent` guard in `ParseTopLevel`'s identifier branch — reject any line whose **raw source tail** (last token → line terminator) still holds a stripped comment — uniformly mirrors `eof()` for all of them. **Metadata is intentionally exempt**: the line parser keeps the raw remainder (comment included) and so does recovery, so they already agree.

## Fix 2 — string escapes

`unquote()` only trimmed surrounding quotes, while the line parser decodes `\"`, `\\`, `\n`, `\t` via `stringValue()` / `identString()` (`lexLineString`). So `"/x\t"` recorded a literal `\`+`t` instead of a tab. Added `decodeString` (mirrors `lexLineString` exactly) and applied it to the values the line parser decodes: **endpoint route, endpoint error page, import path, use package**. Metadata keeps `unquote` (the line parser trims quotes there — it does not decode).

## Tests

- `TestParseTopLevelRejectsTrailingComments` — package/import/use/store/endpoint all emit nothing; endpoint and metadata cases anchored directly against `ParseSyntax`.
- `TestParseTopLevelDecodesStringEscapes` — route and import path decode `\t` to a real tab, matching `ParseSyntax` byte-for-byte.
- Full suite (`./internal/... ./cmd/...`) green; `gofmt`/`go vet` clean.

Refs #306, #312

🤖 Generated with [Claude Code](https://claude.com/claude-code)