### PR TITLE
[codex] Prepare v0.5.0 release

### DIFF
--- a/.agents/skills/gowdk-docs/SKILL.md
+++ b/.agents/skills/gowdk-docs/SKILL.md
@@ -24,7 +24,7 @@ Each doc lane has one owner — write in the right one and link from the others:
   `diagnostic-codes.md` (must mirror `internal/diagnostics/registry.go`),
   routing, addons, deployment, hooks.
 - Onboarding: `README.md`, `docs/getting-started.md` — both pin the current
-  release (`v0.3.0` install snippets); version changes go through
+  release (`v0.5.0` install snippets); version changes go through
   `gowdk-version-bump`, not ad-hoc edits.
 - `CHANGELOG.md` — canonical change log (`## v0.x.y - date` with
   `### Changed` / `### Implemented` / `### Known Gaps`).

--- a/.agents/skills/gowdk-version-bump/SKILL.md
+++ b/.agents/skills/gowdk-version-bump/SKILL.md
@@ -9,7 +9,7 @@ description: Bump the GOWDK release version. Use when updating the CLI version, 
 
 - Source of truth: `const version = "0.x.y"` near the top of
   `cmd/gowdk/main.go` (no `v` prefix). GitHub tags and install snippets use
-  `v0.x.y`. Current line: `const version = "0.3.0"`.
+  `v0.x.y`. Current line: `const version = "0.5.0"`.
 - `editors/vscode/package.json` must match the CLI constant exactly;
   `editors/vscode/scripts/sync-version.js` reads the constant from
   `cmd/gowdk/main.go` and writes/checks `package.json`. Never edit the
@@ -59,5 +59,6 @@ go run ./cmd/gowdk version --json
 
 - Do not create tags or GitHub releases unless explicitly asked.
 - Do not imply production readiness from a `0.x` bump; release bodies must
-  keep the "Experimental 0.x release" framing.
+  keep the "Experimental 0.x release" framing even when GitHub release
+  metadata is not marked pre-release.
 - Keep CLI and VS Code extension version changes intentional and documented.

--- a/.github/release-note-template.md
+++ b/.github/release-note-template.md
@@ -3,7 +3,7 @@
 GOWDK <version> is an experimental 0.x compiler/runtime release.
 
 Not production-ready. Public syntax, generated output, runtime packages, and
-tooling contracts may change before a stable release.
+tooling contracts may change before 1.0.
 
 ## Implemented
 
@@ -90,7 +90,7 @@ code --install-extension gowdk-vscode-<version>.vsix
 ## Release Metadata Checks
 
 - [ ] Release is visible and has all expected download assets.
-- [ ] Release is marked pre-release.
+- [ ] Release is visible and is not marked as a draft.
 - [ ] Release body starts with experimental and not-production-ready warnings.
 - [ ] Release body includes known gaps.
 - [ ] Release body includes checksum and attestation instructions.

--- a/.github/workflows/release-smoke.yml
+++ b/.github/workflows/release-smoke.yml
@@ -21,7 +21,7 @@ jobs:
         include:
           - os: ubuntu-latest
             asset: gowdk-linux-amd64
