### PR TITLE
chore(release): prepare v0.3.0

### DIFF
--- a/.agents/skills/gowdk-docs/SKILL.md
+++ b/.agents/skills/gowdk-docs/SKILL.md
@@ -24,7 +24,7 @@ Each doc lane has one owner — write in the right one and link from the others:
   `diagnostic-codes.md` (must mirror `internal/diagnostics/registry.go`),
   routing, addons, deployment, hooks.
 - Onboarding: `README.md`, `docs/getting-started.md` — both pin the current
-  release (`v0.2.8` install snippets); version changes go through
+  release (`v0.3.0` install snippets); version changes go through
   `gowdk-version-bump`, not ad-hoc edits.
 - `CHANGELOG.md` — canonical change log (`## v0.x.y - date` with
   `### Changed` / `### Implemented` / `### Known Gaps`).

--- a/.agents/skills/gowdk-version-bump/SKILL.md
+++ b/.agents/skills/gowdk-version-bump/SKILL.md
@@ -9,7 +9,7 @@ description: Bump the GOWDK release version. Use when updating the CLI version, 
 
 - Source of truth: `const version = "0.x.y"` near the top of
   `cmd/gowdk/main.go` (no `v` prefix). GitHub tags and install snippets use
-  `v0.x.y`. Current line: `const version = "0.2.8"`.
+  `v0.x.y`. Current line: `const version = "0.3.0"`.
 - `editors/vscode/package.json` must match the CLI constant exactly;
   `editors/vscode/scripts/sync-version.js` reads the constant from
   `cmd/gowdk/main.go` and writes/checks `package.json`. Never edit the
