### PR TITLE
fix(appgen): configure endpoint body limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,13 +242,14 @@ This table describes the current demoable 0.x slice. Status levels:
 
 Security note: request-time features are still 0.x, but the core request-time
 hardening is now in place. Generated handlers apply body-size limits (actions
-and APIs), server read/header/write/idle timeouts, and a per-request handler
-deadline; recovered panics return a generic no-store 500 and are logged
-server-side with secret redaction; ordinary returned 5xx errors use generic
-client messages unless the app sets an explicit `response.HandlerError`
-message; CSRF is opt-in with a 403 invalid-token contract; redirects are
-validated against a safe allowlist (local paths only, no protocol-relative or
-CRLF, same-origin referer); and diagnostics redact secrets quoted from source.
+and APIs, configurable through `Build.BodyLimits`), server
+read/header/write/idle timeouts, and a per-request handler deadline; recovered
+panics return a generic no-store 500 and are logged server-side with secret
+redaction; ordinary returned 5xx errors use generic client messages unless the
+app sets an explicit `response.HandlerError` message; CSRF is opt-in with a 403
+invalid-token contract; redirects are validated against a safe allowlist (local
+paths only, no protocol-relative or CRLF, same-origin referer); and diagnostics
+redact secrets quoted from source.
 Still hardening: full auth/session, multipart uploads, and the broader
 operations policy.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,17 +4,19 @@ GOWDK is an experimental 0.x compiler/runtime. Do not treat generated apps as
 production-ready security enforcement.
 
 First slices exist for generated action decoding, unexpected-field rejection,
-direct literal request-shape validation, opt-in CSRF, action request body caps,
-generated `http.Server` read/header/write/idle timeout defaults,
-`MaxHeaderBytes`, safe local redirects, guard execution, SSR panic boundaries,
-and no-store request-time responses. These are not a complete production
-security model.
+direct literal request-shape validation, opt-in CSRF, configurable action/API
+request body caps, generated `http.Server` read/header/write/idle timeout
+defaults, `MaxHeaderBytes`, safe local redirects, guard execution, SSR panic
+boundaries, log redaction, and no-store request-time responses. These are not a
+complete production security model.
 
 ## Reporting Vulnerabilities
 
 Do not open public issues for vulnerabilities, secrets, private keys, credentials, or sensitive personal data.
 
-Until a private advisory process is enabled for the repository, report security concerns privately to the repository maintainers through the repository owner or organization contact path. Include:
+Use GitHub private vulnerability reporting on the repository Security tab, or
+open a private advisory at
+`https://github.com/cssbruno/GoWDK/security/advisories/new`. Include:
 
 - Affected commit or version.
 - Reproduction steps or proof of concept.
@@ -47,9 +49,8 @@ Known incomplete production areas include:
 - Full guard contract coverage.
 - Multi-key CSRF secret rotation.
 - Full redirect policy.
-- Log redaction.
-- Configurable request body/header limit policy beyond the current generated
-  defaults.
+- Per-route request body/header limit policy beyond the current generated
+  body caps and server header cap.
 - File upload policy.
 - Public API hardening.
 - Realtime security policy.

--- a/docs/compiler/generated-output.md
+++ b/docs/compiler/generated-output.md
@@ -256,8 +256,10 @@ requests, applies `http.Server` defaults of `ReadHeaderTimeout: 5s`,
 files, and does not list directories. It exposes `/_gowdk/health` and adds
 `X-GOWDK-App`, `X-GOWDK-Module`, and `X-GOWDK-Instance-ID` headers to responses.
 Request-time action/API dispatch registers generated backend routes with
-`runtime/app.BackendRouter` and passes the router hook into `runtime/app`;
-older separate action/API hook fields remain a compatibility path for existing
+`runtime/app.BackendRouter` and passes the router hook into `runtime/app`.
+Generated action/API body caps default to 1 MiB and use `Build.BodyLimits`
+overrides when configured. Older separate action/API hook fields remain a
+compatibility path for existing
 generated apps.
 It loads `gowdk-assets.json`, `404.html`, `500.html`, and route-local SSR
 `error` pages from the embedded build output filesystem when present.

--- a/docs/engineering/operations.md
+++ b/docs/engineering/operations.md
@@ -115,7 +115,8 @@ readiness claim:
 - Set `http.Server` read, write, idle, and header timeouts.
 - Set `MaxHeaderBytes`.
 - Cap action/API request body size before form or JSON decoding; generated
-  action handlers currently use a fixed 1 MiB cap.
+  apps default to 1 MiB and can override action/API caps with
+  `Build.BodyLimits`.
 - Enable `Build.CSRF.Enabled` for generated action handlers and provide a
   stable `GOWDK_CSRF_SECRET` or configured `Build.CSRF.SecretEnv` value in each
   runtime environment.

--- a/docs/engineering/release-plan.md
+++ b/docs/engineering/release-plan.md
@@ -220,16 +220,15 @@ Every 0.x minor release must have:
 - [x] Replace outdated "planned but not complete" wording with precise
   "first slice exists, not production enforcement" wording.
 - [x] List implemented first slices: generated action decoding, unexpected