-          - os: macos-13
+          - os: macos-15-intel
             asset: gowdk-darwin-amd64
           - os: macos-14
             asset: gowdk-darwin-arm64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -155,7 +155,7 @@ jobs:
           files: dist/*
           fail_on_unmatched_files: true
           draft: false
-          prerelease: true
+          prerelease: false
 
       - name: Verify release assets
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,20 @@
 # Changelog
 
 GOWDK is experimental 0.x software. Public syntax, generated output, runtime
-packages, and tooling contracts may change before a stable release.
+packages, and tooling contracts may change before 1.0.
 
 ## Unreleased
+
+No changes yet.
+
+## v0.5.0 - 2026-06-15
+
+### Changed
+
+- `gowdk version` and the VS Code extension metadata now report `0.5.0`.
+- GitHub release automation now publishes the selected 0.x tag as a normal
+  visible release instead of marking it as a GitHub pre-release. Release notes
+  and docs still keep the experimental 0.x and not-production-ready warnings.
 
 ### Implemented
 

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ request time. Your logic stays in Go.
 
 <!-- TODO: short GIF of `gowdk dev` rebuilding + live-reloading goes here. -->
 
-**Status:** experimental 0.x pre-release. Public contracts can still change.
-Not production-ready.
+**Status:** experimental 0.x release. Public contracts can still change. Not
+production-ready.
 
 **Website warning:** the public project page is not updated yet and is
 currently only a placeholder. Treat this README and the docs in this repository
@@ -40,7 +40,7 @@ curl -fsSL https://raw.githubusercontent.com/cssbruno/GoWDK/main/scripts/install
 Pin the current CLI release:
 
 ```sh
-GOWDK_VERSION=v0.3.0 GOWDK_INSTALL_DIR="$HOME/.local/bin" \
+GOWDK_VERSION=v0.5.0 GOWDK_INSTALL_DIR="$HOME/.local/bin" \
   sh -c "$(curl -fsSL https://raw.githubusercontent.com/cssbruno/GoWDK/main/scripts/install.sh)"
 ```
 

--- a/cmd/gowdk/main.go
+++ b/cmd/gowdk/main.go
@@ -11,7 +11,7 @@ import (
 	"github.com/cssbruno/gowdk/addons/ssr"
 )
 
-const version = "0.3.0"
+const version = "0.5.0"
 
 var (
 	defaultSourceIncludes = []string{"**/*.gwdk"}

