### PR TITLE
refactor(buildgen): add virtual memory build output base

### DIFF
--- a/docs/compiler/build-report.md
+++ b/docs/compiler/build-report.md
@@ -5,6 +5,9 @@ builds write it to `gowdk-build-report.json` at the selected output root;
 in-memory builds return the same file in `MemoryResult.Files`; failed builds
 wrap the original error in `buildgen.BuildError` so callers can inspect the
 partial report while preserving the original error text.
+Callers without a real output root can use `BuildMemoryWithOptions` or
+`BuildMemoryFromIRWithOptions`; an empty `OutputBase` uses `.` for deterministic
+relative path metadata and does not create files or report directories.
 
 The report is mandatory for compiler-facing build APIs. It is deterministic:
 it does not include timestamps or durations, so unchanged builds can still skip

--- a/internal/buildgen/build.go
+++ b/internal/buildgen/build.go
@@ -179,16 +179,36 @@ func finalizeAssetArtifact(artifact *plannedAssetArtifact) {
 
 func BuildMemory(config gowdk.Config, sources gwdkanalysis.Sources, outputDir string) (MemoryResult, error) {
 	ir := gwdkanalysis.BuildProgram(config, sources)
-	return buildMemoryFromIR(config, ir, compiler.BackendBindingsFromIR(ir), outputDir)
+	return buildMemoryFromIR(config, ir, compiler.BackendBindingsFromIR(ir), outputDir, true)
+}
+
+// BuildMemoryWithOptions plans SPA build artifacts without requiring a real
+// output directory. Empty MemoryBuildOptions.OutputBase defaults to ".".
+func BuildMemoryWithOptions(config gowdk.Config, sources gwdkanalysis.Sources, options MemoryBuildOptions) (MemoryResult, error) {
+	ir := gwdkanalysis.BuildProgram(config, sources)
+	return buildMemoryFromIR(config, ir, compiler.BackendBindingsFromIR(ir), memoryOutputBase(options), false)
 }
 
 // BuildMemoryFromIR plans SPA build artifacts from normalized compiler IR
 // without writing them to disk.
 func BuildMemoryFromIR(config gowdk.Config, ir gwdkir.Program, outputDir string) (MemoryResult, error) {
-	return buildMemoryFromIR(config, ir, compiler.BackendBindingsFromIR(ir), outputDir)
+	return buildMemoryFromIR(config, ir, compiler.BackendBindingsFromIR(ir), outputDir, true)
 }
 
-func buildMemoryFromIR(config gowdk.Config, ir gwdkir.Program, backendBindings []source.BackendBinding, outputDir string) (MemoryResult, error) {
+// BuildMemoryFromIRWithOptions is BuildMemoryWithOptions for orchestrators
+// that already have normalized compiler IR.
+func BuildMemoryFromIRWithOptions(config gowdk.Config, ir gwdkir.Program, options MemoryBuildOptions) (MemoryResult, error) {
+	return buildMemoryFromIR(config, ir, compiler.BackendBindingsFromIR(ir), memoryOutputBase(options), false)
+}
+
+func memoryOutputBase(options MemoryBuildOptions) string {
+	if strings.TrimSpace(options.OutputBase) == "" {
+		return "."
+	}
+	return options.OutputBase
+}
+
+func buildMemoryFromIR(config gowdk.Config, ir gwdkir.Program, backendBindings []source.BackendBinding, outputDir string, requireOutputDir bool) (MemoryResult, error) {
 	reporter := newBuildReporter("memory", outputDir)
 	reporter.info("start", "build_started", "in-memory SPA build started", BuildEvent{
 		Data: map[string]string{
@@ -197,7 +217,7 @@ func buildMemoryFromIR(config gowdk.Config, ir gwdkir.Program, backendBindings [
 			"layouts":    fmt.Sprint(len(ir.Layouts)),
 		},
 	})
-	if strings.TrimSpace(outputDir) == "" {
+	if requireOutputDir && strings.TrimSpace(outputDir) == "" {
 		return MemoryResult{}, reporter.fail("validate", fmt.Errorf("build output directory is required"))
 	}
 	if err := compiler.ValidateProgram(config, ir); err != nil {
@@ -235,7 +255,7 @@ func buildMemoryFromIR(config gowdk.Config, ir gwdkir.Program, backendBindings [
 		},
 		Files: map[string][]byte{},
 	}
-	manifestPath, err := securityManifestPath(outputDir)
+	manifestPath, err := memorySecurityManifestPath(outputDir, requireOutputDir)
 	if err != nil {
 		return MemoryResult{}, reporter.fail("manifest", err)
 	}

--- a/internal/buildgen/build_report_test.go
+++ b/internal/buildgen/build_report_test.go
@@ -313,6 +313,100 @@ func TestBuildMemoryReturnsSPAArtifactsWithoutWriting(t *testing.T) {
 	}
 }
 
+func TestBuildMemoryRejectsEmptyOutputDir(t *testing.T) {
+	app := gwdkanalysis.Sources{Pages: []gwdkir.Page{{
+		ID:    "home",
+		Route: "/",
+		Blocks: gwdkir.Blocks{
+			View:     true,
+			ViewBody: `<main>Home</main>`,
+		},
+	}}}
+
+	_, err := BuildMemory(gowdk.Config{}, app, "")
+	if err == nil || !strings.Contains(err.Error(), "build output directory is required") {
+		t.Fatalf("expected empty outputDir rejection, got %v", err)
+	}
+}
+
+func TestBuildMemoryWithOptionsDoesNotRequireOutputDir(t *testing.T) {
+	cwd := t.TempDir()
+	t.Chdir(cwd)
+	app := gwdkanalysis.Sources{Pages: []gwdkir.Page{{
+		ID:    "home",
+		Route: "/",
+		Blocks: gwdkir.Blocks{
+			View:     true,
+			ViewBody: `<main><h1>Memory only</h1></main>`,
+		},
+	}}}
+
+	result, err := BuildMemoryWithOptions(gowdk.Config{}, app, MemoryBuildOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.RouteManifestPath != routeManifestFile {
+		t.Fatalf("expected relative route manifest path, got %q", result.RouteManifestPath)
+	}
+	if result.AssetManifestPath != assetManifestFile {
+		t.Fatalf("expected relative asset manifest path, got %q", result.AssetManifestPath)
+	}
+	if result.OpenAPIPath != openAPIFile {
+		t.Fatalf("expected relative OpenAPI path, got %q", result.OpenAPIPath)
+	}
+	if result.BuildReportPath != buildReportFile {
+		t.Fatalf("expected relative build report path, got %q", result.BuildReportPath)
+	}
+	expectedSecurityManifestPath := filepath.Join(".gowdk", "reports", "root", securityManifestFile)
+	if result.SecurityManifestPath != expectedSecurityManifestPath {
+		t.Fatalf("expected virtual security manifest path %q, got %q", expectedSecurityManifestPath, result.SecurityManifestPath)
+	}
+	if result.Report.OutputDir != "." {
+		t.Fatalf("expected virtual output base '.', got %q", result.Report.OutputDir)
+	}
+	if result.Artifacts[0].Path != "index.html" {
+		t.Fatalf("expected virtual page artifact path, got %q", result.Artifacts[0].Path)
+	}
+	if !strings.Contains(string(result.Files["index.html"]), "Memory only") {
+		t.Fatalf("expected rendered HTML in memory result: %s", result.Files["index.html"])
+	}
+	if _, err := os.Stat(filepath.Join(cwd, "index.html")); !os.IsNotExist(err) {
+		t.Fatalf("memory build with virtual output base should not write page artifact, stat error = %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(cwd, ".gowdk")); !os.IsNotExist(err) {
+		t.Fatalf("memory build with virtual output base should not write reports, stat error = %v", err)
+	}
+}
+
+func TestBuildMemoryWithOptionsUsesVirtualOutputBase(t *testing.T) {
+	app := gwdkanalysis.Sources{Pages: []gwdkir.Page{{
+		ID:    "home",
+		Route: "/",
+		Blocks: gwdkir.Blocks{
+			View:     true,
+			ViewBody: `<main>Home</main>`,
+		},
+	}}}
+
+	result, err := BuildMemoryWithOptions(gowdk.Config{}, app, MemoryBuildOptions{OutputBase: filepath.Join("virtual", "site")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.RouteManifestPath != filepath.Join("virtual", "site", routeManifestFile) {
+		t.Fatalf("expected route manifest under virtual base, got %q", result.RouteManifestPath)
+	}
+	if result.Artifacts[0].Path != filepath.Join("virtual", "site", "index.html") {
+		t.Fatalf("expected page artifact under virtual base, got %q", result.Artifacts[0].Path)
+	}
+	expectedSecurityManifestPath := filepath.Join("virtual", ".gowdk", "reports", "site", securityManifestFile)
+	if result.SecurityManifestPath != expectedSecurityManifestPath {
+		t.Fatalf("expected virtual security manifest path %q, got %q", expectedSecurityManifestPath, result.SecurityManifestPath)
+	}
+	if _, ok := result.Files["index.html"]; !ok {
+		t.Fatalf("expected served file key to remain relative to the virtual base: %#v", result.Files)
+	}
+}
+
 func TestBuildRemovesStaleServedSecurityManifest(t *testing.T) {
 	outputDir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(outputDir, securityManifestFile), []byte(`{"stale":true}`), 0o644); err != nil {

--- a/internal/buildgen/ir_test.go
+++ b/internal/buildgen/ir_test.go
@@ -118,3 +118,31 @@ func TestBuildMemoryFromIRCollectsArtifacts(t *testing.T) {
 		t.Fatalf("expected generated page content, got:\n%s", result.Files["index.html"])
 	}
 }
+
+func TestBuildMemoryFromIRWithOptionsDoesNotRequireOutputDir(t *testing.T) {
+	config := gowdk.Config{}
+	app := gwdkanalysis.Sources{Pages: []gwdkir.Page{{
+		Source:  "pages/home.page.gwdk",
+		Package: "pages",
+		ID:      "home",
+		Route:   "/",
+		Blocks: gwdkir.Blocks{
+			View:     true,
+			ViewBody: `<main>Home</main>`,
+		},
+	}}}
+
+	result, err := BuildMemoryFromIRWithOptions(config, gwdkanalysis.BuildProgram(config, app), MemoryBuildOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Report.OutputDir != "." {
+		t.Fatalf("expected virtual output base '.', got %q", result.Report.OutputDir)
+	}
+	if result.RouteManifestPath != routeManifestFile {
+		t.Fatalf("expected relative route manifest path, got %q", result.RouteManifestPath)
+	}
+	if !strings.Contains(string(result.Files["index.html"]), "<main>Home</main>") {
+		t.Fatalf("expected generated page content, got:\n%s", result.Files["index.html"])
+	}
+}

--- a/internal/buildgen/security_manifest.go
+++ b/internal/buildgen/security_manifest.go
@@ -50,6 +50,18 @@ func securityManifestPath(outputDir string) (string, error) {
 	return filepath.Join(filepath.Dir(cleanOutput), ".gowdk", "reports", outputName, securityManifestFile), nil
 }
 
+func memorySecurityManifestPath(outputBase string, diskOutputPath bool) (string, error) {
+	if diskOutputPath {
+		return securityManifestPath(outputBase)
+	}
+	cleanOutput := filepath.Clean(outputBase)
+	outputName := filepath.Base(cleanOutput)
+	if outputName == "" || outputName == "." || outputName == string(filepath.Separator) {
+		outputName = "root"
+	}
+	return filepath.Join(filepath.Dir(cleanOutput), ".gowdk", "reports", outputName, securityManifestFile), nil
+}
+
 func removeServedSecurityManifest(outputDir string) error {
 	servedPath := filepath.Join(outputDir, securityManifestFile)
 	if err := os.Remove(servedPath); err != nil && !os.IsNotExist(err) {

--- a/internal/buildgen/types.go
+++ b/internal/buildgen/types.go
@@ -47,6 +47,13 @@ type MemoryResult struct {
 	Files map[string][]byte
 }
 
+// MemoryBuildOptions controls path metadata for in-memory builds.
+type MemoryBuildOptions struct {
+	// OutputBase is a virtual output root used for artifact path metadata.
+	// Empty defaults to "." and never requires a real directory on disk.
+	OutputBase string
+}
+
 type plannedArtifact struct {
 	Artifact
 	contents []byte


### PR DESCRIPTION
## Summary

- Adds `MemoryBuildOptions` plus source and IR memory-build entrypoints that can use a virtual output base instead of requiring a real output directory.
- Keeps existing `BuildMemory` and `BuildMemoryFromIR` strict about empty `outputDir` to preserve current callers.
- Documents the option-based memory-build path and covers default/custom virtual metadata with regression tests.

## Issue Closure

Related: #391

## Verification

- [x] I ran the relevant tests, lint, and build commands.
  - `go test ./internal/buildgen`
  - `git diff --check`
- [x] I ran `scripts/test-go-modules.sh` when Go code or compiler behavior changed.
  - `scripts/test-go-modules.sh`
- [x] I ran `go build ./cmd/gowdk` when CLI, compiler, runtime, addon, or release behavior changed.
  - `go build ./cmd/gowdk`
- [ ] I ran `node --check editors/vscode/extension.js` when editor files changed.
- [x] I updated docs for behavior, setup, or architecture changes.
- [x] I added or updated tests for changed behavior.
- [x] I considered security-sensitive surfaces such as auth, CSRF, redirects,
  request-time handlers, logs, diagnostics, embedded assets, editor commands,
  WASM, contracts, and realtime behavior.

## LLM Assistance

- LLM session summary: Added virtual output-base support for in-memory build APIs, preserving legacy strict output-dir behavior and documenting the new option path.
- Human-reviewed assumptions: This is a partial #391 cleanup and should not close the tracking issue by itself.
- Follow-up work: Continue the remaining #391 cleanup items in separate focused PRs.