-  field rejection, direct literal request-shape validation, opt-in CSRF, action
-  body cap, generated `http.Server` timeout defaults, `MaxHeaderBytes`, safe
-  local redirect slice, guard execution slice, SSR panic boundaries, and
-  no-store request-time responses.
+  field rejection, direct literal request-shape validation, opt-in CSRF,
+  configurable action/API body caps, generated `http.Server` timeout defaults,
+  `MaxHeaderBytes`, safe local redirect slice, guard execution slice, SSR panic
+  boundaries, and no-store request-time responses.
 - [x] List incomplete production areas: auth/session policy, full guard
-  contract, CSRF secret rotation, full redirect policy, log redaction,
-  configurable request body/header limit policy beyond current defaults, file
-  upload policy, public API hardening, realtime security policy, and admin
-  tooling policy.
-- [ ] Enable GitHub private vulnerability reporting if available.
+  contract, CSRF secret rotation, full redirect policy, per-route body/header
+  limit policy beyond current defaults, file upload policy, public API
+  hardening, realtime security policy, and admin tooling policy.
+- [x] Enable GitHub private vulnerability reporting if available.
 - [x] Add a vulnerability report contact path.
 - [x] Add threat models for compiler diagnostics, generated logs, actions,
   APIs, fragments, SSR load, guards, generated assets, VS Code extension, WASM
@@ -240,9 +239,10 @@ Every 0.x minor release must have:
   read-header timeouts.
 - [x] Add `MaxHeaderBytes`.
 - [x] Keep action request body caps and add API/fragment body caps where
-  relevant. Current action and API lanes use 1 MiB caps; generated standalone
-  fragments are GET-only and action fragments share the action cap.
-- [ ] Add configurable body limits.
+  relevant. Current action and API lanes use configurable caps that default to
+  1 MiB; generated standalone fragments are GET-only and action fragments share
+  the action cap.
+- [x] Add configurable body limits.
 - [x] Add explicit 405 responses.
 - [x] Ensure panic recovery wraps all generated request-time user Go.
 - [x] Ensure production-safe error pages and no stack traces in production mode.

--- a/docs/engineering/security-threat-model.md
+++ b/docs/engineering/security-threat-model.md
@@ -33,12 +33,12 @@ current controls, and open follow-up areas for review.
 | --- | --- | --- | --- |
 | `.gwdk` source to compiler diagnostics | Parser, analyzer, `gowdk check`, LSP diagnostics | Stable diagnostic registry, source spans where available, redaction policy for secret-like values | Broader exact spans and diagnostic expansion remain tracked outside M5. |
 | Generated logs and panic sinks | `runtime/app` panic boundaries, contract worker logs | Panic responses avoid stack traces; recovered panic logs pass through secret redaction | Broader app-owned logging guidance and redaction coverage remain planned. |
-| Browser/client to action endpoints | POST forms, enhanced partial forms, command form adapters | Expected-field decoding, direct literal validation, 1 MiB action body cap, opt-in CSRF, 405 on wrong methods, no-store error responses | Configurable body limits, broader upload policy, and full production CSRF rotation remain planned. |
-| Browser/client to API endpoints | Generated API routes, contract query routes | Method dispatch, API body cap in runtime backend router, rate-limit hook when addon is enabled | Public API hardening, typed helper expansion, and per-route policy are tracked in #24 and #57. |
-| Browser/client to fragments | Standalone fragments, action fragment responses | Fragment routing through generated handlers, escaped render core, no-store request-time responses | Broader fragment body-limit and auth/session policy remain planned. |
+| Browser/client to action endpoints | POST forms, enhanced partial forms, command form adapters | Expected-field decoding, direct literal validation, configurable action body cap defaulting to 1 MiB, opt-in CSRF, 405 on wrong methods, no-store error responses | Broader upload policy, per-route limits, and full production CSRF rotation remain planned. |
+| Browser/client to API endpoints | Generated API routes, contract query routes | Method dispatch, configurable API body cap defaulting to 1 MiB, rate-limit hook when addon is enabled | Public API hardening, typed helper expansion, and per-route policy are tracked in #24. |
+| Browser/client to fragments | Standalone fragments, action fragment responses | Fragment routing through generated handlers, escaped render core, no-store request-time responses; standalone fragments are GET-only and action fragments share the action cap | Broader auth/session policy remains planned. |
 | Browser/client to SSR `load {}` | Request-time SSR routes, route-local error pages | SSR feature gate, guard execution, safe local redirect helpers, panic boundaries, no-store failures | Full guard contract, route-local auth/session policy, and richer request-time error policy remain planned. |
 | Guard metadata to user authorization | `guard` declarations, `GOWDKGuardRegistry`, `GOWDKAuthProvider` | Guards run before generated request-time user logic; native RBAC helpers are defense-in-depth only | Backend resource authorization remains app-owned; full guard response contract is planned. |
-| Embedded build output to generated server | Embedded SPA assets, generated error pages, health endpoint | Generated server uses HTTP timeouts and `MaxHeaderBytes`; embedded output is selected from build output | Secret exclusion tests and broader asset policy remain planned. |
+| Embedded build output to generated server | Embedded SPA assets, generated error pages, health endpoint | Generated server uses HTTP timeouts and `MaxHeaderBytes`; embedded output skips known secret/private/temp artifacts | Broader asset policy remains planned. |
 | VS Code extension to workspace | LSP/editor commands and workspace file access | Dependency-light local tooling; no production runtime authority | Extension command/file threat model needs focused review before broader editor automation. |
 | WASM islands to browser runtime | `go client {}`, component WASM assets, host loader | WASM is explicit and separate from backend handlers; browser-unsafe import validation exists | Production ABI hardening and user-code runtime validation remain planned. |
 | Contracts and realtime adapters | Command/query web adapters, workers, outbox, broker, fanout | Web-role validation, CSRF before command decoding, guard/rate-limit preflight, local default dispatch | Split worker/cron wiring, retry policy, managed deployment recipes, and realtime security policy remain planned. |
