### PR TITLE
fix(m8): harden component bindings, exports, and SPA prefetch

### DIFF
--- a/docs/engineering/m8-components-client-language.md
+++ b/docs/engineering/m8-components-client-language.md
@@ -28,7 +28,9 @@ status.
   persistence, shape invalidation, and SPA-navigation hydration cover #19.
 - SPA navigation: internal-link interception, route shell fetch/swap, prefetch,
   scroll/focus restoration, loading/error events, and asset-size reporting cover
-  #370.
+  #370. Hover prefetch waits a short, cancelable delay before issuing a request
+  (focus and touch prefetch immediately), and the prefetch cache is bounded so a
+  long session that hovers many links cannot retain unbounded documents.
 - Generated form validation: direct literal action inputs receive derivable
   numeric HTML attributes and partial form POSTs run browser pre-validation
   before network submission, covering #174. Server validation remains

--- a/docs/language/components.md
+++ b/docs/language/components.md
@@ -290,9 +290,12 @@ Bindable child state is supported on component calls with
 must be declared in `exports`, and must have a scalar type compatible with the
 parent state field. Generated JavaScript sends the parent value down through
 reactive props and listens for the child's typed `exports` event to write the
-new child value back to parent state. Bound state is still local UI state: it is
-not trusted input, server state, auth state, validation, business logic, route
-truth, or cache policy.
+new child value back to parent state. A single component call may bind several
+exported fields at once; the generated assignments share the one `exports`
+listener and run as ordered statements. A component may not export a field named
+`active`, which the exports payload reserves for the mount-state flag. Bound
+state is still local UI state: it is not trusted input, server state, auth state,
+validation, business logic, route truth, or cache policy.
 
 Computed values are read-only derived state. They can depend on props, state,
 and other computed values. The compiler builds a dependency graph for declared

--- a/internal/buildgen/build.go
+++ b/internal/buildgen/build.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
-	goruntime "runtime"
 	"sort"
 	"strings"
 
