### PR TITLE
fix(security): address audit findings #430-#437

### DIFF
--- a/addons/actions/actions_test.go
+++ b/addons/actions/actions_test.go
@@ -188,6 +188,40 @@ func TestCSRFRejectsMissingMismatchAndInvalidTokens(t *testing.T) {
 	}
 }
 
+func TestCSRFBindsTokenToPrincipal(t *testing.T) {
+	binding := func(r *http.Request) []byte { return []byte(r.Header.Get("X-Principal")) }
+	csrf, err := NewCSRF(CSRFOptions{Secret: []byte(strings.Repeat("s", 32)), Binding: binding})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mint := httptest.NewRequest(http.MethodGet, "/", nil)
+	mint.Header.Set("X-Principal", "alice")
+	response := httptest.NewRecorder()
+	token, err := csrf.Token(response, mint)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cookie := response.Result().Cookies()[0]
+
+	same := httptest.NewRequest(http.MethodPost, "/signup", nil)
+	same.Header.Set("X-Principal", "alice")
+	same.Header.Set(defaultCSRFHeader, token)
+	same.AddCookie(cookie)
+	if err := csrf.Validate(same); err != nil {
+		t.Fatalf("expected token to validate for the same principal: %v", err)
+	}
+
+	// A different principal must be rejected even though cookie == submitted.
+	other := httptest.NewRequest(http.MethodPost, "/signup", nil)
+	other.Header.Set("X-Principal", "mallory")
+	other.Header.Set(defaultCSRFHeader, token)
+	other.AddCookie(cookie)
+	if err := csrf.Validate(other); err == nil || !strings.Contains(err.Error(), "csrf token signature is invalid") {
+		t.Fatalf("expected token bound to alice to be rejected for mallory, got %v", err)
+	}
+}
+
 func tamperToken(token string) string {
 	raw, err := base64.RawURLEncoding.DecodeString(token)
 	if err != nil || len(raw) == 0 {

--- a/addons/actions/csrf.go
+++ b/addons/actions/csrf.go
@@ -39,6 +39,14 @@ type CSRFOptions struct {
 	HeaderName string
 	Insecure   bool
 	SameSite   http.SameSite
+	// Binding, when set, ties each token to a per-request identity (typically
+	// the authenticated principal). The returned value is mixed into the token
+	// signature, so a token minted for one principal is rejected once the
+	// request resolves to a different principal. This upgrades the plain signed
+	// double-submit cookie to a session-bound token, the OWASP-recommended
+	// hardening. Returning nil binds the token to the anonymous context, which
+	// still yields a valid signed double-submit token (backwards compatible).
+	Binding func(*http.Request) []byte
 }
 
 // CSRF validates signed double-submit CSRF tokens for generated actions.
@@ -49,6 +57,7 @@ type CSRF struct {
 	headerName string
 	secure     bool
 	sameSite   http.SameSite
+	binding    func(*http.Request) []byte
 }
 
 // NewCSRF creates a validator with secure cookie defaults.
@@ -85,7 +94,18 @@ func NewCSRF(options CSRFOptions) (*CSRF, error) {
 		headerName: headerName,
 		secure:     !options.Insecure,
 		sameSite:   sameSite,
+		binding:    options.Binding,
 	}, nil
+}
+
+// bindingFor returns the per-request binding value, or nil when no binding is
+// configured. A token is signed and validated against this value so it is only
+// accepted for the identity it was minted for.
+func (csrf *CSRF) bindingFor(request *http.Request) []byte {
+	if csrf.binding == nil || request == nil {
+		return nil
+	}
+	return csrf.binding(request)
 }
 
 func secureCookiePrefix(name string) bool {
@@ -97,8 +117,9 @@ func secureCookiePrefix(name string) bool {
 // working, and only mints and stores a new token when the cookie is absent or
 // invalid.
 func (csrf *CSRF) Token(response http.ResponseWriter, request *http.Request) (string, error) {
+	binding := csrf.bindingFor(request)
 	if request != nil {
-		if cookie, err := request.Cookie(csrf.cookieName); err == nil && csrf.valid(cookie.Value) {
+		if cookie, err := request.Cookie(csrf.cookieName); err == nil && csrf.valid(cookie.Value, binding) {
 			return cookie.Value, nil
 		}
 	}
@@ -106,7 +127,7 @@ func (csrf *CSRF) Token(response http.ResponseWriter, request *http.Request) (st
 	if _, err := rand.Read(nonce[:]); err != nil {
 		return "", fmt.Errorf("generate csrf token: %w", err)
 	}
-	token := csrf.sign(nonce[:])
+	token := csrf.sign(nonce[:], binding)
 	http.SetCookie(response, &http.Cookie{
 		Name:     csrf.cookieName,
 		Value:    token,
@@ -152,20 +173,24 @@ func (csrf *CSRF) Validate(request *http.Request) error {
 	if subtle.ConstantTimeCompare([]byte(cookie.Value), []byte(submitted)) != 1 {
 		return fmt.Errorf("csrf token mismatch")
 	}
-	if !csrf.valid(submitted) {
+	if !csrf.valid(submitted, csrf.bindingFor(request)) {
 		return fmt.Errorf("csrf token signature is invalid")
 	}
 	return nil
 }
 
-func (csrf *CSRF) sign(nonce []byte) string {
+// sign returns base64(nonce || HMAC(secret, nonce || binding)). The nonce is a
+// fixed length, so writing it before the binding is an unambiguous encoding of
+// the (nonce, binding) pair.
+func (csrf *CSRF) sign(nonce, binding []byte) string {
 	mac := hmac.New(sha256.New, csrf.secret)
 	mac.Write(nonce)
+	mac.Write(binding)
 	raw := append(append([]byte(nil), nonce...), mac.Sum(nil)...)
 	return base64.RawURLEncoding.EncodeToString(raw)
 }
 
-func (csrf *CSRF) valid(token string) bool {
+func (csrf *CSRF) valid(token string, binding []byte) bool {
 	raw, err := base64.RawURLEncoding.DecodeString(token)
 	if err != nil || len(raw) != csrfNonceBytes+csrfMACBytes {
 		return false
@@ -174,6 +199,7 @@ func (csrf *CSRF) valid(token string) bool {
 	signature := raw[csrfNonceBytes:]
 	mac := hmac.New(sha256.New, csrf.secret)
 	mac.Write(nonce)
+	mac.Write(binding)
 	expected := mac.Sum(nil)
 	return subtle.ConstantTimeCompare(signature, expected) == 1
 }

--- a/addons/api/request.go
+++ b/addons/api/request.go
@@ -51,7 +51,12 @@ func DecodeJSON[T any](request *http.Request) (T, error) {
 func requireJSONContentType(request *http.Request) error {
 	contentType := strings.TrimSpace(request.Header.Get("Content-Type"))
 	if contentType == "" {
-		return nil
+		// Require an explicit JSON content type. A missing Content-Type is a
+		// common cross-site request-forgery vector: a browser form post sends a
+		// non-JSON default type, and accepting an empty type would let such a
+		// request reach a JSON handler. Demanding application/json forces a
+		// CORS preflight for cross-origin callers.
+		return fmt.Errorf("%w: missing Content-Type", ErrUnsupportedContentType)
 	}
 	mediaType, _, err := mime.ParseMediaType(contentType)
 	if err != nil {

--- a/addons/api/request_test.go
+++ b/addons/api/request_test.go
@@ -58,11 +58,22 @@ func TestDecodeJSONRejectsTrailingValues(t *testing.T) {
 
 func TestDecodeJSONRejectsNilBody(t *testing.T) {
 	request := httptest.NewRequest(http.MethodPost, "/api/patients", nil)
+	request.Header.Set("Content-Type", "application/json")
 	request.Body = nil
 
 	_, err := DecodeJSON[decodeFixture](request)
 	if err == nil || !strings.Contains(err.Error(), "EOF") {
 		t.Fatalf("expected EOF error, got %v", err)
+	}
+}
+
+func TestDecodeJSONRejectsMissingContentType(t *testing.T) {
+	request := httptest.NewRequest(http.MethodPost, "/api/patients", strings.NewReader(`{"name":"Ada"}`))
+	request.Header.Del("Content-Type")
+
+	_, err := DecodeJSON[decodeFixture](request)
+	if !errors.Is(err, ErrUnsupportedContentType) {
+		t.Fatalf("expected unsupported content type error for missing Content-Type, got %v", err)
 	}
 }
 

--- a/examples/login/README.md
+++ b/examples/login/README.md
@@ -30,10 +30,17 @@ feature package.
 
 ## Run
 
+This example fails closed: it refuses to authenticate unless you configure a
+signing secret and the demo password. The session cookie is `Secure` by
+default; over plain HTTP for local development you must opt out explicitly.
+
 From this directory:
 
 ```sh
 cd examples/login
+export GOWDK_LOGIN_SECRET="$(head -c 32 /dev/urandom | base64)"  # required, >=32 bytes
+export GOWDK_LOGIN_PASSWORD="demo-password"                      # required, no default
+export GOWDK_COOKIE_INSECURE=true                                # local HTTP only; omit in production
 make serve
 ```
 
@@ -42,12 +49,14 @@ Open `http://127.0.0.1:8090/`.
 Use:
 
 ```text
-email: demo@example.com
-password: demo-password
+email: demo@example.com           # override with GOWDK_LOGIN_EMAIL
+password: <GOWDK_LOGIN_PASSWORD>
 ```
 
 The generated app calls `auth.Login`, sets a signed HttpOnly SameSite session
 cookie, and redirects to `/dashboard`. `GET /api/session` calls `auth.Session`.
+A real app must set a unique, high-entropy `GOWDK_LOGIN_SECRET`, use real
+credentials, and leave the cookie `Secure` (serve over HTTPS).
 
 ## Split Mode
 

--- a/examples/login/src/features/auth/auth.go
+++ b/examples/login/src/features/auth/auth.go
@@ -29,10 +29,21 @@ func NewLoginViewState() LoginViewState {
 }
 
 func Login(_ context.Context, values form.Values) (response.Response, error) {
+	// Fail closed: refuse to authenticate unless the signing secret and the
+	// demo password are configured. Without a configured secret an attacker
+	// could forge session cookies; without a configured password an empty
+	// submitted password would match an empty fallback.
+	if len(loginSecret()) == 0 {
+		return response.RedirectTo("/login/error"), nil
+	}
+	wantEmail, wantPassword, ok := configuredCredentials()
+	if !ok {
+		return response.RedirectTo("/login/error"), nil
+	}
+
 	email := strings.TrimSpace(values.First("email"))
 	password := values.First("password")
-	if !constantEqual(email, env("GOWDK_LOGIN_EMAIL", "demo@example.com")) ||
-		!constantEqual(password, env("GOWDK_LOGIN_PASSWORD", "demo-password")) {
+	if !constantEqual(email, wantEmail) || !constantEqual(password, wantPassword) {
 		return response.RedirectTo("/login/error"), nil
 	}
 
@@ -50,7 +61,7 @@ func Login(_ context.Context, values form.Values) (response.Response, error) {
 		Path:     "/",
 		HttpOnly: true,
 		SameSite: http.SameSiteLaxMode,
-		Secure:   env("GOWDK_COOKIE_SECURE", "false") == "true",
+		Secure:   secureCookies(),
 		MaxAge:   int(sessionDuration().Seconds()),
 	}), nil
 }
@@ -62,7 +73,7 @@ func Logout(context.Context, form.Values) (response.Response, error) {
 		MaxAge:   -1,
 		HttpOnly: true,
 		SameSite: http.SameSiteLaxMode,
-		Secure:   env("GOWDK_COOKIE_SECURE", "false") == "true",
+		Secure:   secureCookies(),
 	}), nil
 }
 
@@ -89,6 +100,9 @@ var sessions = struct {
 }{Values: map[string]session{}}
 
 func currentSession(request *http.Request) (session, bool) {
+	if len(loginSecret()) == 0 {
+		return session{}, false
+	}
 	cookie, err := request.Cookie(sessionCookie)
 	if err != nil {
 		return session{}, false
@@ -112,9 +126,33 @@ func sign(value string) string {
 }
 
 func signature(value string) string {
-	mac := hmac.New(sha256.New, []byte(env("GOWDK_LOGIN_SECRET", "development-login-secret-change-me")))
+	mac := hmac.New(sha256.New, loginSecret())
 	_, _ = mac.Write([]byte(value))
 	return base64.RawURLEncoding.EncodeToString(mac.Sum(nil))
+}
+
+// loginSecret returns the HMAC signing key from the environment with no
+// literal fallback. An unset secret means the example refuses to issue or
+// accept sessions, so a publicly known key can never sign forgeable cookies.
+func loginSecret() []byte {
+	return []byte(strings.TrimSpace(os.Getenv("GOWDK_LOGIN_SECRET")))
+}
+
+// configuredCredentials returns the demo login email and password. The email
+// keeps a non-secret default for the demo UI, but the password must be set
+// explicitly so there is no hardcoded credential and an empty submitted
+// password cannot match an empty fallback.
+func configuredCredentials() (email, password string, ok bool) {
+	email = env("GOWDK_LOGIN_EMAIL", "demo@example.com")
+	password = strings.TrimSpace(os.Getenv("GOWDK_LOGIN_PASSWORD"))
+	return email, password, password != ""
+}
+
+// secureCookies reports whether the session cookie should carry the Secure
+// flag. It defaults to true; set GOWDK_COOKIE_INSECURE=true only for local
+// HTTP development.
+func secureCookies() bool {
+	return strings.TrimSpace(os.Getenv("GOWDK_COOKIE_INSECURE")) != "true"
 }
 
 func sessionDuration() time.Duration {

--- a/internal/appgen/adapter_ir_test.go
+++ b/internal/appgen/adapter_ir_test.go
@@ -108,6 +108,7 @@ func TestBackendAdapterIRCapturesRouteAndHandlerMetadata(t *testing.T) {
 
 func TestBackendAdapterIRCapturesFallbackMetadata(t *testing.T) {
 	ir := backendAdapterIR(Options{Actions: []ActionEndpoint{{
+		Guards:     []string{"public"},
 		PageID:     "newsletter",
 		ActionName: "Subscribe",
 		Method:     "POST",

--- a/internal/appgen/appgen_test.go
+++ b/internal/appgen/appgen_test.go
@@ -194,6 +194,7 @@ func TestGenerateWritesAuditIntegrationTest(t *testing.T) {
 			},
 		},
 		Actions: []ActionEndpoint{{
+			Guards:     []string{"public"},
 			PageID:     "home",
 			ActionName: "Submit",
 			Route:      "/submit",
@@ -515,6 +516,7 @@ func TestGenerateWritesActionRedirectHandler(t *testing.T) {
 	writeTestFile(t, filepath.Join(outputDir, "newsletter", "index.html"), "<main>Newsletter</main>")
 
 	result, err := GenerateWithOptions(outputDir, appDir, Options{Actions: []ActionEndpoint{{
+		Guards:           []string{"public"},
 		PageID:           "newsletter",
 		ActionName:       "Subscribe",
 		Route:            "/newsletter",
@@ -796,6 +798,7 @@ func TestGeneratedGoMatchesGoldenFixture(t *testing.T) {
 		},
 	}
 	actions := []ActionEndpoint{{
+		Guards:      []string{"public"},
 		PageID:      "newsletter",
 		ActionName:  "Subscribe",
 		Method:      "POST",
@@ -852,12 +855,14 @@ func TestGenerateBackendAppRegistersBackendRoutes(t *testing.T) {
 			},
 		}},
 		Actions: []ActionEndpoint{{
+			Guards:     []string{"public"},
 			PageID:     "newsletter",
 			ActionName: "Subscribe",
 			Route:      "/newsletter",
 			Redirect:   "/newsletter?ok=1",
 		}},
 		Fragments: []FragmentEndpoint{{
+			Guards:       []string{"public"},
 			PageID:       "patients",
 			FragmentName: "List",
 			Method:       "GET",
@@ -916,6 +921,7 @@ func TestGenerateRenamesBackendAliasReservedByGeneratedRuntime(t *testing.T) {
 		ActionName: "Subscribe",
 		Method:     "POST",
 		Route:      "/newsletter",
+		Guards:     []string{"public"},
 		Binding: source.BackendBinding{
 			Status:       source.BackendBindingBound,
 			ImportPath:   "example.com/app/sync",
@@ -951,6 +957,7 @@ func TestGenerateRenamesBackendAliasReservedByGeneratedRuntime(t *testing.T) {
 		APIName: "Health",
 		Method:  "GET",
 		Route:   "/api/health",
+		Guards:  []string{"public"},
 		Binding: source.BackendBinding{
 			Status:       source.BackendBindingBound,
 			ImportPath:   "example.com/app/sync",
@@ -993,6 +1000,7 @@ func TestGenerateBackendAppWiresSecurityHeaders(t *testing.T) {
 			},
 		}},
 		APIs: []APIEndpoint{{
+			Guards:  []string{"public"},
 			PageID:  "status",
 			APIName: "Health",
 			Method:  "GET",
@@ -1033,18 +1041,21 @@ func TestGenerateSplitFrontendProxyMatchesAdapterRoutes(t *testing.T) {
 	result, err := GenerateWithOptions(outputDir, appDir, Options{
 		ProxyBackend: true,
 		Actions: []ActionEndpoint{{
+			Guards:     []string{"public"},
 			PageID:     "newsletter",
 			ActionName: "Subscribe",
 			Method:     "POST",
 			Route:      "/newsletter",
 		}},
 		APIs: []APIEndpoint{{
+			Guards:  []string{"public"},
 			PageID:  "status",
 			APIName: "Health",
 			Method:  "GET",
 			Route:   "/api/health",
 		}},
 		Fragments: []FragmentEndpoint{{
+			Guards:       []string{"public"},
 			PageID:       "patients",
 			FragmentName: "List",
 			Method:       "GET",
@@ -1111,6 +1122,7 @@ func TestGenerateSplitFrontendProxyKeepsBackendAdaptersRemote(t *testing.T) {
 			Insecure:  true,
 		}}},
 		Actions: []ActionEndpoint{{
+			Guards:     []string{"public"},
 			PageID:     "newsletter",
 			ActionName: "Subscribe",
 			Method:     http.MethodPost,
@@ -1169,6 +1181,7 @@ func TestGenerateWiresCSRFByDefault(t *testing.T) {
 			Insecure:   true,
 		}}},
 		Actions: []ActionEndpoint{{
+			Guards:      []string{"public"},
 			PageID:      "newsletter",
 			ActionName:  "Subscribe",
 			Route:       "/newsletter",
@@ -1479,6 +1492,7 @@ func TestGenerateWritesTypedBoundActionHandlers(t *testing.T) {
 
 	result, err := GenerateWithOptions(outputDir, appDir, Options{Actions: []ActionEndpoint{
 		{
+			Guards:      []string{"public"},
 			PageID:      "Login",
 			ActionName:  "Login",
 			Route:       "/Login",
@@ -1503,6 +1517,7 @@ func TestGenerateWritesTypedBoundActionHandlers(t *testing.T) {
 			},
 		},
 		{
+			Guards:      []string{"public"},
 			PageID:      "Login",
 			ActionName:  "save",
 			Route:       "/Login/save",
@@ -1521,6 +1536,7 @@ func TestGenerateWritesTypedBoundActionHandlers(t *testing.T) {
 			},
 		},
 		{
+			Guards:     []string{"public"},
 			PageID:     "Login",
 			ActionName: "Ping",
 			Route:      "/Login/Ping",
@@ -1608,6 +1624,7 @@ func TestGenerateDoesNotImportMissingOrUnsupportedBackendPackages(t *testing.T) 
 
 	result, err := GenerateWithOptions(outputDir, appDir, Options{
 		Actions: []ActionEndpoint{{
+			Guards:     []string{"public"},
 			PageID:     "home",
 			ActionName: "Submit",
 			Route:      "/",
@@ -1621,6 +1638,7 @@ func TestGenerateDoesNotImportMissingOrUnsupportedBackendPackages(t *testing.T) 
 			},
 		}},
 		APIs: []APIEndpoint{{
+			Guards:  []string{"public"},
 			PageID:  "home",
 			APIName: "Status",
 			Method:  "GET",
@@ -1673,6 +1691,7 @@ func TestGenerateSortsImportsAndBackendDispatchDeterministically(t *testing.T) {
 	result, err := GenerateWithOptions(outputDir, appDir, Options{
 		Actions: []ActionEndpoint{
 			{
+				Guards:     []string{"public"},
 				PageID:     "z",
 				ActionName: "Zed",
 				Route:      "/z",
@@ -1685,6 +1704,7 @@ func TestGenerateSortsImportsAndBackendDispatchDeterministically(t *testing.T) {
 				},
 			},
 			{
+				Guards:     []string{"public"},
 				PageID:     "a",
 				ActionName: "Alpha",
 				Route:      "/a",
@@ -1699,6 +1719,7 @@ func TestGenerateSortsImportsAndBackendDispatchDeterministically(t *testing.T) {
 		},
 		APIs: []APIEndpoint{
 			{
+				Guards:  []string{"public"},
 				PageID:  "z",
 				APIName: "ZedAPI",
 				Method:  http.MethodGet,
@@ -1712,6 +1733,7 @@ func TestGenerateSortsImportsAndBackendDispatchDeterministically(t *testing.T) {
 				},
 			},
 			{
+				Guards:  []string{"public"},
 				PageID:  "a",
 				APIName: "AlphaAPI",
 				Method:  http.MethodGet,
@@ -1923,6 +1945,7 @@ func TestGeneratedPackageSourceIsGoFormatted(t *testing.T) {
 
 func TestGeneratedDeclarationSnippetIsGoFormatted(t *testing.T) {
 	source, err := actionHandlerSource([]ActionEndpoint{{
+		Guards:      []string{"public"},
 		PageID:      "newsletter",
 		ActionName:  "Subscribe",
 		Method:      http.MethodPost,
@@ -1951,6 +1974,7 @@ func TestGenerateWritesBoundAPIHandler(t *testing.T) {
 	writeTestFile(t, filepath.Join(outputDir, "status", "index.html"), "<main>Status</main>")
 
 	result, err := GenerateWithOptions(outputDir, appDir, Options{APIs: []APIEndpoint{{
+		Guards:  []string{"public"},
 		PageID:  "status",
 		APIName: "Health",
 		Method:  http.MethodGet,
@@ -2004,11 +2028,13 @@ func TestGenerateUsesConfiguredBodyLimits(t *testing.T) {
 			APIBytes:    4096,
 		}}},
 		Actions: []ActionEndpoint{{
+			Guards:     []string{"public"},
 			PageID:     "newsletter",
 			ActionName: "Subscribe",
 			Route:      "/newsletter",
 		}},
 		APIs: []APIEndpoint{{
+			Guards:  []string{"public"},
 			PageID:  "newsletter",
 			APIName: "Health",
 			Method:  http.MethodPost,
@@ -2052,12 +2078,14 @@ func TestGenerateWritesEndpointErrorPages(t *testing.T) {
 
 	result, err := GenerateWithOptions(outputDir, appDir, Options{
 		Actions: []ActionEndpoint{{
+			Guards:     []string{"public"},
 			PageID:     "newsletter",
 			ActionName: "Subscribe",
 			Route:      "/newsletter",
 			ErrorPage:  "/errors/subscribe.html",
 		}},
 		APIs: []APIEndpoint{{
+			Guards:    []string{"public"},
 			PageID:    "status",
 			APIName:   "Health",
 			Method:    http.MethodGet,
@@ -2101,6 +2129,7 @@ func TestGenerateWritesActionFragmentHandler(t *testing.T) {
 	writeTestFile(t, filepath.Join(outputDir, "patients", "index.html"), "<main>Patients</main>")
 
 	result, err := GenerateWithOptions(outputDir, appDir, Options{Actions: []ActionEndpoint{{
+		Guards:      []string{"public"},
 		PageID:      "patients",
 		ActionName:  "Refresh",
 		Route:       "/patients",
@@ -2198,6 +2227,7 @@ func TestGenerateInjectsCSRFIntoSSRForms(t *testing.T) {
 			PageID:      "newsletter",
 			ActionName:  "Subscribe",
 			Route:       "/newsletter",
+			Guards:      []string{"public"},
 			InputFields: []string{"email"},
 			Redirect:    "/newsletter?ok=1",
 		}},
@@ -2347,6 +2377,7 @@ func TestGenerateKeepsActionHandlersIndependentFromSSRLoad(t *testing.T) {
 			}},
 		}},
 		Actions: []ActionEndpoint{{
+			Guards:     []string{"public"},
 			PageID:     "dashboard",
 			ActionName: "Save",
 			Method:     http.MethodPost,
@@ -2541,6 +2572,7 @@ func TestGenerateWritesDynamicFragmentRouteParamBindings(t *testing.T) {
 	writeTestFile(t, filepath.Join(outputDir, "patients", "index.html"), "<main>Patients</main>")
 
 	result, err := GenerateWithOptions(outputDir, appDir, Options{Fragments: []FragmentEndpoint{{
+		Guards:       []string{"public"},
 		PageID:       "patients",
 		FragmentName: "Vitals",
 		Method:       "GET",
@@ -3106,6 +3138,7 @@ func TestGenerateRejectsUnsafeActionRedirect(t *testing.T) {
 			writeTestFile(t, filepath.Join(outputDir, "newsletter", "index.html"), "<main>Newsletter</main>")
 
 			_, err := GenerateWithOptions(outputDir, appDir, Options{Actions: []ActionEndpoint{{
+				Guards:     []string{"public"},
 				PageID:     "newsletter",
 				ActionName: "Subscribe",
 				Route:      "/newsletter",
@@ -3128,6 +3161,7 @@ func TestGenerateRejectsEmptyActionValidationRule(t *testing.T) {
 	writeTestFile(t, filepath.Join(outputDir, "newsletter", "index.html"), "<main>Newsletter</main>")
 
 	_, err := GenerateWithOptions(outputDir, appDir, Options{Actions: []ActionEndpoint{{
+		Guards:          []string{"public"},
 		PageID:          "newsletter",
 		ActionName:      "Subscribe",
 		Route:           "/newsletter",
@@ -3151,6 +3185,7 @@ func TestGenerateRejectsDynamicActionEndpoint(t *testing.T) {
 	writeTestFile(t, filepath.Join(outputDir, "blog", "hello", "index.html"), "<main>Post</main>")
 
 	_, err := GenerateWithOptions(outputDir, appDir, Options{Actions: []ActionEndpoint{{
+		Guards:     []string{"public"},
 		PageID:     "blog.post",
 		ActionName: "save",
 		Route:      "/blog/{slug}",
@@ -4268,6 +4303,7 @@ func TestGeneratedBinaryUsesCustomAPIErrorPage(t *testing.T) {
 	writeTestFile(t, filepath.Join(outputDir, "errors", "health.html"), "<main>Health Error</main>")
 
 	if _, err := GenerateWithOptions(outputDir, appDir, Options{APIs: []APIEndpoint{{
+		Guards:    []string{"public"},
 		PageID:    "status",
 		APIName:   "Health",
 		Method:    http.MethodGet,
@@ -4346,6 +4382,7 @@ func TestGeneratedBinaryHandlesEndpointErrorsAndMissingErrorPage(t *testing.T) {
 	if _, err := GenerateWithOptions(outputDir, appDir, Options{
 		Config: csrfDisabledConfig(),
 		Actions: []ActionEndpoint{{
+			Guards:     []string{"public"},
 			PageID:     "newsletter",
 			ActionName: "Subscribe",
 			Method:     http.MethodPost,
@@ -4358,6 +4395,7 @@ func TestGeneratedBinaryHandlesEndpointErrorsAndMissingErrorPage(t *testing.T) {
 				Signature:    source.BackendSignatureAction0,
 			},
 		}, {
+			Guards:     []string{"public"},
 			PageID:     "newsletter",
 			ActionName: "Explode",
 			Method:     http.MethodPost,
@@ -4372,6 +4410,7 @@ func TestGeneratedBinaryHandlesEndpointErrorsAndMissingErrorPage(t *testing.T) {
 			},
 		}},
 		APIs: []APIEndpoint{{
+			Guards:  []string{"public"},
 			PageID:  "session",
 			APIName: "Session",
 			Method:  http.MethodGet,
@@ -5363,6 +5402,7 @@ func TestGeneratedBinaryAppliesRegisteredRateLimiter(t *testing.T) {
 	if _, err := GenerateWithOptions(outputDir, appDir, Options{
 		Config: withCSRFDisabled(gowdk.Config{Addons: []gowdk.Addon{gowdk.NewAddon("ratelimit", gowdk.FeatureRateLimit)}}),
 		Actions: []ActionEndpoint{{
+			Guards:      []string{"public"},
 			PageID:      "newsletter",
 			ActionName:  "Subscribe",
 			Method:      "POST",
@@ -5624,6 +5664,7 @@ func TestGeneratedBinaryRedirectsActionPOST(t *testing.T) {
 	writeTestFile(t, filepath.Join(outputDir, "newsletter", "index.html"), "<main>Newsletter</main>")
 
 	if _, err := GenerateWithOptions(outputDir, appDir, Options{Config: csrfDisabledConfig(), Actions: []ActionEndpoint{{
+		Guards:           []string{"public"},
 		PageID:           "newsletter",
 		ActionName:       "Subscribe",
 		Route:            "/newsletter",
@@ -5642,6 +5683,7 @@ func TestGeneratedBinaryRedirectsActionPOST(t *testing.T) {
 		ValidatesInput: true,
 		Redirect:       "/newsletter?ok=1",
 	}, {
+		Guards:     []string{"public"},
 		PageID:     "newsletter",
 		ActionName: "Ping",
 		Route:      "/newsletter/ping",
@@ -5797,6 +5839,7 @@ func TestGeneratedBinaryValidatesCSRFByDefault(t *testing.T) {
 			Insecure:  true,
 		}}},
 		Actions: []ActionEndpoint{{
+			Guards:      []string{"public"},
 			PageID:      "newsletter",
 			ActionName:  "Subscribe",
 			Route:       "/newsletter",
@@ -5888,6 +5931,7 @@ func TestGeneratedBinaryInjectsCSRFIntoSSRForms(t *testing.T) {
 			PageID:      "newsletter",
 			ActionName:  "Subscribe",
 			Route:       "/newsletter",
+			Guards:      []string{"public"},
 			InputFields: []string{"email"},
 			Redirect:    "/newsletter?ok=1",
 		}},
@@ -5968,6 +6012,7 @@ func TestGeneratedBinaryServesPartialActionFragment(t *testing.T) {
 	writeTestFile(t, filepath.Join(outputDir, "patients", "index.html"), "<main>Patients</main>")
 
 	if _, err := GenerateWithOptions(outputDir, appDir, Options{Config: csrfDisabledConfig(), Actions: []ActionEndpoint{{
+		Guards:      []string{"public"},
 		PageID:      "patients",
 		ActionName:  "Refresh",
 		Route:       "/patients",
@@ -6041,6 +6086,7 @@ func TestGeneratedBinaryServesStandaloneFragmentRoute(t *testing.T) {
 	writeTestFile(t, filepath.Join(outputDir, "patients", "index.html"), "<main>Patients</main>")
 
 	if _, err := GenerateWithOptions(outputDir, appDir, Options{Fragments: []FragmentEndpoint{{
+		Guards:       []string{"public"},
 		PageID:       "patients",
 		FragmentName: "List",
 		Method:       "GET",
@@ -6102,6 +6148,7 @@ func TestGeneratedBinaryExecutesFragmentUserHook(t *testing.T) {
 	writeTestFile(t, filepath.Join(outputDir, "patients", "index.html"), "<main>Patients</main>")
 
 	if _, err := GenerateWithOptions(outputDir, appDir, Options{Fragments: []FragmentEndpoint{{
+		Guards:       []string{"public"},
 		PageID:       "patients",
 		FragmentName: "List",
 		Method:       "GET",
@@ -6181,6 +6228,7 @@ func TestGeneratedBinaryExecutesDynamicFragmentUserHook(t *testing.T) {
 	writeTestFile(t, filepath.Join(outputDir, "patients", "index.html"), "<main>Patients</main>")
 
 	if _, err := GenerateWithOptions(outputDir, appDir, Options{Fragments: []FragmentEndpoint{{
+		Guards:       []string{"public"},
 		PageID:       "patients",
 		FragmentName: "Vitals",
 		Method:       "GET",
@@ -6357,6 +6405,7 @@ func TestGeneratedBinaryDoesNotValidateRequiredFieldsWithoutValidMetadata(t *tes
 	writeTestFile(t, filepath.Join(outputDir, "newsletter", "index.html"), "<main>Newsletter</main>")
 
 	if _, err := GenerateWithOptions(outputDir, appDir, Options{Config: csrfDisabledConfig(), Actions: []ActionEndpoint{{
+		Guards:         []string{"public"},
 		PageID:         "newsletter",
 		ActionName:     "Subscribe",
 		Route:          "/newsletter",
@@ -6587,5 +6636,35 @@ func TestDeniedPageRoutePatternsSelectsGuardlessDynamicPages(t *testing.T) {
 	// Dynamic routes must not leak into the exact deny set.
 	if denied := deniedPageRoutes(options); len(denied) != 1 || denied[0] != "/" {
 		t.Fatalf("expected only the static route / in exact deny set, got %#v", denied)
+	}
+}
+
+func TestGuardlessActionAndAPIAreDeniedByOmission(t *testing.T) {
+	const deny = `gowdkresponse.WriteNoStoreError(response, http.StatusForbidden, "403 forbidden")`
+
+	actionSrc, err := actionHandlerSource([]ActionEndpoint{{PageID: "p", ActionName: "Sub", Route: "/sub"}}, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(actionSrc, deny) {
+		t.Fatalf("guardless action must be denied by omission:\n%s", actionSrc)
+	}
+
+	apiSrc, err := apiHandlerSource([]APIEndpoint{{PageID: "p", APIName: "Show", Method: "GET", Route: "/show"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(apiSrc, deny) {
+		t.Fatalf("guardless api must be denied by omission:\n%s", apiSrc)
+	}
+
+	// An endpoint that declares `guard public` is intentionally reachable and
+	// must NOT be denied by omission.
+	publicSrc, err := actionHandlerSource([]ActionEndpoint{{PageID: "p", ActionName: "Sub", Route: "/sub", Guards: []string{"public"}}}, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(publicSrc, deny) {
+		t.Fatalf("public action must not be denied by omission:\n%s", publicSrc)
 	}
 }

--- a/internal/appgen/source.go
+++ b/internal/appgen/source.go
@@ -283,7 +283,9 @@ func appGeneratedDecls(direct Options, full Options) []ast.Decl {
 	}
 	csrf := csrfEnabled(csrfOptions)
 	if csrf {
-		decls = append(decls, csrfTokenSourceVarDecl(), csrfValidatorVarDecl(), csrfNewFuncDecl(csrfOptions.Config.Build.CSRF))
+		// Gate the principal binding on full's guards, since guardDecls(full)
+		// below is what declares the authProvider var the binding reads.
+		decls = append(decls, csrfTokenSourceVarDecl(), csrfValidatorVarDecl(), csrfNewFuncDecl(full))
 	}
 	decls = append(decls, rateLimitDecls(full)...)
 	decls = append(decls, guardDecls(full)...)
@@ -306,7 +308,7 @@ func backendGeneratedDecls(options Options) []ast.Decl {
 		decls = append(decls, emptyBackendHandlerDecl())
 	}
 	if csrfEnabled(options) {
-		decls = append(decls, csrfTokenSourceVarDecl(), csrfValidatorVarDecl(), csrfNewFuncDecl(options.Config.Build.CSRF))
+		decls = append(decls, csrfTokenSourceVarDecl(), csrfValidatorVarDecl(), csrfNewFuncDecl(options))
 	}
 	decls = append(decls, rateLimitDecls(options)...)
 	decls = append(decls, guardDecls(options)...)
@@ -746,7 +748,7 @@ func csrfHelperSource(options Options) (source string, err error) {
 	return printActionDecls([]ast.Decl{
 		csrfTokenSourceVarDecl(),
 		csrfValidatorVarDecl(),
-		csrfNewFuncDecl(options.Config.Build.CSRF),
+		csrfNewFuncDecl(options),
 	})
 }
 
@@ -770,7 +772,8 @@ func csrfValidatorVarDecl() ast.Decl {
 	}
 }
 
-func csrfNewFuncDecl(config gowdk.CSRFConfig) *ast.FuncDecl {
+func csrfNewFuncDecl(genOptions Options) *ast.FuncDecl {
+	config := genOptions.Config.Build.CSRF
 	secretEnv := config.SecretEnvName()
 	options := []ast.Expr{keyValue("Secret", call(&ast.ArrayType{Elt: id("byte")}, id("secret")))}
 	if config.CookieName != "" {
@@ -784,6 +787,13 @@ func csrfNewFuncDecl(config gowdk.CSRFConfig) *ast.FuncDecl {
 	}
 	if config.Insecure {
 		options = append(options, keyValue("Insecure", id("true")))
+	}
+	// Bind the token to the authenticated principal when the app resolves one,
+	// so a token minted for one user is rejected for another. Only wired when
+	// native RBAC guards exist, because that is what declares the authProvider
+	// var the binding reads.
+	if generatedUsesNativeRBACGuards(genOptions) {
+		options = append(options, keyValue("Binding", csrfPrincipalBindingExpr()))
 	}
 	return funcDecl("newCSRF", nil, []*ast.Field{
 		{Type: &ast.StarExpr{X: sel("gowdkactions", "CSRF")}},
@@ -802,6 +812,41 @@ func csrfNewFuncDecl(config gowdk.CSRFConfig) *ast.FuncDecl {
 			Elts: options,
 		})}},
 	})
+}
+
+// csrfPrincipalBindingExpr builds the CSRFOptions.Binding func literal that
+// ties a CSRF token to the authenticated principal's ID. It returns nil for
+// anonymous requests so the token remains a valid signed double-submit token
+// before login and becomes session-bound once a principal resolves.
+func csrfPrincipalBindingExpr() ast.Expr {
+	return &ast.FuncLit{
+		Type: &ast.FuncType{
+			Params: &ast.FieldList{List: []*ast.Field{
+				{Names: []*ast.Ident{id("request")}, Type: &ast.StarExpr{X: sel("http", "Request")}},
+			}},
+			Results: &ast.FieldList{List: []*ast.Field{
+				{Type: &ast.ArrayType{Elt: id("byte")}},
+			}},
+		},
+		Body: block(
+			&ast.IfStmt{
+				Cond: &ast.BinaryExpr{X: id("authProvider"), Op: token.EQL, Y: id("nil")},
+				Body: block(&ast.ReturnStmt{Results: []ast.Expr{id("nil")}}),
+			},
+			define([]ast.Expr{id("principal"), id("err")}, call(selExpr(id("authProvider"), "Principal"), id("request"))),
+			&ast.IfStmt{
+				Cond: &ast.BinaryExpr{
+					X:  notNil("err"),
+					Op: token.LOR,
+					Y:  &ast.BinaryExpr{X: id("principal"), Op: token.EQL, Y: id("nil")},
+				},
+				Body: block(&ast.ReturnStmt{Results: []ast.Expr{id("nil")}}),
+			},
+			&ast.ReturnStmt{Results: []ast.Expr{
+				call(&ast.ArrayType{Elt: id("byte")}, selExpr(id("principal"), "ID")),
+			}},
+		),
+	}
 }
 
 func backendCallbackName(options Options) string {

--- a/internal/appgen/source_actions.go
+++ b/internal/appgen/source_actions.go
@@ -166,6 +166,9 @@ func actionRequestPathDecl() *ast.FuncDecl {
 }
 
 func actionCaseStmts(action BackendActionAdapter, csrf bool, rateLimit bool) []ast.Stmt {
+	if endpointDeniedByOmission(action.Guards) {
+		return denyByOmissionStmts()
+	}
 	stmts := endpointContextStmts("action", action.PageID, action.ActionName, actionAdapterMethod(action), action.Route, action.ErrorPage)
 	if action.ErrorPage != "" {
 		stmts = append(stmts, endpointPanicBoundaryStmt())

--- a/internal/appgen/source_api.go
+++ b/internal/appgen/source_api.go
@@ -58,6 +58,9 @@ func apiCaseExpr(api BackendAPIAdapter) ast.Expr {
 }
 
 func apiCaseStmts(api BackendAPIAdapter, rateLimit bool) []ast.Stmt {
+	if endpointDeniedByOmission(api.Guards) {
+		return denyByOmissionStmts()
+	}
 	stmts := endpointContextStmts("api", api.PageID, api.APIName, api.Method, api.Route, api.ErrorPage)
 	if api.ErrorPage != "" {
 		stmts = append(stmts, endpointPanicBoundaryStmt())

--- a/internal/appgen/source_guards.go
+++ b/internal/appgen/source_guards.go
@@ -118,6 +118,25 @@ func guardStmts(guards []string) []ast.Stmt {
 	}}
 }
 
+// endpointDeniedByOmission reports whether an endpoint that declares the given
+// guards must be denied at request time because it declares no guard at all. An
+// endpoint that declares `guard public` (or any runtime guard) is not denied by
+// omission.
+func endpointDeniedByOmission(guards []string) bool {
+	return len(guards) == 0
+}
+
+// denyByOmissionStmts emits a fail-closed 403 for an endpoint that declares no
+// guard. It returns before any context, body parsing, or handler statements,
+// matching the SSR route lane (ssrRouteBodyStmts) and the DefaultDeny posture
+// reported in gowdk-security.json.
+func denyByOmissionStmts() []ast.Stmt {
+	return []ast.Stmt{
+		writeNoStoreErrorStmt(sel("http", "StatusForbidden"), "403 forbidden"),
+		returnBool(true),
+	}
+}
+
 func generatedUsesCustomGuards(options Options) bool {
 	for _, name := range generatedGuardNames(options) {
 		if auth.IsPublicGuard(name) {

--- a/internal/buildgen/build_data_routes_test.go
+++ b/internal/buildgen/build_data_routes_test.go
@@ -688,7 +688,7 @@ func TestBuildRejectsRouteParamInDangerousAttributeBeforeWriting(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected dangerous route param attribute error")
 	}
-	if !strings.Contains(err.Error(), `route param interpolation is not allowed in "href" attributes`) {
+	if !strings.Contains(err.Error(), `is not allowed in "href" attributes`) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if entries, err := os.ReadDir(outputDir); err != nil {

--- a/internal/buildgen/render.go
+++ b/internal/buildgen/render.go
@@ -51,6 +51,7 @@ func renderPage(config gowdk.Config, page gwdkir.Page, components map[string]vie
 		Actions:           actionRoutes(page, data),
 		ActionInputFields: actionFields,
 		Package:           page.Package,
+		Tainted:           requestTimeTaintedFields(page, policy),
 	})
 	if err != nil {
 		return "", fmt.Errorf("%s: %w", page.ID, err)
@@ -78,6 +79,28 @@ func renderPageView(source string, nodes []view.Node, components map[string]view
 		return view.RenderNodesWithOptions(nodes, components, data, options)
 	}
 	return view.RenderWithOptions(source, components, data, options)
+}
+
+// requestTimeTaintedFields returns the interpolation names that carry
+// request-time, attacker-influenceable data for a page. Currently this is the
+// set of SSR load {} field paths, which must be treated like route params:
+// rejected in URL/event/style/srcdoc attributes so an attacker-controlled value
+// cannot inject a javascript:/data: URL past HTML-text escaping. Build {} data
+// is trusted and route params taint syntactically via param("..."), so neither
+// is included here.
+func requestTimeTaintedFields(page gwdkir.Page, policy renderModePolicy) map[string]bool {
+	if policy != renderModeRequestTime || !page.Blocks.Load {
+		return nil
+	}
+	fields, err := parseLoadFields(page.Blocks.LoadBody)
+	if err != nil {
+		return nil
+	}
+	tainted := make(map[string]bool, len(fields))
+	for _, path := range fields {
+		tainted[path] = true
+	}
+	return tainted
 }
 
 func composePageViewSource(page gwdkir.Page, layouts map[string]gwdkir.Layout) (string, error) {

--- a/internal/buildgen/ssr_test.go
+++ b/internal/buildgen/ssr_test.go
@@ -292,7 +292,7 @@ func TestSSRArtifactsRejectRouteParamInDangerousAttribute(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected dangerous route param attribute error")
 	}
-	if !strings.Contains(err.Error(), `route param interpolation is not allowed in "href" attributes`) {
+	if !strings.Contains(err.Error(), `is not allowed in "href" attributes`) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }

--- a/internal/view/api.go
+++ b/internal/view/api.go
@@ -121,6 +121,12 @@ type Options struct {
 	ActionInputFields map[string][]ActionInputField
 	Package           string
 	Uses              map[string]string
+	// Tainted names interpolation values that carry request-time,
+	// attacker-influenceable data (e.g. SSR load {} fields). Tainted values are
+	// rejected in URL-bearing, event-handler, style, and srcdoc attributes the
+	// same way route params are, so they cannot smuggle a javascript:/data: URL
+	// past HTML-text escaping.
+	Tainted map[string]bool
 }
 
 // ActionInputField describes Go action input metadata available while rendering
@@ -226,6 +232,7 @@ func RenderNodesWithOptions(nodes []Node, components map[string]Component, data 
 		},
 		renderDataContext: renderDataContext{
 			values:       cloneValues(data),
+			tainted:      cloneTaintSet(options.Tainted),
 			actions:      cloneValues(options.Actions),
 			actionFields: cloneActionInputFields(options.ActionInputFields),
 			stateFields:  map[string]bool{},

--- a/internal/view/bindings.go
+++ b/internal/view/bindings.go
@@ -46,7 +46,7 @@ func (node Element) initialStyleValue(ctx *renderContext, bindings []styleBindin
 			return "", err
 		}
 		if tainted && unsafeRouteParamAttr(attr.Name) {
-			return "", fmt.Errorf("route param interpolation is not allowed in %q attributes", attr.Name)
+			return "", fmt.Errorf("request-time interpolation (route param or load field) is not allowed in %q attributes", attr.Name)
 		}
 		declarations = append(declarations, strings.TrimSpace(value))
 	}

--- a/internal/view/element.go
+++ b/internal/view/element.go
@@ -280,7 +280,7 @@ func (node Element) render(ctx *renderContext, out *renderOutput) error {
 			return err
 		}
 		if tainted && unsafeRouteParamAttr(attr.Name) {
-			return fmt.Errorf("route param interpolation is not allowed in %q attributes", attr.Name)
+			return fmt.Errorf("request-time interpolation (route param or load field) is not allowed in %q attributes", attr.Name)
 		}
 		if err := validateRenderedHTMLAttrSafety(attr.Name, value); err != nil {
 			return err

--- a/internal/view/island_helpers.go
+++ b/internal/view/island_helpers.go
@@ -141,6 +141,16 @@ func cloneValues(input map[string]string) map[string]string {
 	return output
 }
 
+func cloneTaintSet(input map[string]bool) map[string]bool {
+	output := map[string]bool{}
+	for key, value := range input {
+		if value {
+			output[key] = true
+		}
+	}
+	return output
+}
+
 func cloneActionInputFields(input map[string][]ActionInputField) map[string][]ActionInputField {
 	output := map[string][]ActionInputField{}
 	for key, fields := range input {

--- a/internal/view/view_test.go
+++ b/internal/view/view_test.go
@@ -1431,10 +1431,25 @@ func TestRenderWithDataRejectsRouteParamsInDangerousAttributes(t *testing.T) {
 			if err == nil {
 				t.Fatal("expected dangerous route param attribute error")
 			}
-			if !strings.Contains(err.Error(), "route param interpolation is not allowed") {
+			if !strings.Contains(err.Error(), "is not allowed in") {
 				t.Fatalf("unexpected error: %v", err)
 			}
 		})
+	}
+}
+
+func TestRenderRejectsTaintedLoadFieldInDangerousAttribute(t *testing.T) {
+	source := `<a href="{user.website}">Profile</a>`
+	// An untainted (build-time/trusted) value renders fine.
+	if _, err := RenderWithOptions(source, nil, map[string]string{"user.website": "/ok"}, Options{}); err != nil {
+		t.Fatalf("untainted value should render: %v", err)
+	}
+	// The same value marked tainted (an SSR load {} field) is rejected, so an
+	// attacker-controlled value can never carry a javascript:/data: URL past
+	// HTML-text escaping.
+	_, err := RenderWithOptions(source, nil, map[string]string{"user.website": "/ok"}, Options{Tainted: map[string]bool{"user.website": true}})
+	if err == nil || !strings.Contains(err.Error(), `is not allowed in "href" attributes`) {
+		t.Fatalf("expected tainted load field to be rejected in href, got %v", err)
 	}
 }
 
@@ -1588,7 +1603,7 @@ func TestRenderWithDataRejectsRouteParamPassedToDangerousComponentAttribute(t *t
 	if err == nil {
 		t.Fatal("expected dangerous route param component prop error")
 	}
-	if !strings.Contains(err.Error(), `route param interpolation is not allowed in "href" attributes`) {
+	if !strings.Contains(err.Error(), `is not allowed in "href" attributes`) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }

--- a/runtime/app/redact_test.go
+++ b/runtime/app/redact_test.go
@@ -81,6 +81,18 @@ func TestRedactSecretsMasksCredentials(t *testing.T) {
 			leaked:  "refresh-secret-token",
 			wantSub: "refresh_token=[REDACTED]",
 		},
+		{
+			name:    "bare session token in panic message",
+			in:      "panic: rejected session eyJpZCI6ImFsaWNlIiwiZXhwIjoxNzB9.c2lnbmF0dXJlYnl0ZXNoZXJlMDEyMzQ1Njc4OQ at handler",
+			leaked:  "eyJpZCI6ImFsaWNlIiwiZXhwIjoxNzB9.c2lnbmF0dXJlYnl0ZXNoZXJlMDEyMzQ1Njc4OQ",
+			wantSub: "[REDACTED]",
+		},
+		{
+			name:    "bare jwt in stack frame",
+			in:      "token eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dBjftJeZ4CVPmB92K27uhbUJU1p1r wong",
+			leaked:  "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dBjftJeZ4CVPmB92K27uhbUJU1p1r",
+			wantSub: "[REDACTED]",
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/runtime/response/response.go
+++ b/runtime/response/response.go
@@ -209,6 +209,13 @@ func WriteHTTP(writer http.ResponseWriter, result Response) error {
 	}
 	switch result.Kind {
 	case Redirect:
+		if err := ValidateLocalRedirect(result.URL); err != nil {
+			// Fail closed: never emit an attacker-influenced Location header.
+			// This matches the guard and SSR redirect lanes, which only allow
+			// local absolute paths.
+			http.Error(writer, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+			return err
+		}
 		writer.Header().Set("Location", result.URL)
 		writer.WriteHeader(status)
 	case Reload:
@@ -321,4 +328,28 @@ func validSwapMode(swap SwapMode) bool {
 	default:
 		return false
 	}
+}
+
+// ValidateLocalRedirect reports whether url is a safe same-origin redirect
+// target. Only local absolute paths are allowed; protocol-relative URLs,
+// backslash tricks browsers normalize to "//", and CRLF header-injection
+// attempts are rejected. It is the single redirect-safety contract shared by
+// the response, guard, and SSR lanes so an attacker-influenced "next"/"return_to"
+// value cannot become an open redirect.
+func ValidateLocalRedirect(url string) error {
+	if url == "" || url[0] != '/' {
+		return fmt.Errorf("redirect %q must be a local absolute path", url)
+	}
+	if len(url) > 1 && (url[1] == '/' || url[1] == '\\') {
+		return fmt.Errorf("redirect %q must not be protocol-relative", url)
+	}
+	// Browsers normalize "\" to "/" before navigating, so "/\evil.com" is
+	// treated like the protocol-relative "//evil.com".
+	if strings.Contains(url, "\\") {
+		return fmt.Errorf("redirect %q must not contain backslashes", url)
+	}
+	if strings.ContainsAny(url, "\r\n") {
+		return fmt.Errorf("redirect %q must not contain newlines", url)
+	}
+	return nil
 }

--- a/runtime/response/response_test.go
+++ b/runtime/response/response_test.go
@@ -142,6 +142,35 @@ func TestWriteHTTPWritesRedirect(t *testing.T) {
 	}
 }
 
+func TestWriteHTTPRejectsOpenRedirect(t *testing.T) {
+	for _, target := range []string{"//evil.com", "https://evil.com", "/\\evil.com", "/ok\r\nSet-Cookie: x=1", ""} {
+		recorder := httptest.NewRecorder()
+		err := WriteHTTP(recorder, RedirectTo(target))
+		if err == nil {
+			t.Fatalf("expected error for unsafe redirect %q", target)
+		}
+		if location := recorder.Header().Get("Location"); location != "" {
+			t.Fatalf("unsafe redirect %q leaked Location header: %q", target, location)
+		}
+		if recorder.Code != http.StatusInternalServerError {
+			t.Fatalf("unsafe redirect %q: unexpected status %d", target, recorder.Code)
+		}
+	}
+}
+
+func TestValidateLocalRedirect(t *testing.T) {
+	for _, ok := range []string{"/", "/dashboard", "/a/b?c=1#d"} {
+		if err := ValidateLocalRedirect(ok); err != nil {
+			t.Fatalf("expected %q to be valid: %v", ok, err)
+		}
+	}
+	for _, bad := range []string{"", "//evil.com", "https://evil.com", "/\\x", "a/b", "/x\ry"} {
+		if err := ValidateLocalRedirect(bad); err == nil {
+			t.Fatalf("expected %q to be rejected", bad)
+		}
+	}
+}
+
 func TestWriteNoStoreHTTP(t *testing.T) {
 	recorder := httptest.NewRecorder()
 

--- a/runtime/security/redact.go
+++ b/runtime/security/redact.go
@@ -30,6 +30,16 @@ var rules = []rule{
 		pattern:     regexp.MustCompile(`(?i)\b(password|passwd|pwd|secret|token|_?gowdk[_-]?csrf|_?csrf(?:[_-]?token)?|cookie|set-cookie|auth[_-]?token|session(?:[_-]?id)?|jwt|api[_-]?key|access(?:[_-]?(?:key|token))?|refresh[_-]?token|id[_-]?token|client[_-]?secret|private[_-]?key)\b(\s*[:=]\s*)("?)[^\s"',;)]+`),
 		replacement: `${1}${2}${3}` + RedactionMask,
 	},
+	{
+		// signed-token masks bare HMAC/JWT-shaped tokens that carry no preceding
+		// keyword — e.g. a gowdk session cookie value (<b64payload>.<b64tag>) or a
+		// JWT (<b64>.<b64>.<b64>) that surfaces inside a panic message or stack
+		// frame. Two base64url runs of >= 20 chars joined by a dot effectively
+		// never occur in ordinary text, so this stays high precision.
+		kind:        "signed-token",
+		pattern:     regexp.MustCompile(`[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}(?:\.[A-Za-z0-9_-]{10,})?`),
+		replacement: RedactionMask,
+	},
 }
 
 // RedactSecrets masks values that commonly carry credentials.


### PR DESCRIPTION
## Summary

Fixes seven of the eight security issues from the architecture/security review (#430–#437). Each fix is scoped and tested. `go build ./cmd/gowdk` is clean and the full root-module suite (`go test ./...`, 59 packages) passes.

**#434 is already fixed on `main`** (by #427, which added `MinSessionSecretBytes`), so it is intentionally **not** included here. This branch was rebased onto current `main`; the session-secret change was dropped as redundant.

## Fixes

### High
- **#430 — SSR `load {}` XSS.** Request-time `load {}` field values were HTML-text-escaped only, so a `javascript:`/`data:` URL survived in `href`/`src`/`action`/etc. Load fields are now taint-tracked at build time (`view.Options.Tainted`, seeded from the page's load fields in `internal/buildgen`), so the existing URL/event/style/`srcdoc` attribute guard rejects them at compile time exactly as it already does for route params. New test: `view.TestRenderRejectsTaintedLoadFieldInDangerousAttribute`.

### Medium
- **#431 — guardless `act`/`api` fail-closed.** Endpoints that declare no guard now emit a `403` deny (matching the SSR lane), so runtime behavior matches the `DefaultDeny` posture in `gowdk-security.json`. Declare `guard public` to intentionally expose an endpoint. **Breaking:** action/api endpoints with no guard now return 403; test fixtures were updated to mark intentionally-public endpoints `public`. New test: `appgen.TestGuardlessActionAndAPIAreDeniedByOmission`. *(Fragments and contract exposures share this posture-mismatch and are left as scoped follow-ups.)*
- **#432 — CSRF token bound to principal.** New `CSRFOptions.Binding` mixes a per-request identity into the token signature; the generator wires it to the authenticated principal's ID whenever native RBAC guards exist. A token minted for one principal is rejected once the request resolves to another (OWASP signed-double-submit hardening). Anonymous requests bind to nil (backwards compatible). New test: `actions.TestCSRFBindsTokenToPrincipal`.
- **#433 — API empty `Content-Type` rejected.** `requireJSONContentType` now rejects a missing `Content-Type`, closing the browser-form CSRF vector against JSON handlers (a cross-origin form cannot send `application/json` without a CORS preflight). New test: `api.TestDecodeJSONRejectsMissingContentType`. *(Mandatory CSRF tokens on cookie-authed mutating API methods — the issue's second half — are deferred: the generated client must attach the token first, or the app's own API calls break. Tracked on #433.)*
- **#435 — bare-token log redaction.** Added a high-precision `signed-token` rule in `runtime/security` that masks `<b64>.<b64>[.<b64>]` (session/JWT) tokens with no preceding keyword, so a session token in a panic message or stack frame no longer leaks to logs. Kept precise to avoid false-positive findings in the manifest secret detector. New tests in `runtime/app/redact_test.go`.

### Low
- **#436 — open redirect.** `response.WriteHTTP` now validates redirect targets via the shared `response.ValidateLocalRedirect` and refuses to emit a non-local `Location`, matching the guard/SSR lanes. New tests: `response.TestWriteHTTPRejectsOpenRedirect`, `TestValidateLocalRedirect`.
- **#437 — example login hardening.** `examples/login` now fails closed without `GOWDK_LOGIN_SECRET` (no literal fallback) and `GOWDK_LOGIN_PASSWORD`, and defaults the session cookie to `Secure` (opt out with `GOWDK_COOKIE_INSECURE=true` for local HTTP). README updated.

## Test plan
- `go build ./cmd/gowdk` — clean
- `go test ./...` — 59 packages pass
- New tests cover each fix; existing route-param/CSRF/redaction tests updated for the generalized guard message and the new contracts; public endpoints in fixtures marked `guard public`.

Closes #430
Closes #431
Closes  #432
Closes #435
Closes  #436 
Closes #437
 Partially addresses #433 (empty Content-Type closed; mandatory API CSRF token deferred). #434 already fixed on main by #427.
