### PR TITLE
fix(buildgen): escape store script JSON safely

### DIFF
--- a/docs/compiler/generated-output.md
+++ b/docs/compiler/generated-output.md
@@ -87,6 +87,10 @@ Implemented today:
   through per-binding functions for text, form values, checked state, classes,
   styles, attributes, conditionals, and lists; keyed list updates reuse
   existing DOM nodes by `g:key` and remove stale keyed nodes.
+- Page store seed JSON embedded in compiler-owned
+  `<script type="application/json">` tags escapes literal `<` as `\u003c`, so
+  store data cannot terminate the script element or enter HTML escaped-script
+  parser states.
 - In the default development build mode, generated JavaScript island assets are
   accompanied by `assets/gowdk/islands/<Component>.js.map` source map files
   that reference the component `.gwdk` source, are recorded in

--- a/internal/buildgen/render.go
+++ b/internal/buildgen/render.go
@@ -403,7 +403,5 @@ func socialHeadEnabled(head gowdk.HeadConfig, metadata gwdkir.PageMetadata) bool
 }
 
 func escapeScriptJSON(payload string) string {
-	payload = strings.ReplaceAll(payload, "</script", "<\\/script")
-	payload = strings.ReplaceAll(payload, "</SCRIPT", "<\\/SCRIPT")
-	return payload
+	return strings.ReplaceAll(payload, "<", "\\u003c")
 }

--- a/internal/buildgen/render_test.go
+++ b/internal/buildgen/render_test.go
@@ -1,0 +1,29 @@
+package buildgen
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestEscapeScriptJSONEscapesEveryLiteralLessThan(t *testing.T) {
+	input := `{"value":"</ScRiPt><img src=x onerror=1><!--"}`
+
+	escaped := escapeScriptJSON(input)
+
+	if strings.Contains(escaped, "<") {
+		t.Fatalf("escaped script JSON still contains <: %q", escaped)
+	}
+	for _, expected := range []string{`\u003c/ScRiPt>`, `\u003cimg src=x onerror=1>`, `\u003c!--`} {
+		if !strings.Contains(escaped, expected) {
+			t.Fatalf("expected escaped JSON to contain %q, got %q", expected, escaped)
+		}
+	}
+	var decoded map[string]string
+	if err := json.Unmarshal([]byte(escaped), &decoded); err != nil {
+		t.Fatalf("escaped JSON is invalid: %v\n%s", err, escaped)
+	}
+	if decoded["value"] != `</ScRiPt><img src=x onerror=1><!--` {
+		t.Fatalf("escaped JSON changed value: %q", decoded["value"])
+	}
+}


### PR DESCRIPTION
## Summary

- Escape every literal `<` in page store seed JSON embedded in compiler-owned `application/json` script tags.
- Add a regression test for mixed-case `</script>` and `<!--` payloads while verifying the JSON still decodes to the original value.
- Document the generated-output safety contract for embedded store seed JSON.

## Issue Closure

Fixes #150

## Verification

- [x] I ran the relevant tests, lint, and build commands.
- [x] I ran `scripts/test-go-modules.sh` when Go code or compiler behavior changed.
- [x] I ran `go build ./cmd/gowdk` when CLI, compiler, runtime, addon, or release behavior changed.
- [ ] I ran `node --check editors/vscode/extension.js` when editor files changed.
- [x] I updated docs for behavior, setup, or architecture changes.
- [x] I added or updated tests for changed behavior.

Commands run:

- `go test ./internal/buildgen`
- `go test ./...`
- `go build ./cmd/gowdk`
- `git diff --check`
- `scripts/test-go-modules.sh`

## LLM Assistance

- LLM session summary: Fixed the M5 script JSON escaping bug by replacing all literal `<` characters in embedded store seed JSON with `\u003c`, added direct regression coverage, and documented the generated-output behavior.
- Human-reviewed assumptions: Escaping literal `<` is safe for JSON script payloads because `\u003c` decodes back to `<` and prevents all HTML parser close/comment marker variants.
- Follow-up work: Continue remaining M5 secure endpoint runtime issues before the 0.3 release.