### PR TITLE
[codex] harden auth addon

### DIFF
--- a/addons/auth/auth.go
+++ b/addons/auth/auth.go
@@ -1,13 +1,13 @@
 // Package auth is the batteries-included GOWDK authentication addon. It enables
 // the auth feature and ships a working, dependency-free identity implementation:
-// PBKDF2 password hashing and signed-cookie sessions, all on the Go standard
-// library. It builds on the native RBAC guard machinery in runtime/auth, so
-// pages and routes protected with guard role:... / guard permission:... /
-// guard public resolve through a session-backed Provider.
+// PBKDF2 password hashing, a PasswordHasher replacement point, and signed-cookie
+// sessions, all on the Go standard library. It builds on the native RBAC guard
+// machinery in runtime/auth, so pages and routes protected with guard role:... /
+// guard permission:... / guard public resolve through a session-backed Provider.
 //
 // GOWDK still does not own your user store. Look users up however you like, then
-// hand the addon a Principal to issue a session for; the addon owns hashing,
-// session signing, and request-time principal resolution.
+// hand the addon a Principal to issue a session for; the addon owns default
+// hashing helpers, session signing, and request-time principal resolution.
 package auth
 
 import (

--- a/addons/auth/auth.go
+++ b/addons/auth/auth.go
@@ -2,8 +2,9 @@
 // the auth feature and ships a working, dependency-free identity implementation:
 // PBKDF2 password hashing, a PasswordHasher replacement point, and signed-cookie
 // sessions, all on the Go standard library. It builds on the native RBAC guard
-// machinery in runtime/auth, so pages and routes protected with guard role:... /
-// guard permission:... / guard public resolve through a session-backed Provider.
+// machinery in runtime/auth. Pages and routes protected with guard role:... or
+// guard permission:... resolve through a session-backed Provider; guard public
+// remains intentionally unauthenticated.
 //
 // GOWDK still does not own your user store. Look users up however you like, then
 // hand the addon a Principal to issue a session for; the addon owns default

--- a/addons/auth/auth_test.go
+++ b/addons/auth/auth_test.go
@@ -1,8 +1,10 @@
 package auth
 
 import (
+	"encoding/hex"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -30,6 +32,53 @@ func TestHashPasswordRoundTrip(t *testing.T) {
 	}
 	if VerifyPassword("wrong password", encoded) {
 		t.Fatal("VerifyPassword accepted a wrong password")
+	}
+}
+
+func TestPBKDF2HasherWithCustomIterations(t *testing.T) {
+	hasher := PBKDF2Hasher{Iterations: 2}
+	encoded, err := hasher.HashPassword("same")
+	if err != nil {
+		t.Fatalf("HashPassword: %v", err)
+	}
+	if !strings.HasPrefix(encoded, "pbkdf2-sha256$2$") {
+		t.Fatalf("expected encoded iterations, got %q", encoded)
+	}
+	if !hasher.VerifyPassword("same", encoded) {
+		t.Fatal("VerifyPassword rejected the correct password")
+	}
+}
+
+func TestPBKDF2KnownVector(t *testing.T) {
+	key, err := pbkdf2SHA256("password", []byte("salt"), 1, 32)
+	if err != nil {
+		t.Fatalf("pbkdf2SHA256: %v", err)
+	}
+	if got, want := hex.EncodeToString(key), "120fb6cffcf8b32c43e7225256c4f837a86548c92ccc35480805987cb70be17b"; got != want {
+		t.Fatalf("unexpected PBKDF2 key: got %s want %s", got, want)
+	}
+}
+
+type fixedPasswordHasher struct {
+	hash string
+}
+
+func (hasher fixedPasswordHasher) HashPassword(string) (string, error) {
+	return hasher.hash, nil
+}
+
+func (hasher fixedPasswordHasher) VerifyPassword(_, encoded string) bool {
+	return encoded == hasher.hash
+}
+
+func TestCustomPasswordHasherSatisfiesInterface(t *testing.T) {
+	var hasher PasswordHasher = fixedPasswordHasher{hash: "custom"}
+	encoded, err := hasher.HashPassword("ignored")
+	if err != nil {
+		t.Fatalf("HashPassword: %v", err)
+	}
+	if !hasher.VerifyPassword("ignored", encoded) {
+		t.Fatal("custom hasher did not verify its encoded hash")
 	}
 }
 
@@ -69,7 +118,7 @@ func fixedClock(at time.Time) func() time.Time {
 func newTestSessions(t *testing.T, now time.Time) *Sessions {
 	t.Helper()
 	sessions, err := New(Options{
-		Secret:   []byte("test-secret-value"),
+		Secret:   []byte(strings.Repeat("s", MinSessionSecretBytes)),
 		Insecure: true,
 		Now:      fixedClock(now),
 	})
@@ -151,7 +200,7 @@ func TestSessionRejectsForeignSecret(t *testing.T) {
 		t.Fatalf("Issue: %v", err)
 	}
 
-	other, err := New(Options{Secret: []byte("a-different-secret"), Insecure: true, Now: fixedClock(now)})
+	other, err := New(Options{Secret: []byte(strings.Repeat("x", MinSessionSecretBytes)), Insecure: true, Now: fixedClock(now)})
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
@@ -206,12 +255,59 @@ func TestSessionClearLogsOut(t *testing.T) {
 	}
 }
 
+func TestSessionCookieHelpers(t *testing.T) {
+	sessions := newTestSessions(t, time.Unix(1_700_000_000, 0))
+	cookie, err := sessions.Cookie(Principal{ID: "user-1"})
+	if err != nil {
+		t.Fatalf("Cookie: %v", err)
+	}
+	if cookie.Name != DefaultSessionCookie || cookie.Value == "" || !cookie.HttpOnly {
+		t.Fatalf("unexpected issued cookie: %#v", cookie)
+	}
+	clear := sessions.ClearCookie()
+	if clear.Name != DefaultSessionCookie || clear.MaxAge >= 0 {
+		t.Fatalf("unexpected clear cookie: %#v", clear)
+	}
+}
+
 func TestNewRequiresSecret(t *testing.T) {
 	if _, err := New(Options{}); err == nil {
 		t.Fatal("expected New to fail without a secret")
 	}
 }
 
+func TestNewRejectsUnsafeDirectSecret(t *testing.T) {
+	if _, err := New(Options{Secret: []byte("short")}); err == nil || !strings.Contains(err.Error(), "at least 32 bytes") {
+		t.Fatalf("expected short-secret error, got %v", err)
+	}
+}
+
+func TestNewReadsSecretFromEnv(t *testing.T) {
+	t.Setenv("GOWDK_TEST_AUTH_SECRET", strings.Repeat("s", MinSessionSecretBytes))
+	sessions, err := New(Options{SecretEnv: "GOWDK_TEST_AUTH_SECRET", Insecure: true})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if sessions == nil {
+		t.Fatal("expected sessions")
+	}
+}
+
+func TestNewReportsEnvNameWithoutLeakingSecret(t *testing.T) {
+	t.Setenv("GOWDK_TEST_AUTH_SECRET", "too-short-secret-value")
+	_, err := New(Options{SecretEnv: "GOWDK_TEST_AUTH_SECRET"})
+	if err == nil {
+		t.Fatal("expected short env secret error")
+	}
+	if !strings.Contains(err.Error(), "GOWDK_TEST_AUTH_SECRET") {
+		t.Fatalf("expected env name in error, got %v", err)
+	}
+	if strings.Contains(err.Error(), "too-short-secret-value") {
+		t.Fatalf("secret value leaked in error: %v", err)
+	}
+}
+
 // Sessions must satisfy the Provider interface so it can be registered with the
 // generated RegisterAuthProvider hook.
 var _ Provider = (*Sessions)(nil)
+var _ PasswordHasher = PBKDF2Hasher{}

--- a/addons/auth/auth_test.go
+++ b/addons/auth/auth_test.go
@@ -1,9 +1,11 @@
 package auth
 
 import (
+	"encoding/base64"
 	"encoding/hex"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -36,16 +38,25 @@ func TestHashPasswordRoundTrip(t *testing.T) {
 }
 
 func TestPBKDF2HasherWithCustomIterations(t *testing.T) {
-	hasher := PBKDF2Hasher{Iterations: 2}
+	iterations := DefaultIterations + 1
+	hasher := PBKDF2Hasher{Iterations: iterations}
 	encoded, err := hasher.HashPassword("same")
 	if err != nil {
 		t.Fatalf("HashPassword: %v", err)
 	}
-	if !strings.HasPrefix(encoded, "pbkdf2-sha256$2$") {
+	if !strings.HasPrefix(encoded, "pbkdf2-sha256$"+strconv.Itoa(iterations)+"$") {
 		t.Fatalf("expected encoded iterations, got %q", encoded)
 	}
 	if !hasher.VerifyPassword("same", encoded) {
 		t.Fatal("VerifyPassword rejected the correct password")
+	}
+}
+
+func TestHashPasswordWithIterationsRejectsInvalidIterations(t *testing.T) {
+	for _, iterations := range []int{0, -1, MinIterations - 1} {
+		if _, err := HashPasswordWithIterations("same", iterations); err == nil {
+			t.Fatalf("HashPasswordWithIterations accepted iterations=%d", iterations)
+		}
 	}
 }
 
@@ -97,12 +108,19 @@ func TestHashPasswordUsesFreshSalt(t *testing.T) {
 }
 
 func TestVerifyPasswordRejectsMalformedHash(t *testing.T) {
+	canonicalSalt := base64.RawStdEncoding.EncodeToString([]byte(strings.Repeat("s", pbkdf2SaltLength)))
+	canonicalKey := base64.RawStdEncoding.EncodeToString([]byte(strings.Repeat("k", pbkdf2KeyLength)))
+	shortSalt := base64.RawStdEncoding.EncodeToString([]byte("s"))
+	shortKey := base64.RawStdEncoding.EncodeToString([]byte("k"))
 	for _, encoded := range []string{
 		"",
 		"plain",
 		"pbkdf2-sha256$notanumber$c2FsdA$a2V5",
 		"bcrypt$10$salt$key",
 		"pbkdf2-sha256$600000$$a2V5",
+		"pbkdf2-sha256$1$" + canonicalSalt + "$" + canonicalKey,
+		"pbkdf2-sha256$600000$" + shortSalt + "$" + canonicalKey,
+		"pbkdf2-sha256$600000$" + canonicalSalt + "$" + shortKey,
 	} {
 		if VerifyPassword("anything", encoded) {
 			t.Fatalf("VerifyPassword accepted malformed hash %q", encoded)
@@ -219,8 +237,15 @@ func TestSessionRejectsForeignSecret(t *testing.T) {
 
 func TestSessionExpires(t *testing.T) {
 	issuedAt := time.Unix(1_700_000_000, 0)
-	sessions := newTestSessions(t, issuedAt)
-	sessions.ttl = time.Hour
+	sessions, err := New(Options{
+		Secret:   []byte(strings.Repeat("s", MinSessionSecretBytes)),
+		TTL:      time.Hour,
+		Insecure: true,
+		Now:      fixedClock(issuedAt),
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
 
 	recorder := httptest.NewRecorder()
 	if err := sessions.Issue(recorder, Principal{ID: "user-1"}); err != nil {
@@ -242,6 +267,36 @@ func TestSessionExpires(t *testing.T) {
 	}
 }
 
+func TestSessionOneSecondTTLDoesNotExpireEarlyFromSubsecondIssueTime(t *testing.T) {
+	issuedAt := time.Unix(1_700_000_000, int64(900*time.Millisecond))
+	sessions, err := New(Options{
+		Secret:   []byte(strings.Repeat("s", MinSessionSecretBytes)),
+		TTL:      time.Second,
+		Insecure: true,
+		Now:      fixedClock(issuedAt),
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	recorder := httptest.NewRecorder()
+	if err := sessions.Issue(recorder, Principal{ID: "user-1"}); err != nil {
+		t.Fatalf("Issue: %v", err)
+	}
+	request := httptest.NewRequest(http.MethodGet, "/", nil)
+	for _, cookie := range recorder.Result().Cookies() {
+		request.AddCookie(cookie)
+	}
+
+	sessions.now = fixedClock(issuedAt.Add(200 * time.Millisecond))
+	principal, err := sessions.Principal(request)
+	if err != nil {
+		t.Fatalf("Principal: %v", err)
+	}
+	if principal == nil {
+		t.Fatal("expected one-second session to remain valid after 200ms")
+	}
+}
+
 func TestSessionClearLogsOut(t *testing.T) {
 	sessions := newTestSessions(t, time.Unix(1_700_000_000, 0))
 	recorder := httptest.NewRecorder()
@@ -252,6 +307,42 @@ func TestSessionClearLogsOut(t *testing.T) {
 	}
 	if cookies[0].MaxAge >= 0 {
 		t.Fatalf("expected a negative MaxAge to clear the cookie, got %d", cookies[0].MaxAge)
+	}
+}
+
+func TestSessionCookieDefaultsToSecureAttributes(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	sessions, err := New(Options{
+		Secret: []byte(strings.Repeat("s", MinSessionSecretBytes)),
+		Now:    fixedClock(now),
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	cookie, err := sessions.Cookie(Principal{ID: "user-1"})
+	if err != nil {
+		t.Fatalf("Cookie: %v", err)
+	}
+	if cookie.Name != DefaultSessionCookie || cookie.Path != "/" || !cookie.HttpOnly || !cookie.Secure || cookie.SameSite != http.SameSiteLaxMode {
+		t.Fatalf("unexpected default cookie attributes: %#v", cookie)
+	}
+	if !cookie.Expires.Equal(now.Add(DefaultSessionTTL)) {
+		t.Fatalf("cookie expires at %v, want %v", cookie.Expires, now.Add(DefaultSessionTTL))
+	}
+	clear := sessions.ClearCookie()
+	if clear.Name != DefaultSessionCookie || clear.Path != "/" || !clear.HttpOnly || !clear.Secure || clear.SameSite != http.SameSiteLaxMode {
+		t.Fatalf("unexpected default clear-cookie attributes: %#v", clear)
+	}
+}
+
+func TestSessionCookieAllowsLocalInsecure(t *testing.T) {
+	sessions := newTestSessions(t, time.Unix(1_700_000_000, 0))
+	cookie, err := sessions.Cookie(Principal{ID: "user-1"})
+	if err != nil {
+		t.Fatalf("Cookie: %v", err)
+	}
+	if cookie.Secure {
+		t.Fatal("expected Insecure option to disable the Secure cookie flag")
 	}
 }
 
@@ -270,9 +361,90 @@ func TestSessionCookieHelpers(t *testing.T) {
 	}
 }
 
+func TestSessionCustomCookieNameRoundTrip(t *testing.T) {
+	sessions, err := New(Options{
+		Secret:     []byte(strings.Repeat("s", MinSessionSecretBytes)),
+		CookieName: "custom_session",
+		Insecure:   true,
+		Now:        fixedClock(time.Unix(1_700_000_000, 0)),
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	cookie, err := sessions.Cookie(Principal{ID: "user-1"})
+	if err != nil {
+		t.Fatalf("Cookie: %v", err)
+	}
+	if cookie.Name != "custom_session" {
+		t.Fatalf("cookie.Name = %q, want custom_session", cookie.Name)
+	}
+	request := httptest.NewRequest(http.MethodGet, "/", nil)
+	request.AddCookie(&cookie)
+	principal, err := sessions.Principal(request)
+	if err != nil {
+		t.Fatalf("Principal: %v", err)
+	}
+	if principal == nil || principal.ID != "user-1" {
+		t.Fatalf("resolved principal = %+v", principal)
+	}
+}
+
+func TestSessionCookieRejectsEmptyPrincipalID(t *testing.T) {
+	sessions := newTestSessions(t, time.Unix(1_700_000_000, 0))
+	for _, principal := range []Principal{
+		{},
+		{ID: " ", Roles: []string{"admin"}},
+	} {
+		if _, err := sessions.Cookie(principal); err == nil {
+			t.Fatalf("Cookie accepted principal with ID %q", principal.ID)
+		}
+	}
+}
+
 func TestNewRequiresSecret(t *testing.T) {
 	if _, err := New(Options{}); err == nil {
 		t.Fatal("expected New to fail without a secret")
+	}
+}
+
+func TestNewRejectsBothSecretAndSecretEnv(t *testing.T) {
+	t.Setenv("GOWDK_TEST_AUTH_SECRET", strings.Repeat("e", MinSessionSecretBytes))
+	_, err := New(Options{
+		Secret:    []byte(strings.Repeat("s", MinSessionSecretBytes)),
+		SecretEnv: "GOWDK_TEST_AUTH_SECRET",
+	})
+	if err == nil || !strings.Contains(err.Error(), "Secret or SecretEnv") {
+		t.Fatalf("expected mutually exclusive secret error, got %v", err)
+	}
+}
+
+func TestNewRejectsInvalidSessionTTL(t *testing.T) {
+	_, err := New(Options{
+		Secret: []byte(strings.Repeat("s", MinSessionSecretBytes)),
+		TTL:    -time.Second,
+	})
+	if err == nil || !strings.Contains(err.Error(), "ttl must be non-negative") {
+		t.Fatalf("expected negative TTL error, got %v", err)
+	}
+}
+
+func TestNewRejectsSubsecondSessionTTL(t *testing.T) {
+	_, err := New(Options{
+		Secret: []byte(strings.Repeat("s", MinSessionSecretBytes)),
+		TTL:    time.Nanosecond,
+	})
+	if err == nil || !strings.Contains(err.Error(), "ttl must be at least 1s") {
+		t.Fatalf("expected subsecond TTL error, got %v", err)
+	}
+}
+
+func TestNewRejectsInvalidCookieName(t *testing.T) {
+	_, err := New(Options{
+		Secret:     []byte(strings.Repeat("s", MinSessionSecretBytes)),
+		CookieName: "bad cookie",
+	})
+	if err == nil || !strings.Contains(err.Error(), "cookie name") {
+		t.Fatalf("expected invalid cookie name error, got %v", err)
 	}
 }
 
@@ -290,6 +462,38 @@ func TestNewReadsSecretFromEnv(t *testing.T) {
 	}
 	if sessions == nil {
 		t.Fatal("expected sessions")
+	}
+}
+
+func TestNewPreservesEnvSecretBytes(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	envSecret := " " + strings.Repeat("s", MinSessionSecretBytes) + " "
+	t.Setenv("GOWDK_TEST_AUTH_SECRET", envSecret)
+	issuer, err := New(Options{SecretEnv: "GOWDK_TEST_AUTH_SECRET", Insecure: true, Now: fixedClock(now)})
+	if err != nil {
+		t.Fatalf("New env issuer: %v", err)
+	}
+	cookie, err := issuer.Cookie(Principal{ID: "user-1"})
+	if err != nil {
+		t.Fatalf("Cookie: %v", err)
+	}
+	request := httptest.NewRequest(http.MethodGet, "/", nil)
+	request.AddCookie(&cookie)
+
+	exact, err := New(Options{Secret: []byte(envSecret), Insecure: true, Now: fixedClock(now)})
+	if err != nil {
+		t.Fatalf("New exact verifier: %v", err)
+	}
+	if principal, err := exact.Principal(request); err != nil || principal == nil {
+		t.Fatalf("exact secret did not verify env-issued cookie: principal=%+v err=%v", principal, err)
+	}
+
+	trimmed, err := New(Options{Secret: []byte(strings.TrimSpace(envSecret)), Insecure: true, Now: fixedClock(now)})
+	if err != nil {
+		t.Fatalf("New trimmed verifier: %v", err)
+	}
+	if principal, err := trimmed.Principal(request); err != nil || principal != nil {
+		t.Fatalf("trimmed secret verified env-issued cookie: principal=%+v err=%v", principal, err)
 	}
 }
 

--- a/addons/auth/password.go
+++ b/addons/auth/password.go
@@ -18,6 +18,10 @@ const (
 	// It is encoded into each hash so stored credentials remain verifiable if
 	// this default later increases.
 	DefaultIterations = 600000
+	// MinIterations is the minimum accepted PBKDF2 iteration count for new and
+	// stored hashes. Keep this separate from DefaultIterations so existing
+	// stored hashes remain verifiable if the default later increases.
+	MinIterations = 600000
 
 	pbkdf2SaltLength = 16
 	pbkdf2KeyLength  = 32
@@ -48,6 +52,9 @@ func HashPassword(password string) (string, error) {
 
 // HashPasswordWithIterations is HashPassword with an explicit work factor.
 func HashPasswordWithIterations(password string, iterations int) (string, error) {
+	if err := validateIterations(iterations); err != nil {
+		return "", err
+	}
 	return PBKDF2Hasher{Iterations: iterations}.HashPassword(password)
 }
 
@@ -55,8 +62,8 @@ func HashPasswordWithIterations(password string, iterations int) (string, error)
 // random salt.
 func (hasher PBKDF2Hasher) HashPassword(password string) (string, error) {
 	iterations := hasher.iterations()
-	if iterations < 1 {
-		return "", fmt.Errorf("gowdk auth: iterations must be at least 1")
+	if err := validateIterations(iterations); err != nil {
+		return "", err
 	}
 	salt := make([]byte, pbkdf2SaltLength)
 	if _, err := rand.Read(salt); err != nil {
@@ -102,21 +109,28 @@ func (hasher PBKDF2Hasher) iterations() int {
 	return hasher.Iterations
 }
 
+func validateIterations(iterations int) error {
+	if iterations < MinIterations {
+		return fmt.Errorf("gowdk auth: iterations must be at least %d", MinIterations)
+	}
+	return nil
+}
+
 func decodeHash(encoded string) (iterations int, salt, key []byte, err error) {
 	parts := strings.Split(encoded, "$")
 	if len(parts) != 4 || parts[0] != pbkdf2Prefix {
 		return 0, nil, nil, ErrInvalidHash
 	}
 	iterations, err = strconv.Atoi(parts[1])
-	if err != nil || iterations < 1 {
+	if err != nil || validateIterations(iterations) != nil {
 		return 0, nil, nil, ErrInvalidHash
 	}
 	salt, err = base64.RawStdEncoding.DecodeString(parts[2])
-	if err != nil || len(salt) == 0 {
+	if err != nil || len(salt) != pbkdf2SaltLength {
 		return 0, nil, nil, ErrInvalidHash
 	}
 	key, err = base64.RawStdEncoding.DecodeString(parts[3])
-	if err != nil || len(key) == 0 {
+	if err != nil || len(key) != pbkdf2KeyLength {
 		return 0, nil, nil, ErrInvalidHash
 	}
 	return iterations, salt, key, nil

--- a/addons/auth/password.go
+++ b/addons/auth/password.go
@@ -1,13 +1,14 @@
 package auth
 
 import (
-	"crypto/hmac"
+	"crypto/pbkdf2"
 	"crypto/rand"
 	"crypto/sha256"
 	"crypto/subtle"
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"hash"
 	"strconv"
 	"strings"
 )
@@ -26,15 +27,34 @@ const (
 // ErrInvalidHash reports that an encoded password hash is malformed.
 var ErrInvalidHash = errors.New("gowdk auth: invalid password hash")
 
+// PasswordHasher hashes and verifies stored password credentials.
+type PasswordHasher interface {
+	HashPassword(password string) (string, error)
+	VerifyPassword(password, encoded string) bool
+}
+
+// PBKDF2Hasher is the default dependency-free password hasher used by this
+// addon. Iterations defaults to DefaultIterations when omitted.
+type PBKDF2Hasher struct {
+	Iterations int
+}
+
 // HashPassword derives a PBKDF2-HMAC-SHA256 hash of password using a fresh
 // random salt and the default iteration count. The returned value is
 // self-describing and safe to store: pbkdf2-sha256$<iter>$<b64salt>$<b64hash>.
 func HashPassword(password string) (string, error) {
-	return HashPasswordWithIterations(password, DefaultIterations)
+	return PBKDF2Hasher{}.HashPassword(password)
 }
 
 // HashPasswordWithIterations is HashPassword with an explicit work factor.
 func HashPasswordWithIterations(password string, iterations int) (string, error) {
+	return PBKDF2Hasher{Iterations: iterations}.HashPassword(password)
+}
+
+// HashPassword derives a PBKDF2-HMAC-SHA256 hash of password using a fresh
+// random salt.
+func (hasher PBKDF2Hasher) HashPassword(password string) (string, error) {
+	iterations := hasher.iterations()
 	if iterations < 1 {
 		return "", fmt.Errorf("gowdk auth: iterations must be at least 1")
 	}
@@ -42,7 +62,10 @@ func HashPasswordWithIterations(password string, iterations int) (string, error)
 	if _, err := rand.Read(salt); err != nil {
 		return "", fmt.Errorf("gowdk auth: read salt: %w", err)
 	}
-	key := pbkdf2SHA256([]byte(password), salt, iterations, pbkdf2KeyLength)
+	key, err := pbkdf2SHA256(password, salt, iterations, pbkdf2KeyLength)
+	if err != nil {
+		return "", fmt.Errorf("gowdk auth: derive password hash: %w", err)
+	}
 	return strings.Join([]string{
 		pbkdf2Prefix,
 		strconv.Itoa(iterations),
@@ -56,12 +79,27 @@ func HashPasswordWithIterations(password string, iterations int) (string, error)
 // callers cannot distinguish "wrong password" from "corrupt record" by timing
 // or control flow.
 func VerifyPassword(password, encoded string) bool {
+	return PBKDF2Hasher{}.VerifyPassword(password, encoded)
+}
+
+// VerifyPassword reports whether password matches encoded.
+func (hasher PBKDF2Hasher) VerifyPassword(password, encoded string) bool {
 	iterations, salt, want, err := decodeHash(encoded)
 	if err != nil {
 		return false
 	}
-	got := pbkdf2SHA256([]byte(password), salt, iterations, len(want))
+	got, err := pbkdf2SHA256(password, salt, iterations, len(want))
+	if err != nil {
+		return false
+	}
 	return subtle.ConstantTimeCompare(got, want) == 1
+}
+
+func (hasher PBKDF2Hasher) iterations() int {
+	if hasher.Iterations == 0 {
+		return DefaultIterations
+	}
+	return hasher.Iterations
 }
 
 func decodeHash(encoded string) (iterations int, salt, key []byte, err error) {
@@ -84,38 +122,6 @@ func decodeHash(encoded string) (iterations int, salt, key []byte, err error) {
 	return iterations, salt, key, nil
 }
 
-// pbkdf2SHA256 implements PBKDF2 (RFC 8018) with HMAC-SHA256 as the PRF. It is
-// hand-rolled on crypto/hmac so the addon carries no dependency outside the
-// standard library.
-func pbkdf2SHA256(password, salt []byte, iterations, keyLength int) []byte {
-	prf := hmac.New(sha256.New, password)
-	hashLength := prf.Size()
-	blocks := (keyLength + hashLength - 1) / hashLength
-
-	derived := make([]byte, 0, blocks*hashLength)
-	block := make([]byte, 4)
-	for index := 1; index <= blocks; index++ {
-		block[0] = byte(index >> 24)
-		block[1] = byte(index >> 16)
-		block[2] = byte(index >> 8)
-		block[3] = byte(index)
-
-		prf.Reset()
-		prf.Write(salt)
-		prf.Write(block)
-		current := prf.Sum(nil)
-
-		result := make([]byte, len(current))
-		copy(result, current)
-		for iteration := 1; iteration < iterations; iteration++ {
-			prf.Reset()
-			prf.Write(current)
-			current = prf.Sum(current[:0])
-			for offset := range result {
-				result[offset] ^= current[offset]
-			}
-		}
-		derived = append(derived, result...)
-	}
-	return derived[:keyLength]
+func pbkdf2SHA256(password string, salt []byte, iterations, keyLength int) ([]byte, error) {
+	return pbkdf2.Key(func() hash.Hash { return sha256.New() }, password, salt, iterations, keyLength)
 }

--- a/addons/auth/session.go
+++ b/addons/auth/session.go
@@ -41,8 +41,8 @@ type Options struct {
 	// Secret signs session payloads with HMAC-SHA256. It must be non-empty and
 	// should be high-entropy and stable across instances.
 	Secret []byte
-	// SecretEnv names the environment variable to read when Secret is empty.
-	// Error messages include this name, never the secret value.
+	// SecretEnv names the environment variable to read instead of Secret. Error
+	// messages include this name, never the secret value.
 	SecretEnv string
 	// CookieName overrides DefaultSessionCookie.
 	CookieName string
@@ -83,9 +83,20 @@ func New(options Options) (*Sessions, error) {
 	cookie := options.CookieName
 	if cookie == "" {
 		cookie = DefaultSessionCookie
+	} else {
+		probe := http.Cookie{Name: cookie, Value: "session"}
+		if err := probe.Valid(); err != nil {
+			return nil, fmt.Errorf("gowdk auth: invalid session cookie name %q: %w", cookie, err)
+		}
 	}
 	ttl := options.TTL
-	if ttl <= 0 {
+	if ttl < 0 {
+		return nil, fmt.Errorf("gowdk auth: session ttl must be non-negative")
+	}
+	if ttl > 0 && ttl < time.Second {
+		return nil, fmt.Errorf("gowdk auth: session ttl must be at least 1s")
+	}
+	if ttl == 0 {
 		ttl = DefaultSessionTTL
 	}
 	now := options.Now
@@ -102,6 +113,10 @@ func New(options Options) (*Sessions, error) {
 }
 
 func sessionSecret(options Options) ([]byte, error) {
+	envName := strings.TrimSpace(options.SecretEnv)
+	if len(options.Secret) > 0 && envName != "" {
+		return nil, fmt.Errorf("gowdk auth: set Secret or SecretEnv, not both")
+	}
 	if len(options.Secret) > 0 {
 		if len(options.Secret) < MinSessionSecretBytes {
 			return nil, fmt.Errorf("gowdk auth: session secret must be at least %d bytes", MinSessionSecretBytes)
@@ -110,11 +125,10 @@ func sessionSecret(options Options) ([]byte, error) {
 		copy(secret, options.Secret)
 		return secret, nil
 	}
-	envName := strings.TrimSpace(options.SecretEnv)
 	if envName == "" {
 		return nil, fmt.Errorf("gowdk auth: session secret is required")
 	}
-	value := strings.TrimSpace(os.Getenv(envName))
+	value := os.Getenv(envName)
 	if value == "" {
 		return nil, fmt.Errorf("gowdk auth: %s is required for session signing", envName)
 	}
@@ -139,7 +153,10 @@ func (sessions *Sessions) Issue(writer http.ResponseWriter, principal Principal)
 
 // Cookie creates a signed session cookie for principal.
 func (sessions *Sessions) Cookie(principal Principal) (http.Cookie, error) {
-	expires := sessions.now().Add(sessions.ttl)
+	if strings.TrimSpace(principal.ID) == "" {
+		return http.Cookie{}, fmt.Errorf("gowdk auth: principal id is required")
+	}
+	expires := sessionExpiry(sessions.now(), sessions.ttl)
 	payload := sessionPayload{
 		ID:          principal.ID,
 		Roles:       principal.Roles,
@@ -160,6 +177,14 @@ func (sessions *Sessions) Cookie(principal Principal) (http.Cookie, error) {
 		Secure:   !sessions.insecure,
 		SameSite: http.SameSiteLaxMode,
 	}, nil
+}
+
+func sessionExpiry(now time.Time, ttl time.Duration) time.Time {
+	expires := now.Add(ttl)
+	if expires.Nanosecond() == 0 {
+		return expires
+	}
+	return expires.Truncate(time.Second).Add(time.Second)
 }
 
 // Clear writes an immediately-expired session cookie, logging the request out.
@@ -201,6 +226,9 @@ func (sessions *Sessions) Principal(request *http.Request) (*Principal, error) {
 		return nil, nil
 	}
 	if sessions.now().Unix() >= payload.Expires {
+		return nil, nil
+	}
+	if strings.TrimSpace(payload.ID) == "" {
 		return nil, nil
 	}
 	return &Principal{

--- a/addons/auth/session.go
+++ b/addons/auth/session.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"os"
 	"strings"
 	"time"
 )
@@ -18,6 +19,12 @@ const (
 	DefaultSessionCookie = "gowdk_session"
 	// DefaultSessionTTL is how long an issued session remains valid.
 	DefaultSessionTTL = 24 * time.Hour
+	// DefaultSessionSecretEnv is the recommended runtime environment variable
+	// for session signing secrets.
+	DefaultSessionSecretEnv = "GOWDK_AUTH_SESSION_SECRET"
+	// MinSessionSecretBytes is the minimum accepted session signing secret
+	// length.
+	MinSessionSecretBytes = 32
 )
 
 // ErrNoSession reports that a request carries no readable session cookie.
@@ -28,12 +35,15 @@ var ErrNoSession = errors.New("gowdk auth: no session")
 // callers treat any unreadable cookie as simply unauthenticated.
 var errBadSession = errors.New("gowdk auth: invalid session")
 
-// Options configures a Sessions manager. Secret is required; everything else
-// has a working default.
+// Options configures a Sessions manager. Secret or SecretEnv is required;
+// everything else has a working default.
 type Options struct {
 	// Secret signs session payloads with HMAC-SHA256. It must be non-empty and
 	// should be high-entropy and stable across instances.
 	Secret []byte
+	// SecretEnv names the environment variable to read when Secret is empty.
+	// Error messages include this name, never the secret value.
+	SecretEnv string
 	// CookieName overrides DefaultSessionCookie.
 	CookieName string
 	// TTL overrides DefaultSessionTTL.
@@ -66,8 +76,9 @@ type sessionPayload struct {
 
 // New creates a Sessions manager. It returns an error when no secret is set.
 func New(options Options) (*Sessions, error) {
-	if len(options.Secret) == 0 {
-		return nil, fmt.Errorf("gowdk auth: session secret is required")
+	secret, err := sessionSecret(options)
+	if err != nil {
+		return nil, err
 	}
 	cookie := options.CookieName
 	if cookie == "" {
@@ -81,8 +92,6 @@ func New(options Options) (*Sessions, error) {
 	if now == nil {
 		now = time.Now
 	}
-	secret := make([]byte, len(options.Secret))
-	copy(secret, options.Secret)
 	return &Sessions{
 		secret:   secret,
 		cookie:   cookie,
@@ -92,11 +101,44 @@ func New(options Options) (*Sessions, error) {
 	}, nil
 }
 
+func sessionSecret(options Options) ([]byte, error) {
+	if len(options.Secret) > 0 {
+		if len(options.Secret) < MinSessionSecretBytes {
+			return nil, fmt.Errorf("gowdk auth: session secret must be at least %d bytes", MinSessionSecretBytes)
+		}
+		secret := make([]byte, len(options.Secret))
+		copy(secret, options.Secret)
+		return secret, nil
+	}
+	envName := strings.TrimSpace(options.SecretEnv)
+	if envName == "" {
+		return nil, fmt.Errorf("gowdk auth: session secret is required")
+	}
+	value := strings.TrimSpace(os.Getenv(envName))
+	if value == "" {
+		return nil, fmt.Errorf("gowdk auth: %s is required for session signing", envName)
+	}
+	if len([]byte(value)) < MinSessionSecretBytes {
+		return nil, fmt.Errorf("gowdk auth: %s must be at least %d bytes", envName, MinSessionSecretBytes)
+	}
+	return []byte(value), nil
+}
+
 // Issue writes a signed session cookie for principal to the response.
 func (sessions *Sessions) Issue(writer http.ResponseWriter, principal Principal) error {
 	if writer == nil {
 		return fmt.Errorf("gowdk auth: response writer is required")
 	}
+	cookie, err := sessions.Cookie(principal)
+	if err != nil {
+		return err
+	}
+	http.SetCookie(writer, &cookie)
+	return nil
+}
+
+// Cookie creates a signed session cookie for principal.
+func (sessions *Sessions) Cookie(principal Principal) (http.Cookie, error) {
 	expires := sessions.now().Add(sessions.ttl)
 	payload := sessionPayload{
 		ID:          principal.ID,
@@ -106,10 +148,10 @@ func (sessions *Sessions) Issue(writer http.ResponseWriter, principal Principal)
 	}
 	encoded, err := json.Marshal(payload)
 	if err != nil {
-		return fmt.Errorf("gowdk auth: encode session: %w", err)
+		return http.Cookie{}, fmt.Errorf("gowdk auth: encode session: %w", err)
 	}
 	token := sessions.sign(encoded)
-	http.SetCookie(writer, &http.Cookie{
+	return http.Cookie{
 		Name:     sessions.cookie,
 		Value:    token,
 		Path:     "/",
@@ -117,8 +159,7 @@ func (sessions *Sessions) Issue(writer http.ResponseWriter, principal Principal)
 		HttpOnly: true,
 		Secure:   !sessions.insecure,
 		SameSite: http.SameSiteLaxMode,
-	})
-	return nil
+	}, nil
 }
 
 // Clear writes an immediately-expired session cookie, logging the request out.
@@ -126,7 +167,13 @@ func (sessions *Sessions) Clear(writer http.ResponseWriter) {
 	if writer == nil {
 		return
 	}
-	http.SetCookie(writer, &http.Cookie{
+	cookie := sessions.ClearCookie()
+	http.SetCookie(writer, &cookie)
+}
+
+// ClearCookie creates an immediately-expired session cookie.
+func (sessions *Sessions) ClearCookie() http.Cookie {
+	return http.Cookie{
 		Name:     sessions.cookie,
 		Value:    "",
 		Path:     "/",
@@ -135,7 +182,7 @@ func (sessions *Sessions) Clear(writer http.ResponseWriter) {
 		HttpOnly: true,
 		Secure:   !sessions.insecure,
 		SameSite: http.SameSiteLaxMode,
-	})
+	}
 }
 
 // Principal resolves the current principal from the request's session cookie.

--- a/docs/engineering/auth-addon-hardening-implementation-plan.md
+++ b/docs/engineering/auth-addon-hardening-implementation-plan.md
@@ -1,0 +1,77 @@
+# Implementation Plan: M11 Auth Addon Hardening
+
+## Context
+
+Spec: `docs/product/m11-auth-addon-hardening-spec.md`
+
+Issues: #117, #118, #119, #120, #121
+
+ADR: `docs/engineering/decisions/0011-auth-addon-cryptography.md`
+
+## Assumptions
+
+- The root module remains dependency-light.
+- Go 1.26.4 standard-library `crypto/pbkdf2` is available.
+- Auth remains experimental 0.x behavior and must not be documented as a full
+  production authentication system.
+
+## Proposed Changes
+
+- Replace the hand-rolled PBKDF2 loop with standard-library `crypto/pbkdf2`.
+- Add `PasswordHasher` and `PBKDF2Hasher`.
+- Add env-backed session secret loading with a 32-byte minimum.
+- Add session cookie helper methods for generated action responses.
+- Add focused auth addon docs, CSRF/session ordering notes, and ADR links.
+- Add `examples/auth-guard` with generated app hooks, public login, protected
+  dashboard, and logout action.
+
+## Files Expected To Change
+
+- `addons/auth/*`
+- `docs/reference/addons.md`
+- `docs/reference/hooks.md`
+- `docs/engineering/decisions/*`
+- `docs/product/m11-auth-addon-hardening-spec.md`
+- `docs/engineering/auth-addon-hardening-implementation-plan.md`
+- `examples/auth-guard/*`
+- `examples/README.md`
+
+## Data And API Impact
+
+- New public API: `PasswordHasher`, `PBKDF2Hasher`, `Options.SecretEnv`,
+  `DefaultSessionSecretEnv`, `MinSessionSecretBytes`, `Sessions.Cookie`, and
+  `Sessions.ClearCookie`.
+- Existing `HashPassword`, `HashPasswordWithIterations`, `VerifyPassword`,
+  `Sessions.Issue`, and `Sessions.Clear` remain.
+- Direct session secrets shorter than 32 bytes now fail.
+
+## Tests
+
+- Unit: auth addon password hasher, PBKDF2 vector, custom hasher, session secret
+  env failures, session cookie helpers.
+- Integration: example package tests and `make build`.
+- End-to-end: generated `examples/auth-guard` binary build.
+- Manual: run `examples/auth-guard/bin/auth-guard` with documented env vars.
+
+## Verification Commands
+
+```sh
+go test ./addons/auth
+cd examples/auth-guard && make check && make build
+go test ./...
+go build ./cmd/gowdk
+scripts/test-go-modules.sh
+```
+
+## Rollback Plan
+
+- Revert the auth addon API additions and docs together.
+- Remove `examples/auth-guard` from `examples/README.md`.
+- Keep the ADR as superseded if the cryptography stance changes after review.
+
+## Risks
+
+- Enforcing a 32-byte direct session secret can break experimental callers that
+  used short local secrets.
+- Generated app hooks are still copied into generated app output before build,
+  which is documented but not yet first-class source-adjacent extraction.

--- a/docs/engineering/decisions/0011-auth-addon-cryptography.md
+++ b/docs/engineering/decisions/0011-auth-addon-cryptography.md
@@ -1,0 +1,87 @@
+# ADR 0011: Auth Addon Cryptography Stance
+
+Date: 2026-06-15
+
+## Status
+
+Accepted
+
+## Context
+
+`addons/auth` is an experimental 0.x convenience addon for common authentication
+plumbing: password hashing, signed session cookies, and native RBAC guard
+providers. The repository dependency policy says to prefer maintained libraries
+for cryptography while keeping production dependencies minimal and optional
+integrations isolated.
+
+The root module already targets Go 1.26.4. That standard library includes
+`crypto/pbkdf2`, so the addon can use a maintained PBKDF2 implementation without
+adding `golang.org/x/crypto` to the root module graph.
+
+The addon must also avoid implying that GOWDK owns a complete authentication
+system. Applications still own user lookup, credential lifecycle, MFA, OAuth,
+account recovery, durable session storage, tenant policy, and backend resource
+authorization.
+
+## Decision
+
+Keep the auth addon default dependency-free in the root module and implement the
+default password hasher with Go's standard-library `crypto/pbkdf2` using
+HMAC-SHA256.
+
+Expose a small `PasswordHasher` interface and `PBKDF2Hasher` implementation so
+applications can replace the default with bcrypt, Argon2, a password-hashing
+service, or another app-owned policy without changing generated GOWDK route
+contracts.
+
+Do not add `golang.org/x/crypto` to the root module for this default. If a
+future addon needs Argon2 or bcrypt helpers, package that as an optional or
+nested dependency boundary and document the tradeoff separately.
+
+Session signing secrets must fail closed: the auth addon requires at least
+32 bytes of secret material, can read that secret from a named environment
+variable, and reports only the variable name or structural requirement in
+errors.
+
+## Consequences
+
+### Positive
+
+- The default password hashing path uses a maintained standard-library PBKDF2
+  implementation and adds no production dependency.
+- Root module dependency surface stays small.
+- Applications with stronger or organization-specific password policy have an
+  explicit replacement point.
+- Session secret failures are clear without exposing secret values.
+
+### Negative
+
+- PBKDF2-HMAC-SHA256 is a conservative default, not a modern memory-hard
+  password hashing recommendation.
+- Applications that require bcrypt or Argon2 must provide or import their own
+  hasher for now.
+
+### Neutral
+
+- The auth addon remains experimental 0.x behavior.
+- GOWDK still does not own user stores, OAuth, MFA, durable sessions, or
+  resource authorization.
+
+## Alternatives Considered
+
+- Add `golang.org/x/crypto` to the root module and switch the default to an
+  x/crypto implementation. Rejected for the current default because Go 1.26.4
+  already provides maintained PBKDF2 in the standard library and the root module
+  should avoid unnecessary production dependencies.
+- Keep the hand-rolled PBKDF2 loop. Rejected because the standard library now
+  provides this primitive.
+- Make Argon2 or bcrypt the built-in default. Deferred because those choices
+  need a dependency and parameter policy that is better isolated as an optional
+  package or app-owned hasher.
+
+## Follow-Up
+
+- Keep PBKDF2 default tests pinned with a known vector.
+- Document the `PasswordHasher` replacement point in the addons reference.
+- If GOWDK ships bcrypt or Argon2 helpers later, place them behind an optional
+  dependency boundary and add a new ADR or update this one.

--- a/docs/engineering/decisions/README.md
+++ b/docs/engineering/decisions/README.md
@@ -26,3 +26,5 @@ Recommended naming:
 - `0010-tokenizer-recursive-descent-parser.md`: accepted shared tokenizer and
   recursive-descent parser with error recovery, migrated behind the stable
   `gwdkast` AST seam.
+- `0011-auth-addon-cryptography.md`: accepted auth addon cryptography and
+  dependency stance for PBKDF2 defaults, custom hashers, and session secrets.

--- a/docs/product/m11-auth-addon-hardening-spec.md
+++ b/docs/product/m11-auth-addon-hardening-spec.md
@@ -1,0 +1,95 @@
+# Feature Spec: M11 Auth Addon Hardening
+
+## Problem
+
+Go teams trying the experimental auth addon need explicit contracts for password
+hashing, session secrets, generated guard wiring, and CSRF-protected actions.
+The current addon has useful pieces, but the crypto stance, replacement points,
+runtime secret setup, and example flow need to be clear before users copy the
+pattern.
+
+## Goals
+
+- Record the auth addon cryptography and dependency stance in an ADR.
+- Let applications provide a custom password hasher while keeping PBKDF2 as the
+  default.
+- Make session signing secrets fail closed with errors that name only the
+  missing or unsafe setting.
+- Document how session-backed guards interact with generated CSRF validation.
+- Add a small runnable guard example with one public route and one protected
+  route.
+
+## Non-Goals
+
+- Make the auth addon production-ready.
+- Own user stores, OAuth, MFA, account recovery, durable session storage,
+  tenants, or backend resource authorization.
+- Add a production dependency for password hashing in the root module.
+
+## Users And Permissions
+
+- Primary users: Go developers evaluating GOWDK generated action, SSR, and
+  guard flows.
+- Roles or permissions: native RBAC guard IDs such as `role:user`.
+- Data visibility rules: generated guards protect page and endpoint access;
+  application handlers still authorize protected resources.
+
+## User Flow
+
+1. Configure `auth.Addon()` and request-time rendering for a guarded page.
+2. Provide runtime session and CSRF secrets through environment variables.
+3. Register generated app guard hooks from app-owned Go.
+4. Log in through a generated action, receive a signed session cookie, access a
+   guarded SSR page, and log out through a protected action.
+
+## Requirements
+
+### Functional
+
+- `addons/auth` exposes `PasswordHasher` and keeps `PBKDF2Hasher` as the
+  default implementation.
+- `addons/auth.New` accepts either a direct secret or `SecretEnv` and rejects
+  missing or short session secrets.
+- The docs link to the auth cryptography ADR and explain replacement points.
+- The example builds through a documented command and includes public/protected
+  routes plus login/logout boundaries.
+
+### Non-Functional
+
+- Performance: password hashing uses the encoded iteration count and keeps
+  defaults explicit.
+- Reliability: missing session secrets fail before serving auth flows.
+- Accessibility: the example uses semantic labels and status-safe form markup.
+- Security/privacy: errors mention env var names only and never secret values.
+- Observability: generated route reports show public and protected route
+  metadata.
+
+## Acceptance Criteria
+
+- [x] ADR exists and explains the selected crypto/dependency stance.
+- [x] Auth users can provide a custom password hasher.
+- [x] Default PBKDF2 behavior remains covered by tests.
+- [x] Missing or unsafe session secrets produce clear errors without leaking
+  values.
+- [x] Docs explain generated guard/session and CSRF ordering.
+- [x] Example includes at least one protected route and one public route.
+
+## Edge Cases
+
+- A protected action with no valid session fails at the guard step before CSRF
+  validation.
+- A public login action has no guard and therefore validates CSRF before calling
+  the login handler.
+- A short session secret loaded from env reports the env var name, not the env
+  value.
+
+## Dependencies
+
+- Internal: `addons/auth`, `runtime/auth`, `runtime/guard`, generated action and
+  SSR route support.
+- External: none.
+
+## Open Questions
+
+- Should future bcrypt or Argon2 helpers live in a nested optional module or
+  stay entirely app-owned?

--- a/docs/reference/addons.md
+++ b/docs/reference/addons.md
@@ -159,6 +159,11 @@ if !auth.VerifyPassword(password, encoded) {
 }
 ```
 
+`HashPasswordWithIterations` and `PBKDF2Hasher{Iterations: ...}` reject values
+below `MinIterations`; leave `Iterations` unset to use `DefaultIterations`.
+Verification also rejects malformed PBKDF2 encodings that do not match the
+canonical salt, key, and iteration policy emitted by `HashPassword`.
+
 Or replace it behind the small interface:
 
 ```go
@@ -168,8 +173,9 @@ type PasswordStore struct {
 ```
 
 Session secrets fail closed. Pass a direct `Secret` or read from a runtime
-environment variable with `SecretEnv`; either value must be at least 32 bytes.
-Errors name the setting, never the secret value.
+environment variable with `SecretEnv`; do not set both. Either value must be at
+least 32 bytes. Environment secret values are used as exact bytes. Errors name
+the setting, never the secret value.
 
 ```go
 sessions, err := auth.New(auth.Options{
@@ -181,6 +187,11 @@ if err != nil {
 	return err
 }
 ```
+
+`CookieName` must be a valid HTTP cookie name. A zero `TTL` uses
+`DefaultSessionTTL`; explicit positive values must be at least one second, and
+negative values are rejected. Issued sessions require a non-empty
+`Principal.ID`.
 
 Register the session provider from generated app hook code when using native
 RBAC guard IDs:

--- a/docs/reference/addons.md
+++ b/docs/reference/addons.md
@@ -133,6 +133,81 @@ one-way browser notifications, or opt into the nested
 `runtime/contracts/websocketfanout` module when the app needs WebSocket
 sessions. See `docs/reference/realtime.md`.
 
+## Auth Addon
+
+`addons/auth` is experimental 0.x authentication plumbing. It enables the
+`auth` feature and provides:
+
+- `PasswordHasher`, with `PBKDF2Hasher` as the default.
+- `HashPassword`, `HashPasswordWithIterations`, and `VerifyPassword` helpers
+  backed by Go standard-library PBKDF2-HMAC-SHA256.
+- Signed-cookie `Sessions` that implement `runtime/auth.Provider` for native
+  `role:` and `permission:` guards.
+
+The cryptography and dependency stance is recorded in
+[ADR 0011](../engineering/decisions/0011-auth-addon-cryptography.md).
+
+Use the default hasher:
+
+```go
+encoded, err := auth.HashPassword(password)
+if err != nil {
+	return err
+}
+if !auth.VerifyPassword(password, encoded) {
+	return errors.New("invalid credentials")
+}
+```
+
+Or replace it behind the small interface:
+
+```go
+type PasswordStore struct {
+	Hasher auth.PasswordHasher
+}
+```
+
+Session secrets fail closed. Pass a direct `Secret` or read from a runtime
+environment variable with `SecretEnv`; either value must be at least 32 bytes.
+Errors name the setting, never the secret value.
+
+```go
+sessions, err := auth.New(auth.Options{
+	SecretEnv:  auth.DefaultSessionSecretEnv,
+	CookieName: "myapp_session",
+	TTL:        12 * time.Hour,
+})
+if err != nil {
+	return err
+}
+```
+
+Register the session provider from generated app hook code when using native
+RBAC guard IDs:
+
+```go
+func GOWDKAuthProvider() gowdkauth.Provider {
+	return sessions.Provider()
+}
+```
+
+GOWDK owns generated guard dispatch, CSRF validation, signed session cookie
+helpers, and native RBAC checks. Application Go owns user lookup, credential
+policy, MFA, OAuth, account recovery, durable storage, session lifetime,
+custom guard decisions, and backend resource authorization.
+
+For generated actions, ordering matters:
+
+- A public login action has no guard, so generated CSRF validation runs before
+  form decoding and before the login handler.
+- A protected action, such as logout, runs rate limiting and guards first. A
+  missing or invalid session fails at the guard step before CSRF validation.
+- If the guard succeeds but the CSRF token is missing or invalid, generated
+  code returns HTTP 403 `invalid csrf token` with `Cache-Control: no-store`.
+
+See `examples/auth-guard` for a small public-login and protected-dashboard
+flow.
+
 External addons use normal Go imports:
 
 ```go

--- a/docs/reference/hooks.md
+++ b/docs/reference/hooks.md
@@ -197,6 +197,12 @@ Current generated request-time order:
 7. Call user Go handler, fragment hook, or SSR load/render path.
 8. Write the returned `runtime/response.Response` or generated HTML.
 
+For auth-backed generated actions, this means a public login action validates
+CSRF before calling the login handler, while a guarded logout action checks the
+session guard first and only validates CSRF after the guard allows the request.
+Guard failures use the guard response contract; CSRF failures return HTTP 403
+`invalid csrf token` with `Cache-Control: no-store`.
+
 ## Non-Goals
 
 - No generated route rewriting hook.

--- a/examples/README.md
+++ b/examples/README.md
@@ -19,6 +19,7 @@ even when explicit `.gwdk` files are passed.
 | `pages/layout-stack.page.gwdk` | Page that demonstrates ordered layout metadata. | `go run ./cmd/gowdk check examples/pages/layout-stack.page.gwdk` |
 | `actions/signup.page.gwdk` | Buildable action page with the first POST redirect action subset. | `go run ./cmd/gowdk build --out /tmp/gowdk-action-build --app /tmp/gowdk-action-app --bin /tmp/gowdk-action-site examples/actions/signup.page.gwdk` |
 | `actions/newsletter.page.gwdk` | Action-form syntax example with `g:post` and imported component markup. | `go run ./cmd/gowdk check examples/actions/newsletter.page.gwdk examples/components/base/button.cmp.gwdk examples/components/base/text-field.cmp.gwdk` |
+| `auth-guard/` | Auth addon guard example with public login, session-backed RBAC, protected SSR dashboard, and logout action. | `cd examples/auth-guard && make build` |
 | `login/` | Integrated auth-feature GWDK login with generated frontend binary plus feature-owned Go backend binary. | `cd examples/login && make serve` |
 | `flagship/` | Full-stack native GOWDK vertical slice with static output, endpoints, fragments, SSR load, contracts, islands, CSS/assets, guards, rate limiting, and one generated binary. | `cd examples/flagship && make build` |
 | `endpoints/` | Endpoint cookbook with action redirects, validation fragments, partial responses, APIs, JSON CRUD, webhooks, and standalone fragments. | `cd examples/endpoints && make build` |
@@ -77,6 +78,16 @@ Run the current login backend example:
 ```sh
 cd examples/login
 make serve
+```
+
+Build the auth guard addon example:
+
+```sh
+cd examples/auth-guard
+make check
+make routes
+make build
+test -x bin/auth-guard
 ```
 
 Build the flagship full-stack generated binary:

--- a/examples/auth-guard/.env.example
+++ b/examples/auth-guard/.env.example
@@ -2,3 +2,4 @@ GOWDK_AUTH_SESSION_SECRET=development-auth-session-secret-32bytes
 GOWDK_CSRF_SECRET=development-auth-csrf-secret-32bytes
 GOWDK_AUTH_GUARD_EMAIL=demo@example.com
 GOWDK_AUTH_GUARD_PASSWORD=demo-password
+GOWDK_COOKIE_SECURE=false

--- a/examples/auth-guard/.env.example
+++ b/examples/auth-guard/.env.example
@@ -2,4 +2,3 @@ GOWDK_AUTH_SESSION_SECRET=development-auth-session-secret-32bytes
 GOWDK_CSRF_SECRET=development-auth-csrf-secret-32bytes
 GOWDK_AUTH_GUARD_EMAIL=demo@example.com
 GOWDK_AUTH_GUARD_PASSWORD=demo-password
-GOWDK_COOKIE_SECURE=false

--- a/examples/auth-guard/.env.example
+++ b/examples/auth-guard/.env.example
@@ -1,0 +1,4 @@
+GOWDK_AUTH_SESSION_SECRET=development-auth-session-secret-32bytes
+GOWDK_CSRF_SECRET=development-auth-csrf-secret-32bytes
+GOWDK_AUTH_GUARD_EMAIL=demo@example.com
+GOWDK_AUTH_GUARD_PASSWORD=demo-password

--- a/examples/auth-guard/.gitignore
+++ b/examples/auth-guard/.gitignore
@@ -1,0 +1,4 @@
+.gowdk/
+bin/
+dist/
+gowdk_cache/

--- a/examples/auth-guard/Makefile
+++ b/examples/auth-guard/Makefile
@@ -1,0 +1,31 @@
+ROOT := ../..
+CONFIG := examples/auth-guard/gowdk.config.go
+APP_DIR := examples/auth-guard/.gowdk/app
+HOOK_FILE := $(APP_DIR)/gowdkapp/auth_guard_hooks.go
+GOWDK_AUTH_SESSION_SECRET ?= development-auth-session-secret-32bytes
+GOWDK_CSRF_SECRET ?= development-auth-csrf-secret-32bytes
+
+export GOWDK_AUTH_SESSION_SECRET
+export GOWDK_CSRF_SECRET
+
+.PHONY: check routes build serve clean
+
+check:
+	cd $(ROOT) && go run ./cmd/gowdk check --config $(CONFIG)
+	cd $(ROOT)/examples/auth-guard && go test ./src/authguard
+
+routes:
+	cd $(ROOT) && go run ./cmd/gowdk routes --config $(CONFIG)
+
+$(HOOK_FILE): apphooks/auth_guard_hooks.go.txt
+	mkdir -p $(ROOT)/$(APP_DIR)/gowdkapp
+	cp apphooks/auth_guard_hooks.go.txt $(ROOT)/$(HOOK_FILE)
+
+build: $(HOOK_FILE)
+	cd $(ROOT) && go run ./cmd/gowdk build --config $(CONFIG) --target auth-guard
+
+serve: build
+	GOWDK_ADDR=127.0.0.1:8094 bin/auth-guard
+
+clean:
+	rm -rf .gowdk bin dist gowdk_cache

--- a/examples/auth-guard/README.md
+++ b/examples/auth-guard/README.md
@@ -1,0 +1,46 @@
+# Auth Guard Example
+
+This example shows the experimental 0.x auth addon around generated guards and
+CSRF-protected actions.
+
+Run from this directory:
+
+```sh
+make check
+make routes
+make build
+GOWDK_AUTH_SESSION_SECRET=development-auth-session-secret-32bytes GOWDK_CSRF_SECRET=development-auth-csrf-secret-32bytes GOWDK_ADDR=127.0.0.1:8094 bin/auth-guard
+```
+
+Open `http://127.0.0.1:8094/`.
+
+Use:
+
+```text
+email: demo@example.com
+password: demo-password
+```
+
+## Files
+
+- `gowdk.config.go`: enables `auth.Addon()` and `ssr.Addon()`, declares the
+  required session and CSRF secrets, and builds one generated binary.
+- `apphooks/auth_guard_hooks.go.txt`: copied into the generated app package so
+  `GOWDKGuardRegistry` and `GOWDKAuthProvider` are available at compile time.
+- `src/authguard/auth.go`: owns demo credentials, password verification,
+  session creation, guard behavior, logout, and SSR load data in normal Go.
+- `src/authguard/login.page.gwdk`: public login route and CSRF-protected login
+  action.
+- `src/authguard/dashboard.page.gwdk`: protected SSR dashboard with
+  `guard auth.required, role:user` and a CSRF-protected logout action.
+
+## Ownership
+
+GOWDK owns generated route dispatch, guard execution order, CSRF token
+injection/validation, signed session cookie helpers, and native RBAC guard
+checks. The app owns users, credential policy, durable storage, session
+duration, custom guard decisions, and backend resource authorization.
+
+Runtime secrets are separate: `GOWDK_AUTH_SESSION_SECRET` signs sessions and
+`GOWDK_CSRF_SECRET` signs generated action tokens. Both must be stable
+environment values of at least 32 bytes. Secret values are not stored in config.

--- a/examples/auth-guard/README.md
+++ b/examples/auth-guard/README.md
@@ -14,6 +14,9 @@ GOWDK_AUTH_SESSION_SECRET=development-auth-session-secret-32bytes GOWDK_CSRF_SEC
 
 Open `http://127.0.0.1:8094/`.
 
+The example leaves the session cookie `Secure` flag off by default so localhost
+HTTP works. Set `GOWDK_COOKIE_SECURE=true` when serving it behind HTTPS.
+
 Use:
 
 ```text

--- a/examples/auth-guard/README.md
+++ b/examples/auth-guard/README.md
@@ -14,8 +14,8 @@ GOWDK_AUTH_SESSION_SECRET=development-auth-session-secret-32bytes GOWDK_CSRF_SEC
 
 Open `http://127.0.0.1:8094/`.
 
-The example leaves the session cookie `Secure` flag off by default so localhost
-HTTP works. Set `GOWDK_COOKIE_SECURE=true` when serving it behind HTTPS.
+The example sets `auth.Options.Insecure` so localhost HTTP works. Real apps
+should leave that option false when serving behind HTTPS.
 
 Use:
 

--- a/examples/auth-guard/apphooks/auth_guard_hooks.go.txt
+++ b/examples/auth-guard/apphooks/auth_guard_hooks.go.txt
@@ -1,0 +1,17 @@
+package gowdkapp
+
+import (
+	authguard "github.com/cssbruno/gowdk/examples/auth-guard/src/authguard"
+	gowdkauth "github.com/cssbruno/gowdk/runtime/auth"
+	gowdkguard "github.com/cssbruno/gowdk/runtime/guard"
+)
+
+func GOWDKGuardRegistry() gowdkguard.Registry {
+	return gowdkguard.Registry{
+		"auth.required": authguard.RequireSession,
+	}
+}
+
+func GOWDKAuthProvider() gowdkauth.Provider {
+	return authguard.MustAuthProvider()
+}

--- a/examples/auth-guard/gowdk.config.go
+++ b/examples/auth-guard/gowdk.config.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"github.com/cssbruno/gowdk"
+	authaddon "github.com/cssbruno/gowdk/addons/auth"
+	"github.com/cssbruno/gowdk/addons/ssr"
+)
+
+var Config = gowdk.Config{
+	AppName: "GOWDK Auth Guard",
+	Source: gowdk.SourceConfig{
+		Include: []string{"src/**/*.gwdk"},
+	},
+	Env: gowdk.EnvConfig{
+		Secrets: []gowdk.SecretEnv{
+			{Name: "GOWDK_AUTH_SESSION_SECRET", Required: true},
+			{Name: "GOWDK_CSRF_SECRET", Required: true},
+		},
+	},
+	Build: gowdk.BuildConfig{
+		Output: "examples/auth-guard/dist",
+		CSRF: gowdk.CSRFConfig{
+			Insecure: true,
+		},
+		Targets: []gowdk.BuildTargetConfig{
+			{
+				Name:   "auth-guard",
+				Output: "examples/auth-guard/dist",
+				App:    "examples/auth-guard/.gowdk/app",
+				Binary: "examples/auth-guard/bin/auth-guard",
+			},
+		},
+	},
+	CSS: gowdk.CSSConfig{
+		Include: []string{"examples/auth-guard/styles/**/*.css"},
+		Output: gowdk.CSSOutputConfig{
+			Dir:        "assets/gowdk",
+			HrefPrefix: "/assets/gowdk",
+		},
+	},
+	Addons: []gowdk.Addon{
+		authaddon.Addon(),
+		ssr.Addon(),
+	},
+}

--- a/examples/auth-guard/src/authguard/auth.go
+++ b/examples/auth-guard/src/authguard/auth.go
@@ -131,7 +131,7 @@ func Sessions() (*gowdkauth.Sessions, error) {
 		SecretEnv:  sessionSecretEnv,
 		CookieName: sessionCookie,
 		TTL:        12 * time.Hour,
-		Insecure:   !secureCookie(),
+		Insecure:   true,
 	})
 	return sessionState.manager, sessionState.err
 }
@@ -148,10 +148,6 @@ func demoPasswordHash() (string, error) {
 
 func constantEqual(left, right string) bool {
 	return subtle.ConstantTimeCompare([]byte(left), []byte(right)) == 1
-}
-
-func secureCookie() bool {
-	return strings.EqualFold(strings.TrimSpace(os.Getenv("GOWDK_COOKIE_SECURE")), "true")
 }
 
 func env(name, fallback string) string {

--- a/examples/auth-guard/src/authguard/auth.go
+++ b/examples/auth-guard/src/authguard/auth.go
@@ -131,7 +131,7 @@ func Sessions() (*gowdkauth.Sessions, error) {
 		SecretEnv:  sessionSecretEnv,
 		CookieName: sessionCookie,
 		TTL:        12 * time.Hour,
-		Insecure:   env("GOWDK_COOKIE_SECURE", "false") != "true",
+		Insecure:   !secureCookie(),
 	})
 	return sessionState.manager, sessionState.err
 }
@@ -148,6 +148,10 @@ func demoPasswordHash() (string, error) {
 
 func constantEqual(left, right string) bool {
 	return subtle.ConstantTimeCompare([]byte(left), []byte(right)) == 1
+}
+
+func secureCookie() bool {
+	return strings.EqualFold(strings.TrimSpace(os.Getenv("GOWDK_COOKIE_SECURE")), "true")
 }
 
 func env(name, fallback string) string {

--- a/examples/auth-guard/src/authguard/auth.go
+++ b/examples/auth-guard/src/authguard/auth.go
@@ -1,0 +1,159 @@
+package authguard
+
+import (
+	"context"
+	"crypto/subtle"
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	gowdkauth "github.com/cssbruno/gowdk/addons/auth"
+	"github.com/cssbruno/gowdk/addons/ssr"
+	"github.com/cssbruno/gowdk/runtime/form"
+	"github.com/cssbruno/gowdk/runtime/guard"
+	"github.com/cssbruno/gowdk/runtime/response"
+)
+
+const (
+	sessionSecretEnv = "GOWDK_AUTH_SESSION_SECRET"
+	sessionCookie    = "gowdk_auth_guard_session"
+)
+
+var passwordHasher gowdkauth.PasswordHasher = gowdkauth.PBKDF2Hasher{}
+
+type DashboardData struct {
+	Email     string `json:"email"`
+	Role      string `json:"role"`
+	ExpiresAt string `json:"expiresAt"`
+}
+
+var sessionState struct {
+	sync.Mutex
+	manager *gowdkauth.Sessions
+	err     error
+}
+
+var passwordState struct {
+	sync.Mutex
+	hash string
+	err  error
+}
+
+func Login(_ context.Context, values form.Values) (response.Response, error) {
+	email := strings.TrimSpace(values.First("email"))
+	password := values.First("password")
+	encoded, err := demoPasswordHash()
+	if err != nil {
+		return response.Response{}, err
+	}
+
+	if !constantEqual(email, env("GOWDK_AUTH_GUARD_EMAIL", "demo@example.com")) ||
+		!passwordHasher.VerifyPassword(password, encoded) {
+		return response.RedirectTo("/?login=failed"), nil
+	}
+
+	sessions, err := Sessions()
+	if err != nil {
+		return response.Response{}, err
+	}
+	cookie, err := sessions.Cookie(gowdkauth.Principal{
+		ID:          email,
+		Roles:       []string{"user"},
+		Permissions: []string{"dashboard.read"},
+	})
+	if err != nil {
+		return response.Response{}, err
+	}
+	return response.WithCookie(response.RedirectTo("/dashboard"), cookie), nil
+}
+
+func Logout(context.Context, form.Values) (response.Response, error) {
+	sessions, err := Sessions()
+	if err != nil {
+		return response.Response{}, err
+	}
+	return response.WithCookie(response.RedirectTo("/"), sessions.ClearCookie()), nil
+}
+
+func LoadDashboard(ctx ssr.LoadContext) (map[string]any, error) {
+	sessions, err := Sessions()
+	if err != nil {
+		return nil, err
+	}
+	principal, err := sessions.Principal(ctx.Request)
+	if err != nil {
+		return nil, err
+	}
+	if principal == nil {
+		return nil, fmt.Errorf("dashboard load requires an authenticated session")
+	}
+	return map[string]any{
+		"dashboard": DashboardData{
+			Email:     principal.ID,
+			Role:      "user",
+			ExpiresAt: time.Now().Add(12 * time.Hour).Format(time.RFC822),
+		},
+	}, nil
+}
+
+func RequireSession(ctx guard.Context) error {
+	sessions, err := Sessions()
+	if err != nil {
+		return err
+	}
+	principal, err := sessions.Principal(ctx.Request)
+	if err != nil {
+		return err
+	}
+	if principal == nil {
+		return guard.RedirectTo("/?login=required")
+	}
+	return nil
+}
+
+func MustAuthProvider() gowdkauth.Provider {
+	sessions, err := Sessions()
+	if err != nil {
+		panic(err)
+	}
+	return sessions.Provider()
+}
+
+func Sessions() (*gowdkauth.Sessions, error) {
+	sessionState.Lock()
+	defer sessionState.Unlock()
+	if sessionState.manager != nil || sessionState.err != nil {
+		return sessionState.manager, sessionState.err
+	}
+	sessionState.manager, sessionState.err = gowdkauth.New(gowdkauth.Options{
+		SecretEnv:  sessionSecretEnv,
+		CookieName: sessionCookie,
+		TTL:        12 * time.Hour,
+		Insecure:   env("GOWDK_COOKIE_SECURE", "false") != "true",
+	})
+	return sessionState.manager, sessionState.err
+}
+
+func demoPasswordHash() (string, error) {
+	passwordState.Lock()
+	defer passwordState.Unlock()
+	if passwordState.hash != "" || passwordState.err != nil {
+		return passwordState.hash, passwordState.err
+	}
+	passwordState.hash, passwordState.err = passwordHasher.HashPassword(env("GOWDK_AUTH_GUARD_PASSWORD", "demo-password"))
+	return passwordState.hash, passwordState.err
+}
+
+func constantEqual(left, right string) bool {
+	return subtle.ConstantTimeCompare([]byte(left), []byte(right)) == 1
+}
+
+func env(name, fallback string) string {
+	value := strings.TrimSpace(os.Getenv(name))
+	if value == "" {
+		return fallback
+	}
+	return value
+}

--- a/examples/auth-guard/src/authguard/auth_test.go
+++ b/examples/auth-guard/src/authguard/auth_test.go
@@ -31,6 +31,25 @@ func TestLoginIssuesSessionCookie(t *testing.T) {
 	if len(result.Cookies) != 1 || result.Cookies[0].Name != sessionCookie {
 		t.Fatalf("expected session cookie, got %#v", result.Cookies)
 	}
+	if result.Cookies[0].Secure {
+		t.Fatal("expected local example cookie to be insecure by default")
+	}
+}
+
+func TestLoginIssuesSecureSessionCookieWhenConfigured(t *testing.T) {
+	resetTestState()
+	t.Setenv("GOWDK_AUTH_SESSION_SECRET", strings.Repeat("s", 32))
+	t.Setenv("GOWDK_COOKIE_SECURE", "TRUE")
+	result, err := Login(context.Background(), form.Values{"email": {"demo@example.com"}, "password": {"demo-password"}})
+	if err != nil {
+		t.Fatalf("Login: %v", err)
+	}
+	if len(result.Cookies) != 1 {
+		t.Fatalf("expected session cookie, got %#v", result.Cookies)
+	}
+	if !result.Cookies[0].Secure {
+		t.Fatal("expected secure cookie when GOWDK_COOKIE_SECURE=true")
+	}
 }
 
 func resetTestState() {

--- a/examples/auth-guard/src/authguard/auth_test.go
+++ b/examples/auth-guard/src/authguard/auth_test.go
@@ -36,22 +36,6 @@ func TestLoginIssuesSessionCookie(t *testing.T) {
 	}
 }
 
-func TestLoginIssuesSecureSessionCookieWhenConfigured(t *testing.T) {
-	resetTestState()
-	t.Setenv("GOWDK_AUTH_SESSION_SECRET", strings.Repeat("s", 32))
-	t.Setenv("GOWDK_COOKIE_SECURE", "TRUE")
-	result, err := Login(context.Background(), form.Values{"email": {"demo@example.com"}, "password": {"demo-password"}})
-	if err != nil {
-		t.Fatalf("Login: %v", err)
-	}
-	if len(result.Cookies) != 1 {
-		t.Fatalf("expected session cookie, got %#v", result.Cookies)
-	}
-	if !result.Cookies[0].Secure {
-		t.Fatal("expected secure cookie when GOWDK_COOKIE_SECURE=true")
-	}
-}
-
 func resetTestState() {
 	sessionState.Lock()
 	sessionState.manager = nil

--- a/examples/auth-guard/src/authguard/auth_test.go
+++ b/examples/auth-guard/src/authguard/auth_test.go
@@ -1,0 +1,46 @@
+package authguard
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/cssbruno/gowdk/runtime/form"
+)
+
+func TestLoginRequiresSessionSecret(t *testing.T) {
+	resetTestState()
+	t.Setenv("GOWDK_AUTH_SESSION_SECRET", "")
+	_, err := Login(context.Background(), form.Values{"email": {"demo@example.com"}, "password": {"demo-password"}})
+	if err == nil || !strings.Contains(err.Error(), "GOWDK_AUTH_SESSION_SECRET") {
+		t.Fatalf("expected session secret error, got %v", err)
+	}
+}
+
+func TestLoginIssuesSessionCookie(t *testing.T) {
+	resetTestState()
+	t.Setenv("GOWDK_AUTH_SESSION_SECRET", strings.Repeat("s", 32))
+	result, err := Login(context.Background(), form.Values{"email": {"demo@example.com"}, "password": {"demo-password"}})
+	if err != nil {
+		t.Fatalf("Login: %v", err)
+	}
+	if result.Status != http.StatusSeeOther || result.URL != "/dashboard" {
+		t.Fatalf("unexpected login response: %#v", result)
+	}
+	if len(result.Cookies) != 1 || result.Cookies[0].Name != sessionCookie {
+		t.Fatalf("expected session cookie, got %#v", result.Cookies)
+	}
+}
+
+func resetTestState() {
+	sessionState.Lock()
+	sessionState.manager = nil
+	sessionState.err = nil
+	sessionState.Unlock()
+
+	passwordState.Lock()
+	passwordState.hash = ""
+	passwordState.err = nil
+	passwordState.Unlock()
+}

--- a/examples/auth-guard/src/authguard/dashboard.page.gwdk
+++ b/examples/auth-guard/src/authguard/dashboard.page.gwdk
@@ -1,0 +1,36 @@
+package authguard
+
+page dashboard
+route "/dashboard"
+guard auth.required, role:user
+css authguard
+
+act Logout POST "/logout"
+
+load {
+  => { dashboard.email, dashboard.role, dashboard.expiresAt }
+}
+
+view {
+  <main class="dashboard-shell">
+    <nav>
+      <a href="/">Public login</a>
+      <form g:post={Logout}>
+        <button type="submit">Sign out</button>
+      </form>
+    </nav>
+
+    <section class="dashboard-panel">
+      <p class="eyebrow">Protected route</p>
+      <h1>Dashboard</h1>
+      <dl>
+        <dt>Email</dt>
+        <dd>{dashboard.email}</dd>
+        <dt>Role</dt>
+        <dd>{dashboard.role}</dd>
+        <dt>Session window</dt>
+        <dd>{dashboard.expiresAt}</dd>
+      </dl>
+    </section>
+  </main>
+}

--- a/examples/auth-guard/src/authguard/login.page.gwdk
+++ b/examples/auth-guard/src/authguard/login.page.gwdk
@@ -1,0 +1,27 @@
+package authguard
+
+page login
+route "/"
+guard public
+css authguard
+
+act Login POST "/login"
+
+view {
+  <main class="auth-shell">
+    <section class="auth-panel">
+      <p class="eyebrow">GOWDK Auth Addon</p>
+      <h1>Sign in</h1>
+      <form g:post={Login}>
+        <label for="email">Email</label>
+        <input id="email" name="email" type="email" autocomplete="email" value="demo@example.com" required />
+
+        <label for="password">Password</label>
+        <input id="password" name="password" type="password" autocomplete="current-password" required />
+
+        <button type="submit">Sign in</button>
+      </form>
+      <a href="/dashboard">Open protected dashboard</a>
+    </section>
+  </main>
+}

--- a/examples/auth-guard/styles/authguard.css
+++ b/examples/auth-guard/styles/authguard.css
@@ -1,0 +1,95 @@
+.auth-shell,
+.dashboard-shell {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  margin: 0;
+  background: #f6f7fb;
+  color: #1c2331;
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+.auth-panel,
+.dashboard-panel {
+  width: min(92vw, 520px);
+  border: 1px solid #d8dee9;
+  border-radius: 8px;
+  background: #ffffff;
+  padding: 28px;
+  box-shadow: 0 16px 48px rgba(28, 35, 49, 0.12);
+}
+
+.dashboard-shell {
+  align-content: start;
+  gap: 24px;
+  padding: 32px 16px;
+}
+
+.dashboard-shell nav {
+  width: min(92vw, 720px);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.eyebrow {
+  margin: 0 0 8px;
+  color: #52616f;
+  font-size: 0.8rem;
+  font-weight: 700;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0 0 24px;
+  font-size: 2rem;
+}
+
+form {
+  display: grid;
+  gap: 12px;
+}
+
+label,
+dt {
+  font-weight: 700;
+}
+
+input {
+  min-height: 42px;
+  border: 1px solid #bac4d0;
+  border-radius: 6px;
+  padding: 0 12px;
+  font: inherit;
+}
+
+button,
+a {
+  min-height: 40px;
+  border: 0;
+  border-radius: 6px;
+  padding: 10px 14px;
+  background: #254f9b;
+  color: #ffffff;
+  font: inherit;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a {
+  display: inline-flex;
+  align-items: center;
+  margin-top: 18px;
+}
+
+dl {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: 12px 18px;
+  margin: 0;
+}
+
+dd {
+  margin: 0;
+}


### PR DESCRIPTION
## Summary

- records the M11 auth addon crypto stance in ADR 0011 and adds the M11 spec/implementation plan
- adds `PasswordHasher`/`PBKDF2Hasher`, switches the default PBKDF2 path to standard-library `crypto/pbkdf2`, and keeps the existing top-level helpers
- makes auth sessions fail closed with env-backed 32-byte secret validation and cookie helpers for generated action responses
- documents auth ownership boundaries, password hasher replacement, session secret setup, and CSRF/session ordering
- adds `examples/auth-guard` with public login, session-backed guards, native RBAC, protected SSR dashboard, and logout action

Closes #117
Closes #118
Closes #119
Closes #120
Closes #121

## Verification

- `go test ./addons/auth`
- `cd examples/auth-guard && make check`
- `cd examples/auth-guard && make routes`
- `cd examples/auth-guard && make build`
- `go test ./...`
- `go build ./cmd/gowdk`
- `scripts/test-go-modules.sh`