### PR TITLE
[codex] docs: discourage new Gin use

### DIFF
--- a/docs/reference/framework-integrations.md
+++ b/docs/reference/framework-integrations.md
@@ -103,8 +103,15 @@ echoContext, ok := gowdkecho.Context(ctx)
 
 ## Gin
 
+GOWDK does not recommend Gin for new GOWDK applications. Prefer the generated
+`net/http` handler directly, or use a smaller router such as Chi when the host
+application needs one. The Gin adapter remains available for existing Gin
+codebases and teams that deliberately choose Gin anyway. For background on the
+dependency weight, API surface, and migration cost concerns, see
+[this critique of Gin](https://eblog.fly.dev/ginbad.html).
+
 The Gin adapter is a nested optional module. Add it only when the application
-uses Gin:
+already uses Gin:
 
 ```sh
 go get github.com/cssbruno/gowdk/runtime/adapters/gin


### PR DESCRIPTION
## What changed

Document that GOWDK does not recommend Gin for new GOWDK applications.

The framework integrations reference now recommends using the generated `net/http` handler directly, or Chi when a smaller host router is needed, while keeping the Gin adapter available for existing Gin codebases and teams that deliberately choose it.

## Why

Gin remains supported through an optional adapter, but it should not read as an equally recommended path for new GOWDK applications. The new note points readers to background on dependency weight, API surface, and migration cost concerns.

## Validation

- `git diff --cached --check`

No Go tests were run because this is a docs-only change.