### PR TITLE
docs(security): sync generated server hardening status

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,6 +16,9 @@ issues from words like "Completes". -->
 - [ ] I ran `node --check editors/vscode/extension.js` when editor files changed.
 - [ ] I updated docs for behavior, setup, or architecture changes.
 - [ ] I added or updated tests for changed behavior.
+- [ ] I considered security-sensitive surfaces such as auth, CSRF, redirects,
+  request-time handlers, logs, diagnostics, embedded assets, editor commands,
+  WASM, contracts, and realtime behavior.
 
 ## LLM Assistance
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -5,8 +5,10 @@ production-ready security enforcement.
 
 First slices exist for generated action decoding, unexpected-field rejection,
 direct literal request-shape validation, opt-in CSRF, action request body caps,
-safe local redirects, guard execution, SSR panic boundaries, and no-store
-request-time responses. These are not a complete production security model.
+generated `http.Server` read/header/write/idle timeout defaults,
+`MaxHeaderBytes`, safe local redirects, guard execution, SSR panic boundaries,
+and no-store request-time responses. These are not a complete production
+security model.
 
 ## Reporting Vulnerabilities
 
@@ -46,8 +48,8 @@ Known incomplete production areas include:
 - Multi-key CSRF secret rotation.
 - Full redirect policy.
 - Log redaction.
-- Request timeout defaults.
-- Broad request body/header limits.
+- Configurable request body/header limit policy beyond the current generated
+  defaults.
 - File upload policy.
 - Public API hardening.
 - Realtime security policy.

--- a/docs/compiler/generated-output.md
+++ b/docs/compiler/generated-output.md
@@ -250,8 +250,10 @@ The generated `gowdkapp` package exposes `Handler() (http.Handler, error)` and
 `ServeMux() (*http.ServeMux, error)` for `net/http`, Chi, Echo, Gin, and other
 router integrations. The generated `cmd/server` entrypoint uses that same
 handler, reads `GOWDK_ADDR`, defaults to `127.0.0.1:8080`, serves GET and HEAD
-requests, maps extensionless routes to nested `index.html` files, and does not
-list directories. It exposes `/_gowdk/health` and adds
+requests, applies `http.Server` defaults of `ReadHeaderTimeout: 5s`,
+`ReadTimeout: 10s`, `WriteTimeout: 30s`, `IdleTimeout: 60s`, and
+`MaxHeaderBytes: 1 MiB`, maps extensionless routes to nested `index.html`
+files, and does not list directories. It exposes `/_gowdk/health` and adds
 `X-GOWDK-App`, `X-GOWDK-Module`, and `X-GOWDK-Instance-ID` headers to responses.
 Request-time action/API dispatch registers generated backend routes with
 `runtime/app.BackendRouter` and passes the router hook into `runtime/app`;

--- a/docs/engineering/release-plan.md
+++ b/docs/engineering/release-plan.md
@@ -215,28 +215,30 @@ Every 0.x minor release must have:
 
 ## Security And Production-Safety Gates
 
-- [ ] Update root `SECURITY.md` to match `docs/engineering/security.md`.
-- [ ] Keep the production warning.
-- [ ] Replace outdated "planned but not complete" wording with precise
+- [x] Update root `SECURITY.md` to match `docs/engineering/security.md`.
+- [x] Keep the production warning.
+- [x] Replace outdated "planned but not complete" wording with precise
   "first slice exists, not production enforcement" wording.
-- [ ] List implemented first slices: generated action decoding, unexpected
+- [x] List implemented first slices: generated action decoding, unexpected
   field rejection, direct literal request-shape validation, opt-in CSRF, action
-  body cap, safe local redirect slice, guard execution slice, SSR panic
-  boundaries, and no-store request-time responses.
-- [ ] List incomplete production areas: auth/session policy, full guard
-  contract, CSRF secret rotation, full redirect policy, log redaction, request
-  timeout defaults, broad body/header limits, file upload policy, public API
-  hardening, realtime security policy, and admin tooling policy.
+  body cap, generated `http.Server` timeout defaults, `MaxHeaderBytes`, safe
+  local redirect slice, guard execution slice, SSR panic boundaries, and
+  no-store request-time responses.
+- [x] List incomplete production areas: auth/session policy, full guard
+  contract, CSRF secret rotation, full redirect policy, log redaction,
+  configurable request body/header limit policy beyond current defaults, file
+  upload policy, public API hardening, realtime security policy, and admin
+  tooling policy.
 - [ ] Enable GitHub private vulnerability reporting if available.