@@ -48,7 +48,7 @@ current controls, and open follow-up areas for review.
 | Abuse Path | Impact | Current Mitigation | Priority |
 | --- | --- | --- | --- |
 | Submit unexpected action fields to overwrite handler input. | Integrity of action input. | Generated decoders reject unexpected fields and skip runtime fields such as CSRF. | Medium until broader typed helper contracts stabilize. |
-| Send large request bodies to exhaust memory or handler time. | Availability of generated servers. | Generated action adapters and runtime API backend routing cap bodies; generated server entrypoints set HTTP timeouts and max-header defaults. | Medium because configurable per-route limits remain planned. |
+| Send large request bodies to exhaust memory or handler time. | Availability of generated servers. | Generated action/API adapters cap bodies with configurable app-level limits; generated server entrypoints set HTTP timeouts and max-header defaults. | Medium because per-route limits remain planned. |
 | Reuse or forge action CSRF tokens. | Cross-site action execution. | Generated CSRF is opt-in and validates before decoding or user handlers run. | High for production until secret rotation and deployment guidance are complete. |
 | Trigger handler panics and read stack traces or secret values. | Secret exposure and debugging data leakage. | Runtime panic boundaries avoid stack traces in responses and redact recovered-panic logs. | Medium because app-owned logs are outside generated control. |
 | Use unsafe redirects to move users off-site. | Phishing or token leakage through redirects. | First slices require safe local redirects for generated action/SSR redirect paths. | Medium until full redirect allowlists and diagnostics are complete. |
@@ -72,6 +72,5 @@ Apply the `security review` GitHub label to issues or pull requests that touch:
 
 ## Follow-Up Areas
 
-- Enable GitHub private vulnerability reporting if available for the repository.
-- Add configurable request body/header limit policy.
+- Add per-route request body/header limit policy.
 - Finish public API helper hardening in #24.

--- a/docs/engineering/security.md
+++ b/docs/engineering/security.md
@@ -42,9 +42,9 @@ Before generated app output is considered production-ready:
 - Generated decoders must define how unknown, missing, repeated, and file fields are handled.
 - Guards must have a documented execution contract, failure behavior, and test coverage.
 - Generated server entrypoints set read, read-header, write, idle, and
-  max-header defaults. Broader configurable request body/header limit policy is
-  still planned; action request bodies currently have a fixed 1 MiB generated
-  cap.
+  max-header defaults. Generated action/API body caps default to 1 MiB and can
+  be configured with `Build.BodyLimits`; per-route body/header policy remains
+  planned.
 - Embedded asset selection must exclude secrets, local env files, private source files, and temporary artifacts.
 - Diagnostics and logs must avoid printing sensitive form values, credentials, or private build-time data.
 

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -291,13 +291,13 @@ runtime-specific security controls.
 ## Build
 
 `BuildConfig.Output`, `BuildConfig.Mode`, `BuildConfig.Assets`,
-`BuildConfig.Head`, `BuildConfig.CSRF`, `BuildConfig.AllowMissingBackend`,
-`BuildConfig.Stylesheets`, `BuildConfig.Scripts`, and
-`BuildConfig.Targets` are target build settings. Current `gowdk build` reads
-literal `Build.Output`, `Build.Mode`, `Build.Head`, `Build.CSRF`,
-`Build.AllowMissingBackend`, `Build.Stylesheets`, `Build.Scripts`, and
-`Build.Targets` from `gowdk.config.go`; `--out` overrides `Build.Output` for
-ad hoc builds.
+`BuildConfig.Head`, `BuildConfig.CSRF`, `BuildConfig.BodyLimits`,
+`BuildConfig.AllowMissingBackend`, `BuildConfig.Stylesheets`,
+`BuildConfig.Scripts`, and `BuildConfig.Targets` are target build settings.
+Current `gowdk build` reads literal `Build.Output`, `Build.Mode`,
+`Build.Head`, `Build.CSRF`, `Build.BodyLimits`, `Build.AllowMissingBackend`,
+`Build.Stylesheets`, `Build.Scripts`, and `Build.Targets` from
+`gowdk.config.go`; `--out` overrides `Build.Output` for ad hoc builds.
 `BuildConfig.Assets` remains planned.
 
 `Build.Targets` declares repeatable module-to-output packaging:
