### PR TITLE
fix(appgen): exclude private files from embedded output

### DIFF
--- a/docs/engineering/release-plan.md
+++ b/docs/engineering/release-plan.md
@@ -256,7 +256,7 @@ Every 0.x minor release must have:
   domain policy.
 - [ ] Add safe redirect allowlists, open redirect tests, and unsafe external
   redirect diagnostics.
-- [ ] Add embedded secret exclusion tests for `.env`, source maps with secrets,
+- [x] Add embedded secret exclusion tests for `.env`, source maps with secrets,
   private files, and temporary artifacts.
 - [x] Add reverse proxy, TLS termination, request ID, health endpoint, and
   metrics endpoint security policy docs.

--- a/docs/engineering/security-threat-model.md
+++ b/docs/engineering/security-threat-model.md
@@ -73,7 +73,6 @@ Apply the `security review` GitHub label to issues or pull requests that touch:
 ## Follow-Up Areas
 
 - Enable GitHub private vulnerability reporting if available for the repository.
-- Add focused tests for embedded secret exclusion.
 - Add configurable request body/header limit policy.
 - Finish safe redirect allowlists, diagnostics, and open-redirect tests.
 - Finish public API helper hardening in #24.

--- a/internal/appgen/appgen_test.go
+++ b/internal/appgen/appgen_test.go
@@ -174,6 +174,13 @@ func TestGenerateSkipsUnsafeEmbeddedOutputFiles(t *testing.T) {
 	writeTestFile(t, filepath.Join(outputDir, "source", "home.page.gwdk"), "page home")
 	writeTestFile(t, filepath.Join(outputDir, "source", "main.go"), "package main")
 	writeTestFile(t, filepath.Join(outputDir, "tmp", "asset.css"), "body{}")
+	writeTestFile(t, filepath.Join(outputDir, "private", "notes.txt"), "private")
+	writeTestFile(t, filepath.Join(outputDir, "secrets", "config.json"), `{"token":"secret"}`)
+	writeTestFile(t, filepath.Join(outputDir, "keys", "server.key"), "private key")
+	writeTestFile(t, filepath.Join(outputDir, "keys", "server.pem"), "private key")
+	writeTestFile(t, filepath.Join(outputDir, "keys", "bundle.p12"), "private key")
+	writeTestFile(t, filepath.Join(outputDir, "keys", "id_ed25519"), "private key")
+	writeTestFile(t, filepath.Join(outputDir, ".npmrc"), "//registry.example/:_authToken=secret")
 	writeTestFile(t, filepath.Join(outputDir, "assets", "scratch.tmp"), "temporary")
 	writeTestFile(t, filepath.Join(outputDir, "assets", "app.css"), "body{}")
 
@@ -192,6 +199,13 @@ func TestGenerateSkipsUnsafeEmbeddedOutputFiles(t *testing.T) {
 		filepath.Join(result.OutputDir, "source", "home.page.gwdk"),
 		filepath.Join(result.OutputDir, "source", "main.go"),
 		filepath.Join(result.OutputDir, "tmp", "asset.css"),
+		filepath.Join(result.OutputDir, "private", "notes.txt"),
+		filepath.Join(result.OutputDir, "secrets", "config.json"),
+		filepath.Join(result.OutputDir, "keys", "server.key"),
+		filepath.Join(result.OutputDir, "keys", "server.pem"),
+		filepath.Join(result.OutputDir, "keys", "bundle.p12"),
+		filepath.Join(result.OutputDir, "keys", "id_ed25519"),
+		filepath.Join(result.OutputDir, ".npmrc"),
 		filepath.Join(result.OutputDir, "assets", "scratch.tmp"),
 	} {
 		if _, err := os.Stat(path); !os.IsNotExist(err) {

--- a/internal/appgen/files.go
+++ b/internal/appgen/files.go
@@ -80,7 +80,7 @@ func copyOutputFiles(sourceRoot, targetRoot string) ([]string, error) {
 func unsafeEmbeddedDirectory(rel string) bool {
 	base := path.Base(filepath.ToSlash(rel))
 	switch base {
-	case ".git", ".hg", ".svn", "node_modules", "tmp", "temp", ".tmp":
+	case ".git", ".hg", ".svn", "node_modules", "tmp", "temp", ".tmp", "private", ".private", "secrets", ".secrets":
 		return true
 	default:
 		return false
@@ -94,11 +94,26 @@ func unsafeEmbeddedFile(rel string) bool {
 	switch {
 	case base == ".env" || strings.HasPrefix(base, ".env."):
 		return true
+	case base == ".npmrc" || base == ".netrc":
+		return true
+	case privateKeyFile(base):
+		return true
 	case ext == ".map" || ext == ".gwdk" || ext == ".go":
 		return true
 	case ext == ".tmp" || ext == ".temp" || strings.HasSuffix(base, "~"):
 		return true
+	case ext == ".key" || ext == ".pem" || ext == ".p12" || ext == ".pfx":
+		return true
 	case strings.HasSuffix(base, ".swp") || strings.HasSuffix(base, ".swo"):
+		return true
+	default:
+		return false
+	}
+}
+
+func privateKeyFile(base string) bool {
+	switch base {
+	case "id_rsa", "id_dsa", "id_ecdsa", "id_ed25519":
 		return true
 	default:
 		return false


### PR DESCRIPTION
## Summary

- Extend generated app output copying to skip private/secrets directories and common private key files (`*.key`, `*.pem`, `*.p12`, `*.pfx`, `id_rsa`, `id_dsa`, `id_ecdsa`, `id_ed25519`) plus `.npmrc`/`.netrc`.
- Expand `TestGenerateSkipsUnsafeEmbeddedOutputFiles` to cover `.env`, source maps, source files, temp files, private directories, private key files, and token config files.
- Mark the embedded secret exclusion test item complete in the M5 release checklist and remove it from the threat-model follow-up list.

## Issue Closure

Related: #57

## Generated Output Impact

Generated `--app`/`--bin` output now excludes additional private/secret-looking files from the embedded `gowdkapp/app` tree when copying selected build output.

## Verification

- [x] `go test ./internal/appgen -run TestGenerateSkipsUnsafeEmbeddedOutputFiles`
- [x] `go test ./internal/appgen`
- [x] `git diff --check`
- [x] I updated docs for behavior, setup, or architecture changes.
- [x] I added or updated tests for changed behavior.
- [x] I considered security-sensitive surfaces such as auth, CSRF, redirects, request-time handlers, logs, diagnostics, embedded assets, editor commands, WASM, contracts, and realtime behavior.

## LLM Assistance

- LLM session summary: Codex expanded appgen embedded-output exclusions and tests for private files and secret-bearing config files.
- Human-reviewed assumptions: Skipping private/secrets directories and common private key filenames is acceptable because generated app output should only embed selected public build artifacts.
- Follow-up work: Continue #57 with configurable body/header limits, redirect policy, and private vulnerability reporting if available.