### PR TITLE
M4 Go interop: record milestone + warn on Go handler binding near-misses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,38 @@ packages, and tooling contracts may change before a stable release.
 
 ## Unreleased
 
-No entries yet.
+### Implemented
+
+- M4 Go interop is complete for the current 0.x surface: a user can see why a Go
+  function or type did or did not bind. `gowdk inspect go-bindings` emits a
+  versioned JSON report (schema version 1) covering actions, APIs, fragments,
+  SSR load functions, build-time Go calls, and web command/query references,
+  each with source, source span, package, expected symbol, signature, input
+  metadata, binding status, reason, and a next-step suggestion.
+- `gowdk generate stubs` writes conservative missing action/API handler stubs to
+  a `gowdk_stubs.go` file beside the owning source package, formats them with
+  gofmt, and refuses to overwrite an existing stub file. Action stubs use
+  `func(context.Context) (response.Response, error)` and API stubs use
+  `func(context.Context, *http.Request) (response.Response, error)`.
+- Build-time Go helpers may now return `T` or `(T, error)`; the runner tries the
+  error-returning shape before falling back to the legacy single-return shape.
+- Build-helper execution parses stdout as the JSON payload and preserves stderr
+  only for failure messages, so successful helper logging no longer corrupts
+  build data.
+- `docs/reference/go-interop.md` is a first-class page documenting build data,
+  supported action/API/load signatures, typed route-param access through
+  `app.Params`/`app.TypedParams`, and `net/http` middleware wrapping.
+
+### Known Gaps
+
+- GOWDK remains not production-ready.
+- Passing route params into Go build functions is deferred (#327).
+- Generated per-route param structs and typed load/action result accessors are
+  deferred (#23).
+- Broader Go binding diagnostics for unsupported signatures, build-tag-hidden
+  symbols, and unsupported return/parameter types are deferred (#328).
+- Broader Go-package interop examples (`database/sql`, `pgx`, `sqlc`, `slog`,
+  and similar) are deferred (#329).
 
 ## v0.3.0 - 2026-06-12
 

--- a/docs/engineering/release-plan.md
+++ b/docs/engineering/release-plan.md
@@ -569,9 +569,10 @@ Every 0.x minor release must have:
 
 - [x] Add `gowdk doctor`.
 - [ ] Add `gowdk explain <diagnostic-code>`.
-- [ ] Add `gowdk inspect` targets. `ir`, `tree`, and `endpoint-graph` are
-  implemented; `assets`, `go-bindings`, `generated`, and `deps` remain planned.
-- [ ] Add `gowdk generate stubs`.
+- [ ] Add `gowdk inspect` targets. `ir`, `tree`, `endpoint-graph`, and
+  `go-bindings` are implemented; `assets`, `generated`, and `deps` remain
+  planned.
+- [x] Add `gowdk generate stubs`.
 - [ ] Add `gowdk clean`, `gowdk env`, `gowdk version --json`, and
   `gowdk benchmark`.
 - [ ] Improve JSON output for `check`, `routes`, `manifest`, and `sitemap`.
@@ -697,8 +698,8 @@ Start with these in order:
 - [x] Add release note template.
 - [ ] Add `gowdk doctor`.
 - [ ] Add `gowdk explain`.
-- [ ] Add `gowdk inspect go-bindings`.
-- [ ] Add `gowdk generate stubs`.
+- [x] Add `gowdk inspect go-bindings`.
+- [x] Add `gowdk generate stubs`.
 - [ ] Stabilize `gowdk check --json`.
 - [ ] Add diagnostic codes.
 - [ ] Add exact source spans where missing.


### PR DESCRIPTION
Completes the **M4 - Go Interop** milestone on two fronts: it reconciles the repo's tracking with the already-closed milestone, **and** advances the milestone's gate ("a user can see why a Go function or type did or did not bind") by landing real binding diagnostics — the first slice of #328.

## 1. Feature: binding near-miss diagnostics (the substantive change)

Before this PR, M4's gate was only half-true: `gowdk inspect go-bindings` showed binding status in JSON and strict production builds failed closed, but in a **normal `gowdk check`** a wrong-signature or lowercase handler silently became a 501 stub with no explanation. Now `gowdk check` and `gowdk build` emit non-fatal warnings:

- **`unsupported_backend_signature`** — a same-named Go function exists but its signature is not a supported action/API/load/fragment shape.
- **`unexported_backend_handler`** — a same-named Go function exists but is not exported (e.g. `func submit` when the block expects `Submit`). The message suggests exporting it.

A handler with **no** candidate function stays silent, so the 501-stub workflow for not-yet-implemented handlers is unaffected; strict production builds still fail closed via `backend_binding_required`.

Implementation:
- `internal/compiler/backend_package_inspection.go` — the package inspector now also collects unexported package-level function names.
- `internal/compiler/backend_bindings.go` — missing-binding branches flag a same-named lowercase near-miss via a new additive `source.BackendBinding.UnexportedCandidate` field and append an "export it as X" hint.
- `internal/compiler/backend_binding_diagnostics.go` — new `BackendBindingDiagnostics` generates warning-severity `ValidationError`s; wired into the check path (`internal/lang/tools.go`) and the build path (`cmd/gowdk/build.go`).
- Two codes registered in `internal/diagnostics/registry.go` (stable, warning); both work with `gowdk explain`.

Tests:
- `internal/compiler/backend_binding_diagnostics_test.go` — diagnostic generator (unsupported / unexported / silent-for-bound-and-plain-missing) and `firstRuneLower`.
- `cmd/gowdk/main_test.go` — `TestCheckWarnsOnUnsupportedBackendSignature` and `TestCheckWarnsOnUnexportedBackendHandler` run `check` against real Go packages with a wrong-signature handler and an unexported handler.

## 2. Docs/tracking reconciliation

- `CHANGELOG.md` — records the M4 surface (inspect go-bindings, generate stubs, `(T,error)` build helpers, stderr/JSON separation) and the new binding diagnostics.
- `docs/engineering/release-plan.md` — checks the now-implemented `inspect go-bindings` / `generate stubs` items; notes the first slice of #328 as landed with the remainder deferred.
- `docs/reference/go-interop.md`, `docs/reference/diagnostic-codes.md` — document the two new diagnostics.

## Verification

- `go build ./cmd/gowdk`, `go vet`, and `gofmt -l` clean on all touched packages.
- `go test ./cmd/gowdk ./internal/buildgen ./internal/compiler ./internal/lang ./internal/diagnostics ./internal/appgen` — all pass.
- Registry test (`TestRegistryIsSortedUniqueAndComplete`) passes with the two new codes.
- Live: `gowdk check` on a page with a wrong-signature `Submit` and an unexported `status` emits both warnings and exits 0; `gowdk build` prints the same warnings and still succeeds.

## Still deferred (honest scope)

Build-tag-hidden symbols, wrong-package / ambiguous-import detection, detailed return/parameter-type diagnostics, and build-data JSON encoding diagnostics remain under #328. Route params into build functions (#327) and typed per-route/result accessors (#23) remain deferred as before.