### PR TITLE
test(endpoint): cover strict bindings and decoder goldens

### DIFF
--- a/internal/appgen/appgen_test.go
+++ b/internal/appgen/appgen_test.go
@@ -418,28 +418,73 @@ func TestGeneratedGoMatchesGoldenFixture(t *testing.T) {
 	root := t.TempDir()
 	outputDir := filepath.Join(root, "dist")
 	appDir := filepath.Join(root, "generated-app")
+	writeTestFile(t, filepath.Join(outputDir, "newsletter", "index.html"), "<main>Newsletter</main>")
 	writeTestFile(t, filepath.Join(outputDir, "patients", "index.html"), "<main>Patients</main>")
 
-	program := &gwdkir.Program{ContractRefs: []gwdkir.ContractReference{{
-		Kind:        gwdkir.ContractCommand,
-		Name:        "patients.CreatePatient",
-		ImportAlias: "patients",
-		ImportPath:  "example.com/app/contracts/patients",
-		Type:        "CreatePatient",
-		Result:      "CreatePatientResult",
-		InputFields: []source.BackendInputField{
-			{FieldName: "Name", FormName: "name", Type: "string"},
+	program := &gwdkir.Program{
+		ContractRefs: []gwdkir.ContractReference{{
+			Kind:        gwdkir.ContractCommand,
+			Name:        "patients.CreatePatient",
+			ImportAlias: "patients",
+			ImportPath:  "example.com/app/contracts/patients",
+			Type:        "CreatePatient",
+			Result:      "CreatePatientResult",
+			InputFields: []source.BackendInputField{
+				{FieldName: "Name", FormName: "name", Type: "string"},
+				{FieldName: "Tags", FormName: "tag", Type: "[]string"},
+				{FieldName: "Age", FormName: "age", Type: "int"},
+				{FieldName: "Remember", FormName: "remember", Type: "bool"},
+			},
+			Method:    "POST",
+			Path:      "/patients",
+			Status:    gwdkir.ContractBindingBound,
+			Handler:   "HandleCreatePatient",
+			Register:  "Register",
+			OwnerKind: gwdkir.SourcePage,
+			OwnerID:   "patients",
+		}, {
+			Kind:        gwdkir.ContractQuery,
+			Name:        "patients.GetPatientPage",
+			ImportAlias: "patients",
+			ImportPath:  "example.com/app/contracts/patients",
+			Type:        "GetPatientPage",
+			Result:      "PatientPageData",
+			InputFields: []source.BackendInputField{
+				{FieldName: "Filter", FormName: "filter", Type: "string"},
+			},
+			Method:    "GET",
+			Path:      "/patients",
+			Status:    gwdkir.ContractBindingBound,
+			Handler:   "LoadPatientPage",
+			Register:  "Register",
+			OwnerKind: gwdkir.SourcePage,
+			OwnerID:   "patients",
 		},
-		Method:    "POST",
-		Path:      "/patients",
-		Status:    gwdkir.ContractBindingBound,
-		Handler:   "HandleCreatePatient",
-		Register:  "Register",
-		OwnerKind: gwdkir.SourcePage,
-		OwnerID:   "patients",
-	}}}
+		},
+	}
+	actions := []ActionEndpoint{{
+		PageID:      "newsletter",
+		ActionName:  "Subscribe",
+		Method:      "POST",
+		Route:       "/newsletter",
+		InputFields: []string{"email", "tag", "age", "remember"},
+		Binding: source.BackendBinding{
+			Status:       source.BackendBindingBound,
+			ImportPath:   "example.com/app/newsletter",
+			PackageName:  "newsletter",
+			FunctionName: "Subscribe",
+			Signature:    source.BackendSignatureActionForm,
+			InputType:    "SubscribeInput",
+			InputFields: []source.BackendInputField{
+				{FieldName: "Email", FormName: "email", Type: "string"},
+				{FieldName: "Tags", FormName: "tag", Type: "[]string"},
+				{FieldName: "Age", FormName: "age", Type: "int"},
+				{FieldName: "Remember", FormName: "remember", Type: "bool"},
+			},
+		},
+	}}
 
-	result, err := GenerateWithOptions(outputDir, appDir, Options{IR: program})
+	result, err := GenerateWithOptions(outputDir, appDir, Options{Actions: actions, IR: program})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/appgen/testdata/generated_go_golden/app.go.golden
+++ b/internal/appgen/testdata/generated_go_golden/app.go.golden
@@ -4,12 +4,14 @@ import (
 	"context"
 	"embed"
 	patients "example.com/app/contracts/patients"
+	newsletter "example.com/app/newsletter"
 	gowdkruntime "github.com/cssbruno/gowdk/runtime/app"
 	gowdkcontracts "github.com/cssbruno/gowdk/runtime/contracts"
 	gowdkform "github.com/cssbruno/gowdk/runtime/form"
 	gowdkresponse "github.com/cssbruno/gowdk/runtime/response"
 	"io/fs"
 	"net/http"
+	"path"
 	"strings"
 	"sync"
 )
@@ -36,7 +38,74 @@ func ServeMux() (*http.ServeMux, error) {
 	return mux, nil
 }
 func action(response http.ResponseWriter, request *http.Request) bool {
-	return false
+	requestPath := actionRequestPath(request.URL.Path)
+	switch requestPath {
+	case "/newsletter":
+		ctx := gowdkruntime.WithEndpoint(gowdkruntime.WithRequest(request.Context(), request), gowdkruntime.EndpointMetadata{Kind: "action", PageID: "newsletter", Name: "Subscribe", Method: "POST", Path: "/newsletter"})
+		request = request.WithContext(ctx)
+		request.Body = http.MaxBytesReader(response, request.Body, maxActionBodyBytes)
+		if err := request.ParseForm(); err != nil {
+			if strings.Contains(err.Error(), "request body too large") {
+				gowdkresponse.WriteNoStoreError(response, http.StatusRequestEntityTooLarge, "request body too large")
+				return true
+			}
+			gowdkresponse.WriteNoStoreError(response, http.StatusBadRequest, "invalid form")
+			return true
+		}
+		values := gowdkform.FromURLValues(request.PostForm)
+		if decodedValues, err := gowdkform.DecodeExpected(values, gowdkform.Schema{Fields: []gowdkform.Field{{Name: "email"}, {Name: "tag"}, {Name: "age"}, {Name: "remember"}}}); err != nil {
+			gowdkresponse.WriteNoStoreError(response, http.StatusBadRequest, "invalid form")
+			return true
+		} else {
+			values = decodedValues
+		}
+		input, err := decodeNewsletterSubscribeBoundInput(values)
+		if err != nil {
+			gowdkresponse.WriteNoStoreError(response, http.StatusBadRequest, "invalid form")
+			return true
+		}
+		result, err := newsletter.Subscribe(ctx, input)
+		if err != nil {
+			gowdkresponse.WriteNoStoreHandlerError(response, err, http.StatusInternalServerError)
+			return true
+		}
+		_ = gowdkresponse.WriteNoStoreHTTP(response, result)
+		return true
+	default:
+		return false
+	}
+}
+func actionRequestPath(value string) string {
+	return path.Clean("/" + value)
+}
+func decodeNewsletterSubscribeBoundInput(values gowdkform.Values) (newsletter.SubscribeInput, error) {
+	input := newsletter.SubscribeInput{}
+	field0, ok, err := gowdkform.String(values, "email")
+	if err != nil {
+		return input, err
+	}
+	if ok {
+		input.Email = field0
+	}
+	field1 := gowdkform.Strings(values, "tag")
+	if len(field1) > 0 {
+		input.Tags = field1
+	}
+	field2, ok, err := gowdkform.Int(values, "age", 0)
+	if err != nil {
+		return input, err
+	}
+	if ok {
+		input.Age = int(field2)
+	}
+	field3, ok, err := gowdkform.Bool(values, "remember")
+	if err != nil {
+		return input, err
+	}
+	if ok {
+		input.Remember = field3
+	}
+	return input, nil
 }
 func api(response http.ResponseWriter, request *http.Request) bool {
 	return false
@@ -81,8 +150,32 @@ func commandPatientsCreatePatientPOSTPatients(contractRegistry *gowdkcontracts.R
 		return true
 	}
 }
+func queryPatientsGetPatientPageGETPatients(contractRegistry *gowdkcontracts.Registry) gowdkruntime.BackendHandler {
+	return func(response http.ResponseWriter, request *http.Request) bool {
+		ctx := gowdkruntime.WithEndpoint(gowdkruntime.WithRequest(request.Context(), request), gowdkruntime.EndpointMetadata{Kind: "query", PageID: "patients", Name: "patients.GetPatientPage", Method: "GET", Path: "/patients"})
+		request = request.WithContext(ctx)
+		values := gowdkform.FromURLValues(request.URL.Query())
+		input, err := decodeContractPatientsGetPatientPageInput(values)
+		if err != nil {
+			gowdkresponse.WriteNoStoreError(response, http.StatusBadRequest, "invalid form")
+			return true
+		}
+		result, err := gowdkcontracts.ExecuteQueryForRole[patients.GetPatientPage, patients.PatientPageData](ctx, contractRegistry, gowdkcontracts.RoleWeb, input)
+		if err != nil {
+			gowdkresponse.WriteNoStoreHandlerError(response, err, http.StatusInternalServerError)
+			return true
+		}
+		httpResult, err := gowdkresponse.JSONValue(http.StatusOK, result)
+		if err != nil {
+			gowdkresponse.WriteNoStoreHandlerError(response, err, http.StatusInternalServerError)
+			return true
+		}
+		_ = gowdkresponse.WriteNoStoreHTTP(response, httpResult)
+		return true
+	}
+}
 func decodeContractPatientsCreatePatientInput(values gowdkform.Values) (patients.CreatePatient, error) {
-	decoded, err := gowdkform.DecodeExpected(values, gowdkform.Schema{Fields: []gowdkform.Field{{Name: "name"}}})
+	decoded, err := gowdkform.DecodeExpected(values, gowdkform.Schema{Fields: []gowdkform.Field{{Name: "name"}, {Name: "tag"}, {Name: "age"}, {Name: "remember"}}})
 	if err != nil {
 		return patients.CreatePatient{}, err
 	}
@@ -94,6 +187,40 @@ func decodeContractPatientsCreatePatientInput(values gowdkform.Values) (patients
 	}
 	if ok {
 		input.Name = field0
+	}
+	field1 := gowdkform.Strings(values, "tag")
+	if len(field1) > 0 {
+		input.Tags = field1
+	}
+	field2, ok, err := gowdkform.Int(values, "age", 0)
+	if err != nil {
+		return input, err
+	}
+	if ok {
+		input.Age = int(field2)
+	}
+	field3, ok, err := gowdkform.Bool(values, "remember")
+	if err != nil {
+		return input, err
+	}
+	if ok {
+		input.Remember = field3
+	}
+	return input, nil
+}
+func decodeContractPatientsGetPatientPageInput(values gowdkform.Values) (patients.GetPatientPage, error) {
+	decoded, err := gowdkform.DecodeExpected(values, gowdkform.Schema{Fields: []gowdkform.Field{{Name: "filter"}}})
+	if err != nil {
+		return patients.GetPatientPage{}, err
+	}
+	values = decoded
+	input := patients.GetPatientPage{}
+	field0, ok, err := gowdkform.String(values, "filter")
+	if err != nil {
+		return input, err
+	}
+	if ok {
+		input.Filter = field0
 	}
 	return input, nil
 }
@@ -121,7 +248,7 @@ func RunContractEventWorker(ctx context.Context, source gowdkcontracts.EventSour
 }
 func newBackendRouter() (*gowdkruntime.BackendRouter, error) {
 	contractRegistry := NewContractRegistry()
-	return gowdkruntime.NewBackendRouter(gowdkruntime.BackendRoute{Method: http.MethodPost, Path: "/patients", Kind: "command", Handler: commandPatientsCreatePatientPOSTPatients(contractRegistry)})
+	return gowdkruntime.NewBackendRouter(gowdkruntime.BackendRoute{Method: http.MethodPost, Path: "/newsletter", Kind: "action", Handler: action}, gowdkruntime.BackendRoute{Method: http.MethodPost, Path: "/patients", Kind: "command", Handler: commandPatientsCreatePatientPOSTPatients(contractRegistry)}, gowdkruntime.BackendRoute{Method: http.MethodGet, Path: "/patients", Kind: "query", Handler: queryPatientsGetPatientPageGETPatients(contractRegistry)})
 }
 func ssrExact(response http.ResponseWriter, request *http.Request) (handled bool) {
 	switch request.URL.Path {

--- a/internal/compiler/backend_bindings_test.go
+++ b/internal/compiler/backend_bindings_test.go
@@ -778,6 +778,36 @@ func TestValidateBackendBindingPolicyIRSeesMissingLoadBinding(t *testing.T) {
 	}
 }
 
+func TestValidateBackendBindingPolicyIRFailsProductionUnsupportedFragmentBinding(t *testing.T) {
+	ir := gwdkir.Program{
+		Endpoints: []gwdkir.Endpoint{{
+			Kind:       gwdkir.EndpointFragment,
+			PageID:     "dashboard",
+			SourceFile: "dashboard.page.gwdk",
+			Symbol:     "Stats",
+			Method:     "GET",
+			Path:       "/fragments/stats",
+			Binding: gwdkir.Binding{
+				Status:       source.BackendBindingUnsupportedSignature,
+				FunctionName: "Stats",
+				Message:      "GOWDK fragment handler app.Stats must have signature func(context.Context) (response.Response, error)",
+			},
+		}},
+	}
+
+	err := ValidateBackendBindingPolicyIR(gowdk.Config{Build: gowdk.BuildConfig{Mode: gowdk.Production}}, ir)
+	if err == nil {
+		t.Fatal("expected unsupported fragment binding to fail the production policy")
+	}
+	diagnostics := err.(ValidationErrors)
+	if !hasDiagnosticCode(diagnostics, "backend_binding_required") {
+		t.Fatalf("missing backend_binding_required diagnostic: %#v", diagnostics)
+	}
+	if !strings.Contains(err.Error(), "fragment handler Stats") {
+		t.Fatalf("expected diagnostic to identify the fragment binding, got %v", err)
+	}
+}
+
 func TestBackendBindingFromIRKeepsFragmentKind(t *testing.T) {
 	binding := backendBindingFromIR(gwdkir.Endpoint{
 		Kind:    gwdkir.EndpointFragment,


### PR DESCRIPTION
## Summary

- Adds a production binding-policy regression for unsupported fragment handlers so strict mode coverage includes the fragment lane.
- Expands the generated Go golden fixture to pin action, command, and query decoder source for scalar fields, repeated string fields, unknown-field allowlists, and bad-form responses.

## Issue Closure

Closes #83
Closes #86
Closes #87

## Verification

- [x] I ran the relevant tests, lint, and build commands.
- [ ] I ran `scripts/test-go-modules.sh` when Go code or compiler behavior changed.
- [ ] I ran `go build ./cmd/gowdk` when CLI, compiler, runtime, addon, or release behavior changed.
- [ ] I ran `node --check editors/vscode/extension.js` when editor files changed.
- [ ] I updated docs for behavior, setup, or architecture changes.
- [x] I added or updated tests for changed behavior.

Commands run:

```sh
go test ./internal/compiler -run 'ValidateBackendBindingPolicy|BackendBindingFromIRKeepsFragmentKind'
go test ./internal/appgen -run 'TestGeneratedGoMatchesGoldenFixture|TestGenerateWritesBoundContractBackendRoutes|TestGeneratedBinaryRedirectsActionPOST|TestGenerateWritesBoundActionAdapter|TestGenerateAutoDetectsActionAndSSRRoutes'
go test ./internal/compiler ./internal/appgen ./cmd/gowdk
git diff --check
```

## LLM Assistance

- LLM session summary: Codex audited the narrow M5 endpoint-adapter issues, added missing strict-binding test coverage, expanded generated decoder golden coverage, and ran focused endpoint/appgen/CLI tests.
- Human-reviewed assumptions: The existing production `Build.AllowMissingBackend` / `--allow-missing-backend` behavior satisfies the explicit-stub-mode requirement; this PR pins the behavior with tests rather than changing public semantics.
- Follow-up work: Continue remaining broad M5 tracking issues after these narrow endpoint-adapter checks merge.