### PR TITLE
Fix cleanup drift hazards around guards and runtime boundaries

### DIFF
--- a/docs/engineering/architecture.md
+++ b/docs/engineering/architecture.md
@@ -125,8 +125,8 @@ compatibility model has been removed entirely:
   derived from the IR (`internal/lang/manifest_json.go`); a golden test pins
   the output.
 - Shared leaf value types (source spans, route params, inline scripts, backend
-  binding records and signature enums, error-page path validation) live in the
-  neutral `internal/source` package.
+  binding records and signature enums, supported backend input field types,
+  error-page path validation) live in the neutral `internal/source` package.
 
 New generated-output work should consume `internal/gwdkir.Program` or add
 fields there first.
@@ -178,7 +178,8 @@ manifest report (`internal/lang/testdata/manifest_golden`).
 | `runtime/response` | HTML, redirect, fragment, and JSON response envelopes. | Runtime | Initial response model implemented. |
 | `runtime/asset` | Asset manifest resolution. | Runtime | Initial manifest helper implemented. |
 | `runtime/route` | Runtime route matching for generated request-time routes. | Runtime | Dynamic route matcher for first-slice generated SSR and standalone fragment routes implemented. |
-| `runtime/app` | Shared generated app HTTP server. | Runtime | Serves embedded spa files, configured security headers, identity headers, health checks, asset manifest counts, optional generated 404/500 pages, no-JS cookie acknowledgement, server-side cookie notice hiding, generated CSRF token injection for POST forms, request-time panic boundaries, and generated action/API/fragment/SSR callback hooks. |
+| `runtime/app` | Shared generated app HTTP server. | Runtime | Serves embedded spa files, configured security headers, identity headers, health checks, asset manifest counts, optional generated 404/500 pages, no-JS cookie acknowledgement, server-side cookie notice hiding, generated CSRF token injection for POST forms, request-time panic boundaries with `runtime/security` redaction, and generated action/API/fragment/SSR callback hooks. |
+| `runtime/security` | Runtime-safe security text helpers. | Runtime | Provides conservative secret-like text redaction for generated app panic/error logging without importing compiler-private `internal/` packages. |
 | `runtime/testkit` | Generated audit test helpers. | Runtime | Provides small `httptest` helpers used by generated `gowdk_audit_test.go` files and `gowdk audit --run` to verify route status, method rejection, and configured response headers in-process against generated app handlers. |
 | `runtime/contracts` | Typed contract registry and in-process dispatch. | Runtime | First runtime slice implemented for queries, commands, backend-owned domain and integration events, presentation events, jobs, metadata, stable observation names and labels for logs/metrics/traces, local command-buffered event dispatch, event-envelope capture/replay with stable IDs, dependency-free outbox/broker/presentation-fanout/event-source/seen-store interfaces, command event sinks, an event worker loop with ack/nack plus context cancellation and optional post-ack deduplication windows, a dependency-free file outbox adapter, dependency-free in-memory broker/EventSource adapter, dependency-free in-memory and file-backed seen stores, and dependency-free SSE presentation fanout adapter. Concrete Redis Streams, Redis TTL seen-store, NATS, and WebSocket adapters are nested optional modules. Split worker/cron generation, retry backoff policy, and managed deployment recipes remain planned. |
 | `addons/static` | Build-time static page output. | Addon | Capability boundary implemented; build-time output uses `runtime/render` through the compiler view renderer. |

--- a/internal/appgen/appgen_test.go
+++ b/internal/appgen/appgen_test.go
@@ -670,6 +670,25 @@ func TestGenerateWritesBoundContractBackendRoutes(t *testing.T) {
 	}
 }
 