@@ -309,6 +309,7 @@ type BuildConfig struct {
 	Assets              gowdk.AssetMode
 	Head                gowdk.HeadConfig
 	CSRF                gowdk.CSRFConfig
+	BodyLimits          gowdk.BodyLimitsConfig
 	AllowMissingBackend bool
 	Stylesheets         []gowdk.Stylesheet
 	Scripts             []gowdk.Script
@@ -329,6 +330,11 @@ type CSRFConfig struct {
 	FieldName  string
 	HeaderName string
 	Insecure   bool
+}
+
+type BodyLimitsConfig struct {
+	ActionBytes int64
+	APIBytes    int64
 }
 
 type Script struct {
@@ -380,6 +386,12 @@ generated decoding or user handlers run. Invalid or missing tokens return HTTP
 flag, uses the default cookie name `gowdk-csrf` instead of
 `__Host-gowdk-csrf`, and rejects explicit `__Host-`/`__Secure-` cookie names
 because browsers require those prefixes to be Secure.
+
+`BodyLimits` controls generated request body caps in bytes. Omitted or
+non-positive values use the default 1 MiB cap. `ActionBytes` applies to
+generated action POST handlers and web command form adapters before form
+decoding. `APIBytes` applies to generated API handlers before user code reads
+the request body.
 
 `Name` is required. `Output` is optional and defaults to
 `.gowdk/output/<target-name>` when omitted. `Modules` selects configured

--- a/docs/reference/deployment.md
+++ b/docs/reference/deployment.md
@@ -416,6 +416,8 @@ Generated binaries currently support:
 - Feature-bound same-package action handlers with no-input, typed value, typed
   pointer, or `form.Values` signatures.
 - Feature-bound same-package API handlers.
+- Configurable action and API request body caps through
+  `Build.BodyLimits`, defaulting to 1 MiB.
 - No-store panic boundaries for generated SSR, action, and API request-time
   lanes.
 - First-slice same-page POST action redirects.

--- a/gowdk.go
+++ b/gowdk.go
@@ -163,6 +163,7 @@ type BuildConfig struct {
 	Assets              AssetMode
 	Head                HeadConfig
 	CSRF                CSRFConfig
+	BodyLimits          BodyLimitsConfig
 	AllowMissingBackend bool
 	Stylesheets         []Stylesheet
 	Scripts             []Script
@@ -197,6 +198,33 @@ func (config CSRFConfig) SecretEnvName() string {
 		return DefaultCSRFSecretEnv
 	}
 	return config.SecretEnv
+}
+
+// DefaultRequestBodyLimitBytes is the default generated request body cap for
+// action and API endpoints.
+const DefaultRequestBodyLimitBytes int64 = 1 << 20
+
+// BodyLimitsConfig controls generated request body caps. Omitted or non-positive
+// values use the default 1 MiB cap.
+type BodyLimitsConfig struct {
+	ActionBytes int64
+	APIBytes    int64
+}
+
+// ActionLimitBytes returns the configured action body cap or the default cap.
+func (config BodyLimitsConfig) ActionLimitBytes() int64 {
+	if config.ActionBytes > 0 {
+		return config.ActionBytes
+	}
+	return DefaultRequestBodyLimitBytes
+}
+
+// APILimitBytes returns the configured API body cap or the default cap.
+func (config BodyLimitsConfig) APILimitBytes() int64 {
+	if config.APIBytes > 0 {
+		return config.APIBytes
+	}
+	return DefaultRequestBodyLimitBytes
 }
 
 // BuildTargetConfig declares one configured build target. Modules selects the

--- a/internal/appgen/appgen_test.go
+++ b/internal/appgen/appgen_test.go
@@ -1287,10 +1287,12 @@ func TestGenerateWritesBoundAPIHandler(t *testing.T) {
 	source := string(payload)
 	for _, expected := range []string{
 		`status "example.com/app/status"`,
+		`const maxAPIBodyBytes int64 = 1 << 20`,
 		`func api(response http.ResponseWriter, request *http.Request) bool`,
 		`requestPath := path.Clean("/" + request.URL.Path)`,
 		`case request.Method == "GET" && requestPath == "/api/health":`,
 		`ctx := gowdkruntime.WithEndpoint(gowdkruntime.WithRequest(request.Context(), request), gowdkruntime.EndpointMetadata{Kind: "api", PageID: "status", Name: "Health", Method: "GET", Path: "/api/health"})`,
+		`request.Body = http.MaxBytesReader(response, request.Body, maxAPIBodyBytes)`,
 		`result, err := status.Health(ctx, request)`,
 		`gowdkresponse.WriteNoStoreHandlerError(response, err, http.StatusInternalServerError)`,
 		`gowdkresponse.WriteNoStoreHTTP(response, result)`,
@@ -1301,6 +1303,56 @@ func TestGenerateWritesBoundAPIHandler(t *testing.T) {
 	}
 	if strings.Contains(source, `github.com/cssbruno/gowdk/addons/ssr`) || strings.Contains(source, `github.com/cssbruno/gowdk/runtime/render`) {
 		t.Fatalf("API output should not import SSR or render helpers:\n%s", source)
+	}
+}
+
+func TestGenerateUsesConfiguredBodyLimits(t *testing.T) {
+	root := t.TempDir()
+	outputDir := filepath.Join(root, "dist")
+	appDir := filepath.Join(root, "generated-app")
+	writeTestFile(t, filepath.Join(outputDir, "newsletter", "index.html"), "<main>Newsletter</main>")
+
+	result, err := GenerateWithOptions(outputDir, appDir, Options{
+		Config: gowdk.Config{Build: gowdk.BuildConfig{BodyLimits: gowdk.BodyLimitsConfig{
+			ActionBytes: 2048,
+			APIBytes:    4096,
+		}}},
+		Actions: []ActionEndpoint{{
+			PageID:     "newsletter",
+			ActionName: "Subscribe",
+			Route:      "/newsletter",
+		}},
+		APIs: []APIEndpoint{{
+			PageID:  "newsletter",
+			APIName: "Health",
+			Method:  http.MethodPost,
+			Route:   "/api/health",
+			Binding: source.BackendBinding{
+				Status:       source.BackendBindingBound,
+				ImportPath:   "example.com/app/status",
+				PackageName:  "status",
+				FunctionName: "Health",
+				Signature:    source.BackendSignatureAPI,
+			},
+		}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload, err := os.ReadFile(result.PackagePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	source := string(payload)
+	for _, expected := range []string{
+		`const maxActionBodyBytes int64 = 2048`,
+		`const maxAPIBodyBytes int64 = 4096`,
+		`request.Body = http.MaxBytesReader(response, request.Body, maxActionBodyBytes)`,
+		`request.Body = http.MaxBytesReader(response, request.Body, maxAPIBodyBytes)`,
+	} {
+		if !strings.Contains(source, expected) {
+			t.Fatalf("expected generated app source to contain %q:\n%s", expected, source)
+		}
 	}
 }
 

--- a/internal/appgen/source.go
+++ b/internal/appgen/source.go
@@ -218,7 +218,8 @@ func forceImportAlias(importPath string) bool {
 
 func appShellDecls(options Options) []ast.Decl {
 	decls := []ast.Decl{
-		maxActionBodyBytesDecl(),
+		maxActionBodyBytesDecl(options),
+		maxAPIBodyBytesDecl(options),
 		embeddedFilesDecl(),
 		handlerDecl(),
 		serveMuxDecl(options, true),
@@ -229,7 +230,8 @@ func appShellDecls(options Options) []ast.Decl {
 
 func backendShellDecls(options Options) []ast.Decl {
 	decls := []ast.Decl{
-		maxActionBodyBytesDecl(),
+		maxActionBodyBytesDecl(options),
+		maxAPIBodyBytesDecl(options),
 		handlerDecl(),
 		serveMuxDecl(options, false),
 	}
@@ -296,16 +298,31 @@ func actionHandlerDecls(actions []ActionEndpoint, csrf bool, rateLimit bool) []a
 	return decls
 }
 
-func maxActionBodyBytesDecl() ast.Decl {
+func maxActionBodyBytesDecl(options Options) ast.Decl {
+	return maxBodyBytesDecl("maxActionBodyBytes", options.Config.Build.BodyLimits.ActionLimitBytes())
+}
+
+func maxAPIBodyBytesDecl(options Options) ast.Decl {
+	return maxBodyBytesDecl("maxAPIBodyBytes", options.Config.Build.BodyLimits.APILimitBytes())
+}
+
+func maxBodyBytesDecl(name string, bytes int64) ast.Decl {
 	return &ast.GenDecl{Tok: token.CONST, Specs: []ast.Spec{&ast.ValueSpec{
-		Names: []*ast.Ident{id("maxActionBodyBytes")},
-		Type:  id("int64"),
-		Values: []ast.Expr{&ast.BinaryExpr{
+		Names:  []*ast.Ident{id(name)},
+		Type:   id("int64"),
+		Values: []ast.Expr{bodyLimitExpr(bytes)},
+	}}}
+}
+
+func bodyLimitExpr(bytes int64) ast.Expr {
+	if bytes == gowdk.DefaultRequestBodyLimitBytes {
+		return &ast.BinaryExpr{
 			X:  intLit(1),
 			Op: token.SHL,
 			Y:  intLit(20),
-		}},
-	}}}
+		}
+	}
+	return int64Lit(bytes)
 }
 
 func embeddedFilesDecl() ast.Decl {

--- a/internal/appgen/source_actions.go
+++ b/internal/appgen/source_actions.go
@@ -863,6 +863,10 @@ func intLit(value int) *ast.BasicLit {
 	return &ast.BasicLit{Kind: token.INT, Value: strconv.Itoa(value)}
 }
 
+func int64Lit(value int64) *ast.BasicLit {
+	return &ast.BasicLit{Kind: token.INT, Value: strconv.FormatInt(value, 10)}
+}
+
 func goString(value string) string {
 	return strconv.Quote(value)
 }

--- a/internal/appgen/source_api.go
+++ b/internal/appgen/source_api.go
@@ -68,6 +68,7 @@ func apiCaseStmts(api APIEndpoint, rateLimit bool) []ast.Stmt {
 		return stmts
 	}
 	stmts = append(stmts,
+		assign([]ast.Expr{selExpr(id("request"), "Body")}, call(sel("http", "MaxBytesReader"), id("response"), selExpr(id("request"), "Body"), id("maxAPIBodyBytes"))),
 		define([]ast.Expr{id("result"), id("err")}, call(sel(api.BackendAlias, api.Binding.FunctionName), id("ctx"), id("request"))),
 		&ast.IfStmt{
 			Cond: notNil("err"),

--- a/internal/appgen/testdata/generated_go_golden/app.go.golden
+++ b/internal/appgen/testdata/generated_go_golden/app.go.golden
@@ -17,6 +17,7 @@ import (
 )
 
 const maxActionBodyBytes int64 = 1 << 20
+const maxAPIBodyBytes int64 = 1 << 20
 
 //go:embed app
 var embeddedFiles embed.FS

--- a/internal/project/config.go
+++ b/internal/project/config.go
@@ -480,6 +480,8 @@ func parseBuildConfig(expression ast.Expr) gowdk.BuildConfig {
 			build.Head = parseHeadConfig(keyValue.Value)
 		case "CSRF":
 			build.CSRF = parseCSRFConfig(keyValue.Value)
+		case "BodyLimits":
+			build.BodyLimits = parseBodyLimitsConfig(keyValue.Value)
 		case "AllowMissingBackend":
 			build.AllowMissingBackend = parseBool(keyValue.Value)
 		case "Stylesheets":
@@ -491,6 +493,32 @@ func parseBuildConfig(expression ast.Expr) gowdk.BuildConfig {
 		}
 	}
 	return build
+}
+
+func parseBodyLimitsConfig(expression ast.Expr) gowdk.BodyLimitsConfig {
+	literal, ok := expression.(*ast.CompositeLit)
+	if !ok {
+		return gowdk.BodyLimitsConfig{}
+	}
+
+	var limits gowdk.BodyLimitsConfig
+	for _, element := range literal.Elts {
+		keyValue, ok := element.(*ast.KeyValueExpr)
+		if !ok {
+			continue
+		}
+		key, ok := keyValue.Key.(*ast.Ident)
+		if !ok {
+			continue
+		}
+		switch key.Name {
+		case "ActionBytes":
+			limits.ActionBytes = parseInt64(keyValue.Value)
+		case "APIBytes":
+			limits.APIBytes = parseInt64(keyValue.Value)
+		}
+	}
+	return limits
 }
 
 func parseHeadConfig(expression ast.Expr) gowdk.HeadConfig {
@@ -943,6 +971,32 @@ func parseString(expression ast.Expr) string {
 func parseBool(expression ast.Expr) bool {
 	identifier, ok := expression.(*ast.Ident)
 	return ok && identifier.Name == "true"
+}
+
+func parseInt64(expression ast.Expr) int64 {
+	switch typed := expression.(type) {
+	case *ast.BasicLit:
+		if typed.Kind != token.INT {
+			return 0
+		}
+		value, err := strconv.ParseInt(typed.Value, 0, 64)
+		if err != nil {
+			return 0
+		}
+		return value
+	case *ast.UnaryExpr:
+		value := parseInt64(typed.X)
+		switch typed.Op {
+		case token.ADD:
+			return value
+		case token.SUB:
+			return -value
+		default:
+			return 0
+		}
+	default:
+		return 0
+	}
 }
 
 func isConfigType(expression ast.Expr) bool {

--- a/internal/project/config_test.go
+++ b/internal/project/config_test.go
@@ -64,6 +64,10 @@ var Config = gowdk.Config{
 			HeaderName: "X-Example-CSRF",
 			Insecure: true,
 		},
+		BodyLimits: gowdk.BodyLimitsConfig{
+			ActionBytes: 2097152,
+			APIBytes: 524288,
+		},
 		AllowMissingBackend: true,
 		Stylesheets: []gowdk.Stylesheet{
 			{Href: "/assets/app.css"},
@@ -159,6 +163,9 @@ var Config = gowdk.Config{
 	}
 	if !config.Build.CSRF.Enabled || config.Build.CSRF.SecretEnv != "EXAMPLE_CSRF_SECRET" || config.Build.CSRF.CookieName != "__Host-example-csrf" || config.Build.CSRF.FieldName != "_example_csrf" || config.Build.CSRF.HeaderName != "X-Example-CSRF" || !config.Build.CSRF.Insecure {
 		t.Fatalf("unexpected build csrf config: %#v", config.Build.CSRF)
+	}
+	if config.Build.BodyLimits.ActionBytes != 2097152 || config.Build.BodyLimits.APIBytes != 524288 {
+		t.Fatalf("unexpected body limits config: %#v", config.Build.BodyLimits)
 	}
 	if !config.Build.AllowMissingBackend {
 		t.Fatal("expected AllowMissingBackend to be parsed")

--- a/runtime/app/app_test.go
+++ b/runtime/app/app_test.go
@@ -1018,6 +1018,22 @@ func TestActionValuesRejectsTooLargeBody(t *testing.T) {
 	}
 }
 
+func TestActionValuesWithBodyLimitRejectsTooLargeBody(t *testing.T) {
+	handler := ActionValuesWithBodyLimit(8, func(context.Context, form.Values) (response.Response, error) {
+		t.Fatal("handler should not run for oversized body")
+		return response.Response{}, nil
+	})
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodPost, "/submit", strings.NewReader("field=too-large"))
+	request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	handler(recorder, request)
+
+	if recorder.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("unexpected status: %d", recorder.Code)
+	}
+}
+
 func TestAPIHandlerCapsRequestBody(t *testing.T) {
 	var readErr error
 	handler := APIHandler(func(_ context.Context, request *http.Request) (response.Response, error) {
@@ -1030,6 +1046,28 @@ func TestAPIHandlerCapsRequestBody(t *testing.T) {
 	recorder := httptest.NewRecorder()
 	oversized := strings.Repeat("a", int(DefaultAPIBodyLimit)+1)
 	request := httptest.NewRequest(http.MethodPost, "/api/echo", strings.NewReader(oversized))
+
+	handler(recorder, request)
+
+	if readErr == nil {
+		t.Fatal("expected oversized API body read to fail")
+	}
+	if !strings.Contains(readErr.Error(), "request body too large") {
+		t.Fatalf("expected body-too-large read error, got %v", readErr)
+	}
+}
+
+func TestAPIHandlerWithBodyLimitCapsRequestBody(t *testing.T) {
+	var readErr error
+	handler := APIHandlerWithBodyLimit(4, func(_ context.Context, request *http.Request) (response.Response, error) {
+		_, readErr = io.ReadAll(request.Body)
+		if readErr != nil {
+			return response.Response{}, readErr
+		}
+		return response.JSONBody(http.StatusOK, `{"ok":true}`), nil
+	})
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodPost, "/api/echo", strings.NewReader("12345"))
 
 	handler(recorder, request)
 

--- a/runtime/app/backend.go
+++ b/runtime/app/backend.go
@@ -154,11 +154,17 @@ func (router *BackendRouter) ServeHTTP(writer http.ResponseWriter, request *http
 
 // Action0 adapts a no-input action handler.
 func Action0(handler func(context.Context) (response.Response, error)) BackendHandler {
+	return Action0WithBodyLimit(DefaultActionBodyLimit, handler)
+}
+
+// Action0WithBodyLimit adapts a no-input action handler with a custom request
+// body limit. Non-positive limits use DefaultActionBodyLimit.
+func Action0WithBodyLimit(bodyLimit int64, handler func(context.Context) (response.Response, error)) BackendHandler {
 	if handler == nil {
 		return NotImplemented("GOWDK action handler is not implemented")
 	}
 	return func(writer http.ResponseWriter, request *http.Request) bool {
-		ctx, ok := prepareAction(writer, request)
+		ctx, ok := prepareAction(writer, request, bodyLimit)
 		if !ok {
 			return true
 		}
@@ -170,11 +176,18 @@ func Action0(handler func(context.Context) (response.Response, error)) BackendHa
 
 // ActionForm adapts a typed value action handler with an explicit decoder.
 func ActionForm[T any](decode func(form.Values) (T, error), handler func(context.Context, T) (response.Response, error)) BackendHandler {
+	return ActionFormWithBodyLimit(DefaultActionBodyLimit, decode, handler)
+}
+
+// ActionFormWithBodyLimit adapts a typed value action handler with an explicit
+// decoder and custom request body limit. Non-positive limits use
+// DefaultActionBodyLimit.
+func ActionFormWithBodyLimit[T any](bodyLimit int64, decode func(form.Values) (T, error), handler func(context.Context, T) (response.Response, error)) BackendHandler {
 	if decode == nil || handler == nil {
 		return NotImplemented("GOWDK action handler is not implemented")
 	}
 	return func(writer http.ResponseWriter, request *http.Request) bool {
-		ctx, values, ok := prepareActionValues(writer, request)
+		ctx, values, ok := prepareActionValues(writer, request, bodyLimit)
 		if !ok {
 			return true
 		}
@@ -191,11 +204,18 @@ func ActionForm[T any](decode func(form.Values) (T, error), handler func(context
 
 // ActionFormPtr adapts a typed pointer action handler with an explicit decoder.
 func ActionFormPtr[T any](decode func(form.Values) (T, error), handler func(context.Context, *T) (response.Response, error)) BackendHandler {
+	return ActionFormPtrWithBodyLimit(DefaultActionBodyLimit, decode, handler)
+}
+
+// ActionFormPtrWithBodyLimit adapts a typed pointer action handler with an
+// explicit decoder and custom request body limit. Non-positive limits use
+// DefaultActionBodyLimit.
+func ActionFormPtrWithBodyLimit[T any](bodyLimit int64, decode func(form.Values) (T, error), handler func(context.Context, *T) (response.Response, error)) BackendHandler {
 	if decode == nil || handler == nil {
 		return NotImplemented("GOWDK action handler is not implemented")
 	}
 	return func(writer http.ResponseWriter, request *http.Request) bool {
-		ctx, values, ok := prepareActionValues(writer, request)
+		ctx, values, ok := prepareActionValues(writer, request, bodyLimit)
 		if !ok {
 			return true
 		}
@@ -212,11 +232,17 @@ func ActionFormPtr[T any](decode func(form.Values) (T, error), handler func(cont
 
 // ActionValues adapts a low-level form.Values action handler.
 func ActionValues(handler func(context.Context, form.Values) (response.Response, error)) BackendHandler {
+	return ActionValuesWithBodyLimit(DefaultActionBodyLimit, handler)
+}
+
+// ActionValuesWithBodyLimit adapts a low-level form.Values action handler with
+// a custom request body limit. Non-positive limits use DefaultActionBodyLimit.
+func ActionValuesWithBodyLimit(bodyLimit int64, handler func(context.Context, form.Values) (response.Response, error)) BackendHandler {
 	if handler == nil {
 		return NotImplemented("GOWDK action handler is not implemented")
 	}
 	return func(writer http.ResponseWriter, request *http.Request) bool {
-		ctx, values, ok := prepareActionValues(writer, request)
+		ctx, values, ok := prepareActionValues(writer, request, bodyLimit)
 		if !ok {
 			return true
 		}
@@ -228,11 +254,17 @@ func ActionValues(handler func(context.Context, form.Values) (response.Response,
 
 // APIHandler adapts an API handler.
 func APIHandler(handler func(context.Context, *http.Request) (response.Response, error)) BackendHandler {
+	return APIHandlerWithBodyLimit(DefaultAPIBodyLimit, handler)
+}
+
+// APIHandlerWithBodyLimit adapts an API handler with a custom request body
+// limit. Non-positive limits use DefaultAPIBodyLimit.
+func APIHandlerWithBodyLimit(bodyLimit int64, handler func(context.Context, *http.Request) (response.Response, error)) BackendHandler {
 	if handler == nil {
 		return NotImplemented("GOWDK API handler is not implemented")
 	}
 	return func(writer http.ResponseWriter, request *http.Request) bool {
-		request.Body = http.MaxBytesReader(writer, request.Body, DefaultAPIBodyLimit)
+		request.Body = http.MaxBytesReader(writer, request.Body, normalizeBodyLimit(bodyLimit, DefaultAPIBodyLimit))
 		ctx := WithRequest(request.Context(), request)
 		result, err := handler(ctx, request)
 		writeBackendResult(writer, result, err)
@@ -252,18 +284,18 @@ func NotImplemented(message string) BackendHandler {
 	}
 }
 
-func prepareAction(writer http.ResponseWriter, request *http.Request) (context.Context, bool) {
-	ctx, _, ok := prepareActionValues(writer, request)
+func prepareAction(writer http.ResponseWriter, request *http.Request, bodyLimit int64) (context.Context, bool) {
+	ctx, _, ok := prepareActionValues(writer, request, bodyLimit)
 	return ctx, ok
 }
 
-func prepareActionValues(writer http.ResponseWriter, request *http.Request) (context.Context, form.Values, bool) {
+func prepareActionValues(writer http.ResponseWriter, request *http.Request, bodyLimit int64) (context.Context, form.Values, bool) {
 	if request.Method != http.MethodPost {
 		writer.Header().Set("Allow", http.MethodPost)
 		response.WriteNoStoreError(writer, http.StatusMethodNotAllowed, "method not allowed")
 		return nil, nil, false
 	}
-	request.Body = http.MaxBytesReader(writer, request.Body, DefaultActionBodyLimit)
+	request.Body = http.MaxBytesReader(writer, request.Body, normalizeBodyLimit(bodyLimit, DefaultActionBodyLimit))
 	if err := request.ParseForm(); err != nil {
 		if strings.Contains(err.Error(), "request body too large") {
 			response.WriteNoStoreError(writer, http.StatusRequestEntityTooLarge, "request body too large")
@@ -274,6 +306,13 @@ func prepareActionValues(writer http.ResponseWriter, request *http.Request) (con
 	}
 	ctx := WithRequest(request.Context(), request)
 	return ctx, form.FromURLValues(request.PostForm), true
+}
+
+func normalizeBodyLimit(bodyLimit int64, fallback int64) int64 {
+	if bodyLimit > 0 {
+		return bodyLimit
+	}
+	return fallback
 }
 
 func writeBackendResult(writer http.ResponseWriter, result response.Response, err error) {


### PR DESCRIPTION
## Summary

- Add `Build.BodyLimits` with action/API byte caps, AST config parsing, and default 1 MiB behavior when omitted.
- Emit generated action/API body-limit constants from config and cap generated API request bodies before calling user handlers.
- Add runtime `*WithBodyLimit` adapter variants and sync security/release docs, including private vulnerability reporting status.

## Issue Closure

Closes #57

## Verification

- [x] I ran the relevant tests, lint, and build commands.
  - `go test ./internal/project -run 'TestLoadConfigFileReadsLiteralSourceAndBuildFields'`
  - `go test ./internal/appgen -run 'TestGenerateWritesBoundAPIHandler|TestGenerateUsesConfiguredBodyLimits|TestGeneratedGoMatchesGoldenFixture'`
  - `go test ./runtime/app -run 'TestActionValuesRejectsTooLargeBody|TestActionValuesWithBodyLimitRejectsTooLargeBody|TestAPIHandlerCapsRequestBody|TestAPIHandlerWithBodyLimitCapsRequestBody|TestAPIHandlerAllowsBodyWithinLimit'`
  - `go test ./internal/project ./runtime/app`
  - `go test ./internal/appgen`
  - `go test ./cmd/gowdk`
  - `go test ./...`
  - `git diff --check`
- [x] I ran `scripts/test-go-modules.sh` when Go code or compiler behavior changed.
- [x] I ran `go build ./cmd/gowdk` when CLI, compiler, runtime, addon, or release behavior changed.
- [ ] I ran `node --check editors/vscode/extension.js` when editor files changed. Not applicable: no editor files changed.
- [x] I updated docs for behavior, setup, or architecture changes.
- [x] I added or updated tests for changed behavior.
- [x] I considered security-sensitive surfaces such as auth, CSRF, redirects, request-time handlers, logs, diagnostics, embedded assets, editor commands, WASM, contracts, and realtime behavior.

## LLM Assistance

- LLM session summary: Implemented configurable generated action/API request body caps, added runtime custom-limit adapters, updated tests/goldens, and synchronized M5 security documentation.
- Human-reviewed assumptions: `Build.BodyLimits` is an app-level policy for the current slice; per-route body/header policy remains planned instead of being inferred here.
- Follow-up work: Continue #24 for API request/response helper expansion and the documented per-route body/header policy follow-up.