### PR TITLE
fix(actions): use browser-safe CSRF cookie in insecure mode

### DIFF
--- a/addons/actions/actions_test.go
+++ b/addons/actions/actions_test.go
@@ -101,6 +101,41 @@ func TestCSRFGeneratesSecureCookieAndValidatesFormToken(t *testing.T) {
 	}
 }
 
+func TestCSRFInsecureDefaultUsesBrowserAcceptedCookieName(t *testing.T) {
+	csrf, err := NewCSRF(CSRFOptions{
+		Secret:   []byte(strings.Repeat("s", 32)),
+		Insecure: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	response := httptest.NewRecorder()
+	token, err := csrf.Token(response, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cookies := response.Result().Cookies()
+	if len(cookies) != 1 {
+		t.Fatalf("expected csrf cookie, got %#v", cookies)
+	}
+	cookie := cookies[0]
+	if cookie.Name != defaultInsecureCSRFCookie || cookie.Secure {
+		t.Fatalf("unexpected insecure csrf cookie: %#v", cookie)
+	}
+	if csrf.CookieName() != defaultInsecureCSRFCookie {
+		t.Fatalf("unexpected insecure csrf cookie name: %q", csrf.CookieName())
+	}
+
+	form := url.Values{defaultCSRFField: []string{token}}
+	request := httptest.NewRequest(http.MethodPost, "/signup", strings.NewReader(form.Encode()))
+	request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	request.AddCookie(cookie)
+
+	if err := csrf.Validate(request); err != nil {
+		t.Fatalf("expected csrf validation to pass: %v", err)
+	}
+}
+
 func TestCSRFValidatesHeaderToken(t *testing.T) {
 	csrf, err := NewCSRF(CSRFOptions{Secret: []byte(strings.Repeat("s", 32))})
 	if err != nil {
@@ -166,6 +201,22 @@ func TestNewCSRFRejectsShortSecret(t *testing.T) {
 	_, err := NewCSRF(CSRFOptions{Secret: []byte("short")})
 	if err == nil {
 		t.Fatal("expected short secret error")
+	}
+}
+
+func TestNewCSRFRejectsSecureCookiePrefixInInsecureMode(t *testing.T) {
+	for _, name := range []string{"__Host-gowdk-csrf", "__Secure-gowdk-csrf"} {
+		_, err := NewCSRF(CSRFOptions{
+			Secret:     []byte(strings.Repeat("s", 32)),
+			CookieName: name,
+			Insecure:   true,
+		})
+		if err == nil {
+			t.Fatalf("expected insecure secure-prefix cookie error for %q", name)
+		}
+		if !strings.Contains(err.Error(), "requires Secure") {
+			t.Fatalf("unexpected error for %q: %v", name, err)
+		}
 	}
 }
 

--- a/addons/actions/csrf.go
+++ b/addons/actions/csrf.go
@@ -8,14 +8,16 @@ import (
 	"encoding/base64"
 	"fmt"
 	"net/http"
+	"strings"
 )
 
 const (
-	defaultCSRFCookie = "__Host-gowdk-csrf"
-	defaultCSRFField  = "_gowdk_csrf"
-	defaultCSRFHeader = "X-GOWDK-CSRF"
-	csrfNonceBytes    = 32
-	csrfMACBytes      = sha256.Size
+	defaultCSRFCookie         = "__Host-gowdk-csrf"
+	defaultInsecureCSRFCookie = "gowdk-csrf"
+	defaultCSRFField          = "_gowdk_csrf"
+	defaultCSRFHeader         = "X-GOWDK-CSRF"
+	csrfNonceBytes            = 32
+	csrfMACBytes              = sha256.Size
 )
 
 // CSRFValidator validates action requests before generated handlers run.
@@ -57,6 +59,12 @@ func NewCSRF(options CSRFOptions) (*CSRF, error) {
 	cookieName := options.CookieName
 	if cookieName == "" {
 		cookieName = defaultCSRFCookie
+		if options.Insecure {
+			cookieName = defaultInsecureCSRFCookie
+		}
+	}
+	if options.Insecure && secureCookiePrefix(cookieName) {
+		return nil, fmt.Errorf("csrf cookie name %q requires Secure and cannot be used with insecure CSRF mode", cookieName)
 	}
 	fieldName := options.FieldName
 	if fieldName == "" {
@@ -78,6 +86,10 @@ func NewCSRF(options CSRFOptions) (*CSRF, error) {
 		secure:     !options.Insecure,
 		sameSite:   sameSite,
 	}, nil
+}
+
+func secureCookiePrefix(name string) bool {
+	return strings.HasPrefix(name, "__Host-") || strings.HasPrefix(name, "__Secure-")
 }
 
 // Token returns the CSRF token for a generated hidden form field. It reuses

--- a/docs/language/actions.md
+++ b/docs/language/actions.md
@@ -83,8 +83,10 @@ Current behavior:
 - `addons/actions.ValidateRequired` exposes the same required-field behavior as
   a `runtime/validation.Result` for addon and generated-handler integrations.
 - `addons/actions.NewCSRF` provides signed double-submit CSRF tokens with an
-  HttpOnly, Secure, SameSite=Lax cookie by default. Normal builds do not expose
-  a no-op CSRF validator; package tests keep their no-op helper in `_test.go`.
+  HttpOnly, Secure, SameSite=Lax cookie by default. Local HTTP `Insecure` mode
+  uses a non-prefixed `gowdk-csrf` cookie because browsers reject `__Host-`
+  cookies without Secure. Normal builds do not expose a no-op CSRF validator;
+  package tests keep their no-op helper in `_test.go`.
 - `Build.CSRF.Enabled` wires generated CSRF token generation and validation for
   generated action adapters. Generated apps read the signing secret from
   `Build.CSRF.SecretEnv` or `GOWDK_CSRF_SECRET`, inject a hidden token field into

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -376,7 +376,10 @@ hidden token field into served HTML POST forms, and validate action POSTs before
 generated decoding or user handlers run. Invalid or missing tokens return HTTP
 403 with `invalid csrf token` and `Cache-Control: no-store`. `CookieName`,
 `FieldName`, and `HeaderName` override the generated token transport names.
-`Insecure` disables the Secure cookie flag for local HTTP development only.
+`Insecure` is for local HTTP development only: it disables the Secure cookie
+flag, uses the default cookie name `gowdk-csrf` instead of
+`__Host-gowdk-csrf`, and rejects explicit `__Host-`/`__Secure-` cookie names
+because browsers require those prefixes to be Secure.
 
 `Name` is required. `Output` is optional and defaults to
 `.gowdk/output/<target-name>` when omitted. `Modules` selects configured

--- a/internal/appgen/appgen_test.go
+++ b/internal/appgen/appgen_test.go
@@ -4388,7 +4388,7 @@ func TestGeneratedBinaryValidatesCSRFWhenEnabled(t *testing.T) {
 		t.Fatalf("expected generated form csrf token, got %s", body)
 	}
 	cookie := cookieHeader(headers.Get("Set-Cookie"))
-	if !strings.Contains(cookie, "__Host-gowdk-csrf=") {
+	if !strings.HasPrefix(cookie, "gowdk-csrf=") {
 		t.Fatalf("expected csrf cookie, got %q", headers.Get("Set-Cookie"))
 	}
 


### PR DESCRIPTION
## Summary

- Use `gowdk-csrf` as the default CSRF cookie name when `Insecure` local HTTP mode is enabled, avoiding the browser-rejected `__Host-` prefix without `Secure`.
- Reject explicit `__Host-` and `__Secure-` CSRF cookie names when `Insecure` is set.
- Update addon and generated-binary tests plus action/config docs for the local HTTP cookie behavior.

## Issue Closure

Fixes #156

## Verification

- [x] I ran the relevant tests, lint, and build commands.
- [x] I ran `scripts/test-go-modules.sh` when Go code or compiler behavior changed.
- [x] I ran `go build ./cmd/gowdk` when CLI, compiler, runtime, addon, or release behavior changed.
- [ ] I ran `node --check editors/vscode/extension.js` when editor files changed.
- [x] I updated docs for behavior, setup, or architecture changes.
- [x] I added or updated tests for changed behavior.

Commands run:

- `go test ./addons/actions ./internal/appgen`
- `go test ./...`
- `go build ./cmd/gowdk`
- `git diff --check`
- `scripts/test-go-modules.sh`

## LLM Assistance

- LLM session summary: Fixed the local HTTP CSRF cookie mismatch by switching the insecure default to `gowdk-csrf`, rejecting secure-prefix cookie names in insecure mode, and updating generated-binary expectations and docs.
- Human-reviewed assumptions: Production/default CSRF should keep the `__Host-gowdk-csrf` Secure cookie; only explicit local HTTP `Insecure` mode should use a non-prefixed non-Secure default.
- Follow-up work: Continue remaining M5 secure endpoint runtime issues before the 0.3 release.