@@ -652,7 +651,7 @@ func reportAssetSizes(reporter *buildReporter, outputDir string, assets []AssetA
 			data["cache"] = artifact.CachePolicy
 		}
 		if logical == islandWASMExecAssetPath() {
-			data["wasmExecGoVersion"] = goruntime.Version()
+			data["wasmExecGoVersion"] = islandWASMExecGoVersion()
 		}
 		reporter.info("report", "asset_size", "generated asset size recorded", BuildEvent{
 			Path: rel,

--- a/internal/buildgen/components.go
+++ b/internal/buildgen/components.go
@@ -240,6 +240,12 @@ func componentEmits(component gwdkir.Component) map[string]clientlang.Emit {
 	return out
 }
 
+// componentExportActiveFlag is the reserved key the generated island runtime
+// writes into every exports payload to report mount/unmount state
+// (dispatchComponentExports in island_js_source.go). A component may not export
+// a field with this name or it would clobber the flag and be mistyped.
+const componentExportActiveFlag = "active"
+
 func componentExports(component gwdkir.Component, propTypes map[string]clientlang.ValueType, stateTypes map[string]clientlang.ValueType, computeds []clientlang.Computed) (map[string]clientlang.ValueType, []string, []string) {
 	if len(component.Exports) == 0 {
 		return nil, nil, nil
@@ -255,6 +261,10 @@ func componentExports(component gwdkir.Component, propTypes map[string]clientlan
 	for _, export := range component.Exports {
 		if seen[export.Name] {
 			failures = append(failures, fmt.Sprintf("component %s declares duplicate export %q", component.Name, export.Name))
+			continue
+		}
+		if export.Name == componentExportActiveFlag {
+			failures = append(failures, fmt.Sprintf("component %s export %q uses reserved name %q; the exports payload reserves it for the mount flag", component.Name, export.Name, componentExportActiveFlag))
 			continue
 		}
 		seen[export.Name] = true

--- a/internal/buildgen/components.go
+++ b/internal/buildgen/components.go
@@ -240,12 +240,6 @@ func componentEmits(component gwdkir.Component) map[string]clientlang.Emit {
 	return out
 }
 
-// componentExportActiveFlag is the reserved key the generated island runtime
-// writes into every exports payload to report mount/unmount state
-// (dispatchComponentExports in island_js_source.go). A component may not export
-// a field with this name or it would clobber the flag and be mistyped.
-const componentExportActiveFlag = "active"
-
 func componentExports(component gwdkir.Component, propTypes map[string]clientlang.ValueType, stateTypes map[string]clientlang.ValueType, computeds []clientlang.Computed) (map[string]clientlang.ValueType, []string, []string) {
 	if len(component.Exports) == 0 {
 		return nil, nil, nil
@@ -263,8 +257,8 @@ func componentExports(component gwdkir.Component, propTypes map[string]clientlan
 			failures = append(failures, fmt.Sprintf("component %s declares duplicate export %q", component.Name, export.Name))
 			continue
 		}
-		if export.Name == componentExportActiveFlag {
-			failures = append(failures, fmt.Sprintf("component %s export %q uses reserved name %q; the exports payload reserves it for the mount flag", component.Name, export.Name, componentExportActiveFlag))
+		if export.Name == gwdkir.ComponentExportActiveFlag {
+			failures = append(failures, fmt.Sprintf("component %s export %q uses reserved name %q; the exports payload reserves it for the mount flag", component.Name, export.Name, gwdkir.ComponentExportActiveFlag))
 			continue
 		}
 		seen[export.Name] = true

--- a/internal/buildgen/island_js_source.go
+++ b/internal/buildgen/island_js_source.go
@@ -446,6 +446,39 @@ func islandJSSource(componentName string, includeSourceMap bool) string {
     return args;
   }
 
+  function splitStatements(source) {
+    source = (source || "").trim();
+    if (!source) return [];
+    const statements = [];
+    let start = 0;
+    let depth = 0;
+    let inString = false;
+    let escaped = false;
+    for (let i = 0; i < source.length; i++) {
+      const char = source[i];
+      if (escaped) {
+        escaped = false;
+        continue;
+      }
+      if (inString) {
+        if (char === "\\") escaped = true;
+        else if (char === "\"") inString = false;
+        continue;
+      }
+      if (char === "\"") inString = true;
+      else if (char === "(" || char === "[" || char === "{") depth++;
+      else if (char === ")" || char === "]" || char === "}") depth--;
+      else if (char === ";" && depth === 0) {
+        const piece = source.slice(start, i).trim();
+        if (piece) statements.push(piece);
+        start = i + 1;
+      }
+    }
+    const tail = source.slice(start).trim();
+    if (tail) statements.push(tail);
+    return statements;
+  }
+
   function emitComponentEvent(root, emitEvents, name, args, state, scope, helpers) {
     const event = emitEvents && emitEvents[name];
     if (!event) return;
@@ -1040,7 +1073,7 @@ func islandJSSource(componentName string, includeSourceMap bool) string {
               const eventScope = Object.create(null);
               eventScope.event = customEvent.detail || {};
               try {
-                await applyExpression(attr.value, state, handlers, helpers, eventScope, refs, computeds, asyncTokens, root, emitEvents);
+                await applyStatements(splitStatements(attr.value), state, handlers, helpers, eventScope, refs, computeds, asyncTokens, root, emitEvents);
               } catch (error) {
                 if (error !== staleAsyncResult) recordAsyncError(state, error);
               } finally {

--- a/internal/buildgen/islands_test.go
+++ b/internal/buildgen/islands_test.go
@@ -701,6 +701,10 @@ func TestBuildEmitsTypedExportRuntimeForJSIsland(t *testing.T) {
 		`if (event === "exports" && node.__gowdkExports)`,
 		`dispatchComponentExports(root, exportNames, state, true);`,
 		`dispatchComponentExports(root, exportNames, state, false);`,
+		// Parent-event expressions run as ordered statements so a component can
+		// carry several g:bind:<export> assignments on the single exports event.
+		`function splitStatements(source)`,
+		`await applyStatements(splitStatements(attr.value), state, handlers, helpers, eventScope, refs, computeds, asyncTokens, root, emitEvents);`,
 	} {
 		if !strings.Contains(js, expected) {
 			t.Fatalf("expected %q in generated typed export runtime:\n%s", expected, js)
@@ -842,6 +846,31 @@ func TestBuildRejectsTypedExportWithoutLocalSymbol(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), `export "Missing" must reference a declared prop, state field, or computed value`) {
 		t.Fatalf("unexpected export error: %v", err)
+	}
+}
+
+func TestBuildRejectsReservedActiveExportName(t *testing.T) {
+	outputDir := t.TempDir()
+	component := textComponent()
+	component.Exports = []gwdkir.Export{{Name: "active", Type: "bool"}}
+	app := gwdkanalysis.Sources{
+		Pages: []gwdkir.Page{{
+			ID:    "home",
+			Route: "/",
+			Blocks: gwdkir.Blocks{
+				View:     true,
+				ViewBody: `<main><Search /></main>`,
+			},
+		}},
+		Components: []gwdkir.Component{component},
+	}
+
+	_, err := Build(gowdk.Config{}, app, outputDir)
+	if err == nil {
+		t.Fatal("expected reserved export name error")
+	}
+	if !strings.Contains(err.Error(), `export "active" uses reserved name "active"`) {
+		t.Fatalf("unexpected reserved export error: %v", err)
 	}
 }
 

--- a/internal/buildgen/runtime_asset_paths.go
+++ b/internal/buildgen/runtime_asset_paths.go
@@ -6,10 +6,26 @@ import (
 	"path"
 	"path/filepath"
 	"runtime"
+	"strings"
 
 	"github.com/cssbruno/gowdk/internal/gwdkir"
 	"github.com/cssbruno/gowdk/internal/source"
 )
+
+// islandWASMExecGoVersion reports the Go toolchain version that supplies
+// wasm_exec.js. It reads $GOROOT/VERSION -- the same GOROOT that
+// islandWASMExecArtifact reads wasm_exec.js from -- so the reported version
+// matches the emitted glue even when this binary was compiled by a different
+// toolchain. It falls back to the build version when VERSION is unreadable.
+func islandWASMExecGoVersion() string {
+	if contents, err := os.ReadFile(filepath.Join(runtime.GOROOT(), "VERSION")); err == nil {
+		line, _, _ := strings.Cut(strings.TrimSpace(string(contents)), "\n")
+		if line = strings.TrimSpace(line); line != "" {
+			return line
+		}
+	}
+	return runtime.Version()
+}
 
 func islandWASMLoaderArtifact(outputDir, componentName string) plannedAssetArtifact {
 	assetPath := islandWASMLoaderAssetPath(componentName)

--- a/internal/clientrt/runtime.go
+++ b/internal/clientrt/runtime.go
@@ -110,6 +110,7 @@ const runtimeSource = `(function () {
   document.addEventListener('submit', submitPartial);
   document.addEventListener('click', navigateLink);
   document.addEventListener('mouseover', prefetchLink);
+  document.addEventListener('mouseout', cancelHoverPrefetch);
   document.addEventListener('focusin', prefetchLink);
   document.addEventListener('touchstart', prefetchLink, { passive: true });
   if (typeof window !== 'undefined' && window.addEventListener) {
@@ -119,6 +120,11 @@ const runtimeSource = `(function () {
   }
 
   var prefetchedDocuments = {};
+  var prefetchOrder = [];
+  var prefetchLimit = 8;
+  var hoverPrefetchDelay = 65;
+  var hoverPrefetchTimer = 0;
+  var hoverPrefetchURL = '';
 
   async function navigateLink(event) {
     if (event.defaultPrevented || event.button !== 0 || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) {
@@ -159,34 +165,86 @@ const runtimeSource = `(function () {
     }
   }
 
-  function prefetchLink(event) {
+  function prefetchTarget(event) {
     var link = event.target && event.target.closest && event.target.closest('a[href]');
     if (!link || link.target || link.hasAttribute('download')) {
-      return;
+      return '';
     }
     var url;
     try {
       url = new URL(link.href, window.location.href);
     } catch (error) {
-      return;
+      return '';
     }
     if (!isNavigableURL(url)) {
-      return;
+      return '';
     }
     if (url.hash && url.pathname === window.location.pathname && url.search === window.location.search) {
+      return '';
+    }
+    return url.href;
+  }
+
+  function prefetchLink(event) {
+    var href = prefetchTarget(event);
+    if (!href) {
       return;
     }
-    prefetchDocument(url.href).catch(function () {});
+    // Pointer hovers are noisy and often incidental, so wait a beat before
+    // spending a request; focus and touch are deliberate, so prefetch at once.
+    if (event.type === 'mouseover') {
+      if (href === hoverPrefetchURL) {
+        return;
+      }
+      cancelHoverPrefetch();
+      hoverPrefetchURL = href;
+      hoverPrefetchTimer = setTimeout(function () {
+        hoverPrefetchTimer = 0;
+        hoverPrefetchURL = '';
+        prefetchDocument(href).catch(function () {});
+      }, hoverPrefetchDelay);
+      return;
+    }
+    prefetchDocument(href).catch(function () {});
+  }
+
+  function cancelHoverPrefetch() {
+    if (hoverPrefetchTimer) {
+      clearTimeout(hoverPrefetchTimer);
+      hoverPrefetchTimer = 0;
+    }
+    hoverPrefetchURL = '';
   }
 
   function prefetchDocument(url) {
     if (!prefetchedDocuments[url]) {
       prefetchedDocuments[url] = fetchDocument(url, true).catch(function (error) {
-        delete prefetchedDocuments[url];
+        forgetPrefetched(url);
         throw error;
       });
+      rememberPrefetched(url);
     }
     return prefetchedDocuments[url];
+  }
+
+  // rememberPrefetched bounds the prefetch cache so a long session that hovers
+  // many links cannot retain an unbounded set of full documents in memory.
+  function rememberPrefetched(url) {
+    prefetchOrder.push(url);
+    while (prefetchOrder.length > prefetchLimit) {
+      var oldest = prefetchOrder.shift();
+      if (oldest !== url) {
+        delete prefetchedDocuments[oldest];
+      }
+    }
+  }
+
+  function forgetPrefetched(url) {
+    delete prefetchedDocuments[url];
+    var index = prefetchOrder.indexOf(url);
+    if (index !== -1) {
+      prefetchOrder.splice(index, 1);
+    }
   }
 
   async function partialRequestError(response) {
@@ -219,7 +277,7 @@ const runtimeSource = `(function () {
       var fetched = prefetchedDocuments[url]
         ? await prefetchedDocuments[url]
         : await fetchDocument(url, false);
-      delete prefetchedDocuments[url];
+      forgetPrefetched(url);
       if (!fetched || !fetched.html) {
         window.location.href = url;
         return;

--- a/internal/clientrt/runtime_test.go
+++ b/internal/clientrt/runtime_test.go
@@ -45,8 +45,14 @@ func TestSourceEmitsSPANavigationRuntime(t *testing.T) {
 	for _, expected := range []string{
 		`document.addEventListener('click', navigateLink)`,
 		`document.addEventListener('mouseover', prefetchLink)`,
+		`document.addEventListener('mouseout', cancelHoverPrefetch)`,
 		`document.addEventListener('focusin', prefetchLink)`,
 		`document.addEventListener('touchstart', prefetchLink, { passive: true })`,
+		// Hover prefetch waits a beat (cancelable) and the cache stays bounded.
+		`hoverPrefetchTimer = setTimeout(`,
+		`function cancelHoverPrefetch()`,
+		`function rememberPrefetched(url)`,
+		`while (prefetchOrder.length > prefetchLimit)`,
 		`window.addEventListener('popstate'`,
 		`event.target.closest && event.target.closest('a[href]')`,
 		`X-GOWDK-Navigate`,

--- a/internal/compiler/validate.go
+++ b/internal/compiler/validate.go
@@ -86,6 +86,7 @@ func validateProgram(config gowdk.Config, ir gwdkir.Program, crossFile bool) Val
 	diagnostics = append(diagnostics, validateUniquePages(ir.Pages)...)
 	diagnostics = append(diagnostics, validateUniqueComponents(ir.Components)...)
 	diagnostics = append(diagnostics, validateComponentEmits(ir.Components)...)
+	diagnostics = append(diagnostics, validateComponentExports(ir.Components)...)
 	diagnostics = append(diagnostics, validateComponentGoContracts(ir.Components)...)
 	diagnostics = append(diagnostics, validateComponentStoreUses(ir.Pages, ir.Components)...)
 	diagnostics = append(diagnostics, validatePersistedStoreConflicts(ir.Pages)...)

--- a/internal/compiler/validate_component_contracts.go
+++ b/internal/compiler/validate_component_contracts.go
@@ -2,18 +2,37 @@ package compiler
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/cssbruno/gowdk/internal/clientlang"
 	"github.com/cssbruno/gowdk/internal/gotypes"
 	"github.com/cssbruno/gowdk/internal/gwdkir"
 	"github.com/cssbruno/gowdk/internal/source"
-	"strings"
 )
 
 func validateComponentGoContracts(components []gwdkir.Component) []ValidationError {
 	var diagnostics []ValidationError
 	for _, component := range components {
 		diagnostics = append(diagnostics, validateComponentGoContract(component)...)
+	}
+	return diagnostics
+}
+
+func validateComponentExports(components []gwdkir.Component) []ValidationError {
+	var diagnostics []ValidationError
+	for _, component := range components {
+		for _, export := range component.Exports {
+			if export.Name != gwdkir.ComponentExportActiveFlag {
+				continue
+			}
+			diagnostics = append(diagnostics, ValidationError{
+				Code:          "component_contract_error",
+				ComponentName: component.Name,
+				Source:        component.Source,
+				Span:          firstSpan(export.Span, component.Blocks.Spans.Exports, component.Span),
+				Message:       fmt.Sprintf("component %s export %q uses reserved name %q; the exports payload reserves it for the mount flag", component.Name, export.Name, gwdkir.ComponentExportActiveFlag),
+			})
+		}
 	}
 	return diagnostics
 }

--- a/internal/compiler/validate_test.go
+++ b/internal/compiler/validate_test.go
@@ -1421,6 +1421,38 @@ func TestValidateManifestRejectsMissingGoTypedComponentType(t *testing.T) {
 	}
 }
 
+func TestValidateManifestRejectsReservedActiveExportName(t *testing.T) {
+	app := appFixture{Components: []gwdkir.Component{{
+		Package: "components",
+		Name:    "Toggle",
+		Source:  "components/toggle.cmp.gwdk",
+		Props:   []gwdkir.Prop{{Name: "active", Type: "bool"}},
+		Exports: []gwdkir.Export{{
+			Name: "active",
+			Type: "bool",
+			Span: testSourceSpan(8, 3, 8, 14),
+		}},
+		Blocks: gwdkir.Blocks{
+			View:     true,
+			ViewBody: `<p>{active}</p>`,
+		},
+	}}}
+
+	err := validateManifest(gowdk.Config{}, app)
+	if err == nil {
+		t.Fatal("expected reserved export diagnostic")
+	}
+	diagnostics := err.(ValidationErrors)
+	diagnostic := firstDiagnostic(diagnostics, "component_contract_error")
+	if diagnostic == nil {
+		t.Fatalf("missing component_contract_error diagnostic: %#v", diagnostics)
+	}
+	if !strings.Contains(diagnostic.Message, `export "active" uses reserved name "active"`) {
+		t.Fatalf("unexpected reserved export diagnostic: %#v", diagnostic)
+	}
+	assertSourceSpan(t, diagnostic.Span, 8, 3, 8, 14)
+}
+
 func TestValidateManifestAllowsClientFunctionEventCall(t *testing.T) {
 	app := appFixture{Components: []gwdkir.Component{{
 		Name:    "Counter",

--- a/internal/gwdkir/ir.go
+++ b/internal/gwdkir/ir.go
@@ -289,6 +289,10 @@ type Export struct {
 	Span source.SourceSpan
 }
 
+// ComponentExportActiveFlag is reserved in generated exports payloads for the
+// island mount-state flag.
+const ComponentExportActiveFlag = "active"
+
 type Emit struct {
 	Name   string
 	Params []EmitParam

--- a/internal/lang/tools_test.go
+++ b/internal/lang/tools_test.go
@@ -38,6 +38,43 @@ view {
 	}
 }
 
+func TestCheckFilesRejectsReservedActiveComponentExport(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "toggle.cmp.gwdk")
+	writeGWDK(t, path, `package components
+
+component Toggle
+props {
+  active bool
+}
+exports {
+  active bool
+}
+
+view {
+  <p>{active}</p>
+}
+`)
+
+	_, diagnostics := CheckFiles(gowdk.Config{}, []string{path})
+	if !diagnostics.HasErrors() {
+		t.Fatal("expected reserved export diagnostic")
+	}
+	if len(diagnostics) != 1 {
+		t.Fatalf("expected one diagnostic, got %#v", diagnostics)
+	}
+	diagnostic := diagnostics[0]
+	if diagnostic.Code != "component_contract_error" {
+		t.Fatalf("expected component_contract_error, got %#v", diagnostic)
+	}
+	if !strings.Contains(diagnostic.Message, `export "active" uses reserved name "active"`) {
+		t.Fatalf("unexpected diagnostic message: %#v", diagnostic)
+	}
+	if diagnostic.Pos.Line != 8 || diagnostic.Pos.Column != 3 {
+		t.Fatalf("expected export diagnostic at line 8, got %#v", diagnostic.Pos)
+	}
+}
+
 func TestCheckSourceValidatesUnsavedBuffer(t *testing.T) {
 	_, diagnostics := CheckSource(gowdk.Config{}, "untitled.gwdk", []byte(`package app
 

--- a/internal/view/component.go
+++ b/internal/view/component.go
@@ -121,10 +121,11 @@ func (node ComponentCall) render(ctx *renderContext, out *renderOutput) error {
 				if err != nil {
 					return err
 				}
-				if hasParentListener(parentListeners, listener.Event) {
-					return fmt.Errorf("component %s declares multiple parent listeners for event %q", node.Name, listener.Event)
+				merged, err := addParentListener(parentListeners, listener)
+				if err != nil {
+					return fmt.Errorf("component %s %w", node.Name, err)
 				}
-				parentListeners = append(parentListeners, listener)
+				parentListeners = merged
 				continue
 			}
 			if attr.Name == "g:event" {
@@ -135,10 +136,11 @@ func (node ComponentCall) render(ctx *renderContext, out *renderOutput) error {
 				if err != nil {
 					return err
 				}
-				if hasParentListener(parentListeners, listener.Event) {
-					return fmt.Errorf("component %s declares multiple parent listeners for event %q", node.Name, listener.Event)
+				merged, err := addParentListener(parentListeners, listener)
+				if err != nil {
+					return fmt.Errorf("component %s %w", node.Name, err)
 				}
-				parentListeners = append(parentListeners, listener)
+				parentListeners = merged
 				continue
 			}
 			if attr.Name == "g:bind" {
@@ -370,13 +372,29 @@ func (ctx *renderContext) writeSymbols() map[string]clientlang.ValueType {
 	return boolFieldSymbols(ctx.bindFields)
 }
 
-func hasParentListener(listeners []parentComponentListener, event string) bool {
-	for _, listener := range listeners {
-		if listener.Event == event {
-			return true
+// addParentListener appends a parent listener, merging it into an existing
+// listener for the same event instead of rejecting it. This lets a component
+// bind several exported state fields at once (multiple g:bind:<export>) or pair
+// a g:on:exports handler with bindings: their expressions are joined and run as
+// ordered statements in the browser. Conflicting non-empty event modifiers are
+// rejected because a single data-gowdk-parent-event-* attribute cannot carry
+// both.
+func addParentListener(listeners []parentComponentListener, next parentComponentListener) ([]parentComponentListener, error) {
+	for i, existing := range listeners {
+		if existing.Event != next.Event {
+			continue
 		}
+		if existing.Modifiers != "" && next.Modifiers != "" && existing.Modifiers != next.Modifiers {
+			return listeners, fmt.Errorf("declares conflicting modifiers for parent event %q", next.Event)
+		}
+		existing.Expression = existing.Expression + "; " + next.Expression
+		if existing.Modifiers == "" {
+			existing.Modifiers = next.Modifiers
+		}
+		listeners[i] = existing
+		return listeners, nil
 	}
-	return false
+	return append(listeners, next), nil
 }
 
 func componentPropTarget(component Component, callName string, attr Attr) (string, string, error) {

--- a/internal/view/component.go
+++ b/internal/view/component.go
@@ -376,21 +376,18 @@ func (ctx *renderContext) writeSymbols() map[string]clientlang.ValueType {
 // listener for the same event instead of rejecting it. This lets a component
 // bind several exported state fields at once (multiple g:bind:<export>) or pair
 // a g:on:exports handler with bindings: their expressions are joined and run as
-// ordered statements in the browser. Conflicting non-empty event modifiers are
-// rejected because a single data-gowdk-parent-event-* attribute cannot carry
-// both.
+// ordered statements in the browser. Different event modifiers are rejected
+// because a single data-gowdk-parent-event-* attribute cannot preserve separate
+// listener timing for each merged expression.
 func addParentListener(listeners []parentComponentListener, next parentComponentListener) ([]parentComponentListener, error) {
 	for i, existing := range listeners {
 		if existing.Event != next.Event {
 			continue
 		}
-		if existing.Modifiers != "" && next.Modifiers != "" && existing.Modifiers != next.Modifiers {
-			return listeners, fmt.Errorf("declares conflicting modifiers for parent event %q", next.Event)
+		if existing.Modifiers != next.Modifiers {
+			return listeners, fmt.Errorf("declares incompatible modifiers for parent event %q", next.Event)
 		}
 		existing.Expression = existing.Expression + "; " + next.Expression
-		if existing.Modifiers == "" {
-			existing.Modifiers = next.Modifiers
-		}
 		listeners[i] = existing
 		return listeners, nil
 	}

--- a/internal/view/view_test.go
+++ b/internal/view/view_test.go
@@ -194,6 +194,36 @@ func TestRenderWithComponentsWiresBindableChildState(t *testing.T) {
 	}
 }
 
+func TestRenderWithComponentsWiresMultipleBindableChildState(t *testing.T) {
+	got, err := RenderWithComponents(`<Parent />`, map[string]Component{
+		"Parent": {
+			Name:       "Parent",
+			State:      map[string]string{"SelectedID": "first", "Label": "x"},
+			StateJSON:  `{"SelectedID":"first","Label":"x"}`,
+			StateTypes: map[string]clientlang.ValueType{"SelectedID": clientlang.TypeString, "Label": clientlang.TypeString},
+			Body:       `<Child g:bind:selected={SelectedID} g:bind:label={Label} />`,
+		},
+		"Child": {
+			Name:         "Child",
+			State:        map[string]string{"selected": "", "label": ""},
+			StateJSON:    `{"selected":"","label":""}`,
+			StateTypes:   map[string]clientlang.ValueType{"selected": clientlang.TypeString, "label": clientlang.TypeString},
+			Exports:      map[string]clientlang.ValueType{"selected": clientlang.TypeString, "label": clientlang.TypeString},
+			HandlersJSON: `{"exports":["selected","label"]}`,
+			Body:         `<p>{selected}{label}</p>`,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Both bindings collapse into the single exports event as ordered
+	// statements, in attribute order; the runtime runs them via applyStatements.
+	want := `data-gowdk-parent-on-exports="SelectedID = event.selected; Label = event.label"`
+	if !strings.Contains(got, want) {
+		t.Fatalf("expected %q in multi-bind output:\n%s", want, got)
+	}
+}
+
 func TestRenderWithComponentsRejectsBindableChildStateWithoutExport(t *testing.T) {
 	_, err := RenderWithComponents(`<Parent />`, map[string]Component{
 		"Parent": {

--- a/internal/view/view_test.go
+++ b/internal/view/view_test.go
@@ -224,6 +224,33 @@ func TestRenderWithComponentsWiresMultipleBindableChildState(t *testing.T) {
 	}
 }
 
+func TestRenderWithComponentsRejectsBindingMergedWithModifiedExportsListener(t *testing.T) {
+	_, err := RenderWithComponents(`<Parent />`, map[string]Component{
+		"Parent": {
+			Name:       "Parent",
+			State:      map[string]string{"SelectedID": "first", "Seen": "false"},
+			StateJSON:  `{"SelectedID":"first","Seen":false}`,
+			StateTypes: map[string]clientlang.ValueType{"SelectedID": clientlang.TypeString, "Seen": clientlang.TypeBool},
+			Body:       `<Child g:bind:selected={SelectedID} g:on:exports.once={Seen = event.active} />`,
+		},
+		"Child": {
+			Name:         "Child",
+			State:        map[string]string{"selected": ""},
+			StateJSON:    `{"selected":""}`,
+			StateTypes:   map[string]clientlang.ValueType{"selected": clientlang.TypeString},
+			Exports:      map[string]clientlang.ValueType{"selected": clientlang.TypeString},
+			HandlersJSON: `{"exports":["selected"]}`,
+			Body:         `<p>{selected}</p>`,
+		},
+	})
+	if err == nil {
+		t.Fatal("expected modifier merge error")
+	}
+	if !strings.Contains(err.Error(), `incompatible modifiers for parent event "exports"`) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestRenderWithComponentsRejectsBindableChildStateWithoutExport(t *testing.T) {
 	_, err := RenderWithComponents(`<Parent />`, map[string]Component{
 		"Parent": {


### PR DESCRIPTION
## Summary

Post-merge follow-ups to #373 found while reviewing it. Five fixes, each with tests:

- **Multiple `g:bind:<export>` per component.** A component with several exports could only bind one (the second hit a "multiple parent listeners for event \"exports\"" error). Parent listeners for the same event are now merged into one ordered-statement expression instead of rejected, so a call can bind several exports at once (and pair `g:bind` with `g:on:exports`). The generated island runtime runs parent-event handlers via `applyStatements(splitStatements(attr.value), …)` — a quote/paren-aware splitter mirroring `splitArgs`. Single-binding output is byte-identical.
- **Reserved export name `active`.** The exports payload reserves `active` for the mount-state flag; a component exporting a field named `active` would clobber it and be mistyped. Now rejected at build time.
- **Bounded SPA prefetch cache.** `prefetchedDocuments` was never evicted, so a long session that hovers many links retained unbounded full documents. Added FIFO eviction (8 entries).
- **Hover-intent prefetch.** `mouseover` now waits a short, cancelable delay (new `mouseout` listener) before issuing a request; `focusin`/`touchstart` stay immediate.
- **`wasmExecGoVersion` accuracy.** Now derived from `$GOROOT/VERSION` (the source of the emitted `wasm_exec.js`), falling back to the build version — so the reported version matches the emitted glue under toolchain switching.

Deliberately **not** changed: explicit-prop-overrides-`{...props}` rejection and the `func() uint32` WASM ABI tightening are intended, tested behavior from #373.

## Issue Closure

Related to #373

## Verification

- [x] I ran the relevant tests, lint, and build commands.
- [x] I ran `scripts/test-go-modules.sh` when Go code or compiler behavior changed.
- [x] I ran `go build ./cmd/gowdk` when CLI, compiler, runtime, addon, or release behavior changed.
- [ ] I ran `node --check editors/vscode/extension.js` when editor files changed. (no editor files changed)
- [x] I updated docs for behavior, setup, or architecture changes.
- [x] I added or updated tests for changed behavior.
- [x] I considered security-sensitive surfaces such as auth, CSRF, redirects, request-time handlers, logs, diagnostics, embedded assets, editor commands, WASM, contracts, and realtime behavior.

Commands run:

```sh
go build ./cmd/gowdk
go test ./internal/view ./internal/buildgen ./internal/clientrt ./internal/parser ./internal/compiler ./internal/appgen ./internal/lang ./runtime/asset
gofmt -l <changed files>   # clean
go vet ./internal/view ./internal/buildgen ./internal/clientrt
scripts/test-go-modules.sh
```

The `buildgen` suite includes the node/playwright browser tests that execute the generated island JS end-to-end (the changed parent-event + exports paths), and all pass.

## LLM Assistance

- LLM session summary: Claude Code reviewed #373, identified the issues, implemented the fixes in an isolated worktree off `main`, added regression tests, and ran the verification commands above.
- Human-reviewed assumptions: multi-binding is a desired capability (not an intended limit); `active` is genuinely reserved by the runtime payload; #6/#7 from the review are intended behavior and left unchanged.
- Follow-up work: none required for these fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)