@@ -43,7 +43,7 @@ node editors/vscode/scripts/sync-version.js --check
    skill file):
 
 ```bash
-grep -rn "0\.2\.8\|v0\.2\.8" README.md docs/ cmd/ editors/vscode/package.json .agents/
+grep -rn "0\.3\.0\|v0\.3\.0" README.md docs/ cmd/ editors/vscode/package.json .agents/
 ```
 
    Leave historical records (old CHANGELOG entries, dated release notes,

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,6 +52,9 @@ jobs:
           go run ./cmd/gowdk manifest --ssr $examples
           go run ./cmd/gowdk sitemap --ssr $examples
           go run ./cmd/gowdk routes --ssr $examples
+          go run ./cmd/gowdk endpoints --ssr $examples
+          go run ./cmd/gowdk inspect tree --json --ssr $examples
+          go run ./cmd/gowdk inspect endpoint-graph --json --ssr $examples
           (
             set -euxo pipefail
             cd examples/login

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,14 @@ packages, and tooling contracts may change before a stable release.
 
 ## Unreleased
 
+No entries yet.
+
+## v0.3.0 - 2026-06-12
+
 ### Changed
 
+- `gowdk version` and the VS Code extension metadata now report `0.3.0`.
+- Optional contract adapter modules require `github.com/cssbruno/gowdk v0.3.0`.
 - Conflict diagnostics (`duplicate_route`, `route_method_conflict`, including
   contract-route conflicts) now carry a related source location pointing at the
   first declaration. `gowdk check --json` gains an additive `related` array per
@@ -14,9 +20,26 @@ packages, and tooling contracts may change before a stable release.
 - The formatter now tracks brace depth with the parser's string- and
   comment-aware scanner, so braces inside string literals, comments, and
   template literals (for example `title "a { b"`) no longer skew indentation.
+- A page that declares no `guard` is no longer a build error. `guard` is now
+  optional, but a page is not public by default: `missing_page_guard` is now a
+  **warning** and the page's route is denied (403) at request time until the
+  author adds `guard public` or a protective guard. Static pages are denied
+  through the generated app's deny registry; request-time SSR pages are denied
+  in their own handler. Access is never granted by omission.
+- Compiler validation diagnostics now carry a severity. Warning-severity
+  diagnostics surface to authors and editors but do not fail the build.
 
 ### Implemented
 
+- M3 route, endpoint, and contract reporting is complete for the current 0.x
+  surface: `gowdk routes`, `gowdk endpoints`, `gowdk inspect tree`, and
+  `gowdk inspect endpoint-graph` expose source-linked route and backend
+  metadata without requiring users to read generated source.
+- `gowdk build` writes `openapi.json` for the routable web surface and
+  `asyncapi.json` for contract integration-event metadata.
+- Route and endpoint reports include versioned JSON, source spans, route
+  params, render/cache metadata, guards, planned handlers, backend binding
+  state, contract binding state, and non-fatal route-mode notes.
 - A machine-checked `.gwdk` conformance corpus
   (`internal/lang/testdata/conformance/`) pins the language contract: `accept/`
   cases must check clean and `reject/` cases must produce their declared stable
@@ -30,23 +53,7 @@ packages, and tooling contracts may change before a stable release.
   AST-backed formatting and precise editor edits.
 - ADR 0010 records the decision to replace the line-oriented parser with a
   shared tokenizer and a recursive-descent parser with error recovery, migrated
-  behind the stable `gwdkast` AST seam.
-
-### Changed
-
-- A page that declares no `guard` is no longer a build error. `guard` is now
-  optional, but a page is not public by default: `missing_page_guard` is now a
-  **warning** and the page's route is denied (403) at request time until the
-  author adds `guard public` (or a protective guard). Static pages are denied
-  through the generated app's deny registry; request-time (SSR) pages are denied
-  in their own handler. Access is never granted by omission. A pure static
-  export served without the generated Go server cannot enforce the 403 — the
-  build warning is the backstop.
-- Compiler validation diagnostics now carry a severity. Warning-severity
-  diagnostics surface to authors and editors but do not fail the build.
-
-### Implemented
-
+  behind the stable `gwdkast` AST boundary.
 - The default-deny contract now covers every way a guardless page could leak:
   dynamic build-time pages (`paths {}`) are denied by route pattern so each
   concrete artifact returns 403, direct index artifact paths
@@ -54,6 +61,14 @@ packages, and tooling contracts may change before a stable release.
   and a guardless page that declares `act`/`api`/`fragment` endpoints is a build
   **error** (`missing_page_guard`) because those endpoints would otherwise be
   publicly callable.
+
+### Known Gaps
+
+- GOWDK remains not production-ready.
+- Generated output and tooling reports remain pre-1.0 and may change unless a
+  reference document marks a surface stable.
+- M3 completes the current reportability milestone; it does not complete secure
+  runtime, SSR/hybrid, component/client, or production operations hardening.
 
 ## v0.2.8 - 2026-06-10
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ curl -fsSL https://raw.githubusercontent.com/cssbruno/GoWDK/main/scripts/install
 Pin the current CLI release:
 
 ```sh
-GOWDK_VERSION=v0.2.8 GOWDK_INSTALL_DIR="$HOME/.local/bin" \
+GOWDK_VERSION=v0.3.0 GOWDK_INSTALL_DIR="$HOME/.local/bin" \
   sh -c "$(curl -fsSL https://raw.githubusercontent.com/cssbruno/GoWDK/main/scripts/install.sh)"
 ```
 

--- a/cmd/gowdk/main.go
+++ b/cmd/gowdk/main.go
@@ -11,7 +11,7 @@ import (
 	"github.com/cssbruno/gowdk/addons/ssr"
 )
 
-const version = "0.2.8"
+const version = "0.3.0"
 
 var (
 	defaultSourceIncludes = []string{"**/*.gwdk"}

--- a/cmd/gowdk/release_workflow_test.go
+++ b/cmd/gowdk/release_workflow_test.go
@@ -58,6 +58,9 @@ func TestReleaseTrustWorkflowCoverage(t *testing.T) {
 		"draft: false",
 		"prerelease: true",
 		"Verify release assets",
+		"gowdk endpoints",
+		"inspect tree",
+		"inspect endpoint-graph",
 	} {
 		if !strings.Contains(releaseText, expected) {
 			t.Fatalf("expected %q in release.yml:\n%s", expected, releaseText)

--- a/docs/engineering/release-notes-v0.3.md
+++ b/docs/engineering/release-notes-v0.3.md
@@ -1,0 +1,136 @@
+# Experimental 0.x release: GOWDK v0.3
+
+GOWDK v0.3 is an experimental 0.x compiler/runtime release.
+
+Not production-ready. Public syntax, generated output, runtime packages, and
+tooling contracts may change before a stable release.
+
+## Implemented
+
+- M3 route, endpoint, and contract reportability for the current 0.x surface.
+- `gowdk endpoints` prints a versioned endpoint-only report for actions, APIs,
+  fragments, and routable command/query contract references.
+- `gowdk inspect tree --json` prints a source-linked compiler node tree for
+  editor and tooling navigation.
+- `gowdk inspect endpoint-graph --json` prints a source-linked endpoint dispatch
+  graph with pages, routes, endpoints, guards, handlers, bindings, and notes.
+- `gowdk routes` exposes source spans, binding state, route params,
+  render/cache metadata, guards, planned handlers, and non-fatal route-mode
+  notes for the supported route and endpoint surface.
+- `gowdk build` writes `openapi.json` for the routable web surface and
+  `asyncapi.json` for contract integration-event metadata.
+- `gowdk check --json` diagnostics can include related source locations, and
+  the language server reports those locations as related information.
+- A machine-checked `.gwdk` conformance corpus pins accept/reject cases against
+  stable diagnostic codes.
+- A per-construct stability and deprecation table documents current language
+  support and is checked against the code registries.
+- The shared tokenizer/parser cutover records byte offsets for source positions
+  and keeps formatter indentation stable around braces inside strings,
+  comments, and template literals.
+- Guardless pages are default-denied in generated apps: omission produces a
+  warning, public access still requires `guard public`, and pages with backend
+  endpoints still hard-error without an explicit guard.
+- `v0.3.0` release metadata: CLI/editor versions, optional module root-version
+  requirements, root changelog, release-doc current-version examples, and M3
+  release-note body.
+
+## Partial
+
+- Route, endpoint, and contract reports are versioned for the current 0.x
+  surface, but broader exact source spans and future report fields may still be
+  added.
+- Generated OpenAPI and AsyncAPI reports cover the implemented routable web and
+  integration-event metadata slices, not every future API or contract shape.
+- Guard metadata is still generated access redundancy and does not replace
+  authorization in normal Go backend handlers and services.
+
+## Planned
+
+- M4 Go interop: Go binding inspection, stubs, typed params, build/load
+  contracts, and package resolution.
+- M5 secure endpoint runtime: strict adapters, request limits, CSRF response
+  contract, panic boundaries, and tested failure paths.
+- M7 request-time SSR/hybrid hardening and later component/client-language
+  milestones remain separate work.
+
+## Intentionally Out Of Scope
+
+- Production-readiness claims.
+- Migration guides.
+- Framework comparison docs as core positioning.
+- Mandatory full-page SSR or full-page hydration.
+- User-written JavaScript as the normal app contract.
+- Mandatory Tailwind, npm, Gin, Echo, Fiber, Redis, NATS, or another optional
+  framework/tool dependency.
+- Replacing backend authorization with generated page guards.
+
+## Known Gaps
+
+- v0.3 remains experimental and focused on reportability and language/compiler
+  hardening.
+- Generated output remains pre-1.0 and unstable unless a reference doc marks a
+  surface stable.
+- Secure runtime, SSR/hybrid, component/client, operations, and production
+  hardening milestones remain incomplete.
+
+## Breaking Or Unstable Generated Output
+
+Generated output is pre-1.0. Treat generated Go, generated JavaScript,
+manifests, build reports, route reports, endpoint reports, inspect reports, and
+runtime package contracts as unstable unless a reference doc explicitly marks a
+surface stable.
+
+## Required Release Verification
+
+Run the full release checklist before publishing:
+
+- `docs/engineering/release.md`
+- `docs/engineering/release-plan.md`
+
+Required local gates:
+
+```sh
+git diff --check
+scripts/test-go-modules.sh
+scripts/vulncheck-go-modules.sh
+go build ./cmd/gowdk
+node editors/vscode/scripts/sync-version.js --check
+node --check editors/vscode/extension.js
+node --check editors/vscode/extension-core.js
+node --test editors/vscode/*.test.js
+```
+
+## Artifact Verification
+
+Download the CLI artifact for your platform and `checksums.txt` from the GitHub
+release.
+
+```sh
+grep ' <artifact>$' checksums.txt | sha256sum -c -
+```
+
+On macOS, use:
+
+```sh
+shasum -a 256 <artifact>
+```
+
+Verify GitHub artifact attestations:
+
+```sh
+gh attestation verify <artifact> -R cssbruno/GOWDK
+```
+
+## VS Code Extension
+
+Install the packaged `.vsix` manually when the release includes one:
+
+```sh
+code --install-extension gowdk-vscode-0.3.0.vsix
+```
+
+## Tool Versions
+
+- Go: `1.26.4`
+- Node.js for extension checks: `24`

--- a/docs/engineering/release.md
+++ b/docs/engineering/release.md
@@ -6,14 +6,14 @@ pre-releases with downloadable assets from `v*` tags or a manual workflow
 dispatch. VS Code Marketplace publishing lives in
 `.github/workflows/vscode-extension-publish.yml`.
 
-The current CLI version is `0.2.8`, but this is not a production-readiness
+The current CLI version is `0.3.0`, but this is not a production-readiness
 claim. It identifies the current development line while the compiler, generated
 runtime, and docs continue through the 0.x line. Public release notes must
 call the build experimental until the release gates below are satisfied.
 
 Use `docs/engineering/v0.2-release-checklist.md` for the current Public Truth
 and Release Trust checklist.
-Use `docs/engineering/release-notes-v0.2.md` as the draft v0.2 release notes.
+Use `docs/engineering/release-notes-v0.3.md` as the draft v0.3 release notes.
 Use `docs/engineering/release-plan.md` for the open-ended 0.x hardening
 checklist. It does not make any minor version a production-readiness target.
 Use `.github/release-note-template.md` for future 0.x release bodies.
@@ -77,6 +77,9 @@ go run ./cmd/gowdk check --ssr examples/pages/*.gwdk examples/actions/*.gwdk exa
 go run ./cmd/gowdk manifest --ssr examples/pages/*.gwdk examples/actions/*.gwdk examples/partials/*.gwdk examples/api/*.gwdk examples/ssr/*.gwdk examples/go-interop/*.gwdk examples/components/base/*.gwdk examples/components/css/*.gwdk examples/components/assets/*.gwdk examples/embed/*.gwdk examples/css/*.gwdk examples/tailwind/*.gwdk
 go run ./cmd/gowdk sitemap --ssr examples/pages/*.gwdk examples/actions/*.gwdk examples/partials/*.gwdk examples/api/*.gwdk examples/ssr/*.gwdk examples/go-interop/*.gwdk examples/components/base/*.gwdk examples/components/css/*.gwdk examples/components/assets/*.gwdk examples/embed/*.gwdk examples/css/*.gwdk examples/tailwind/*.gwdk
 go run ./cmd/gowdk routes --ssr examples/pages/*.gwdk examples/actions/*.gwdk examples/partials/*.gwdk examples/api/*.gwdk examples/ssr/*.gwdk examples/go-interop/*.gwdk examples/components/base/*.gwdk examples/components/css/*.gwdk examples/components/assets/*.gwdk examples/embed/*.gwdk examples/css/*.gwdk examples/tailwind/*.gwdk
+go run ./cmd/gowdk endpoints --ssr examples/pages/*.gwdk examples/actions/*.gwdk examples/partials/*.gwdk examples/api/*.gwdk examples/ssr/*.gwdk examples/go-interop/*.gwdk examples/components/base/*.gwdk examples/components/css/*.gwdk examples/components/assets/*.gwdk examples/embed/*.gwdk examples/css/*.gwdk examples/tailwind/*.gwdk
+go run ./cmd/gowdk inspect tree --json --ssr examples/pages/*.gwdk examples/actions/*.gwdk examples/partials/*.gwdk examples/api/*.gwdk examples/ssr/*.gwdk examples/go-interop/*.gwdk examples/components/base/*.gwdk examples/components/css/*.gwdk examples/components/assets/*.gwdk examples/embed/*.gwdk examples/css/*.gwdk examples/tailwind/*.gwdk
+go run ./cmd/gowdk inspect endpoint-graph --json --ssr examples/pages/*.gwdk examples/actions/*.gwdk examples/partials/*.gwdk examples/api/*.gwdk examples/ssr/*.gwdk examples/go-interop/*.gwdk examples/components/base/*.gwdk examples/components/css/*.gwdk examples/components/assets/*.gwdk examples/embed/*.gwdk examples/css/*.gwdk examples/tailwind/*.gwdk
 go run ./cmd/gowdk build --ssr --out /tmp/gowdk-hybrid-build --app /tmp/gowdk-hybrid-app --bin /tmp/gowdk-hybrid-site examples/ssr/hybrid-static.page.gwdk
 go run ./cmd/gowdk build --out /tmp/gowdk-component-assets examples/components/assets/*.gwdk
 ```
@@ -85,14 +88,14 @@ After those gates pass on the release commit, run the release workflow manually
 for the current CLI line or push the corresponding tag:
 
 ```sh
-gh workflow run release.yml -f version=v0.2.8
+gh workflow run release.yml -f version=v0.3.0
 ```
 
 After the release workflow completes, smoke the published artifacts for each
 supported OS artifact:
 
 ```sh
-gh workflow run release-smoke.yml -f version=v0.2.8
+gh workflow run release-smoke.yml -f version=v0.3.0
 ```
 
 ## Artifacts
@@ -103,7 +106,7 @@ gh workflow run release-smoke.yml -f version=v0.2.8
 - `gowdk-darwin-arm64`
 - `gowdk-windows-amd64.exe`
 - `checksums.txt`
-- `gowdk-vscode-0.2.8.vsix`
+- `gowdk-vscode-0.3.0.vsix`
 
 ## Install Script
 
@@ -117,7 +120,7 @@ binary SHA-256, and writes `gowdk` into `GOWDK_INSTALL_DIR` or
 Pinned install:
 
 ```sh
-GOWDK_VERSION=v0.2.8 GOWDK_INSTALL_DIR="$HOME/.local/bin" \
+GOWDK_VERSION=v0.3.0 GOWDK_INSTALL_DIR="$HOME/.local/bin" \
   sh -c "$(curl -fsSL https://raw.githubusercontent.com/cssbruno/GoWDK/main/scripts/install.sh)"
 ```
 
@@ -138,7 +141,7 @@ gh attestation verify <artifact> -R <owner>/<repo>
 ## Extension Publishing
 
 The release workflow packages the extension into a `.vsix` named from
-`editors/vscode/package.json`, currently `gowdk-vscode-0.2.8.vsix`.
+`editors/vscode/package.json`, currently `gowdk-vscode-0.3.0.vsix`.
 Marketplace publishing is handled by the `Publish VS Code Extension` workflow.
 It is manual-only so CLI/runtime releases do not accidentally republish an
 extension version that already exists on the Marketplace.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -21,7 +21,7 @@ gowdk version
 Pin the current CLI release or install into a user-writable directory:
 
 ```sh
-GOWDK_VERSION=v0.2.8 GOWDK_INSTALL_DIR="$HOME/.local/bin" \
+GOWDK_VERSION=v0.3.0 GOWDK_INSTALL_DIR="$HOME/.local/bin" \
   sh -c "$(curl -fsSL https://raw.githubusercontent.com/cssbruno/GoWDK/main/scripts/install.sh)"
 ```
 
@@ -96,7 +96,7 @@ Direct artifact names:
 Manual Linux install:
 
 ```sh
-version=v0.2.8
+version=v0.3.0
 curl -fsSLO "https://github.com/cssbruno/GoWDK/releases/download/$version/gowdk-linux-amd64"
 curl -fsSLO "https://github.com/cssbruno/GoWDK/releases/download/$version/checksums.txt"
 grep ' gowdk-linux-amd64$' checksums.txt | sha256sum -c -
@@ -109,7 +109,7 @@ gowdk version
 Manual macOS Intel install:
 
 ```sh
-version=v0.2.8
+version=v0.3.0
 curl -fsSLO "https://github.com/cssbruno/GoWDK/releases/download/$version/gowdk-darwin-amd64"
 curl -fsSLO "https://github.com/cssbruno/GoWDK/releases/download/$version/checksums.txt"
 expected="$(awk '$2 == "gowdk-darwin-amd64" { print $1 }' checksums.txt)"
@@ -124,7 +124,7 @@ gowdk version
 Manual macOS ARM install:
 
 ```sh
-version=v0.2.8
+version=v0.3.0
 curl -fsSLO "https://github.com/cssbruno/GoWDK/releases/download/$version/gowdk-darwin-arm64"
 curl -fsSLO "https://github.com/cssbruno/GoWDK/releases/download/$version/checksums.txt"
 expected="$(awk '$2 == "gowdk-darwin-arm64" { print $1 }' checksums.txt)"
@@ -139,7 +139,7 @@ gowdk version
 Manual Windows install from PowerShell:
 
 ```powershell
-$version = "v0.2.8"
+$version = "v0.3.0"
 Invoke-WebRequest "https://github.com/cssbruno/GoWDK/releases/download/$version/gowdk-windows-amd64.exe" -OutFile "gowdk.exe"
 Invoke-WebRequest "https://github.com/cssbruno/GoWDK/releases/download/$version/checksums.txt" -OutFile "checksums.txt"
 $expected = (Select-String -Path checksums.txt -Pattern "gowdk-windows-amd64.exe").Line.Split(" ")[0]
@@ -158,7 +158,7 @@ Install the VS Code extension package from a release when a `.vsix` is
 published:
 
 ```sh
-code --install-extension gowdk-vscode-0.1.9.vsix
+code --install-extension gowdk-vscode-0.3.0.vsix
 ```
 
 ## Build From Source

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "gowdk-vscode",
   "displayName": "GOWDK",
   "description": "Language tools for portable .gwdk files.",
-  "version": "0.2.8",
+  "version": "0.3.0",
   "publisher": "gowdk",
   "license": "MIT",
   "icon": "icons/gowdk.png",

--- a/runtime/contracts/natsbroker/go.mod
+++ b/runtime/contracts/natsbroker/go.mod
@@ -3,7 +3,7 @@ module github.com/cssbruno/gowdk/runtime/contracts/natsbroker
 go 1.26.4
 
 require (
-	github.com/cssbruno/gowdk v0.2.8
+	github.com/cssbruno/gowdk v0.3.0
 	github.com/nats-io/nats.go v1.52.0
 )
 

--- a/runtime/contracts/redisstream/go.mod
+++ b/runtime/contracts/redisstream/go.mod
@@ -3,7 +3,7 @@ module github.com/cssbruno/gowdk/runtime/contracts/redisstream
 go 1.26.4
 
 require (
-	github.com/cssbruno/gowdk v0.2.8
+	github.com/cssbruno/gowdk v0.3.0
 	github.com/redis/go-redis/v9 v9.20.0
 )
 

--- a/runtime/contracts/websocketfanout/go.mod
+++ b/runtime/contracts/websocketfanout/go.mod
@@ -4,7 +4,7 @@ go 1.26.4
 
 require (
 	github.com/coder/websocket v1.8.14
-	github.com/cssbruno/gowdk v0.2.8
+	github.com/cssbruno/gowdk v0.3.0
 )
 
 replace github.com/cssbruno/gowdk => ../../..


### PR DESCRIPTION
## Summary

Prepare the experimental GOWDK v0.3.0 release.

- Bump the CLI and VS Code extension metadata to `0.3.0`.
- Update install snippets, release docs, optional contract adapter module requirements, and the version-bump/doc skills.
- Move current changelog entries into `v0.3.0 - 2026-06-12` and add `docs/engineering/release-notes-v0.3.md`.
- Add M3 report gates (`endpoints`, `inspect tree`, `inspect endpoint-graph`) to the release workflow and pin them in the release workflow test.

## Notes

Direct push to `main` was rejected by repository rules, so this release prep is going through PR as required. The release remains explicitly experimental and not production-ready.

## Verification

- `git diff --check`
- `node editors/vscode/scripts/sync-version.js --check`
- `scripts/test-go-modules.sh`
- `scripts/vulncheck-go-modules.sh`
- `go build -o /tmp/gowdk-release-0.3.0 ./cmd/gowdk && /tmp/gowdk-release-0.3.0 version --json`
- `go test ./cmd/gowdk -run 'Version|Release'`
- `node --check editors/vscode/extension.js`
- `node --check editors/vscode/extension-core.js`
- `node --test editors/vscode/*.test.js`
- `go run ./cmd/gowdk check --ssr ...examples...`
- `go run ./cmd/gowdk manifest --ssr ...examples...`
- `go run ./cmd/gowdk sitemap --ssr ...examples...`
- `go run ./cmd/gowdk routes --ssr ...examples...`
- `go run ./cmd/gowdk endpoints --ssr ...examples...`
- `go run ./cmd/gowdk inspect tree --json --ssr ...examples...`
- `go run ./cmd/gowdk inspect endpoint-graph --json --ssr ...examples...`
- Generated-output smokes for login, CSS, embed, hybrid, and component assets.