### PR TITLE
fix(appgen): reject backslash action redirects

### DIFF
--- a/docs/engineering/release-plan.md
+++ b/docs/engineering/release-plan.md
@@ -254,7 +254,7 @@ Every 0.x minor release must have:
   HSTS.
 - [x] Add cookie helper docs for `HttpOnly`, `Secure`, `SameSite`, path, and
   domain policy.
-- [ ] Add safe redirect allowlists, open redirect tests, and unsafe external
+- [x] Add safe redirect allowlists, open redirect tests, and unsafe external
   redirect diagnostics.
 - [x] Add embedded secret exclusion tests for `.env`, source maps with secrets,
   private files, and temporary artifacts.

--- a/docs/engineering/security-threat-model.md
+++ b/docs/engineering/security-threat-model.md
@@ -74,5 +74,4 @@ Apply the `security review` GitHub label to issues or pull requests that touch:
 
 - Enable GitHub private vulnerability reporting if available for the repository.
 - Add configurable request body/header limit policy.
-- Finish safe redirect allowlists, diagnostics, and open-redirect tests.
 - Finish public API helper hardening in #24.

--- a/docs/language/actions.md
+++ b/docs/language/actions.md
@@ -152,9 +152,10 @@ through `runtime/response.Response`.
   `runtime/response.ValidationFragment` provide reusable patterns for returning
   structured validation errors or an escaped live-region fragment for partial
   form updates.
-- Generated action redirects must stay local. User handlers should also keep
-  redirects local unless they intentionally implement and audit an external
-  redirect allowlist.
+- Generated action redirects must stay local. Generated declarations reject
+  external, protocol-relative, newline-bearing, and backslash-bearing redirect
+  targets before output. User handlers should also keep redirects local unless
+  they intentionally implement and audit an external redirect allowlist.
 - Generated action, validation, redirect, fragment, invalid-form, oversized
   body, missing-handler, unsupported-handler, and invalid-CSRF responses use
   `Cache-Control: no-store`.

--- a/internal/appgen/appgen_test.go
+++ b/internal/appgen/appgen_test.go
@@ -2249,22 +2249,37 @@ func TestGenerateRejectsSPAOutputInsideGeneratedSPADir(t *testing.T) {
 }
 
 func TestGenerateRejectsUnsafeActionRedirect(t *testing.T) {
-	root := t.TempDir()
-	outputDir := filepath.Join(root, "dist")
-	appDir := filepath.Join(root, "generated-app")
-	writeTestFile(t, filepath.Join(outputDir, "newsletter", "index.html"), "<main>Newsletter</main>")
-
-	_, err := GenerateWithOptions(outputDir, appDir, Options{Actions: []ActionEndpoint{{
-		PageID:     "newsletter",
-		ActionName: "Subscribe",
-		Route:      "/newsletter",
-		Redirect:   "https://example.com",
-	}}})
-	if err == nil {
-		t.Fatal("expected unsafe redirect error")
+	tests := []struct {
+		redirect string
+		message  string
+	}{
+		{redirect: "https://example.com", message: "must be a local absolute path"},
+		{redirect: "//example.com", message: "must not be protocol-relative"},
+		{redirect: "/login\nSet-Cookie: bad=true", message: "must not contain newlines"},
+		{redirect: `/\evil.com`, message: "must not contain backslashes"},
+		{redirect: `\\evil.com`, message: "must be a local absolute path"},
+		{redirect: `/foo\..\\evil.com`, message: "must not contain backslashes"},
 	}
-	if !strings.Contains(err.Error(), `redirect "https://example.com" must be a local absolute path`) {
-		t.Fatalf("unexpected error: %v", err)
+	for _, test := range tests {
+		t.Run(test.redirect, func(t *testing.T) {
+			root := t.TempDir()
+			outputDir := filepath.Join(root, "dist")
+			appDir := filepath.Join(root, "generated-app")
+			writeTestFile(t, filepath.Join(outputDir, "newsletter", "index.html"), "<main>Newsletter</main>")
+
+			_, err := GenerateWithOptions(outputDir, appDir, Options{Actions: []ActionEndpoint{{
+				PageID:     "newsletter",
+				ActionName: "Subscribe",
+				Route:      "/newsletter",
+				Redirect:   test.redirect,
+			}}})
+			if err == nil {
+				t.Fatal("expected unsafe redirect error")
+			}
+			if !strings.Contains(err.Error(), test.message) {
+				t.Fatalf("expected error to contain %q, got %v", test.message, err)
+			}
+		})
 	}
 }
 

--- a/internal/appgen/validate_actions.go
+++ b/internal/appgen/validate_actions.go
@@ -235,6 +235,11 @@ func validateActionRedirect(value string) error {
 	if strings.HasPrefix(value, "//") {
 		return fmt.Errorf("redirect %q must not be protocol-relative", value)
 	}
+	// Browsers normalize "\" to "/" before navigating, so "/\evil.com" is
+	// treated like the protocol-relative "//evil.com".
+	if strings.Contains(value, "\\") {
+		return fmt.Errorf("redirect %q must not contain backslashes", value)
+	}
 	if strings.ContainsAny(value, "\r\n") {
 		return fmt.Errorf("redirect %q must not contain newlines", value)
 	}


### PR DESCRIPTION
## Summary

- Harden generated action redirect validation to reject backslash-bearing targets, matching the SSR redirect safety rule.
- Expand unsafe action redirect tests for external, protocol-relative, newline, and backslash open-redirect shapes.
- Document the generated action redirect allowlist as local absolute paths only and mark the M5 redirect-safety checklist item complete.

## Issue Closure

Related: #57

## Generated Output Impact

Generated action declarations with unsafe redirect targets now fail generated app output earlier instead of emitting a redirect that a browser could normalize into a protocol-relative target.

## Verification

- [x] `go test ./internal/appgen -run 'TestGenerateRejectsUnsafeActionRedirect|TestGeneratedBinaryRedirectsActionPOST'`
- [x] `go test ./addons/ssr -run TestRedirectRejectsUnsafeURL`
- [x] `go test ./internal/appgen ./addons/ssr`
- [x] `git diff --check`
- [x] I updated docs for behavior, setup, or architecture changes.
- [x] I added or updated tests for changed behavior.
- [x] I considered security-sensitive surfaces such as auth, CSRF, redirects, request-time handlers, logs, diagnostics, embedded assets, editor commands, WASM, contracts, and realtime behavior.

## LLM Assistance

- LLM session summary: Codex compared action redirect validation against SSR redirect validation, added backslash rejection and broader tests, and synced the M5 checklist.
- Human-reviewed assumptions: Generated redirect declarations should remain local-only; external redirect allowlists are app-owned behavior, not generated default behavior.
- Follow-up work: Continue #57 with configurable body/header limits and private vulnerability reporting if available.