### PR TITLE
test(appgen): cover generated-app module loud-failure path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,10 @@ packages, and tooling contracts may change before a stable release.
   generated app imports app-owned packages it now fails with the real `go list`
   error instead of producing a go.mod that fails to build with an opaque
   "cannot find package".
+- The generated-app module loud-failure path is now covered by an integration
+  test: with `go list -m` unable to determine the main module, `moduleSource`
+  fails when the app imports app-owned packages and stays silent when it does
+  not, so the fail-loudly contract for app-module resolution is regression-proof.
 
 ### Known Gaps
 

--- a/internal/appgen/appgen_test.go
+++ b/internal/appgen/appgen_test.go
@@ -3125,6 +3125,50 @@ func HomeTitle() string { return local.Suffix() }`,
 	}
 }
 
+func TestModuleSourceFailsLoudlyWhenAppModuleUndeterminedWithLocalImports(t *testing.T) {
+	// Run outside any Go module so `go list -m -json` fails with a clear reason
+	// (no go.mod). When the generated app imports an app-owned package we cannot
+	// emit its require/replace without the module path, so that failure must
+	// surface here instead of producing an app that later fails to build with an
+	// opaque "cannot find package" error.
+	t.Chdir(t.TempDir())
+
+	ir := gwdkir.Program{
+		Pages: []gwdkir.Page{{
+			Package: "pages",
+			ID:      "home",
+			Route:   "/",
+			Blocks: gwdkir.Blocks{GoBlocks: []gwdkir.GoBlock{{
+				Body: `import local "example.com/site/local"
+
+func HomeTitle() string { return local.Suffix() }`,
+			}}},
+		}},
+	}
+
+	if _, err := moduleSource(Options{IR: &ir}); err == nil {
+		t.Fatal("expected moduleSource to fail when the app module is undetermined and the app imports app-owned packages")
+	} else if !strings.Contains(err.Error(), "cannot determine the app Go module") {
+		t.Fatalf("expected the app-module determination failure to be surfaced, got: %v", err)
+	}
+}
+
+func TestModuleSourceToleratesUndeterminedAppModuleWithoutLocalImports(t *testing.T) {
+	// The same `go list -m` failure is non-fatal when the generated app imports
+	// nothing app-owned: there is no require/replace to add, so a missing main
+	// module is irrelevant and module generation must still succeed.
+	t.Chdir(t.TempDir())
+
+	empty := gwdkir.Program{Pages: []gwdkir.Page{{Package: "pages", ID: "home", Route: "/"}}}
+	source, err := moduleSource(Options{IR: &empty})
+	if err != nil {
+		t.Fatalf("expected moduleSource to tolerate an undetermined app module without app-owned imports, got: %v", err)
+	}
+	if !strings.Contains(source, "module gowdk-generated-app") {
+		t.Fatalf("expected a valid generated go.mod, got:\n%s", source)
+	}
+}
+
 func TestGenerateWritesAddonGoBlockConsumerFiles(t *testing.T) {
 	root := t.TempDir()
 	outputDir := filepath.Join(root, "dist")


### PR DESCRIPTION
## What

Closes the one concrete gap left after PR #350 (the fail-loudly fallback hardening, now merged): the `moduleSource` loud-failure path had **no test**. Only the decision heuristic (`isLocalModuleImportPath` / `appHasLocalModuleImports`) was unit-tested; the actual error propagation was unverified.

## Changes

Two integration tests in `internal/appgen/appgen_test.go`. Both run outside any Go module via `t.Chdir(t.TempDir())`, so `go list -m -json` fails with a genuine "no go.mod" reason:

- `TestModuleSourceFailsLoudlyWhenAppModuleUndeterminedWithLocalImports` — with an app-owned inline `go {}` import, `moduleSource` surfaces `cannot determine the app Go module` instead of silently dropping the `require`/`replace`.
- `TestModuleSourceToleratesUndeterminedAppModuleWithoutLocalImports` — with no app-owned imports, the same `go list -m` failure is tolerated and a valid generated `go.mod` is still produced.

This pins down **both** sides of the intentional behavior so neither can regress silently.

## Verification

- `go test ./...` across all **55 non-example packages** passes (full suite, not just touched packages — closing the earlier "full suite not run" gap).
- `examples/*` fail to `go build` as before — they are `.gwdk` demo projects, not Go mains; pre-existing and unrelated.

## Deferred items — evaluated, not bugs

While here I re-checked the two "judgment call" items from the gap review and confirmed neither is masked error-handling:

- **build-data `{name}` precedence** (data wins over route param for a bare name): documented precedence with explicit `param("x")` / `field("x")` overrides; both values are valid. Not a masked error — a hard error would break valid usage.
- **layout/component scope-shadowing** (same-package shadows global): standard scoping semantics. Unresolved / cross-package cases already fail loudly (`validate_identity`, `validate_stores`); route overlaps via `ambiguous_dynamic_route`.

No behavior change — test + changelog only.