### PR TITLE
fix(security): broaden secret redaction policy

### DIFF
--- a/docs/engineering/operations.md
+++ b/docs/engineering/operations.md
@@ -123,7 +123,11 @@ readiness claim:
 - Serve app assets with deterministic cache headers.
 - Avoid public debug endpoints by default.
 - Exclude local env files, private source files, and temporary build artifacts from embedded output.
-- Keep logs useful for route/action/API/SSR failures without logging secrets or sensitive form values.
+- Keep logs useful for route/action/API/SSR failures without logging secrets or
+  sensitive form values. Generated panic-boundary logs and diagnostics redact
+  common secret fields (`password`, `secret`, `_gowdk_csrf`, cookies,
+  authorization headers, session IDs, and access/refresh/id tokens), but
+  app-owned logs remain the application's responsibility.
 
 ## Maintenance
 

--- a/docs/reference/errors.md
+++ b/docs/reference/errors.md
@@ -99,8 +99,24 @@ Not supported today:
 Generated panic boundaries render safe fixed messages or generated HTML error
 documents. They intentionally do not render panic values.
 
-Returned handler errors are user-owned. If a handler returns an error message
-that includes secrets, tokens, credentials, submitted values, SQL details, or
-internal service details, GOWDK will not rewrite that message. Prefer returning
-a safe `response.Response` or `response.NewHandlerError` message and logging
-the detailed cause in app-owned middleware or handler code.
+Generated action, API, fragment, contract, SSR load, and addon 5xx responses
+hide ordinary returned error details. Apps can expose an intentional
+client-facing message by returning `response.HandlerError` with an explicit
+`Message`; 4xx handler errors keep their application message contract.
+
+Runtime panic logs and compiler diagnostics apply conservative redaction before
+writing to logs, terminal output, JSON diagnostics, or LSP diagnostics. The
+redaction policy masks common credential surfaces:
+
+- DSN passwords such as `postgres://user:password@host`.
+- Bearer and Basic authorization header values.
+- `password`, `passwd`, `pwd`, `secret`, `token`, `_gowdk_csrf`,
+  `csrf_token`, `cookie`, `set-cookie`, `auth_token`, `session`,
+  `session_id`, `jwt`, `api_key`, `access_key`, `access_token`,
+  `refresh_token`, `id_token`, `client_secret`, and `private_key` values when
+  they appear as `name=value` or `name: value`.
+
+Limitations: app-owned logging is outside GOWDK's control, and explicit
+client-facing `HandlerError.Message` values are trusted as app-owned text. Do
+not put secrets, credentials, submitted sensitive values, SQL details, or
+internal service details in messages intended for clients.

--- a/internal/lang/redact.go
+++ b/internal/lang/redact.go
@@ -38,10 +38,11 @@ var redactionRules = []struct {
 		pattern:     regexp.MustCompile(`(?i)\b(Bearer|Basic)\s+[A-Za-z0-9._~+/=-]{8,}`),
 		replacement: `${1} ` + redactionMask,
 	},
-	// key=value / key: value where key names a secret. Requires an explicit
-	// : or = separator so it does not swallow following words by whitespace.
+	// key=value / key: value where key names a secret-bearing header, cookie,
+	// form field, query param, or credential. Requires an explicit : or =
+	// separator so it does not swallow following words by whitespace.
 	{
-		pattern:     regexp.MustCompile(`(?i)\b(password|passwd|pwd|secret|token|api[_-]?key|access[_-]?key|client[_-]?secret|private[_-]?key)\b(\s*[:=]\s*)("?)[^\s"',;)]+`),
+		pattern:     regexp.MustCompile(`(?i)\b(password|passwd|pwd|secret|token|_?gowdk[_-]?csrf|_?csrf(?:[_-]?token)?|cookie|set-cookie|auth[_-]?token|session(?:[_-]?id)?|jwt|api[_-]?key|access(?:[_-]?(?:key|token))?|refresh[_-]?token|id[_-]?token|client[_-]?secret|private[_-]?key)\b(\s*[:=]\s*)("?)[^\s"',;)]+`),
 		replacement: `${1}${2}${3}` + redactionMask,
 	},
 }

--- a/internal/lang/redact_test.go
+++ b/internal/lang/redact_test.go
@@ -31,6 +31,30 @@ func TestRedactMessageMasksSecrets(t *testing.T) {
 			leaked:  "live_sk_99aabb",
 			wantSub: "api_key=[REDACTED]",
 		},
