### PR TITLE
fix: security + correctness batch (#385, #382, #386, #357, #419)

### DIFF
--- a/cmd/gowdk/audit.go
+++ b/cmd/gowdk/audit.go
@@ -59,9 +59,11 @@ func (err auditExitError) Error() string {
 func (auditExitError) SilentCLIError() {}
 
 // audit derives the security posture from validated IR, evaluates the baseline
-// policy against it, and reports findings. It is a standalone command: gowdk
-// build never runs it, so it can never fail a build implicitly. It exits
-// non-zero when any error-severity finding exists so it can gate CI.
+// policy against it, and reports findings. It is the full report surface
+// (posture JSON, declared policies, optional runtime tests) and exits non-zero
+// when any error-severity finding exists so it can gate CI. gowdk build runs the
+// same baseline as a production gate (see enforceBuildSecurityAudit); this
+// command stays available for explicit reports and non-production checks.
 func audit(args []string) error {
 	auditOptions, projectArgs, err := parseAuditCommandOptions(args)
 	if err != nil {

--- a/cmd/gowdk/build.go
+++ b/cmd/gowdk/build.go
@@ -21,7 +21,7 @@ import (
 	"github.com/cssbruno/gowdk/internal/source"
 )
 
-const buildUsage = "usage: gowdk build [--config <file>] [--debug] [--timings[=<file>]] [--ssr] [--allow-missing-backend] [--obfuscate-assets] [--target <name>] [--module <name>] [--out <dir>] [--app <dir>] [--bin <file>] [--docker] [--docker-base <distroless|scratch>] [--wasm <file>] [--backend-app <dir>] [--backend-bin <file>] [files...]"
+const buildUsage = "usage: gowdk build [--config <file>] [--debug] [--timings[=<file>]] [--ssr] [--allow-missing-backend] [--allow-insecure] [--obfuscate-assets] [--target <name>] [--module <name>] [--out <dir>] [--app <dir>] [--bin <file>] [--docker] [--docker-base <distroless|scratch>] [--wasm <file>] [--backend-app <dir>] [--backend-bin <file>] [files...]"
 
 func build(args []string) error {
 	started := time.Now()
@@ -226,6 +226,12 @@ func buildOnce(options cliOptions, request buildRequest, timings *buildTimingRec
 			return newDevDiagnosticError("build failed", devOverlayDiagnosticsFromCompiler(report))
 		}
 		return fmt.Errorf("build failed")
+	}
+
+	if err := timings.measure("security_audit", func() error {
+		return enforceBuildSecurityAudit(options, ir)
+	}); err != nil {
+		return err
 	}
 
 	var result buildgen.Result
@@ -595,6 +601,8 @@ func parseBuildOptions(args []string) (buildOptions, error) {
 		case arg == "--allow-missing-backend":
 			plan.Options.AllowMissingBackend = true
 			plan.Options.Config.Build.AllowMissingBackend = true
+		case arg == "--allow-insecure":
+			plan.Options.AllowInsecure = true
 		case arg == "--obfuscate-assets":
 			plan.Options.ObfuscateAssets = true
 			plan.Options.Config.Build.ObfuscateAssets = true

--- a/cmd/gowdk/build.go
+++ b/cmd/gowdk/build.go
@@ -182,11 +182,9 @@ func buildOnce(options cliOptions, request buildRequest, timings *buildTimingRec
 	timings.counter("endpoints", len(ir.Endpoints))
 	var bindings []source.BackendBinding
 	if err := timings.measure("go_binding", func() error {
-		if err := compiler.DiscoverGoEndpoints(options.Config, &ir); err != nil {
-			return err
-		}
-		bindings = compiler.BindBackendHandlers(&ir)
-		return nil
+		var bindErr error
+		bindings, bindErr = compiler.EnrichProgram(options.Config, &ir)
+		return bindErr
 	}); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		return fmt.Errorf("build failed")

--- a/cmd/gowdk/build_audit.go
+++ b/cmd/gowdk/build_audit.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/cssbruno/gowdk"
+	"github.com/cssbruno/gowdk/internal/auditspec"
+	"github.com/cssbruno/gowdk/internal/diagnostics"
+	"github.com/cssbruno/gowdk/internal/gwdkir"
+	"github.com/cssbruno/gowdk/internal/securitymanifest"
+)
+
+// buildSecurityAuditError reports that gowdk build was blocked by error-severity
+// security findings. It is not silent: main prints its message so the developer
+// learns why the build stopped and how to proceed.
+type buildSecurityAuditError struct {
+	errors int
+}
+
+func (err buildSecurityAuditError) Error() string {
+	return fmt.Sprintf(
+		"build blocked by %d security error finding(s); fix them (run 'gowdk audit' for the full report) or pass --allow-insecure to build anyway",
+		err.errors,
+	)
+}
+
+// enforceBuildSecurityAudit derives the security posture from the validated IR
+// and evaluates the built-in baseline together with any declared *.audit.gwdk
+// policies. Unlike the standalone gowdk audit command, this runs as part of
+// gowdk build so a critical exposure (a roleless contract, a missing CSRF guard,
+// a public-by-omission API, a bundled secret) blocks shipping instead of relying
+// on a team remembering to gate CI on gowdk audit. Error-severity findings block
+// a production build (the baseline encodes production-readiness gates); other
+// builds print a prominent summary so the exposure is visible without breaking
+// dev iteration. The --allow-insecure flag downgrades the production gate to a
+// warning for 0.x experimentation.
+func enforceBuildSecurityAudit(options cliOptions, ir gwdkir.Program) error {
+	manifest := securitymanifest.Build(options.Config, ir)
+	declared := auditspec.PoliciesFromIR(ir.AuditSpecs)
+	findings := auditspec.Evaluate(manifest, auditspec.ComposeBaseline(declared))
+	auditspec.SortFindings(findings)
+	summary := auditspec.Summarize(findings)
+	if summary.Errors == 0 {
+		return nil
+	}
+
+	printBuildSecurityFindings(findings)
+	if options.Config.Build.Mode == gowdk.Production && !options.AllowInsecure {
+		return buildSecurityAuditError{errors: summary.Errors}
+	}
+
+	reason := "this build is not in production mode"
+	if options.AllowInsecure {
+		reason = "--allow-insecure was set"
+	}
+	fmt.Fprintf(os.Stderr, "warning: %d security error finding(s) did not block the build because %s; run 'gowdk audit' to gate them in CI\n", summary.Errors, reason)
+	return nil
+}
+
+// printBuildSecurityFindings prints the error-severity findings that block the
+// build, each with its remediation and the explain command, mirroring the
+// standalone audit output so the two surfaces read the same.
+func printBuildSecurityFindings(findings []auditspec.Finding) {
+	fmt.Fprintln(os.Stderr, "security audit found build-blocking findings:")
+	for _, finding := range findings {
+		if finding.Severity != diagnostics.SeverityError {
+			continue
+		}
+		fmt.Fprintf(os.Stderr, "[%s] %s: %s\n", strings.ToUpper(string(finding.Severity)), finding.Code, finding.Message)
+		location := finding.Target
+		if finding.Source != "" {
+			location = finding.Source
+		}
+		if location != "" {
+			fmt.Fprintf(os.Stderr, "  at: %s\n", location)
+		}
+		if finding.Remediation != "" {
+			fmt.Fprintf(os.Stderr, "  fix: %s\n", finding.Remediation)
+		}
+		fmt.Fprintf(os.Stderr, "  why: gowdk explain %s\n", finding.Code)
+	}
+}

--- a/cmd/gowdk/main.go
+++ b/cmd/gowdk/main.go
@@ -146,6 +146,7 @@ type cliOptions struct {
 	JSON                bool
 	Debug               bool
 	AllowMissingBackend bool
+	AllowInsecure       bool
 	ObfuscateAssets     bool
 	WarningsAsErrors    bool
 }

--- a/cmd/gowdk/main_test.go
+++ b/cmd/gowdk/main_test.go
@@ -6274,6 +6274,52 @@ view {
 	}
 }
 
+func TestBuildCommandProductionBlocksInsecureAuditFindings(t *testing.T) {
+	root := t.TempDir()
+	page := filepath.Join(root, "newsletter.page.gwdk")
+	outputDir := filepath.Join(root, "dist")
+	config := filepath.Join(root, "gowdk.config.go")
+	writeCLIFile(t, config, `package app
+
+import "github.com/cssbruno/gowdk"
+
+var Config = gowdk.Config{
+	Build: gowdk.BuildConfig{
+		Mode: gowdk.Production,
+		CSRF: gowdk.CSRFConfig{Disabled: true},
+	},
+}
+`)
+	writeCLIFile(t, page, `package app
+
+page newsletter
+route "/newsletter"
+
+act Subscribe POST "/newsletter"
+
+view {
+  <form g:post={Subscribe}>
+    <input name="email" required />
+    <button type="submit">Subscribe</button>
+  </form>
+}
+`)
+
+	err := run([]string{"build", "--config", config, "--allow-missing-backend", "--out", outputDir, page})
+	if err == nil {
+		t.Fatal("expected production build to be blocked by error-severity security findings")
+	}
+	if !strings.Contains(err.Error(), "build blocked by") {
+		t.Fatalf("unexpected build audit error: %v", err)
+	}
+
+	// --allow-insecure downgrades the production gate to a warning so the build
+	// proceeds for 0.x experimentation.
+	if err := run([]string{"build", "--config", config, "--allow-missing-backend", "--allow-insecure", "--out", outputDir, page}); err != nil {
+		t.Fatalf("expected --allow-insecure to override the security gate: %v", err)
+	}
+}
+
 func TestBuildCommandBuildsBinaryWithFeatureBoundActionAndAPI(t *testing.T) {
 	root := t.TempDir()
 	moduleRoot, err := filepath.Abs("../..")

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -28,7 +28,7 @@ gowdk contracts [--json] [dir]
 gowdk graph [--json] [dir]
 gowdk trace <contract> [--json] [dir]
 gowdk list commands|queries|events|jobs [--json] [dir]
-gowdk build [--config <file>] [--debug] [--timings[=<file>]] [--ssr] [--allow-missing-backend] [--obfuscate-assets] [--target <name>] [--module <name>] [--out <dir>] [--app <dir>] [--bin <file>] [--docker] [--docker-base <distroless|scratch>] [--wasm <file>] [--backend-app <dir>] [--backend-bin <file>] [files...]
+gowdk build [--config <file>] [--debug] [--timings[=<file>]] [--ssr] [--allow-missing-backend] [--allow-insecure] [--obfuscate-assets] [--target <name>] [--module <name>] [--out <dir>] [--app <dir>] [--bin <file>] [--docker] [--docker-base <distroless|scratch>] [--wasm <file>] [--backend-app <dir>] [--backend-bin <file>] [files...]
 gowdk dev [--addr <addr>] [--interval <duration>] [build flags...]
 gowdk preview [--addr <addr>] [--hot] [build flags...]
 gowdk serve --dir <dir> [--addr <addr>]
@@ -90,6 +90,7 @@ gowdk lsp [--ssr]
   contract references, invalid contract handler signatures, and duplicate
   command owners.
 - `--allow-missing-backend`: supported by `build` and forwarded by `dev`; in production mode, allows missing or unsupported action/API handlers to generate HTTP 501 stubs instead of failing the build.
+- Security audit gate: `gowdk build` runs the same baseline as `gowdk audit` (see [security.md](../engineering/security.md)). A production build (`Build.Mode = gowdk.Production`) fails on any error-severity finding (missing CSRF, guardless or public-by-omission endpoints, roleless contracts, bundled secrets, raw-HTML sinks); non-production builds print a prominent summary without blocking. `--allow-insecure` downgrades the production gate to a warning for 0.x experimentation. Run `gowdk audit` for the full report and to gate CI explicitly.
 - `--obfuscate-assets`: supported by `build` and forwarded by `dev`; enables
   deterministic production obfuscation/minification for compiler-owned
   generated browser JavaScript, forces `Build.Mode` to `gowdk.Production` for

--- a/docs/reference/diagnostic-codes.md
+++ b/docs/reference/diagnostic-codes.md
@@ -161,7 +161,7 @@ Parser diagnostics emit stable codes for common unsupported syntax and keep
   `client_go_block_wasm_export_error`.
 - Security audit (`gowdk audit`): `audit_action_missing_csrf`,
   `audit_api_missing_csrf`, `audit_api_public_by_omission`,
-  `audit_command_missing_csrf`,
+  `audit_command_missing_csrf`, `audit_contract_roleless`,
   `audit_guardless_endpoint_page`, `audit_bundle_secret`,
   `audit_client_route_unguarded`,
   `audit_headers_missing`, `audit_headers_runtime_missing`,

--- a/docs/reference/diagnostic-codes.md
+++ b/docs/reference/diagnostic-codes.md
@@ -173,6 +173,25 @@ Parser diagnostics emit stable codes for common unsupported syntax and keep
   experimental and emitted by `gowdk audit`, declared audit policies, or the
   optional runtime audit test runner.
 
+## Source Ranges
+
+Diagnostics carry an exact source span (`internal/source.SourceSpan`) when one
+is available at the emit site; the LSP and dev overlay use it directly and fall
+back to a file/owner-level range only when no precise span exists.
+
+Exact ranges now cover the backend-binding family, which point at the declaring
+`act` / `api` / `fragment` block (or standalone `//gowdk:` endpoint):
+`ambiguous_backend_handler`, `unsupported_backend_signature`,
+`unexported_backend_handler`, and `backend_binding_required`. The
+`source.BackendBinding` produced by `compiler.BindBackendHandlers` captures the
+block span so both `gowdk check`/build diagnostics and the editor highlight the
+exact declaration.
+
+Known gaps (no precise span available, file/owner-level only): `go_package_error`
+for an unparseable sibling `.go` file or a missing package clause — these arise
+before a Go AST exists, so only the file path is known. Inline `go {}` block
+package errors already carry the block span.
+
 ## Adding A Code
 
 When adding or renaming a diagnostic code:

--- a/internal/appgen/appgen_test.go
+++ b/internal/appgen/appgen_test.go
@@ -4927,7 +4927,7 @@ type PatientPageData struct {
 }
 
 func Register(registry *contracts.Registry) {
-	contracts.RegisterQuery[GetPatientPage, PatientPageData](registry, LoadPatientPage)
+	contracts.RegisterQuery[GetPatientPage, PatientPageData](registry, LoadPatientPage, contracts.RoleWeb)
 }
 
 func LoadPatientPage(ctx context.Context, query GetPatientPage) (PatientPageData, error) {
@@ -5032,7 +5032,7 @@ type PatientCreated struct {
 }
 
 func Register(registry *contracts.Registry) {
-	contracts.RegisterCommand[CreatePatient, CreatePatientResult](registry, HandleCreatePatient)
+	contracts.RegisterCommand[CreatePatient, CreatePatientResult](registry, HandleCreatePatient, contracts.RoleWeb)
 }
 
 func HandleCreatePatient(ctx context.Context, command CreatePatient) (CreatePatientResult, error) {
@@ -5173,7 +5173,7 @@ type PatientCreated struct {
 }
 
 func Register(registry *contracts.Registry) {
-	contracts.RegisterCommand[CreatePatient, CreatePatientResult](registry, HandleCreatePatient)
+	contracts.RegisterCommand[CreatePatient, CreatePatientResult](registry, HandleCreatePatient, contracts.RoleWeb)
 }
 
 func HandleCreatePatient(ctx context.Context, command CreatePatient) (CreatePatientResult, error) {
@@ -5434,8 +5434,8 @@ type PatientPageData struct {
 }
 
 func Register(registry *contracts.Registry) {
-	contracts.RegisterCommand[CreatePatient, CreatePatientResult](registry, HandleCreatePatient)
-	contracts.RegisterQuery[GetPatientPage, PatientPageData](registry, LoadPatientPage)
+	contracts.RegisterCommand[CreatePatient, CreatePatientResult](registry, HandleCreatePatient, contracts.RoleWeb)
+	contracts.RegisterQuery[GetPatientPage, PatientPageData](registry, LoadPatientPage, contracts.RoleWeb)
 }
 
 func HandleCreatePatient(ctx context.Context, command CreatePatient) (CreatePatientResult, error) {
@@ -5610,7 +5610,7 @@ type CreatePatientResult struct {
 }
 
 func Register(registry *contracts.Registry) {
-	contracts.RegisterCommand[CreatePatient, CreatePatientResult](registry, HandleCreatePatient)
+	contracts.RegisterCommand[CreatePatient, CreatePatientResult](registry, HandleCreatePatient, contracts.RoleWeb)
 }
 
 func HandleCreatePatient(ctx context.Context, command CreatePatient) (CreatePatientResult, error) {

--- a/internal/auditspec/auditspec.go
+++ b/internal/auditspec/auditspec.go
@@ -17,6 +17,7 @@ type SelectorKind string
 const (
 	SelectorRoute    SelectorKind = "route"
 	SelectorEndpoint SelectorKind = "endpoint"
+	SelectorContract SelectorKind = "contract"
 	SelectorFrontend SelectorKind = "frontend"
 	SelectorUnknown  SelectorKind = "unknown"
 )
@@ -50,6 +51,11 @@ const (
 	// RuleAllowRawHTML allowlists one raw-HTML sink (source:field); every sink
 	// not allowlisted is reported.
 	RuleAllowRawHTML RuleKind = "allow_raw_html"
+	// RuleDenyRolelessContract reports a web-exposed command or query contract
+	// that declares no roles, so the data-layer authorization gate has no role to
+	// admit. The contract must declare at least one role (or RoleAny to be
+	// intentionally public).
+	RuleDenyRolelessContract RuleKind = "deny_roleless_contract"
 )
 
 // Selector targets a set of routes, endpoints, or the frontend surface.

--- a/internal/auditspec/baseline.go
+++ b/internal/auditspec/baseline.go
@@ -64,6 +64,16 @@ func Baseline() []Policy {
 			},
 		},
 		{
+			Name:    "baseline.contracts",
+			Builtin: true,
+			Selectors: []Selector{
+				{Raw: "contract:*", Kind: SelectorContract},
+			},
+			Rules: []Rule{
+				{Kind: RuleDenyRolelessContract, Code: "audit_contract_roleless"},
+			},
+		},
+		{
 			Name:    "baseline.frontend",
 			Builtin: true,
 			Selectors: []Selector{

--- a/internal/auditspec/engine.go
+++ b/internal/auditspec/engine.go
@@ -50,6 +50,16 @@ func Evaluate(manifest securitymanifest.SecurityManifest, policies []Policy) []F
 		}
 	}
 
+	for _, contract := range manifest.Contracts {
+		for _, policy := range resolved {
+			if !policy.matchesContract(contract) {
+				continue
+			}
+			matchedAnything[policy.Name] = true
+			findings = append(findings, evalContract(contract, policy)...)
+		}
+	}
+
 	for _, policy := range resolved {
 		if !policy.hasFrontendSelector() {
 			continue
@@ -217,6 +227,19 @@ func (policy Policy) matchesRoute(route securitymanifest.RouteEntry) bool {
 	return false
 }
 
+func (policy Policy) matchesContract(contract securitymanifest.ContractEntry) bool {
+	for _, selector := range policy.Selectors {
+		if selector.Kind != SelectorContract {
+			continue
+		}
+		glob := contractSelectorGlob(selector.Raw)
+		if matchGlob(glob, contract.Name) || matchGlob(glob, contract.Kind) {
+			return true
+		}
+	}
+	return false
+}
+
 func (policy Policy) hasFrontendSelector() bool {
 	for _, selector := range policy.Selectors {
 		if selector.Kind == SelectorFrontend {
@@ -295,6 +318,21 @@ func evalRoute(route securitymanifest.RouteEntry, policy Policy) []Finding {
 					fmt.Sprintf("route %s is public but policy denies public access", route.Route),
 					"Replace guard public with a protective guard, or narrow the policy selector."))
 			}
+		}
+	}
+	return findings
+}
+
+func evalContract(contract securitymanifest.ContractEntry, policy Policy) []Finding {
+	var findings []Finding
+	for _, rule := range policy.Rules {
+		if rule.Kind != RuleDenyRolelessContract {
+			continue
+		}
+		if len(contract.Roles) == 0 {
+			findings = append(findings, finding(rule, policy, contractTarget(contract), "",
+				fmt.Sprintf("%s contract %s is web-exposed but declares no roles; the data-layer gate denies every web caller and the endpoint is unreachable", contract.Kind, contract.Name),
+				"Declare the roles permitted to execute the contract at registration, or RoleAny to expose it to every role intentionally."))
 		}
 	}
 	return findings
@@ -433,6 +471,10 @@ func routeTarget(route securitymanifest.RouteEntry) string {
 	return "route:" + route.Route
 }
 
+func contractTarget(contract securitymanifest.ContractEntry) string {
+	return "contract:" + contract.Name
+}
+
 func containsGuard(guards []string, want string) bool {
 	for _, guard := range guards {
 		if guard == want {
@@ -458,6 +500,8 @@ func ParseSelector(raw string) Selector {
 	switch {
 	case raw == "frontend":
 		return Selector{Raw: raw, Kind: SelectorFrontend}
+	case raw == "contract" || strings.HasPrefix(raw, "contract:"):
+		return Selector{Raw: raw, Kind: SelectorContract}
 	case strings.HasPrefix(raw, "/"):
 		return Selector{Raw: raw, Kind: SelectorRoute}
 	default:
@@ -466,6 +510,18 @@ func ParseSelector(raw string) Selector {
 		}
 		return Selector{Raw: raw, Kind: SelectorUnknown}
 	}
+}
+
+// contractSelectorGlob extracts the glob from a contract selector. "contract"
+// and "contract:" match every contract; "contract:<glob>" matches by contract
+// name or kind.
+func contractSelectorGlob(raw string) string {
+	glob := strings.TrimPrefix(raw, "contract")
+	glob = strings.TrimPrefix(glob, ":")
+	if glob == "" {
+		return "*"
+	}
+	return glob
 }
 
 func splitEndpointSelector(raw string) (kind, glob string, ok bool) {

--- a/internal/auditspec/engine_test.go
+++ b/internal/auditspec/engine_test.go
@@ -62,6 +62,19 @@ func TestBaselinePassesWhenPostureIsSound(t *testing.T) {
 	}
 }
 
+func TestBaselineFlagsRolelessContract(t *testing.T) {
+	manifest := securitymanifest.SecurityManifest{
+		Contracts: []securitymanifest.ContractEntry{
+			{Name: "patients.CreatePatient", Kind: "command"},
+			{Name: "patients.GetPatientPage", Kind: "query", Roles: []string{"web"}},
+		},
+	}
+	got := codes(Evaluate(manifest, Baseline()))
+	if got["audit_contract_roleless"] != 1 {
+		t.Fatalf("expected exactly one roleless-contract finding, got %d (%#v)", got["audit_contract_roleless"], got)
+	}
+}
+
 func TestBaselineFlagsFrontendAuditFindings(t *testing.T) {
 	manifest := securitymanifest.SecurityManifest{
 		Frontend: securitymanifest.FrontendSurface{

--- a/internal/buildgen/build.go
+++ b/internal/buildgen/build.go
@@ -16,8 +16,11 @@ import (
 )
 
 func Build(config gowdk.Config, sources gwdkanalysis.Sources, outputDir string) (Result, error) {
-	ir := gwdkanalysis.BuildProgram(config, sources)
-	return buildFromIR(config, ir, compiler.BackendBindingsFromIR(ir), outputDir, true)
+	ir, bindings, err := compiler.AssembleProgram(config, sources)
+	if err != nil {
+		return Result{}, err
+	}
+	return buildFromIR(config, ir, bindings, outputDir, true)
 }
 
 // BuildFromIR writes SPA build artifacts from normalized compiler IR.

--- a/internal/buildgen/build.go
+++ b/internal/buildgen/build.go
@@ -205,15 +205,21 @@ func finalizeAssetArtifact(artifact *plannedAssetArtifact) {
 }
 
 func BuildMemory(config gowdk.Config, sources gwdkanalysis.Sources, outputDir string) (MemoryResult, error) {
-	ir := gwdkanalysis.BuildProgram(config, sources)
-	return buildMemoryFromIR(config, ir, compiler.BackendBindingsFromIR(ir), outputDir, true)
+	ir, bindings, err := compiler.AssembleProgram(config, sources)
+	if err != nil {
+		return MemoryResult{}, err
+	}
+	return buildMemoryFromIR(config, ir, bindings, outputDir, true)
 }
 
 // BuildMemoryWithOptions plans SPA build artifacts without requiring a real
 // output directory. Empty MemoryBuildOptions.OutputBase defaults to ".".
 func BuildMemoryWithOptions(config gowdk.Config, sources gwdkanalysis.Sources, options MemoryBuildOptions) (MemoryResult, error) {
-	ir := gwdkanalysis.BuildProgram(config, sources)
-	return buildMemoryFromIR(config, ir, compiler.BackendBindingsFromIR(ir), memoryOutputBase(options), false)
+	ir, bindings, err := compiler.AssembleProgram(config, sources)
+	if err != nil {
+		return MemoryResult{}, err
+	}
+	return buildMemoryFromIR(config, ir, bindings, memoryOutputBase(options), false)
 }
 
 // BuildMemoryFromIR plans SPA build artifacts from normalized compiler IR

--- a/internal/buildgen/ssr.go
+++ b/internal/buildgen/ssr.go
@@ -36,7 +36,11 @@ type SSRReplacement = source.SSRReplacement
 type SSRLoadReplacement = source.SSRLoadReplacement
 
 func SSRArtifacts(config gowdk.Config, sources gwdkanalysis.Sources, outputDir string) ([]SSRArtifact, error) {
-	return SSRArtifactsFromIR(config, gwdkanalysis.BuildProgram(config, sources), outputDir)
+	ir, _, err := compiler.AssembleProgram(config, sources)
+	if err != nil {
+		return nil, err
+	}
+	return SSRArtifactsFromIR(config, ir, outputDir)
 }
 
 // SSRArtifactsFromIR renders request-time page artifacts from normalized

--- a/internal/compiler/assemble.go
+++ b/internal/compiler/assemble.go
@@ -1,0 +1,40 @@
+package compiler
+
+import (
+	"github.com/cssbruno/gowdk"
+	"github.com/cssbruno/gowdk/internal/gwdkanalysis"
+	"github.com/cssbruno/gowdk/internal/gwdkir"
+	"github.com/cssbruno/gowdk/internal/source"
+)
+
+// EnrichProgram runs the IR enrichment phases that every codegen orchestrator
+// needs, in the one order they must run: discover standalone Go endpoints, then
+// bind backend handlers. It mutates program in place and returns the backend
+// bindings.
+//
+// This is the single definition of the discover -> bind phase order. Codegen
+// orchestrators must not re-sequence these phases by hand; doing so is how the
+// source-taking buildgen entrypoints previously produced under-enriched IR (no
+// discovered Go endpoints, empty bindings) by skipping these steps entirely.
+//
+// Contract linking and validation are deliberately left to the caller: they
+// require a project root and a contract-scan report, and each orchestrator has
+// a different error-handling contract (the CLI fails hard; the LSP/check path
+// collects diagnostics).
+func EnrichProgram(config gowdk.Config, program *gwdkir.Program) ([]source.BackendBinding, error) {
+	if err := DiscoverGoEndpoints(config, program); err != nil {
+		return nil, err
+	}
+	return BindBackendHandlers(program), nil
+}
+
+// AssembleProgram builds the canonical compiler IR from parsed sources and runs
+// EnrichProgram on it, returning the enriched program together with its backend
+// bindings. It is the single entrypoint for callers that start from sources
+// rather than an already-assembled program, so they cannot accidentally build
+// on a base program that skipped discovery and binding.
+func AssembleProgram(config gowdk.Config, sources gwdkanalysis.Sources) (gwdkir.Program, []source.BackendBinding, error) {
+	program := gwdkanalysis.BuildProgram(config, sources)
+	bindings, err := EnrichProgram(config, &program)
+	return program, bindings, err
+}

--- a/internal/compiler/assemble_test.go
+++ b/internal/compiler/assemble_test.go
@@ -1,0 +1,61 @@
+package compiler
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/cssbruno/gowdk"
+	"github.com/cssbruno/gowdk/internal/gwdkanalysis"
+	"github.com/cssbruno/gowdk/internal/gwdkir"
+	"github.com/cssbruno/gowdk/internal/source"
+)
+
+// TestAssembleProgramEnrichesBindings proves the canonical pipeline runs the
+// discover -> bind phases, so a source-taking caller cannot end up with an
+// under-enriched program (the bug behind #386): assembling from sources and
+// reading bindings out of the bare program leaves the inline go-block action
+// unbound, whereas AssembleProgram binds it.
+func TestAssembleProgramEnrichesBindings(t *testing.T) {
+	root := t.TempDir()
+	sources := gwdkanalysis.Sources{
+		Pages: []gwdkir.Page{{
+			ID:      "home",
+			Package: "pages",
+			Source:  filepath.Join(root, "home.page.gwdk"),
+			Route:   "/",
+			Blocks: gwdkir.Blocks{
+				Actions: []gwdkir.Action{{Name: "Subscribe", Method: "POST", Route: "/newsletter"}},
+				GoBlocks: []gwdkir.GoBlock{{Body: `import (
+	"context"
+
+	"github.com/cssbruno/gowdk/runtime/response"
+)
+
+func Subscribe(context.Context) (response.Response, error) {
+	return response.RedirectTo("/?subscribed=1"), nil
+}`}},
+			},
+		}},
+	}
+	config := gowdk.Config{}
+
+	// The old under-enriched path: assemble, then read bindings out of the bare
+	// program. Discovery and binding never ran, so Subscribe is not bound.
+	base := gwdkanalysis.BuildProgram(config, sources)
+	if binding := compilerBindingsByBlock(BackendBindingsFromIR(base))["Subscribe"]; binding.Status == source.BackendBindingBound {
+		t.Fatalf("expected bare BuildProgram to leave Subscribe unbound, got %#v", binding)
+	}
+
+	// The canonical pipeline runs discover -> bind, so Subscribe is bound.
+	_, bindings, err := AssembleProgram(config, sources)
+	if err != nil {
+		t.Fatalf("AssembleProgram: %v", err)
+	}
+	binding, ok := compilerBindingsByBlock(bindings)["Subscribe"]
+	if !ok {
+		t.Fatalf("expected AssembleProgram to return a Subscribe binding, got %#v", bindings)
+	}
+	if binding.Status != source.BackendBindingBound {
+		t.Fatalf("expected AssembleProgram to bind Subscribe, got status %q (%#v)", binding.Status, binding)
+	}
+}

--- a/internal/compiler/backend_binding_diagnostics.go
+++ b/internal/compiler/backend_binding_diagnostics.go
@@ -44,6 +44,7 @@ func backendBindingDiagnostic(code string, binding source.BackendBinding) Valida
 		Code:     code,
 		PageID:   binding.PageID,
 		Source:   binding.Source,
+		Span:     binding.Span,
 		Message:  binding.Message,
 		Severity: SeverityWarning,
 	}

--- a/internal/compiler/backend_binding_diagnostics_test.go
+++ b/internal/compiler/backend_binding_diagnostics_test.go
@@ -59,6 +59,43 @@ func TestProductionPolicyStillRejectsUnsupportedFragmentSignature(t *testing.T) 
 	}
 }
 
+func TestBackendBindingDiagnosticsCarryExactActionSpan(t *testing.T) {
+	actionSpan := source.SourceSpan{
+		Start: source.SourcePosition{Line: 6, Column: 1, Offset: 40},
+		End:   source.SourcePosition{Line: 6, Column: 20, Offset: 59},
+	}
+	ir := gwdkir.Program{
+		Pages: []gwdkir.Page{{
+			ID:      "signup",
+			Package: "pages",
+			Source:  emptyPackageSource(t, "signup.page.gwdk"),
+			Route:   "/signup",
+			Blocks: gwdkir.Blocks{
+				Actions: []gwdkir.Action{{Name: "Submit", Method: "POST", Route: "/signup", Span: actionSpan}},
+				// Same-named inline handler with an unsupported signature.
+				GoBlocks: []gwdkir.GoBlock{{Body: "func Submit(x int) {}"}},
+			},
+		}},
+	}
+
+	bindings := BindBackendHandlers(&ir)
+	diagnostics := BackendBindingDiagnostics(bindings)
+
+	var found bool
+	for _, diagnostic := range diagnostics {
+		if diagnostic.Code != "unsupported_backend_signature" {
+			continue
+		}
+		found = true
+		if diagnostic.Span != actionSpan {
+			t.Fatalf("expected the diagnostic to carry the exact action span %#v, got %#v", actionSpan, diagnostic.Span)
+		}
+	}
+	if !found {
+		t.Fatalf("expected an unsupported_backend_signature diagnostic, got %#v", diagnostics)
+	}
+}
+
 func findBindingByName(bindings []source.BackendBinding, kind, name string) (source.BackendBinding, bool) {
 	for _, binding := range bindings {
 		if binding.Kind == kind && binding.FunctionName == name {

--- a/internal/compiler/backend_binding_policy.go
+++ b/internal/compiler/backend_binding_policy.go
@@ -76,6 +76,7 @@ func backendBindingRequiredDiagnostic(binding source.BackendBinding) ValidationE
 		Code:    "backend_binding_required",
 		PageID:  binding.PageID,
 		Source:  binding.Source,
+		Span:    binding.Span,
 		Message: message,
 	}
 }

--- a/internal/compiler/backend_bindings.go
+++ b/internal/compiler/backend_bindings.go
@@ -106,7 +106,7 @@ func bindLoad(page gwdkir.Page, pkg featurePackage) source.BackendBinding {
 	// of falling back to an inline go ssr {} block and reporting a misleading
 	// bound status. The broken package itself is reported by go_package_error.
 	if pkg.LoadError != "" {
-		binding := baseBackendBinding(page, loadHandlerKind, functionName, "GET", page.Route, pkg)
+		binding := baseBackendBinding(page, loadHandlerKind, functionName, "GET", page.Route, page.Blocks.Spans.Load, pkg)
 		binding.Status = source.BackendBindingMissing
 		binding.Message = fmt.Sprintf("GOWDK SSR load handler %s.%s could not be inspected: %s", bindingPackageLabel(binding, pkg), functionName, pkg.LoadError)
 		return binding
@@ -125,7 +125,7 @@ func bindLoad(page gwdkir.Page, pkg featurePackage) source.BackendBinding {
 	case inInline:
 		return bindLoadFromPackage(page, functionName, inlinePkg)
 	default:
-		binding := baseBackendBinding(page, loadHandlerKind, functionName, "GET", page.Route, pkg)
+		binding := baseBackendBinding(page, loadHandlerKind, functionName, "GET", page.Route, page.Blocks.Spans.Load, pkg)
 		binding.Status = source.BackendBindingMissing
 		binding.Message = fmt.Sprintf("GOWDK SSR load handler %s.%s is not implemented", bindingPackageLabel(binding, pkg), functionName)
 		binding = markUnexportedCandidate(binding, pkg)
@@ -137,7 +137,7 @@ func bindLoad(page gwdkir.Page, pkg featurePackage) source.BackendBinding {
 }
 
 func bindLoadFromPackage(page gwdkir.Page, functionName string, pkg featurePackage) source.BackendBinding {
-	binding := baseBackendBinding(page, loadHandlerKind, functionName, "GET", page.Route, pkg)
+	binding := baseBackendBinding(page, loadHandlerKind, functionName, "GET", page.Route, page.Blocks.Spans.Load, pkg)
 	function := pkg.Functions[functionName]
 	if !function.Load() {
 		binding.Status = source.BackendBindingUnsupportedSignature
@@ -225,7 +225,7 @@ func bindAction(page gwdkir.Page, action gwdkir.Action, pkg featurePackage) sour
 	if route == "" {
 		route = page.Route
 	}
-	return bindActionEndpoint(baseBackendBinding(page, actionHandlerKind, action.Name, method, route, pkg), pkg)
+	return bindActionEndpoint(baseBackendBinding(page, actionHandlerKind, action.Name, method, route, action.Span, pkg), pkg)
 }
 
 func bindAPI(page gwdkir.Page, api gwdkir.API, pkg featurePackage) source.BackendBinding {
@@ -237,7 +237,7 @@ func bindAPI(page gwdkir.Page, api gwdkir.API, pkg featurePackage) source.Backen
 	if route == "" {
 		route = page.Route
 	}
-	return bindAPIEndpoint(baseBackendBinding(page, apiHandlerKind, api.Name, method, route, pkg), pkg)
+	return bindAPIEndpoint(baseBackendBinding(page, apiHandlerKind, api.Name, method, route, api.Span, pkg), pkg)
 }
 
 func bindFragment(page gwdkir.Page, fragment gwdkir.FragmentEndpoint, pkg featurePackage) (source.BackendBinding, bool) {
@@ -245,7 +245,7 @@ func bindFragment(page gwdkir.Page, fragment gwdkir.FragmentEndpoint, pkg featur
 	if method == "" {
 		method = "GET"
 	}
-	binding := baseBackendBinding(page, fragmentHandlerKind, fragment.Name, method, strings.TrimSpace(fragment.Route), pkg)
+	binding := baseBackendBinding(page, fragmentHandlerKind, fragment.Name, method, strings.TrimSpace(fragment.Route), fragment.Span, pkg)
 	function, ok := pkg.Functions[binding.FunctionName]
 	if !ok {
 		return source.BackendBinding{}, false
@@ -272,7 +272,7 @@ func bindMissingFragmentCandidate(page gwdkir.Page, fragment gwdkir.FragmentEndp
 		method = "GET"
 	}
 	for _, pkg := range pkgs {
-		binding := baseBackendBinding(page, fragmentHandlerKind, fragment.Name, method, strings.TrimSpace(fragment.Route), pkg)
+		binding := baseBackendBinding(page, fragmentHandlerKind, fragment.Name, method, strings.TrimSpace(fragment.Route), fragment.Span, pkg)
 		binding.Status = source.BackendBindingMissing
 		binding.Message = fmt.Sprintf("GOWDK fragment handler %s.%s is not implemented", bindingPackageLabel(binding, pkg), binding.FunctionName)
 		if binding = markUnexportedCandidate(binding, pkg); binding.UnexportedCandidate {
@@ -282,11 +282,12 @@ func bindMissingFragmentCandidate(page gwdkir.Page, fragment gwdkir.FragmentEndp
 	return source.BackendBinding{}, false
 }
 
-func baseBackendBinding(page gwdkir.Page, kind, blockName, method, route string, pkg featurePackage) source.BackendBinding {
+func baseBackendBinding(page gwdkir.Page, kind, blockName, method, route string, span source.SourceSpan, pkg featurePackage) source.BackendBinding {
 	return source.BackendBinding{
 		Kind:         kind,
 		PageID:       page.ID,
 		Source:       page.Source,
+		Span:         span,
 		BlockName:    blockName,
 		Method:       method,
 		Route:        route,
@@ -302,6 +303,7 @@ func baseStandaloneBackendBinding(endpoint gwdkir.GoEndpoint, kind, method strin
 		Kind:         kind,
 		PageID:       standaloneEndpointPageID(endpoint.Package, endpoint.Name),
 		Source:       endpoint.Source,
+		Span:         endpoint.Span,
 		BlockName:    endpoint.Name,
 		Method:       method,
 		Route:        endpoint.Route,

--- a/internal/contractscan/ast_helpers.go
+++ b/internal/contractscan/ast_helpers.go
@@ -214,6 +214,8 @@ func roleName(expr ast.Expr) string {
 			return string(runtimecontracts.RoleAPI)
 		case "RoleAdmin":
 			return string(runtimecontracts.RoleAdmin)
+		case "RoleAny":
+			return string(runtimecontracts.RoleAny)
 		}
 	case *ast.BasicLit:
 		value, err := strconv.Unquote(typed.Value)

--- a/internal/contractscan/ast_helpers_test.go
+++ b/internal/contractscan/ast_helpers_test.go
@@ -1,0 +1,33 @@
+package contractscan
+
+import (
+	goparser "go/parser"
+	"testing"
+)
+
+// TestRoleNameNormalizesKnownRoles guards that every runtime role constant maps
+// to its stable role value, so scanned metadata, route reports, and the audit
+// manifest match the role the runtime uses for authorization.
+func TestRoleNameNormalizesKnownRoles(t *testing.T) {
+	cases := []struct {
+		src  string
+		want string
+	}{
+		{"contracts.RoleWeb", "web"},
+		{"contracts.RoleWorker", "worker"},
+		{"contracts.RoleCron", "cron"},
+		{"contracts.RoleAPI", "api"},
+		{"contracts.RoleAdmin", "admin"},
+		{"contracts.RoleAny", "any"},
+		{`"custom"`, "custom"},
+	}
+	for _, tc := range cases {
+		expr, err := goparser.ParseExpr(tc.src)
+		if err != nil {
+			t.Fatalf("parse %q: %v", tc.src, err)
+		}
+		if got := roleName(expr); got != tc.want {
+			t.Fatalf("roleName(%q) = %q, want %q", tc.src, got, tc.want)
+		}
+	}
+}

--- a/internal/diagnostics/explain.go
+++ b/internal/diagnostics/explain.go
@@ -272,6 +272,13 @@ guard public
 			"Override the built-in baseline.contract_commands policy in a *.audit.gwdk file if the endpoint is intentionally exempt.",
 		},
 	},
+	"audit_contract_roleless": {
+		Details: "A command or query contract is exposed to the web surface but declares no roles. The contract layer is the source of truth for authorization, so a roleless contract has no role to admit: the runtime data-layer gate fails closed and denies every web caller, which makes the endpoint unreachable, while a developer following the \"authz in contracts, guards as redundancy\" model may believe it is protected by the page guard alone.",
+		NextSteps: []string{
+			"Declare the roles permitted to execute the contract at registration (for example RoleWeb or RoleAdmin).",
+			"Declare RoleAny only when the contract is intentionally callable by every role, including unauthenticated web callers.",
+		},
+	},
 	"audit_guardless_endpoint_page": {
 		Details: "A page that declares backend endpoints has no guard. Actions, fragments, commands, queries, and APIs would be publicly callable even when the page GET route is denied, which contradicts default-deny.",
 		NextSteps: []string{

--- a/internal/diagnostics/registry.go
+++ b/internal/diagnostics/registry.go
@@ -66,6 +66,7 @@ var Registry = []Code{
 	{Code: "audit_bundle_secret", Area: "audit", Stability: StabilityExperimental, Severity: SeverityError, Summary: "embedded build output or build-time data carries a secret-shaped value"},
 	{Code: "audit_client_route_unguarded", Area: "audit", Stability: StabilityExperimental, Severity: SeverityWarning, Summary: "a client or SPA route declares no guard and is protected only by the generated runtime default-deny gate, which is absent under static export"},
 	{Code: "audit_command_missing_csrf", Area: "audit", Stability: StabilityExperimental, Severity: SeverityError, Summary: "command endpoint does not enforce CSRF as required by the security baseline or policy"},
+	{Code: "audit_contract_roleless", Area: "audit", Stability: StabilityExperimental, Severity: SeverityError, Summary: "a web-exposed command or query contract declares no roles, so the data-layer authorization gate has no role to admit"},
 	{Code: "audit_guardless_endpoint_page", Area: "audit", Stability: StabilityExperimental, Severity: SeverityError, Summary: "a page exposing backend endpoints declares no guard"},
 	{Code: "audit_headers_missing", Area: "audit", Stability: StabilityExperimental, Severity: SeverityWarning, Summary: "generated app does not declare a security response header required by policy"},
 	{Code: "audit_headers_runtime_missing", Area: "audit", Stability: StabilityExperimental, Severity: SeverityError, Summary: "running app did not emit a security response header required by policy"},

--- a/internal/lsp/features.go
+++ b/internal/lsp/features.go
@@ -18,7 +18,11 @@ func (server *Server) completionItems(params completionParams) []completionItem 
 			Detail: completion.Detail,
 		})
 	}
-	return appendProjectCompletionItems(items, server.projectCompletions(params.TextDocument.URI))
+	items = appendProjectCompletionItems(items, server.projectCompletions(params.TextDocument.URI))
+	if doc, ok := server.documents[params.TextDocument.URI]; ok {
+		items = append(items, storePersistCompletionItems(linePrefixAt(doc.Text, params.Position))...)
+	}
+	return items
 }
 
 func (server *Server) hover(params hoverParams) *hoverResult {
@@ -29,6 +33,9 @@ func (server *Server) hover(params hoverParams) *hoverResult {
 	token := tokenAtPosition(doc.Text, params.Position)
 	if token == "" {
 		return nil
+	}
+	if hover := storePersistHover(doc.Text, params.Position, token); hover != nil {
+		return hover
 	}
 	for _, item := range server.hoverItems(params.TextDocument.URI) {
 		if item.Label == token {
@@ -186,6 +193,9 @@ func (server *Server) semanticTokens(params semanticTokensParams) semanticTokens
 		length := utf16Length(token.Lexeme)
 		if length == 0 {
 			continue
+		}
+		if token.Kind == lang.TokenIdentifier && token.Lexeme == "persist" && isStorePersistKeyword(doc.Text, start.Line) {
+			tokenType = "decorator"
 		}
 
 		deltaLine := start.Line

--- a/internal/lsp/store_persist.go
+++ b/internal/lsp/store_persist.go
@@ -1,0 +1,85 @@
+package lsp
+
+import "strings"
+
+// persistHoverMarkdown explains the store persist modifier and points at the
+// explain entry that documents the valid scopes.
+const persistHoverMarkdown = "**persist**\n\n" +
+	"Persist a page store to browser storage. Use `persist \"local\"` for " +
+	"`window.localStorage` (survives a browser restart) or `persist \"session\"` " +
+	"for `window.sessionStorage` (survives reload and SPA navigation, cleared when " +
+	"the tab closes). No other scope is supported.\n\n" +
+	"See: `gowdk explain page_store_persist_scope_invalid`"
+
+// storePersistCompletionItems offers persist-modifier completions based on the
+// store declaration text typed before the cursor: `persist` once the store
+// initializer call is complete, then the `"local"` / `"session"` scopes once
+// `persist` has been typed.
+func storePersistCompletionItems(linePrefix string) []completionItem {
+	if !strings.HasPrefix(strings.TrimSpace(linePrefix), "store ") {
+		return nil
+	}
+	closeParen := strings.LastIndex(linePrefix, ")")
+	if closeParen < 0 {
+		// The initializer call is not complete yet; nothing to suggest.
+		return nil
+	}
+	afterInit := linePrefix[closeParen+1:]
+	if strings.Contains(afterInit, "persist") {
+		// Past the persist keyword: suggest the scopes until one is typed.
+		if strings.Contains(afterInit, `"`) {
+			return nil
+		}
+		return []completionItem{
+			{Label: `"local"`, Kind: completionItemKindText, Detail: "Persist to window.localStorage (survives a browser restart)."},
+			{Label: `"session"`, Kind: completionItemKindText, Detail: "Persist to window.sessionStorage (cleared when the tab closes)."},
+		}
+	}
+	return []completionItem{
+		{Label: "persist", Kind: completionItemKindKeyword, Detail: `Persist the store to browser storage: persist "local" or persist "session".`},
+	}
+}
+
+// storePersistHover returns rich hover text when the cursor is on the persist
+// keyword or one of its scope literals within a store declaration.
+func storePersistHover(text string, pos position, token string) *hoverResult {
+	switch token {
+	case "persist", "local", "session":
+	default:
+		return nil
+	}
+	line := lineTextAt(text, pos.Line)
+	trimmed := strings.TrimSpace(line)
+	if !strings.HasPrefix(trimmed, "store ") || !strings.Contains(line, "persist") {
+		return nil
+	}
+	return &hoverResult{Contents: markupContent{Kind: "markdown", Value: persistHoverMarkdown}}
+}
+
+// isStorePersistKeyword reports whether the persist identifier token at line is
+// the store persist modifier, so semantic highlighting can classify it as a
+// keyword rather than a plain identifier.
+func isStorePersistKeyword(text string, line int) bool {
+	trimmed := strings.TrimSpace(lineTextAt(text, line))
+	return strings.HasPrefix(trimmed, "store ") && strings.Contains(trimmed, "persist")
+}
+
+func linePrefixAt(text string, pos position) string {
+	line := lineTextAt(text, pos.Line)
+	index := byteIndexFromUTF16Column(line, pos.Character)
+	if index > len(line) {
+		index = len(line)
+	}
+	return line[:index]
+}
+
+func lineTextAt(text string, line int) string {
+	if line < 0 {
+		return ""
+	}
+	lines := strings.Split(text, "\n")
+	if line >= len(lines) {
+		return ""
+	}
+	return lines[line]
+}

--- a/internal/lsp/store_persist_test.go
+++ b/internal/lsp/store_persist_test.go
@@ -1,0 +1,132 @@
+package lsp
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/cssbruno/gowdk"
+)
+
+const persistStorePage = `package app
+import ui "github.com/cssbruno/gowdk/testfixture/islands"
+
+page home
+route "/products"
+
+store cart ui.CounterState = ui.NewCounterState() persist "local"
+
+view {
+  <main></main>
+}
+`
+
+func hasItemLabel(items []completionItem, label string) bool {
+	for _, item := range items {
+		if item.Label == label {
+			return true
+		}
+	}
+	return false
+}
+
+func TestStorePersistCompletionItems(t *testing.T) {
+	const initializer = "store cart ui.CounterState = ui.NewCounterState()"
+
+	if items := storePersistCompletionItems(initializer); !hasItemLabel(items, "persist") {
+		t.Fatalf("expected persist completion after a complete store initializer, got %#v", items)
+	}
+	scopes := storePersistCompletionItems(initializer + " persist ")
+	if !hasItemLabel(scopes, `"local"`) || !hasItemLabel(scopes, `"session"`) {
+		t.Fatalf("expected local/session completions after persist, got %#v", scopes)
+	}
+	if items := storePersistCompletionItems(initializer + ` persist "local"`); len(items) != 0 {
+		t.Fatalf("expected no completions once a scope is typed, got %#v", items)
+	}
+	if items := storePersistCompletionItems("store cart ui.CounterState = ui.NewCounterState"); len(items) != 0 {
+		t.Fatalf("expected no completions before the initializer call closes, got %#v", items)
+	}
+	if items := storePersistCompletionItems(`route "/products"`); len(items) != 0 {
+		t.Fatalf("expected no persist completions outside a store declaration, got %#v", items)
+	}
+}
+
+func TestServerCompletionOffersPersistAfterStoreInitializer(t *testing.T) {
+	server := NewServer(gowdk.Config{})
+	server.log = nil
+	uri := "file:///tmp/home.page.gwdk"
+	server.documents[uri] = document{URI: uri, Path: "/tmp/home.page.gwdk", Version: 1, Text: persistStorePage}
+
+	items := server.completionItems(completionParams{
+		TextDocument: textDocumentIdentifier{URI: uri},
+		Position:     position{Line: 6, Character: 49},
+	})
+	if !hasItemLabel(items, "persist") {
+		t.Fatalf("expected the server to offer persist after the store initializer, got %#v", items)
+	}
+}
+
+func TestServerHoverExplainsPersistModifier(t *testing.T) {
+	server := NewServer(gowdk.Config{})
+	server.log = nil
+	uri := "file:///tmp/home.page.gwdk"
+	server.documents[uri] = document{URI: uri, Path: "/tmp/home.page.gwdk", Version: 1, Text: persistStorePage}
+
+	hover := server.hover(hoverParams{
+		TextDocument: textDocumentIdentifier{URI: uri},
+		Position:     position{Line: 6, Character: 53},
+	})
+	if hover == nil {
+		t.Fatal("expected hover for the persist keyword")
+	}
+	if !strings.Contains(hover.Contents.Value, "page_store_persist_scope_invalid") {
+		t.Fatalf("expected persist hover to link the explain code, got %q", hover.Contents.Value)
+	}
+
+	// A non-store line with the same word must not produce the store hover.
+	if got := storePersistHover("route \"/products\"", position{Line: 0, Character: 2}, "persist"); got != nil {
+		t.Fatalf("expected no persist hover outside a store declaration, got %#v", got)
+	}
+}
+
+func TestSemanticTokensClassifyPersistAsDecorator(t *testing.T) {
+	server := NewServer(gowdk.Config{})
+	server.log = nil
+	uri := "file:///tmp/home.page.gwdk"
+	server.documents[uri] = document{URI: uri, Path: "/tmp/home.page.gwdk", Version: 1, Text: persistStorePage}
+
+	result := server.semanticTokens(semanticTokensParams{TextDocument: textDocumentIdentifier{URI: uri}})
+	tokens := decodeSemanticTokens(result.Data)
+
+	var found bool
+	for _, token := range tokens {
+		if token.line == 6 && token.length == len("persist") && token.typeIndex == semanticTokenTypeIndex["decorator"] {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected persist on the store line to be a decorator token, got %#v", tokens)
+	}
+}
+
+type decodedToken struct {
+	line      int
+	character int
+	length    int
+	typeIndex int
+}
+
+func decodeSemanticTokens(data []int) []decodedToken {
+	var tokens []decodedToken
+	line, character := 0, 0
+	for index := 0; index+5 <= len(data); index += 5 {
+		deltaLine, deltaStart, length, typeIndex := data[index], data[index+1], data[index+2], data[index+3]
+		if deltaLine == 0 {
+			character += deltaStart
+		} else {
+			line += deltaLine
+			character = deltaStart
+		}
+		tokens = append(tokens, decodedToken{line: line, character: character, length: length, typeIndex: typeIndex})
+	}
+	return tokens
+}

--- a/internal/parser/audit.go
+++ b/internal/parser/audit.go
@@ -308,6 +308,10 @@ func parseAuditDenyRule(tokens []syntax.Token, lineNumber int, rawLine string) (
 		rule.Kind = "deny_raw_html_sinks"
 		rule.Code = "audit_raw_html_sink"
 		return finishAuditRule(rule, tokens[2:], lineNumber)
+	case "roleless_contract":
+		rule.Kind = "deny_roleless_contract"
+		rule.Code = "audit_contract_roleless"
+		return finishAuditRule(rule, tokens[2:], lineNumber)
 	default:
 		return gwdkast.AuditRule{}, true, fmt.Errorf("line %d: unsupported deny rule %q", lineNumber, tokens[1].Lexeme)
 	}

--- a/internal/parser/audit_test.go
+++ b/internal/parser/audit_test.go
@@ -41,6 +41,30 @@ func TestParseAuditFileGolden(t *testing.T) {
 	}
 }
 
+func TestParseAuditDenyRolelessContractRule(t *testing.T) {
+	file, err := ParseAuditSyntax([]byte(`policy contracts {
+  apply to "contract:*"
+  deny roleless_contract
+}
+`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(file.Policies) != 1 {
+		t.Fatalf("len(policies) = %d, want 1", len(file.Policies))
+	}
+	policy := file.Policies[0]
+	if len(policy.Applies) != 1 || policy.Applies[0].Selector != "contract:*" {
+		t.Fatalf("unexpected applies: %#v", policy.Applies)
+	}
+	if len(policy.Rules) != 1 {
+		t.Fatalf("len(rules) = %d, want 1", len(policy.Rules))
+	}
+	if policy.Rules[0].Kind != "deny_roleless_contract" || policy.Rules[0].Code != "audit_contract_roleless" {
+		t.Fatalf("unexpected rule: %#v", policy.Rules[0])
+	}
+}
+
 func TestParseAuditSyntaxReportsUnsupportedPolicyLine(t *testing.T) {
 	_, err := ParseAuditSyntax([]byte(`policy bad {
   surprise now

--- a/internal/source/source.go
+++ b/internal/source/source.go
@@ -393,6 +393,7 @@ type BackendBinding struct {
 	Kind         string
 	PageID       string
 	Source       string
+	Span         SourceSpan
 	BlockName    string
 	Method       string
 	Route        string

--- a/runtime/contracts/command.go
+++ b/runtime/contracts/command.go
@@ -147,7 +147,7 @@ func runCommand[C, R any](ctx context.Context, registry *Registry, command C, ro
 	if !ok {
 		return zero, nil, missingHandlerError(Command, typeName[C]())
 	}
-	if !rolesAllow(entry.roles, role) {
+	if !roleMayExecute(entry.roles, role) {
 		return zero, nil, roleNotAllowedError(Command, typeName[C](), role)
 	}
 	handler, ok := entry.handler.(CommandHandler[C, R])

--- a/runtime/contracts/contracts_test.go
+++ b/runtime/contracts/contracts_test.go
@@ -784,7 +784,7 @@ func TestContractsForRoleFiltersMetadata(t *testing.T) {
 	}, RoleWeb))
 	must(t, RegisterQuery[patientPageQuery, patientPage](registry, func(ctx context.Context, query patientPageQuery) (patientPage, error) {
 		return patientPage{}, nil
-	}))
+	}, RoleWeb))
 	must(t, RegisterDomainEvent[patientCreated](registry, func(ctx context.Context, event patientCreated) error {
 		return nil
 	}, RoleWorker))
@@ -808,6 +808,27 @@ func TestContractsForRoleFiltersMetadata(t *testing.T) {
 	}
 	if !slices.Equal(kinds, []Kind{Command, Event, Query}) {
 		t.Fatalf("web metadata kinds = %#v, want command, event, query", kinds)
+	}
+}
+
+func TestContractsForRoleExcludesRolelessCommandsAndQueries(t *testing.T) {
+	registry := NewRegistry()
+	must(t, RegisterCommand[createPatient, createPatientResult](registry, func(ctx context.Context, command createPatient) (createPatientResult, error) {
+		return createPatientResult{}, nil
+	}))
+	must(t, RegisterQuery[patientPageQuery, patientPage](registry, func(ctx context.Context, query patientPageQuery) (patientPage, error) {
+		return patientPage{}, nil
+	}))
+
+	// A concrete role must not see roleless command/query metadata, mirroring the
+	// fail-closed Execute*ForRole gate: advertising them would contradict
+	// execution, which denies the same call.
+	if metadata := registry.ContractsForRole(RoleWeb); len(metadata) != 0 {
+		t.Fatalf("roleless command/query leaked into web metadata: %#v", metadata)
+	}
+	// Trusted in-process enumeration (no role) still sees everything.
+	if metadata := registry.Contracts(); len(metadata) != 2 {
+		t.Fatalf("roleless enumeration = %d, want 2: %#v", len(metadata), metadata)
 	}
 }
 

--- a/runtime/contracts/contracts_test.go
+++ b/runtime/contracts/contracts_test.go
@@ -958,6 +958,52 @@ func TestMetadataIsDeterministic(t *testing.T) {
 	}
 }
 
+func TestExecuteRolelessContractFailsClosedForConcreteRole(t *testing.T) {
+	registry := NewRegistry()
+	must(t, RegisterCommand[createPatient, createPatientResult](registry, func(ctx context.Context, command createPatient) (createPatientResult, error) {
+		return createPatientResult{}, nil
+	}))
+	must(t, RegisterQuery[patientPageQuery, patientPage](registry, func(ctx context.Context, query patientPageQuery) (patientPage, error) {
+		return patientPage{}, nil
+	}))
+
+	// A contract that declares no roles must not be executable by the web
+	// surface (or any other concrete role): the data-layer gate fails closed.
+	if _, err := ExecuteCommandForRole[createPatient, createPatientResult](context.Background(), registry, RoleWeb, createPatient{}); !Is(err, ErrRoleNotAllowed) {
+		t.Fatalf("roleless command for web = %v, want %s", err, ErrRoleNotAllowed)
+	}
+	if _, err := ExecuteQueryForRole[patientPageQuery, patientPage](context.Background(), registry, RoleWeb, patientPageQuery{}); !Is(err, ErrRoleNotAllowed) {
+		t.Fatalf("roleless query for web = %v, want %s", err, ErrRoleNotAllowed)
+	}
+
+	// Trusted in-process callers (no role context) still execute.
+	if _, err := ExecuteCommand[createPatient, createPatientResult](context.Background(), registry, createPatient{}); err != nil {
+		t.Fatalf("roleless command in-process: %v", err)
+	}
+	if _, err := ExecuteQuery[patientPageQuery, patientPage](context.Background(), registry, patientPageQuery{}); err != nil {
+		t.Fatalf("roleless query in-process: %v", err)
+	}
+}
+
+func TestExecuteRoleAnyContractAllowsConcreteRole(t *testing.T) {
+	registry := NewRegistry()
+	must(t, RegisterCommand[createPatient, createPatientResult](registry, func(ctx context.Context, command createPatient) (createPatientResult, error) {
+		return createPatientResult{}, nil
+	}, RoleAny))
+	must(t, RegisterQuery[patientPageQuery, patientPage](registry, func(ctx context.Context, query patientPageQuery) (patientPage, error) {
+		return patientPage{}, nil
+	}, RoleAny))
+
+	// RoleAny is the explicit opt-in that makes a contract executable by any
+	// caller role, including the untrusted web surface.
+	if _, err := ExecuteCommandForRole[createPatient, createPatientResult](context.Background(), registry, RoleWeb, createPatient{}); err != nil {
+		t.Fatalf("RoleAny command for web: %v", err)
+	}
+	if _, err := ExecuteQueryForRole[patientPageQuery, patientPage](context.Background(), registry, RoleWeb, patientPageQuery{}); err != nil {
+		t.Fatalf("RoleAny query for web: %v", err)
+	}
+}
+
 func must(t *testing.T, err error) {
 	t.Helper()
 	if err != nil {

--- a/runtime/contracts/helpers.go
+++ b/runtime/contracts/helpers.go
@@ -33,7 +33,32 @@ func rolesAllow(roles []Role, role Role) bool {
 		return true
 	}
 	for _, candidate := range roles {
-		if candidate == role {
+		if candidate == role || candidate == RoleAny {
+			return true
+		}
+	}
+	return false
+}
+
+// roleMayExecute reports whether a concrete caller role is authorized to execute
+// a command or query guarded by roles. Unlike rolesAllow — which is permissive
+// so roleless event subscribers receive every role's events — this gate fails
+// CLOSED: a contract that declares no roles is callable only by trusted
+// in-process callers (role == ""), never by the web surface or any other
+// concrete role. A contract opts into universal execution by declaring RoleAny.
+//
+// This is the data-layer authorization boundary the architecture treats as the
+// source of truth, so a developer who forgets to declare roles gets a denied
+// contract rather than a publicly executable one.
+func roleMayExecute(roles []Role, role Role) bool {
+	if role == "" {
+		return true
+	}
+	if len(roles) == 0 {
+		return false
+	}
+	for _, candidate := range roles {
+		if candidate == role || candidate == RoleAny {
 			return true
 		}
 	}

--- a/runtime/contracts/query.go
+++ b/runtime/contracts/query.go
@@ -26,7 +26,7 @@ func executeQuery[Q, R any](ctx context.Context, registry *Registry, query Q, ro
 	if !ok {
 		return zero, missingHandlerError(Query, typeName[Q]())
 	}
-	if !rolesAllow(entry.roles, role) {
+	if !roleMayExecute(entry.roles, role) {
 		return zero, roleNotAllowedError(Query, typeName[Q](), role)
 	}
 	handler, ok := entry.handler.(QueryHandler[Q, R])

--- a/runtime/contracts/registry.go
+++ b/runtime/contracts/registry.go
@@ -40,12 +40,15 @@ func (registry *Registry) contractsForRole(role Role) []Metadata {
 	defer registry.mu.RUnlock()
 	metadata := make([]Metadata, 0, len(registry.queries)+len(registry.commands)+len(registry.events)+len(registry.jobs))
 	for _, entry := range registry.queries {
-		if rolesAllow(entry.roles, role) {
+		// Match Execute*ForRole: command/query metadata is filtered by the
+		// fail-closed gate so a roleless contract is never advertised as callable
+		// by a concrete role that execution would then deny.
+		if roleMayExecute(entry.roles, role) {
 			metadata = append(metadata, Metadata{Kind: Query, Type: entry.query, Result: entry.result, Handlers: 1, Roles: copyRoles(entry.roles)})
 		}
 	}
 	for _, entry := range registry.commands {
-		if rolesAllow(entry.roles, role) {
+		if roleMayExecute(entry.roles, role) {
 			metadata = append(metadata, Metadata{Kind: Command, Type: entry.command, Result: entry.result, Handlers: 1, Roles: copyRoles(entry.roles)})
 		}
 	}

--- a/runtime/contracts/types.go
+++ b/runtime/contracts/types.go
@@ -33,6 +33,12 @@ const (
 	RoleCron   Role = "cron"
 	RoleAPI    Role = "api"
 	RoleAdmin  Role = "admin"
+
+	// RoleAny marks a contract as executable by every caller role, including the
+	// untrusted web surface. It is the explicit, audited opt-in that a contract
+	// must declare to be reachable without naming concrete roles; an empty role
+	// set is treated as "no role may execute" rather than "any role may execute".
+	RoleAny Role = "any"
 )
 
 // Handler types accepted by the registry.


### PR DESCRIPTION
Batch of five well-scoped fixes (security + correctness + DX), each its own commit. Branched from `main` in a dedicated worktree. The full non-example test suite passes; `gofmt`/`go vet` are clean.

## Fixes

### #385 — Contract-layer authorization fails open for roleless contracts (security, High)
Command/query execution admitted any concrete role when a contract declared no roles, so a roleless web-exposed contract was callable by anyone at the data layer.
- `runtime/contracts`: new `roleMayExecute` gate for command/query execution — fails **closed** (trusted in-process `role==""` calls still pass; concrete roles are denied unless declared). Added `RoleAny` as the explicit opt-in for universal execution.
- Event-subscriber and listing semantics keep the permissive `rolesAllow` (roleless subscribers intentionally receive every role's events — preserved a regression test for this).
- `auditspec`: new `deny_roleless_contract` rule + `contract:` selector; `Evaluate` now iterates `manifest.Contracts` (baseline `baseline.contracts`), so the audit surfaces the same exposure.
- `diagnostics`: registered `audit_contract_roleless` (+ explain + docs).

### #382 — `gowdk build` does not run the audit (security, High)
Security posture/policy evaluation fed only the standalone `gowdk audit`, so binaries shipped regardless of critical findings.
- `cmd/gowdk`: `enforceBuildSecurityAudit` runs the baseline + declared policies as part of `gowdk build`. **Production** builds fail on error-severity findings; non-production builds print a prominent summary without blocking dev iteration. New `--allow-insecure` flag downgrades the production gate to a warning for 0.x experimentation.
- Updated `docs/reference/cli.md` and the stale `audit.go` comment.

### #386 — Multi-phase Program enrichment ordering is unenforced/divergent (correctness, High)
The assemble→discover→bind order lived only as divergent hand-written sequences; the source-taking buildgen entrypoints skipped discovery/binding and produced under-enriched IR.
- `compiler.EnrichProgram` is the single definition of the discover→bind order; `compiler.AssembleProgram` = build + enrich for source-taking callers.
- `buildgen.Build` / `buildgen.SSRArtifacts` now assemble through `AssembleProgram` instead of under-enriching via `BackendBindingsFromIR` on a bare program. `cmd/gowdk build` routes its discover/bind phase through `EnrichProgram` (timing buckets preserved).
- Contract linking + validation stay in callers (differing error-handling contracts); the LSP/check path keeps its deliberate validate-then-bind-if-clean diagnostic flow.

### #357 — LSP editor support for the `persist` store modifier (DX)
- Completion: suggest `persist` once the store initializer is complete, then `"local"` / `"session"`.
- Hover: explains the modifier and links `gowdk explain page_store_persist_scope_invalid`.
- Semantic tokens: classify the `persist` keyword on a store line as a decorator.
- Implemented in the LSP layer without touching the lexer keyword set, so `syntax.parseStoreTokens` is unaffected.

### #419 — Exact source ranges for backend-binding diagnostics (DX/diagnostics)
- `source.BackendBinding` now carries the declaring block's `Span` (populated by `compiler.BindBackendHandlers` for act/api/fragment/load and standalone endpoints).
- `ambiguous_backend_handler`, `unsupported_backend_signature`, `unexported_backend_handler`, and `backend_binding_required` emit that span, so the LSP/dev overlay highlight the exact declaration (the span→range plumbing already existed).
- `docs/reference/diagnostic-codes.md` gains a Source Ranges section with the covered diagnostics and remaining file-level gaps.

## Tests
New regression tests for each fix: roleless fail-closed + `RoleAny` (runtime), `deny_roleless_contract` (auditspec), production build gate + `--allow-insecure` override (cmd/gowdk), `AssembleProgram` enrichment (compiler), persist completion/hover/semantic-token (lsp), exact action span on a binding diagnostic (compiler). Existing generated-binary fixtures updated to declare `RoleWeb` (they relied on the old fail-open behavior).

Closes #385, #382, #386, #357, #419.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
