### PR TITLE
refactor(compiler): share diagnostic severity type

### DIFF
--- a/internal/compiler/backend_binding_diagnostics.go
+++ b/internal/compiler/backend_binding_diagnostics.go
@@ -36,7 +36,7 @@ func BackendBindingDiagnostics(bindings []source.BackendBinding) []ValidationErr
 			diagnostics = append(diagnostics, backendBindingDiagnostic("unexported_backend_handler", binding))
 		}
 	}
-	return diagnostics
+	return normalizeValidationErrors(diagnostics)
 }
 
 func backendBindingDiagnostic(code string, binding source.BackendBinding) ValidationError {

--- a/internal/compiler/backend_binding_policy.go
+++ b/internal/compiler/backend_binding_policy.go
@@ -39,7 +39,7 @@ func ValidateBackendBindingPolicyIR(config gowdk.Config, ir gwdkir.Program) erro
 	if len(diagnostics) == 0 {
 		return nil
 	}
-	return ValidationErrors(diagnostics)
+	return normalizeValidationErrors(diagnostics)
 }
 
 func programDeclaresBackendEndpoints(ir gwdkir.Program) bool {

--- a/internal/compiler/go_endpoints.go
+++ b/internal/compiler/go_endpoints.go
@@ -32,7 +32,7 @@ func DiscoverGoEndpoints(ir *gwdkir.Program) error {
 		diagnostics = append(diagnostics, found...)
 	}
 	if len(diagnostics) > 0 {
-		return ValidationErrors(diagnostics)
+		return normalizeValidationErrors(diagnostics)
 	}
 	sort.Slice(endpoints, func(i, j int) bool {
 		if endpoints[i].Source == endpoints[j].Source {

--- a/internal/compiler/validate.go
+++ b/internal/compiler/validate.go
@@ -4,18 +4,19 @@ import (
 	"fmt"
 
 	"github.com/cssbruno/gowdk"
+	"github.com/cssbruno/gowdk/internal/diagnostics"
 	"github.com/cssbruno/gowdk/internal/gwdkir"
 	"github.com/cssbruno/gowdk/internal/source"
 )
 
 // Severity classifies a diagnostic as a hard error or a non-fatal warning.
-type Severity int
+type Severity = diagnostics.Severity
 
 const (
 	// SeverityError is the default: it fails the build.
-	SeverityError Severity = iota
+	SeverityError = diagnostics.SeverityError
 	// SeverityWarning is surfaced to the author but does not fail the build.
-	SeverityWarning
+	SeverityWarning = diagnostics.SeverityWarning
 )
 
 type ValidationError struct {
@@ -78,7 +79,7 @@ func asError(report ValidationErrors) error {
 
 func validateProgram(config gowdk.Config, ir gwdkir.Program, crossFile bool) ValidationErrors {
 	if err := gwdkir.CheckInvariants(ir); err != nil {
-		return ValidationErrors{{Message: fmt.Sprintf("internal compiler error: %v", err)}}
+		return normalizeValidationErrors([]ValidationError{{Message: fmt.Sprintf("internal compiler error: %v", err)}})
 	}
 	var diagnostics ValidationErrors
 	diagnostics = append(diagnostics, validateIRDiagnostics(ir.Diagnostics)...)
@@ -106,7 +107,7 @@ func validateProgram(config gowdk.Config, ir gwdkir.Program, crossFile bool) Val
 	for _, page := range ir.Pages {
 		diagnostics = append(diagnostics, ValidatePage(config, page)...)
 	}
-	return diagnostics
+	return normalizeValidationErrors(diagnostics)
 }
 
 func validateIRDiagnostics(items []gwdkir.Diagnostic) []ValidationError {

--- a/internal/compiler/validate_contract_refs.go
+++ b/internal/compiler/validate_contract_refs.go
@@ -27,7 +27,7 @@ func ValidateContractReferences(refs []gwdkir.ContractReference) error {
 	if len(diagnostics) == 0 {
 		return nil
 	}
-	return ValidationErrors(diagnostics)
+	return normalizeValidationErrors(diagnostics)
 }
 
 func contractReferenceAllowsWeb(ref gwdkir.ContractReference) bool {

--- a/internal/compiler/validate_errors.go
+++ b/internal/compiler/validate_errors.go
@@ -2,6 +2,8 @@ package compiler
 
 import (
 	"strings"
+
+	"github.com/cssbruno/gowdk/internal/diagnostics"
 )
 
 type ValidationErrors []ValidationError
@@ -34,4 +36,26 @@ func (errs ValidationErrors) Warnings() ValidationErrors {
 		}
 	}
 	return out
+}
+
+func normalizeValidationErrors(errs []ValidationError) ValidationErrors {
+	normalized := make(ValidationErrors, len(errs))
+	copy(normalized, errs)
+	for index := range normalized {
+		normalized[index].normalizeSeverity()
+	}
+	return normalized
+}
+
+func (err *ValidationError) normalizeSeverity() {
+	if err.Severity != "" {
+		return
+	}
+	if err.Code != "" {
+		if severity, ok := diagnostics.DefaultSeverity(err.Code); ok {
+			err.Severity = severity
+			return
+		}
+	}
+	err.Severity = SeverityError
 }

--- a/internal/compiler/validate_errors_test.go
+++ b/internal/compiler/validate_errors_test.go
@@ -1,0 +1,33 @@
+package compiler
+
+import (
+	"testing"
+
+	"github.com/cssbruno/gowdk/internal/diagnostics"
+)
+
+func TestNormalizeValidationErrorsUsesRegistrySeverity(t *testing.T) {
+	errs := normalizeValidationErrors([]ValidationError{{Code: "missing_page_guard"}})
+	if len(errs) != 1 {
+		t.Fatalf("expected one diagnostic, got %d", len(errs))
+	}
+	if errs[0].Severity != diagnostics.SeverityWarning {
+		t.Fatalf("expected registry warning severity, got %q", errs[0].Severity)
+	}
+	if errs.HasErrors() {
+		t.Fatalf("warning-only diagnostics should not fail the build: %#v", errs)
+	}
+}
+
+func TestNormalizeValidationErrorsFailsClosedForUnknownCodes(t *testing.T) {
+	errs := normalizeValidationErrors([]ValidationError{{Code: "not_registered"}})
+	if len(errs) != 1 {
+		t.Fatalf("expected one diagnostic, got %d", len(errs))
+	}
+	if errs[0].Severity != SeverityError {
+		t.Fatalf("unknown diagnostic should default to error, got %q", errs[0].Severity)
+	}
+	if !errs.HasErrors() {
+		t.Fatalf("unknown diagnostic should fail the build")
+	}
+}

--- a/internal/compiler/validate_page.go
+++ b/internal/compiler/validate_page.go
@@ -200,7 +200,7 @@ func ValidatePage(config gowdk.Config, page gwdkir.Page) []ValidationError {
 	}
 	diagnostics = append(diagnostics, validatePageCSS(page)...)
 
-	return diagnostics
+	return normalizeValidationErrors(diagnostics)
 }
 
 func validatePageGuards(page gwdkir.Page) []ValidationError {


### PR DESCRIPTION
## Summary

- Replace the compiler-local severity enum with aliases to `internal/diagnostics.Severity`.
- Normalize compiler validation diagnostics at public compiler boundaries so omitted severities resolve from `diagnostics.DefaultSeverity(code)`, while unknown/internal diagnostics still fail closed as errors.
- Add focused tests for registry severity normalization and unknown-code fail-closed behavior.

## Issue Closure

Related: #391

## Verification

- [x] I ran the relevant tests, lint, and build commands.
  - `go test ./internal/compiler ./internal/diagnostics`
  - `go test ./internal/gwdkast ./internal/gwdkanalysis ./internal/gwdkir ./internal/diagnosticfix ./internal/buildgen ./internal/appgen ./internal/lsp`
  - `go test ./internal/compiler ./internal/diagnostics ./internal/diagnosticfix`
  - `go run ./cmd/gowdk inspect ir examples/pages/home.page.gwdk`
  - `git diff --check`
- [x] I ran `scripts/test-go-modules.sh` when Go code or compiler behavior changed.
- [x] I ran `go build ./cmd/gowdk` when CLI, compiler, runtime, addon, or release behavior changed.
- [ ] I ran `node --check editors/vscode/extension.js` when editor files changed.
  - Not applicable; no editor files changed.
- [ ] I updated docs for behavior, setup, or architecture changes.
  - Not applicable; public behavior is unchanged.
- [x] I added or updated tests for changed behavior.
- [x] I considered security-sensitive surfaces such as auth, CSRF, redirects, request-time handlers, logs, diagnostics, embedded assets, editor commands, WASM, contracts, and realtime behavior.

## LLM Assistance

- LLM session summary: Codex consolidated compiler validation severity onto the central diagnostics severity type and added normalization tests.
- Human-reviewed assumptions: This PR is internal compiler diagnostic plumbing only and should not close #391 by itself.
- Follow-up work: Continue remaining #391 cleanup slices in separate focused PRs.