+		{
+			name:    "csrf token in generated form field",
+			in:      `invalid submitted field "_gowdk_csrf=csrf-secret-token"`,
+			leaked:  "csrf-secret-token",
+			wantSub: "_gowdk_csrf=[REDACTED]",
+		},
+		{
+			name:    "cookie header",
+			in:      `request Cookie: gowdk_session=signed-secret; theme=dark`,
+			leaked:  "signed-secret",
+			wantSub: "Cookie: [REDACTED]",
+		},
+		{
+			name:    "authorization key value",
+			in:      `request authorization=Bearer abc123secret`,
+			leaked:  "abc123secret",
+			wantSub: "Bearer [REDACTED]",
+		},
+		{
+			name:    "sensitive query param",
+			in:      `route query refresh_token=refresh-secret-token is invalid`,
+			leaked:  "refresh-secret-token",
+			wantSub: "refresh_token=[REDACTED]",
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/runtime/app/redact.go
+++ b/runtime/app/redact.go
@@ -36,11 +36,11 @@ var redactionRules = []struct {
 		pattern:     regexp.MustCompile(`(?i)\b(Bearer|Basic)\s+[A-Za-z0-9._~+/=-]{8,}`),
 		replacement: `${1} ` + redactionMask,
 	},
-	// key=value / key: value where key names a secret (password, token, secret,
-	// apikey, access_key, client_secret, private_key). Requires an explicit
-	// : or = separator so it does not swallow following words by whitespace.
+	// key=value / key: value where key names a secret-bearing header, cookie,
+	// form field, query param, or credential. Requires an explicit : or =
+	// separator so it does not swallow following words by whitespace.
 	{
-		pattern:     regexp.MustCompile(`(?i)\b(password|passwd|pwd|secret|token|api[_-]?key|access[_-]?key|client[_-]?secret|private[_-]?key)\b(\s*[:=]\s*)("?)[^\s"',;)]+`),
+		pattern:     regexp.MustCompile(`(?i)\b(password|passwd|pwd|secret|token|_?gowdk[_-]?csrf|_?csrf(?:[_-]?token)?|cookie|set-cookie|auth[_-]?token|session(?:[_-]?id)?|jwt|api[_-]?key|access(?:[_-]?(?:key|token))?|refresh[_-]?token|id[_-]?token|client[_-]?secret|private[_-]?key)\b(\s*[:=]\s*)("?)[^\s"',;)]+`),
 		replacement: `${1}${2}${3}` + redactionMask,
 	},
 }

--- a/runtime/app/redact_test.go
+++ b/runtime/app/redact_test.go
@@ -51,6 +51,36 @@ func TestRedactSecretsMasksCredentials(t *testing.T) {
 			leaked:  "live_sk_9921aabbcc",
 			wantSub: "api_key=[REDACTED]",
 		},
+		{
+			name:    "csrf token",
+			in:      "invalid form _gowdk_csrf=csrf-secret-token",
+			leaked:  "csrf-secret-token",
+			wantSub: "_gowdk_csrf=[REDACTED]",
+		},
+		{
+			name:    "cookie header",
+			in:      "request Cookie: gowdk_session=signed-secret; theme=dark",
+			leaked:  "signed-secret",
+			wantSub: "Cookie: [REDACTED]",
+		},
+		{
+			name:    "set cookie header",
+			in:      "response Set-Cookie: gowdk_session=signed-secret; HttpOnly",
+			leaked:  "signed-secret",
+			wantSub: "Set-Cookie: [REDACTED]",
+		},
+		{
+			name:    "session query value",
+			in:      "request query session_id=abc123secret path=/account",
+			leaked:  "abc123secret",
+			wantSub: "session_id=[REDACTED]",
+		},
+		{
+			name:    "refresh token form value",
+			in:      "form refresh_token=refresh-secret-token rejected",
+			leaked:  "refresh-secret-token",
+			wantSub: "refresh_token=[REDACTED]",
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary

- Broaden runtime panic-log and compiler diagnostic redaction for CSRF fields, cookies, session identifiers, JWTs, and access/refresh/id/auth tokens.
- Add redaction coverage in both `runtime/app` and `internal/lang` tests for generated CSRF fields, cookies, authorization, sessions, and sensitive query/form values.
- Document the redaction policy, covered names, 5xx client-message behavior, and current limitations for app-owned logs and explicit client messages.

## Issue Closure

Fixes #92

## Verification

- [x] I ran the relevant tests, lint, and build commands.
- [x] I ran `scripts/test-go-modules.sh` when Go code or compiler behavior changed.
- [x] I ran `go build ./cmd/gowdk` when CLI, compiler, runtime, addon, or release behavior changed.
- [ ] I ran `node --check editors/vscode/extension.js` when editor files changed.
- [x] I updated docs for behavior, setup, or architecture changes.
- [x] I added or updated tests for changed behavior.

Commands run:

- `go test ./runtime/app ./internal/lang`
- `go test ./...`
- `go build ./cmd/gowdk`
- `git diff --check`
- `scripts/test-go-modules.sh`

## LLM Assistance

- LLM session summary: Broadened the existing generated-runtime and diagnostic redaction rules, added focused tests for sensitive header/cookie/form/query names, and documented coverage and limitations.
- Human-reviewed assumptions: Generated panic-boundary logs and compiler diagnostics are the GOWDK-owned redaction sinks; app-owned logs and explicit `HandlerError.Message` client text remain application responsibility.
- Follow-up work: Continue remaining M5 endpoint hardening bucket work before the 0.3 release.