### PR TITLE
Share SSR replacement metadata types

### DIFF
--- a/internal/appgen/auto_routes.go
+++ b/internal/appgen/auto_routes.go
@@ -179,31 +179,9 @@ func ssrRoutes(artifacts []buildgen.SSRArtifact) []SSRRoute {
 			HasLoad:          artifact.HasLoad,
 			LoadBinding:      artifact.LoadBinding,
 			HTML:             artifact.HTML,
-			Replacements:     ssrReplacements(artifact.Replacements),
-			LoadReplacements: ssrLoadReplacements(artifact.LoadReplacements),
+			Replacements:     append([]SSRReplacement(nil), artifact.Replacements...),
+			LoadReplacements: append([]SSRLoadReplacement(nil), artifact.LoadReplacements...),
 		})
 	}
 	return routes
-}
-
-func ssrReplacements(replacements []buildgen.SSRReplacement) []SSRReplacement {
-	out := make([]SSRReplacement, 0, len(replacements))
-	for _, replacement := range replacements {
-		out = append(out, SSRReplacement{
-			Param:       replacement.Param,
-			Placeholder: replacement.Placeholder,
-		})
-	}
-	return out
-}
-
-func ssrLoadReplacements(replacements []buildgen.SSRLoadReplacement) []SSRLoadReplacement {
-	out := make([]SSRLoadReplacement, 0, len(replacements))
-	for _, replacement := range replacements {
-		out = append(out, SSRLoadReplacement{
-			Path:        replacement.Path,
-			Placeholder: replacement.Placeholder,
-		})
-	}
-	return out
 }

--- a/internal/appgen/types.go
+++ b/internal/appgen/types.go
@@ -113,15 +113,6 @@ type SSRRoute struct {
 	LoadReplacements []SSRLoadReplacement
 }
 
-// SSRReplacement maps a generated placeholder back to a request route param.
-type SSRReplacement struct {
-	Param       string
-	Placeholder string
-}
+type SSRReplacement = source.SSRReplacement
 
-// SSRLoadReplacement maps a generated placeholder back to a request-time load
-// field path.
-type SSRLoadReplacement struct {
-	Path        string
-	Placeholder string
-}
+type SSRLoadReplacement = source.SSRLoadReplacement

--- a/internal/buildgen/ssr.go
+++ b/internal/buildgen/ssr.go
@@ -31,15 +31,9 @@ type SSRArtifact struct {
 	LoadReplacements []SSRLoadReplacement
 }
 
-type SSRReplacement struct {
-	Param       string
-	Placeholder string
-}
+type SSRReplacement = source.SSRReplacement
 
-type SSRLoadReplacement struct {
-	Path        string
-	Placeholder string
-}
+type SSRLoadReplacement = source.SSRLoadReplacement
 
 func SSRArtifacts(config gowdk.Config, sources gwdkanalysis.Sources, outputDir string) ([]SSRArtifact, error) {
 	return SSRArtifactsFromIR(config, gwdkanalysis.BuildProgram(config, sources), outputDir)

--- a/internal/source/source.go
+++ b/internal/source/source.go
@@ -115,6 +115,19 @@ type RouteParam struct {
 	Span SourceSpan
 }
 
+// SSRReplacement maps a generated placeholder back to a request route param.
+type SSRReplacement struct {
+	Param       string
+	Placeholder string
+}
+
+// SSRLoadReplacement maps a generated placeholder back to a request-time load
+// field path.
+type SSRLoadReplacement struct {
+	Path        string
+	Placeholder string
+}
+
 // InlineScript records browser module code declared directly inside a .gwdk
 // source file. Path-based script declarations should remain preferred.
 type InlineScript struct {


### PR DESCRIPTION
## Summary
- Refs #391.
- Hoist SSR replacement metadata value types to `internal/source`.
- Alias buildgen/appgen SSR replacement types to the shared definitions.
- Remove appgen copy-converter functions and copy shared slices directly.

## Verification
- `go test -count=1 ./internal/source ./internal/buildgen ./internal/appgen`
- `go build ./cmd/gowdk`
- `go test ./...`
- `scripts/test-go-modules.sh`