--- a/cmd/gowdk/release_workflow_test.go
+++ b/cmd/gowdk/release_workflow_test.go
@@ -57,7 +57,7 @@ func TestReleaseTrustWorkflowCoverage(t *testing.T) {
 		"if-no-files-found: error",
 		"fail_on_unmatched_files: true",
 		"draft: false",
-		"prerelease: true",
+		"prerelease: false",
 		"Verify release assets",
 		"scripts/check-example-reports.sh --extended",
 	} {

--- a/docs/engineering/release-notes-v0.5.md
+++ b/docs/engineering/release-notes-v0.5.md
@@ -1,0 +1,134 @@
+# Experimental 0.x release: GOWDK v0.5
+
+GOWDK v0.5 is the first normal GitHub release for the 0.x line.
+
+Not production-ready. Public syntax, generated output, runtime packages, and
+tooling contracts may change before 1.0.
+
+## Changed
+
+- `gowdk version` and the VS Code extension metadata report `0.5.0`.
+- GitHub release automation publishes the selected 0.x tag as a normal visible
+  release instead of marking it as a GitHub pre-release.
+
+## Implemented
+
+- Page stores can opt into browser persistence with `persist "local"` or
+  `persist "session"`, including schema-hash invalidation, SPA navigation
+  rehydration, cross-tab localStorage mirroring, and persistence diagnostics.
+- M4 Go interop reports are available through `gowdk inspect go-bindings` for
+  actions, APIs, fragments, SSR load functions, build-time Go calls, and web
+  command/query references.
+- `gowdk generate stubs` writes conservative missing action/API handler stubs.
+- Build-time Go helpers may return `T` or `(T, error)`.
+- Build-helper stdout/stderr handling no longer lets successful helper logging
+  corrupt JSON build data.
+- `docs/reference/go-interop.md` documents current Go binding, route-param,
+  and middleware contracts.
+- `gowdk check` and `gowdk build` surface same-name Go binding near-misses as
+  non-fatal warnings.
+- Backend handler binding reports ambiguous handlers, sibling package
+  compilation failures, and component-script resolution failures instead of
+  silently falling back.
+- Generated `g:command` and `g:query` web adapters use one JSON success/error
+  response contract.
+- Contract event envelopes carry stable IDs for durable delivery, with
+  deduplication support for event workers and safer file-backed record updates.
+
+## Partial
+
+- Store persistence is a JS-island/store runtime feature; WASM islands do not
+  yet participate in page stores.
+- Go interop diagnostics cover the current 0.x surface, but broader examples
+  and unsupported-signature diagnostics remain in hardening.
+- Contract web adapter JSON behavior is defined for the generated web surface;
+  fragment/API-specific query execution and richer realtime patch shapes remain
+  planned.
+
+## Planned
+
+- Passing route params into Go build functions.
+- Generated per-route param structs and typed load/action result accessors.
+- Broader Go binding diagnostics for unsupported signatures, build-tag-hidden
+  symbols, and unsupported return/parameter types.
+- Broader Go-package interop examples for `database/sql`, `pgx`, `sqlc`,
+  `slog`, and similar packages.
+
+## Intentionally Out Of Scope
+
+- Production-readiness claims.
+- Migration guides.
+- Framework comparison docs as core positioning.
+- Mandatory full-page SSR or full-page hydration.
+- User-written JavaScript as the normal app contract.
+- Mandatory Tailwind, npm, Chi, Gin, Echo, Fiber, Redis, NATS, or another
+  optional framework/tool dependency.
+
+## Known Gaps
+
+- GOWDK remains not production-ready.
+- Generated output remains pre-1.0 and unstable unless a reference doc marks a
+  surface stable.
+- Secure runtime, SSR/hybrid, component/client, operations, and production
+  hardening milestones remain incomplete.
+
+## Breaking Or Unstable Generated Output
+
+Generated output is pre-1.0. Treat generated Go, generated JavaScript,
+manifests, build reports, route reports, endpoint reports, inspect reports, and
+runtime package contracts as unstable unless a reference doc explicitly marks a
+surface stable.
+
+## Required Release Verification
+
+Run the full release checklist before publishing:
+
+- `docs/engineering/release.md`
+- `docs/engineering/release-plan.md`
+
+Required local gates:
+
+```sh
+git diff --check
+scripts/test-go-modules.sh
+scripts/vulncheck-go-modules.sh
+go build ./cmd/gowdk
+node editors/vscode/scripts/sync-version.js --check
+node --check editors/vscode/extension.js
+node --check editors/vscode/extension-core.js
+node --test editors/vscode/*.test.js
+```
+
+## Artifact Verification
+
+Download the CLI artifact for your platform and `checksums.txt` from the GitHub
+release.
+
+```sh
+grep ' <artifact>$' checksums.txt | sha256sum -c -
+```
+
+On macOS, use:
+
+```sh
+shasum -a 256 <artifact>
+```
+
+Verify GitHub artifact attestations:
+
+```sh
+gh attestation verify <artifact> -R cssbruno/GOWDK
+```
+
+## VS Code Extension
+
+Install the packaged `.vsix` manually when the release includes one:
+
+```sh
+code --install-extension gowdk-vscode-0.5.0.vsix
+```
+
+## Tool Versions
+
+- Go: `1.26.4`
+- Node.js for extension checks: `24`

--- a/docs/engineering/release-plan.md
+++ b/docs/engineering/release-plan.md
@@ -101,8 +101,8 @@ Every 0.x minor release must have:
 - [ ] Checksums and artifact attestation instructions in release notes.
 - [ ] A release checklist link in release notes.
 - [ ] A "no production claim" check before publishing.
-- [ ] Draft and pre-release GitHub release settings unless the release policy is
-  deliberately changed.
+- [ ] Normal GitHub release settings for v0.5.0 and later, unless release
+  policy deliberately changes again.
 
 ## Public Truth
 
@@ -139,7 +139,7 @@ Every 0.x minor release must have:
 
 ## README And Getting Started
 
-- [ ] Keep the pre-release warning near the top.
+- [ ] Keep the experimental 0.x warning near the top.
 - [ ] Add "experimental 0.x" wording near the top.
 - [ ] Add "public contracts may change" near the install section.
 - [ ] Move "What works today," "What is partial," and "What is planned" higher.
@@ -742,7 +742,8 @@ helpers in [#122](https://github.com/cssbruno/GOWDK/issues/122).
 
 Start with these in order:
 
-- [x] Verify release metadata shows experimental/pre-release correctly.
+- [x] Verify release metadata shows experimental/non-production-ready wording
+  correctly.
 - [x] Open public issue backlog.
 - [x] Add `0.x Hardening` project board.
 - [x] Update website install docs for release binaries.

--- a/docs/engineering/release.md
+++ b/docs/engineering/release.md
@@ -1,19 +1,20 @@
 # Release
 
-GOWDK is currently pre-release compiler/runtime scaffolding. Release packaging
-automation lives in `.github/workflows/release.yml` and creates visible
-pre-releases with downloadable assets from `v*` tags or a manual workflow
-dispatch. VS Code Marketplace publishing lives in
+GOWDK is currently experimental 0.x compiler/runtime software. Release
+packaging automation lives in `.github/workflows/release.yml` and creates
+visible normal GitHub releases with downloadable assets from `v*` tags or a
+manual workflow dispatch. VS Code Marketplace publishing lives in
 `.github/workflows/vscode-extension-publish.yml`.
 
-The current CLI version is `0.3.0`, but this is not a production-readiness
+The current CLI version is `0.5.0`, but this is not a production-readiness
 claim. It identifies the current development line while the compiler, generated
-runtime, and docs continue through the 0.x line. Public release notes must
-call the build experimental until the release gates below are satisfied.
+runtime, and docs continue through the 0.x line. Public release notes must keep
+the build experimental and not production-ready until the 1.0 release gates are
+satisfied.
 
-Use `docs/engineering/v0.2-release-checklist.md` for the current Public Truth
-and Release Trust checklist.
-Use `docs/engineering/release-notes-v0.3.md` as the draft v0.3 release notes.
+Use `docs/engineering/v0.2-release-checklist.md` for the historical v0.2
+Public Truth and Release Trust checklist.
+Use `docs/engineering/release-notes-v0.5.md` as the draft v0.5 release notes.
 Use `docs/engineering/release-plan.md` for the open-ended 0.x hardening
 checklist. It does not make any minor version a production-readiness target.
 Use `.github/release-note-template.md` for future 0.x release bodies.
@@ -44,12 +45,11 @@ Patch-release changes belong in `CHANGELOG.md` and the selected release notes.
 No current release should be described as production-ready. Before tagging a
 public release, confirm:
 
-- The GitHub release is marked as a pre-release.
 - The release body starts with "Experimental 0.x release" and "Not
   production-ready."
 - README, requirements, architecture, examples, generated-output docs, and
   release notes clearly separate implemented, partial, and planned behavior.
-- Version and release notes are reflected in the visible pre-release.
+- Version and release notes are reflected in the visible GitHub release.
 - CI workflow is passing.
 - Release artifact list is still accurate.
 - GitHub artifact attestations are enabled for release artifacts.
@@ -89,14 +89,14 @@ After those gates pass on the release commit, run the release workflow manually
 for the current CLI line or push the corresponding tag:
 
 ```sh
-gh workflow run release.yml -f version=v0.3.0
+gh workflow run release.yml -f version=v0.5.0
 ```
 
 After the release workflow completes, smoke the published artifacts for each
 supported OS artifact:
 
 ```sh
-gh workflow run release-smoke.yml -f version=v0.3.0
+gh workflow run release-smoke.yml -f version=v0.5.0
 ```
 
 ## Artifacts
@@ -107,21 +107,20 @@ gh workflow run release-smoke.yml -f version=v0.3.0
 - `gowdk-darwin-arm64`
 - `gowdk-windows-amd64.exe`
 - `checksums.txt`
-- `gowdk-vscode-0.3.0.vsix`
+- `gowdk-vscode-0.5.0.vsix`
 
 ## Install Script
 
 `scripts/install.sh` installs the latest visible published GitHub release by
-default, including 0.x pre-releases. It selects the current operating system
-and architecture, downloads `checksums.txt`, verifies that the matching CLI
-artifact exists for the current platform before binary download, verifies the
-binary SHA-256, and writes `gowdk` into `GOWDK_INSTALL_DIR` or
-`/usr/local/bin`.
+default. It selects the current operating system and architecture, downloads
+`checksums.txt`, verifies that the matching CLI artifact exists for the current
+platform before binary download, verifies the binary SHA-256, and writes
+`gowdk` into `GOWDK_INSTALL_DIR` or `/usr/local/bin`.
 
 Pinned install:
 
 ```sh
-GOWDK_VERSION=v0.3.0 GOWDK_INSTALL_DIR="$HOME/.local/bin" \
+GOWDK_VERSION=v0.5.0 GOWDK_INSTALL_DIR="$HOME/.local/bin" \
   sh -c "$(curl -fsSL https://raw.githubusercontent.com/cssbruno/GoWDK/main/scripts/install.sh)"
 ```
 
@@ -142,7 +141,7 @@ gh attestation verify <artifact> -R <owner>/<repo>
 ## Extension Publishing
 
 The release workflow packages the extension into a `.vsix` named from
-`editors/vscode/package.json`, currently `gowdk-vscode-0.3.0.vsix`.
+`editors/vscode/package.json`, currently `gowdk-vscode-0.5.0.vsix`.
 Marketplace publishing is handled by the `Publish VS Code Extension` workflow.
 It is manual-only so CLI/runtime releases do not accidentally republish an
 extension version that already exists on the Marketplace.

--- a/docs/engineering/v0.2-release-checklist.md
+++ b/docs/engineering/v0.2-release-checklist.md
@@ -50,11 +50,14 @@ milestones listed below, not through version-number planning buckets.
   }
   ```
 
-- [x] Verify future 0.x releases are created as visible pre-releases with
-  downloadable assets.
+- [x] Under the v0.2 release policy, verify future 0.x releases are created as
+  visible pre-releases with downloadable assets. This policy is superseded for
+  v0.5.0 and later by `docs/engineering/release.md`, which publishes normal
+  GitHub releases while keeping experimental/not-production-ready wording.
 
-  `softprops/action-gh-release` is configured with `draft: false` and
-  `prerelease: true` in `.github/workflows/release.yml`.
+  At the time, `softprops/action-gh-release` was configured with `draft: false`
+  and `prerelease: true` in `.github/workflows/release.yml` for the v0.2
+  policy.
 
 ## Repo Truth Gates
 
@@ -247,6 +250,6 @@ against `checksums.txt`, and runs `gowdk version`.
   Intel, macOS ARM, and Windows CLI artifacts by checksum and `gowdk version`.
 - [x] The release workflow checks Go and Node gates, builds CLI artifacts,
   checks `gowdk version --json`, packages the VS Code `.vsix`, verifies
-  `checksums.txt`, and creates visible pre-releases.
+  `checksums.txt`, and created visible pre-releases under the v0.2 policy.
 - [x] The VS Code publish workflow supports manual Marketplace pre-release
   publishing and uploads the packaged `.vsix` as a workflow artifact.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -11,7 +11,7 @@ app binary, and run it locally.
 
 ## Install The CLI
 
-Install the latest visible GitHub release, including 0.x pre-releases:
+Install the latest visible GitHub release:
 
 ```sh
 curl -fsSL https://raw.githubusercontent.com/cssbruno/GoWDK/main/scripts/install.sh | sh
@@ -21,7 +21,7 @@ gowdk version
 Pin the current CLI release or install into a user-writable directory:
 
 ```sh
-GOWDK_VERSION=v0.3.0 GOWDK_INSTALL_DIR="$HOME/.local/bin" \
+GOWDK_VERSION=v0.5.0 GOWDK_INSTALL_DIR="$HOME/.local/bin" \
   sh -c "$(curl -fsSL https://raw.githubusercontent.com/cssbruno/GoWDK/main/scripts/install.sh)"
 ```
 
@@ -96,7 +96,7 @@ Direct artifact names:
 Manual Linux install:
 
 ```sh
-version=v0.3.0
+version=v0.5.0
 curl -fsSLO "https://github.com/cssbruno/GoWDK/releases/download/$version/gowdk-linux-amd64"
 curl -fsSLO "https://github.com/cssbruno/GoWDK/releases/download/$version/checksums.txt"
 grep ' gowdk-linux-amd64$' checksums.txt | sha256sum -c -
@@ -109,7 +109,7 @@ gowdk version
 Manual macOS Intel install:
 
 ```sh
-version=v0.3.0
+version=v0.5.0
 curl -fsSLO "https://github.com/cssbruno/GoWDK/releases/download/$version/gowdk-darwin-amd64"
 curl -fsSLO "https://github.com/cssbruno/GoWDK/releases/download/$version/checksums.txt"
 expected="$(awk '$2 == "gowdk-darwin-amd64" { print $1 }' checksums.txt)"
@@ -124,7 +124,7 @@ gowdk version
 Manual macOS ARM install:
 
 ```sh
-version=v0.3.0
+version=v0.5.0
 curl -fsSLO "https://github.com/cssbruno/GoWDK/releases/download/$version/gowdk-darwin-arm64"
 curl -fsSLO "https://github.com/cssbruno/GoWDK/releases/download/$version/checksums.txt"
 expected="$(awk '$2 == "gowdk-darwin-arm64" { print $1 }' checksums.txt)"
@@ -139,7 +139,7 @@ gowdk version
 Manual Windows install from PowerShell:
 
 ```powershell
-$version = "v0.3.0"
+$version = "v0.5.0"
 Invoke-WebRequest "https://github.com/cssbruno/GoWDK/releases/download/$version/gowdk-windows-amd64.exe" -OutFile "gowdk.exe"
 Invoke-WebRequest "https://github.com/cssbruno/GoWDK/releases/download/$version/checksums.txt" -OutFile "checksums.txt"
 $expected = (Select-String -Path checksums.txt -Pattern "gowdk-windows-amd64.exe").Line.Split(" ")[0]
@@ -158,7 +158,7 @@ Install the VS Code extension package from a release when a `.vsix` is
 published:
 
 ```sh
-code --install-extension gowdk-vscode-0.3.0.vsix
+code --install-extension gowdk-vscode-0.5.0.vsix
 ```
 
 ## Build From Source

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "gowdk-vscode",
   "displayName": "GOWDK",
   "description": "Language tools for portable .gwdk files.",
-  "version": "0.3.0",
+  "version": "0.5.0",
   "publisher": "gowdk",
   "license": "MIT",
   "icon": "icons/gowdk.png",


### PR DESCRIPTION
## What changed

- Bumps the CLI and VS Code extension metadata to `0.5.0`.
- Updates install snippets, release docs, changelog, release-note template, and release runbooks for `v0.5.0`.
- Changes the GitHub release workflow to publish normal visible GitHub releases for the 0.x line instead of marking them as pre-releases.
- Adds `docs/engineering/release-notes-v0.5.md`.
- Updates the Intel macOS release-smoke job from retired `macos-13` to `macos-15-intel`.

## Why

The `v0.5.0` release should be the first normal GitHub release for the 0.x line while still keeping the experimental/not-production-ready warnings until 1.0.

The smoke workflow also needed a runner-label update because GitHub retired the `macos-13` image.

## Verification

Local:

- `node editors/vscode/scripts/sync-version.js --check`
- `go test ./cmd/gowdk -run 'Version|Release'`
- `go run ./cmd/gowdk version --json`
- `git diff --check`
- `go build ./cmd/gowdk`

Release:

- `release.yml` succeeded for `v0.5.0`: https://github.com/cssbruno/GoWDK/actions/runs/27577689876
- Published release: https://github.com/cssbruno/GoWDK/releases/tag/v0.5.0
- Replacement `release-smoke.yml` run passed all four artifacts from this PR branch: https://github.com/cssbruno/GoWDK/actions/runs/27578449701

## Release notes

The release body uses `docs/engineering/release-notes-v0.5.md`.