+func TestBoundActionFieldDecodePanicsOnUnsupportedFieldType(t *testing.T) {
+	defer func() {
+		recovered := recover()
+		if recovered == nil {
+			t.Fatal("expected unsupported backend input field type panic")
+		}
+		message, ok := recovered.(string)
+		if !ok || !strings.Contains(message, `unsupported backend input field type "float64"`) {
+			t.Fatalf("unexpected panic: %v", recovered)
+		}
+	}()
+
+	_ = boundActionFieldDecodeStmts(0, source.BackendInputField{
+		FieldName: "Amount",
+		FormName:  "amount",
+		Type:      "float64",
+	})
+}
+
 func TestGenerateWritesDerivedCommandContractBackendRoute(t *testing.T) {
 	root := t.TempDir()
 	outputDir := filepath.Join(root, "dist")
@@ -2296,8 +2315,9 @@ func TestGenerateAutoDetectsActionAndSSRRoutes(t *testing.T) {
 
 	app := gwdkanalysis.Sources{Pages: []gwdkir.Page{
 		{
-			ID:    "newsletter",
-			Route: "/newsletter",
+			ID:     "newsletter",
+			Route:  "/newsletter",
+			Guards: []string{"public"},
 			Blocks: gwdkir.Blocks{
 				View:     true,
 				ViewBody: `<form g:post={Subscribe}><input name="email" required /></form>`,

--- a/internal/appgen/source_actions.go
+++ b/internal/appgen/source_actions.go
@@ -663,16 +663,16 @@ func boundActionDecoderDecl(action BackendActionAdapter) *ast.FuncDecl {
 
 func boundActionFieldDecodeStmts(index int, field source.BackendInputField) []ast.Stmt {
 	value := id(fmtFieldValueName(index))
-	switch field.Type {
-	case "string":
+	switch {
+	case field.Type == "string":
 		return boundActionScalarFieldDecodeStmts(value, field, call(sel("gowdkform", "String"), id("values"), stringLit(field.FormName)), value)
-	case "bool":
+	case field.Type == "bool":
 		return boundActionScalarFieldDecodeStmts(value, field, call(sel("gowdkform", "Bool"), id("values"), stringLit(field.FormName)), value)
-	case "int", "int8", "int16", "int32", "int64":
-		return boundActionScalarFieldDecodeStmts(value, field, call(sel("gowdkform", "Int"), id("values"), stringLit(field.FormName), intLit(inputIntegerBitSize(field.Type))), convertIfNeeded(field.Type, value))
-	case "uint", "uint8", "uint16", "uint32", "uint64":
-		return boundActionScalarFieldDecodeStmts(value, field, call(sel("gowdkform", "Uint"), id("values"), stringLit(field.FormName), intLit(inputIntegerBitSize(field.Type))), convertIfNeeded(field.Type, value))
-	case "[]string":
+	case source.BackendInputFieldSignedInteger(field.Type):
+		return boundActionScalarFieldDecodeStmts(value, field, call(sel("gowdkform", "Int"), id("values"), stringLit(field.FormName), intLit(source.BackendInputFieldIntegerBitSize(field.Type))), convertIfNeeded(field.Type, value))
+	case source.BackendInputFieldUnsignedInteger(field.Type):
+		return boundActionScalarFieldDecodeStmts(value, field, call(sel("gowdkform", "Uint"), id("values"), stringLit(field.FormName), intLit(source.BackendInputFieldIntegerBitSize(field.Type))), convertIfNeeded(field.Type, value))
+	case field.Type == "[]string":
 		return []ast.Stmt{
 			define([]ast.Expr{value}, call(sel("gowdkform", "Strings"), id("values"), stringLit(field.FormName))),
 			&ast.IfStmt{
@@ -681,7 +681,7 @@ func boundActionFieldDecodeStmts(index int, field source.BackendInputField) []as
 			},
 		}
 	default:
-		return nil
+		panic(fmt.Sprintf("unsupported backend input field type %q for %s.%s", field.Type, field.FieldName, field.FormName))
 	}
 }
 
@@ -701,21 +701,6 @@ func boundActionScalarFieldDecodeStmts(value *ast.Ident, field source.BackendInp
 
 func fmtFieldValueName(index int) string {
 	return "field" + strconv.Itoa(index)
-}
-
-func inputIntegerBitSize(value string) int {
-	switch value {
-	case "int8", "uint8":
-		return 8
-	case "int16", "uint16":
-		return 16
-	case "int32", "uint32":
-		return 32
-	case "int64", "uint64":
-		return 64
-	default:
-		return 0
-	}
 }
 
 func convertIfNeeded(goType string, value ast.Expr) ast.Expr {

--- a/internal/buildgen/actions_partials_test.go
+++ b/internal/buildgen/actions_partials_test.go
@@ -18,6 +18,7 @@ func TestBuildLowersGPostDirectiveForActionPage(t *testing.T) {
 		ID:     "signup",
 		Route:  "/signup",
 		Render: gowdk.Action,
+		Guards: []string{"public"},
 		Blocks: gwdkir.Blocks{
 			View:     true,
 			ViewBody: `<form g:post={Submit}><input name="email" /></form>`,
@@ -48,6 +49,7 @@ func TestBuildSynthesizesActionInputAttrsFromBindingFields(t *testing.T) {
 		ID:     "signup",
 		Route:  "/signup",
 		Render: gowdk.Action,
+		Guards: []string{"public"},
 		Blocks: gwdkir.Blocks{
 			View:     true,
 			ViewBody: `<form g:post={Submit}><input name="age" /><input name="score" /></form>`,
@@ -93,6 +95,7 @@ func TestBuildProductionRequiresBoundBackendHandlers(t *testing.T) {
 		Source:  filepath.Join(t.TempDir(), "signup.page.gwdk"),
 		Route:   "/signup",
 		Render:  gowdk.Action,
+		Guards:  []string{"public"},
 		Blocks: gwdkir.Blocks{
 			View:     true,
 			ViewBody: `<form g:post={Submit}><input name="email" /></form>`,
@@ -117,6 +120,7 @@ func TestBuildProductionAllowsExplicitMissingBackendStubs(t *testing.T) {
 		Source:  filepath.Join(t.TempDir(), "signup.page.gwdk"),
 		Route:   "/signup",
 		Render:  gowdk.Action,
+		Guards:  []string{"public"},
 		Blocks: gwdkir.Blocks{
 			View:     true,
 			ViewBody: `<form g:post={Submit}><input name="email" /></form>`,
@@ -142,6 +146,7 @@ func TestBuildAllowsGPostWithLocalValueBinding(t *testing.T) {
 			ID:     "search",
 			Route:  "/search",
 			Render: gowdk.Action,
+			Guards: []string{"public"},
 			Blocks: gwdkir.Blocks{
 				View:     true,
 				ViewBody: `<main><Search /></main>`,
@@ -182,8 +187,9 @@ func TestBuildAllowsGPostWithLocalValueBinding(t *testing.T) {
 func TestBuildEmitsPartialRuntimeForFragmentForms(t *testing.T) {
 	outputDir := t.TempDir()
 	app := gwdkanalysis.Sources{Pages: []gwdkir.Page{{
-		ID:    "patients",
-		Route: "/patients",
+		ID:     "patients",
+		Route:  "/patients",
+		Guards: []string{"public"},
 		Blocks: gwdkir.Blocks{
 			View: true,
 			ViewBody: `<main>
@@ -233,8 +239,9 @@ func TestBuildEmitsPartialRuntimeForFragmentForms(t *testing.T) {
 func TestBuildRejectsUnknownGPostActionBeforeWriting(t *testing.T) {
 	outputDir := t.TempDir()
 	app := gwdkanalysis.Sources{Pages: []gwdkir.Page{{
-		ID:    "signup",
-		Route: "/signup",
+		ID:     "signup",
+		Route:  "/signup",
+		Guards: []string{"public"},
 		Blocks: gwdkir.Blocks{
 			View:     true,
 			ViewBody: `<form g:post={Missing}></form>`,

--- a/internal/buildgen/build_data_routes_test.go
+++ b/internal/buildgen/build_data_routes_test.go
@@ -715,6 +715,7 @@ func TestBuildExpandsTypedDynamicSPAPathsAndInheritedActionRoutes(t *testing.T) 
 		ID:     "patients.show",
 		Route:  "/patients/{id:int}",
 		Render: gowdk.Action,
+		Guards: []string{"public"},
 		Blocks: gwdkir.Blocks{
 			Paths:     true,
 			PathsBody: `=> { id: "123" }`,

--- a/internal/buildgen/build_report_test.go
+++ b/internal/buildgen/build_report_test.go
@@ -346,7 +346,7 @@ func TestBuildReportIncludesContractReferences(t *testing.T) {
 		Package: "pages",
 		ID:      "patients",
 		Route:   "/patients",
-		Guards:  []string{"public", "auth.required"},
+		Guards:  []string{"public"},
 		Blocks: gwdkir.Blocks{
 			View:     true,
 			ViewBody: `<main><form method="post" action="/patients" g:command="patients.CreatePatient"><input name="name" /></form></main>`,
@@ -373,7 +373,7 @@ func TestBuildReportIncludesContractReferences(t *testing.T) {
 	if event.Data["method"] != "POST" || event.Data["path"] != "/patients" {
 		t.Fatalf("unexpected command method/path: %#v", event.Data)
 	}
-	if event.Data["guards"] != "public,auth.required" {
+	if event.Data["guards"] != "public" {
 		t.Fatalf("unexpected command guards: %#v", event.Data)
 	}
 }

--- a/internal/compiler/backend_input_fields.go
+++ b/internal/compiler/backend_input_fields.go
@@ -190,12 +190,10 @@ func structTagValue(tag string, key string) (string, bool, error) {
 
 func backendInputFieldType(expression ast.Expr) (string, bool) {
 	if ident, ok := expression.(*ast.Ident); ok {
-		switch ident.Name {
-		case "string", "bool", "int", "int8", "int16", "int32", "int64", "uint", "uint8", "uint16", "uint32", "uint64":
+		if source.BackendInputFieldTypeSupported(ident.Name) {
 			return ident.Name, true
-		default:
-			return "", false
 		}
+		return "", false
 	}
 	array, ok := expression.(*ast.ArrayType)
 	if !ok || array.Len != nil {
@@ -211,12 +209,10 @@ func backendInputFieldType(expression ast.Expr) (string, bool) {
 func backendTypedInputFieldType(typ types.Type) (string, bool) {
 	typ = types.Unalias(typ)
 	if basic, ok := typ.Underlying().(*types.Basic); ok {
-		switch basic.Kind() {
-		case types.String, types.Bool, types.Int, types.Int8, types.Int16, types.Int32, types.Int64, types.Uint, types.Uint8, types.Uint16, types.Uint32, types.Uint64:
+		if source.BackendInputFieldTypeSupported(basic.Name()) {
 			return basic.Name(), true
-		default:
-			return "", false
 		}
+		return "", false
 	}
 	slice, ok := typ.Underlying().(*types.Slice)
 	if !ok {

--- a/internal/compiler/validate_page.go
+++ b/internal/compiler/validate_page.go
@@ -2,7 +2,6 @@ package compiler
 
 import (
 	"fmt"
-	"os"
 	"sort"
 	"strings"
 
@@ -204,9 +203,6 @@ func ValidatePage(config gowdk.Config, page gwdkir.Page) []ValidationError {
 }
 
 func validatePageGuards(page gwdkir.Page) []ValidationError {
-	if !validateSourceBackedPageGuards(page) {
-		return nil
-	}
 	if len(page.Guards) == 0 {
 		// A guardless page route is denied (403) at request time, so warning is
 		// enough. But act/api/fragment endpoints derived from the page inherit
@@ -259,7 +255,7 @@ func validatePageGuards(page gwdkir.Page) []ValidationError {
 }
 
 func validateProtectedPageGuardRender(page gwdkir.Page, mode gowdk.RenderMode) []ValidationError {
-	if !validateSourceBackedPageGuards(page) || !isBuildTimeRoute(mode, page) || !hasProtectedPageGuard(page) {
+	if !isBuildTimeRoute(mode, page) || !hasProtectedPageGuard(page) {
 		return nil
 	}
 	return []ValidationError{{
@@ -269,16 +265,6 @@ func validateProtectedPageGuardRender(page gwdkir.Page, mode gowdk.RenderMode) [
 		Span:    firstNamedSpan(page.Spans.Guard, firstSpan(page.Spans.Page, page.Spans.Route)),
 		Message: fmt.Sprintf("%s declares protected guard IDs on a build-time page route. Add load {} or go ssr {} with the SSR addon so frontend page access is request-time guarded, or use guard public for an intentionally public page", page.ID),
 	}}
-}
-
-func validateSourceBackedPageGuards(page gwdkir.Page) bool {
-	if strings.TrimSpace(page.Source) == "" {
-		return false
-	}
-	if _, err := os.Stat(page.Source); err != nil {
-		return false
-	}
-	return true
 }
 
 func pageDeclaresBackendEndpoints(page gwdkir.Page) bool {

--- a/internal/compiler/validate_test.go
+++ b/internal/compiler/validate_test.go
@@ -681,7 +681,7 @@ func TestValidatePageRejectsSSRWithoutAddon(t *testing.T) {
 		},
 	}
 
-	diagnostics := ValidatePage(gowdk.Config{}, irPage(page))
+	diagnostics := ValidatePage(gowdk.Config{}, page)
 	if len(diagnostics) != 1 {
 		t.Fatalf("expected 1 diagnostic, got %d", len(diagnostics))
 	}
@@ -705,7 +705,7 @@ func TestValidatePageWarnsOnMissingGuard(t *testing.T) {
 		Blocks: gwdkir.Blocks{View: true},
 	}
 
-	diagnostics := ValidatePage(gowdk.Config{}, irPage(page))
+	diagnostics := ValidatePage(gowdk.Config{}, irGuardlessPage(page))
 	var guard *ValidationError
 	for i := range diagnostics {
 		if diagnostics[i].Code == "missing_page_guard" {
@@ -739,7 +739,7 @@ func TestValidatePageErrorsOnGuardlessBackendEndpoints(t *testing.T) {
 		},
 	}
 
-	diagnostics := ValidatePage(gowdk.Config{}, irPage(page))
+	diagnostics := ValidatePage(gowdk.Config{}, irGuardlessPage(page))
 	var guard *ValidationError
 	for i := range diagnostics {
 		if diagnostics[i].Code == "missing_page_guard" {
@@ -755,6 +755,31 @@ func TestValidatePageErrorsOnGuardlessBackendEndpoints(t *testing.T) {
 	// The derived act/api/fragment endpoints would be public, so the build fails.
 	if !ValidationErrors(diagnostics).HasErrors() {
 		t.Fatalf("guardless page with endpoints should fail the build: %#v", diagnostics)
+	}
+}
+
+func TestValidatePageErrorsOnGuardlessBackendEndpointsWithoutSourcePath(t *testing.T) {
+	page := gwdkir.Page{
+		ID:    "signup",
+		Route: "/signup",
+		Blocks: gwdkir.Blocks{
+			View:    true,
+			Actions: []gwdkir.Action{{Name: "Submit"}},
+		},
+	}
+
+	diagnostics := ValidatePage(gowdk.Config{}, page)
+	var guard *ValidationError
+	for i := range diagnostics {
+		if diagnostics[i].Code == "missing_page_guard" {
+			guard = &diagnostics[i]
+		}
+	}
+	if guard == nil {
+		t.Fatalf("missing missing_page_guard diagnostic: %#v", diagnostics)
+	}
+	if guard.Severity != SeverityError {
+		t.Fatalf("guardless page with endpoints should be an error, got severity %v", guard.Severity)
 	}
 }
 
@@ -786,6 +811,22 @@ func TestValidatePageRejectsProtectedGuardOnBuildTimePage(t *testing.T) {
 		ID:     "dashboard",
 		Route:  "/dashboard",
 		Source: sourcePath,
+		Guards: []string{"auth.required"},
+		Render: gowdk.SPA,
+		Blocks: gwdkir.Blocks{View: true},
+	}
+
+	diagnostics := ValidatePage(gowdk.Config{}, irPage(page))
+	if !hasDiagnosticCode(diagnostics, "guard_requires_request_render") {
+		t.Fatalf("missing guard_requires_request_render diagnostic: %#v", diagnostics)
+	}
+}
+
+func TestValidatePageRejectsProtectedGuardOnBuildTimePageWithMissingSourceFile(t *testing.T) {
+	page := gwdkir.Page{
+		ID:     "dashboard",
+		Route:  "/dashboard",
+		Source: filepath.Join(t.TempDir(), "missing.page.gwdk"),
 		Guards: []string{"auth.required"},
 		Render: gowdk.SPA,
 		Blocks: gwdkir.Blocks{View: true},
@@ -4986,8 +5027,12 @@ type appFixture struct {
 }
 
 func (app appFixture) program(config gowdk.Config) gwdkir.Program {
+	pages := append([]gwdkir.Page(nil), app.Pages...)
+	for index := range pages {
+		pages[index] = publicTestPage(pages[index])
+	}
 	ir := gwdkanalysis.BuildProgram(config, gwdkanalysis.Sources{
-		Pages:      app.Pages,
+		Pages:      pages,
 		Components: app.Components,
 		Layouts:    app.Layouts,
 	})
@@ -5004,7 +5049,22 @@ func validateManifest(config gowdk.Config, app appFixture) error {
 // path so page-level validator tests assert against exactly what the build
 // pipeline validates.
 func irPage(page gwdkir.Page) gwdkir.Page {
-	program := appFixture{Pages: []gwdkir.Page{page}}.program(gowdk.Config{})
+	return lowerTestPage(publicTestPage(page))
+}
+
+func irGuardlessPage(page gwdkir.Page) gwdkir.Page {
+	return lowerTestPage(page)
+}
+
+func publicTestPage(page gwdkir.Page) gwdkir.Page {
+	if len(page.Guards) == 0 {
+		page.Guards = []string{"public"}
+	}
+	return page
+}
+
+func lowerTestPage(page gwdkir.Page) gwdkir.Page {
+	program := gwdkanalysis.BuildProgram(gowdk.Config{}, gwdkanalysis.Sources{Pages: []gwdkir.Page{page}})
 	if len(program.Pages) != 1 {
 		panic(fmt.Sprintf("irPage: expected 1 IR page, got %d", len(program.Pages)))
 	}

--- a/internal/lang/tools_test.go
+++ b/internal/lang/tools_test.go
@@ -80,6 +80,7 @@ func TestCheckSourceValidatesUnsavedBuffer(t *testing.T) {
 
 page post
 route "/blog/{slug}"
+guard public
 
 view {
 }

--- a/internal/lsp/server_test.go
+++ b/internal/lsp/server_test.go
@@ -18,7 +18,7 @@ import (
 func TestServerHandlesInitializeDiagnosticsFormattingCompletionAndShutdown(t *testing.T) {
 	uri := "file:///tmp/bad.page.gwdk"
 	input := framed(`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}`) +
-		framed(`{"jsonrpc":"2.0","method":"textDocument/didOpen","params":{"textDocument":{"uri":"`+uri+`","languageId":"gwdk","version":1,"text":"package app\n\npage bad\nroute \"/bad\"\n\nview {\n<h1>Bad</h1>\n}\n"}}}`) +
+		framed(`{"jsonrpc":"2.0","method":"textDocument/didOpen","params":{"textDocument":{"uri":"`+uri+`","languageId":"gwdk","version":1,"text":"package app\n\npage bad\nroute \"/bad\"\nguard public\n\nview {\n<h1>Bad</h1>\n}\n"}}}`) +
 		framed(`{"jsonrpc":"2.0","id":2,"method":"textDocument/formatting","params":{"textDocument":{"uri":"`+uri+`"}}}`) +
 		framed(`{"jsonrpc":"2.0","id":3,"method":"textDocument/completion","params":{"textDocument":{"uri":"`+uri+`"},"position":{"line":0,"character":0}}}`) +
 		framed(`{"jsonrpc":"2.0","id":4,"method":"shutdown","params":null}`) +
@@ -54,7 +54,7 @@ func TestServerHandlesInitializeDiagnosticsFormattingCompletionAndShutdown(t *te
 		t.Fatalf("expected one formatting edit, got %#v", edits)
 	}
 	edit := edits[0].(map[string]any)
-	if edit["newText"] != "package app\n\npage bad\nroute \"/bad\"\n\nview {\n  <h1>Bad</h1>\n}\n" {
+	if edit["newText"] != "package app\n\npage bad\nroute \"/bad\"\nguard public\n\nview {\n  <h1>Bad</h1>\n}\n" {
 		t.Fatalf("unexpected formatted text: %#v", edit["newText"])
 	}
 

--- a/internal/securitytext/securitytext.go
+++ b/internal/securitytext/securitytext.go
@@ -1,55 +1,17 @@
-// Package securitytext contains conservative secret-like text detection and
-// redaction helpers shared by runtime logs and audit posture projection.
+// Package securitytext wraps runtime security text helpers for compiler-private
+// callers.
 package securitytext
 
-import "regexp"
+import "github.com/cssbruno/gowdk/runtime/security"
 
-const RedactionMask = "[REDACTED]"
-
-type rule struct {
-	kind        string
-	pattern     *regexp.Regexp
-	replacement string
-}
-
-// Rules run in order. The DSN and Bearer/Basic scheme rules run before the
-// generic key=value rule so an "Authorization: Bearer <token>" string has its
-// token masked by the scheme rule rather than half-consumed by the key rule.
-var rules = []rule{
-	{
-		kind:        "dsn-password",
-		pattern:     regexp.MustCompile(`([a-zA-Z][a-zA-Z0-9+.-]*://[^:/@\s]+:)[^@/\s]+(@)`),
-		replacement: `${1}` + RedactionMask + `${2}`,
-	},
-	{
-		kind:        "authorization-token",
-		pattern:     regexp.MustCompile(`(?i)\b(Bearer|Basic)\s+[A-Za-z0-9._~+/=-]{8,}`),
-		replacement: `${1} ` + RedactionMask,
-	},
-	{
-		kind:        "secret-key-value",
-		pattern:     regexp.MustCompile(`(?i)\b(password|passwd|pwd|secret|token|_?gowdk[_-]?csrf|_?csrf(?:[_-]?token)?|cookie|set-cookie|auth[_-]?token|session(?:[_-]?id)?|jwt|api[_-]?key|access(?:[_-]?(?:key|token))?|refresh[_-]?token|id[_-]?token|client[_-]?secret|private[_-]?key)\b(\s*[:=]\s*)("?)[^\s"',;)]+`),
-		replacement: `${1}${2}${3}` + RedactionMask,
-	},
-}
+const RedactionMask = security.RedactionMask
 
 // RedactSecrets masks values that commonly carry credentials.
 func RedactSecrets(message string) string {
-	if message == "" {
-		return message
-	}
-	for _, rule := range rules {
-		message = rule.pattern.ReplaceAllString(message, rule.replacement)
-	}
-	return message
+	return security.RedactSecrets(message)
 }
 
 // FirstSecretKind returns the first secret-like rule kind matched in text.
 func FirstSecretKind(text string) (string, bool) {
-	for _, rule := range rules {
-		if rule.pattern.MatchString(text) {
-			return rule.kind, true
-		}
-	}
-	return "", false
+	return security.FirstSecretKind(text)
 }

--- a/internal/source/source.go
+++ b/internal/source/source.go
@@ -343,6 +343,59 @@ type BackendInputField struct {
 	Type      string
 }
 
+// BackendInputFieldTypeSupported reports whether goType is a form-decoder type
+// supported by compiler validation and generated action decoders.
+func BackendInputFieldTypeSupported(goType string) bool {
+	switch goType {
+	case "string", "bool",
+		"int", "int8", "int16", "int32", "int64",
+		"uint", "uint8", "uint16", "uint32", "uint64",
+		"[]string":
+		return true
+	default:
+		return false
+	}
+}
+
+// BackendInputFieldSignedInteger reports whether goType uses the signed integer
+// form decoder.
+func BackendInputFieldSignedInteger(goType string) bool {
+	switch goType {
+	case "int", "int8", "int16", "int32", "int64":
+		return true
+	default:
+		return false
+	}
+}
+
+// BackendInputFieldUnsignedInteger reports whether goType uses the unsigned
+// integer form decoder.
+func BackendInputFieldUnsignedInteger(goType string) bool {
+	switch goType {
+	case "uint", "uint8", "uint16", "uint32", "uint64":
+		return true
+	default:
+		return false
+	}
+}
+
+// BackendInputFieldIntegerBitSize returns the explicit bit size passed to form
+// integer decoders. Zero means the platform-sized int or uint type.
+func BackendInputFieldIntegerBitSize(goType string) int {
+	switch goType {
+	case "int8", "uint8":
+		return 8
+	case "int16", "uint16":
+		return 16
+	case "int32", "uint32":
+		return 32
+	case "int64", "uint64":
+		return 64
+	default:
+		return 0
+	}
+}
+
 // BackendBinding describes the Go handler selected for a backend block (a page
 // load, act, api, or fragment block, or a standalone Go endpoint).
 type BackendBinding struct {

--- a/runtime/app/redact.go
+++ b/runtime/app/redact.go
@@ -1,6 +1,6 @@
 package app
 
-import "github.com/cssbruno/gowdk/internal/securitytext"
+import "github.com/cssbruno/gowdk/runtime/security"
 
 // redactSecrets masks values that commonly carry credentials so a recovered
 // panic or error can be logged without leaking secrets into operator logs.
@@ -8,5 +8,5 @@ import "github.com/cssbruno/gowdk/internal/securitytext"
 // over letting a real secret through, and it never touches the HTTP response
 // (which already returns a generic message).
 func redactSecrets(message string) string {
-	return securitytext.RedactSecrets(message)
+	return security.RedactSecrets(message)
 }

--- a/runtime/imports_test.go
+++ b/runtime/imports_test.go
@@ -1,0 +1,46 @@
+package runtime_test
+
+import (
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestRuntimePackagesDoNotImportInternalPackages(t *testing.T) {
+	err := filepath.WalkDir(".", func(path string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() {
+			switch entry.Name() {
+			case ".git", "vendor":
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if filepath.Ext(path) != ".go" {
+			return nil
+		}
+		file, err := parser.ParseFile(token.NewFileSet(), path, nil, parser.ImportsOnly)
+		if err != nil {
+			return err
+		}
+		for _, item := range file.Imports {
+			importPath, err := strconv.Unquote(item.Path.Value)
+			if err != nil {
+				return err
+			}
+			if strings.Contains(importPath, "/internal/") || strings.HasSuffix(importPath, "/internal") {
+				t.Errorf("%s imports internal package %q", path, importPath)
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/runtime/security/redact.go
+++ b/runtime/security/redact.go
@@ -1,0 +1,54 @@
+// Package security contains conservative runtime security helpers.
+package security
+
+import "regexp"
+
+const RedactionMask = "[REDACTED]"
+
+type rule struct {
+	kind        string
+	pattern     *regexp.Regexp
+	replacement string
+}
+
+// Rules run in order. The DSN and Bearer/Basic scheme rules run before the
+// generic key=value rule so an "Authorization: Bearer <token>" string has its
+// token masked by the scheme rule rather than half-consumed by the key rule.
+var rules = []rule{
+	{
+		kind:        "dsn-password",
+		pattern:     regexp.MustCompile(`([a-zA-Z][a-zA-Z0-9+.-]*://[^:/@\s]+:)[^@/\s]+(@)`),
+		replacement: `${1}` + RedactionMask + `${2}`,
+	},
+	{
+		kind:        "authorization-token",
+		pattern:     regexp.MustCompile(`(?i)\b(Bearer|Basic)\s+[A-Za-z0-9._~+/=-]{8,}`),
+		replacement: `${1} ` + RedactionMask,
+	},
+	{
+		kind:        "secret-key-value",
+		pattern:     regexp.MustCompile(`(?i)\b(password|passwd|pwd|secret|token|_?gowdk[_-]?csrf|_?csrf(?:[_-]?token)?|cookie|set-cookie|auth[_-]?token|session(?:[_-]?id)?|jwt|api[_-]?key|access(?:[_-]?(?:key|token))?|refresh[_-]?token|id[_-]?token|client[_-]?secret|private[_-]?key)\b(\s*[:=]\s*)("?)[^\s"',;)]+`),
+		replacement: `${1}${2}${3}` + RedactionMask,
+	},
+}
+
+// RedactSecrets masks values that commonly carry credentials.
+func RedactSecrets(message string) string {
+	if message == "" {
+		return message
+	}
+	for _, rule := range rules {
+		message = rule.pattern.ReplaceAllString(message, rule.replacement)
+	}
+	return message
+}
+
+// FirstSecretKind returns the first secret-like rule kind matched in text.
+func FirstSecretKind(text string) (string, bool) {
+	for _, rule := range rules {
+		if rule.pattern.MatchString(text) {
+			return rule.kind, true
+		}
+	}
+	return "", false
+}


### PR DESCRIPTION
## Summary
- Refs #391.
- Validate page guard policy from IR even when `Page.Source` is empty or the source file is missing, with regressions for guardless backend endpoints and protected build-time pages.
- Move supported backend input field type classification into `internal/source` and make appgen panic on impossible unsupported field metadata instead of silently dropping fields.
- Promote secret redaction into public `runtime/security`, keep `internal/securitytext` as a compiler wrapper, and add a runtime import-boundary test that rejects runtime imports of `internal/`.
- Update affected tests and docs to make public guard intent explicit.

## Verification
- `go test -count=1 ./internal/compiler ./internal/appgen ./internal/source ./internal/securitytext ./runtime ./runtime/app ./runtime/security`
- `go test -count=1 ./internal/buildgen ./internal/lang ./internal/lsp ./internal/compiler ./internal/appgen`
- `go build ./cmd/gowdk`
- `go run ./cmd/gowdk build --out /tmp/gowdk-issue-391-build examples/pages/*.gwdk`
- `go test ./...`
- `scripts/test-go-modules.sh`