-- [ ] Add a vulnerability report contact path.
+- [x] Add a vulnerability report contact path.
 - [ ] Add threat models for compiler diagnostics, generated logs, actions,
   APIs, fragments, SSR load, guards, generated assets, VS Code extension, WASM
   islands, and contracts/realtime.
-- [ ] Add security checklist items to the PR template.
+- [x] Add security checklist items to the PR template.
 - [ ] Add security review trigger labels.
-- [ ] Add generated `http.Server` timeout configuration: read, write, idle, and
+- [x] Add generated `http.Server` timeout configuration: read, write, idle, and
   read-header timeouts.
-- [ ] Add `MaxHeaderBytes`.
+- [x] Add `MaxHeaderBytes`.
 - [ ] Keep action request body caps and add API/fragment body caps where
   relevant.
 - [ ] Add configurable body limits.

--- a/docs/engineering/security.md
+++ b/docs/engineering/security.md
@@ -26,6 +26,8 @@ Do not treat current `act`, `api`, `partial`, `guard`, or SSR scaffolding as com
   validation, cleanup, auth, and logging rules.
 - Generated action handlers must cap request bodies before parsing submitted
   form values.
+- Generated server entrypoints must set conservative `http.Server` read,
+  read-header, write, idle, and max-header defaults.
 - `partial` responses must render escaped HTML through the shared render core.
 - `ssr` pages with `load {}` must make auth/session access explicit through guards or request-aware APIs.
 - Embedded assets must not include local env files, source maps with secrets, or private files outside configured build output.
@@ -39,8 +41,10 @@ Before generated app output is considered production-ready:
 - Redirects must reject unsafe external destinations unless explicitly allowed.
 - Generated decoders must define how unknown, missing, repeated, and file fields are handled.
 - Guards must have a documented execution contract, failure behavior, and test coverage.
-- Generated servers must enforce request body/header limits and HTTP timeouts;
-  action request bodies currently have a fixed 1 MiB generated cap.
+- Generated server entrypoints set read, read-header, write, idle, and
+  max-header defaults. Broader configurable request body/header limit policy is
+  still planned; action request bodies currently have a fixed 1 MiB generated
+  cap.
 - Embedded asset selection must exclude secrets, local env files, private source files, and temporary artifacts.
 - Diagnostics and logs must avoid printing sensitive form values, credentials, or private build-time data.
 

--- a/internal/appgen/appgen_test.go
+++ b/internal/appgen/appgen_test.go
@@ -63,6 +63,10 @@ func TestGenerateWritesEmbeddedSPAApp(t *testing.T) {
 		`"gowdk-generated-app/gowdkapp"`,
 		"handler, err := gowdkapp.Handler()",
 		"ReadHeaderTimeout: 5 * time.Second",
+		"ReadTimeout: 10 * time.Second",
+		"WriteTimeout: 30 * time.Second",
+		"IdleTimeout: 60 * time.Second",
+		"MaxHeaderBytes: 1 << 20",
 	} {
 		if !strings.Contains(string(mainPayload), expected) {
 			t.Fatalf("expected generated server main.go to contain %q:\n%s", expected, mainPayload)


### PR DESCRIPTION
## Summary

- Align root `SECURITY.md` and `docs/engineering/security.md` with implemented generated server timeout and `MaxHeaderBytes` defaults.
- Document generated `cmd/server` timeout defaults in the generated-output contract and expand appgen test coverage for those fields.
- Add a PR-template prompt for security-sensitive surfaces and mark the corresponding release-plan items complete.

## Issue Closure

Related: #57

## Verification

- [x] `go test ./internal/appgen -run TestGenerateWritesEmbeddedSPAApp`
- [x] `go test ./internal/appgen`
- [x] `git diff --check`
- [x] I updated docs for behavior, setup, or architecture changes.
- [x] I added or updated tests for changed behavior.
- [x] I considered security-sensitive surfaces such as auth, CSRF, redirects, request-time handlers, logs, diagnostics, embedded assets, editor commands, WASM, contracts, and realtime behavior.

## LLM Assistance

- LLM session summary: Codex found stale M5 security checklist/docs state for generated server timeout defaults, synchronized docs and strengthened appgen assertions.
- Human-reviewed assumptions: #57 remains open because threat models, broader configurable limits, label/process work, and additional runtime hardening are still pending.
- Follow-up work: Continue the remaining #57 checklist items, then return to #24 for the API helper contract.