### PR TITLE
feat(ci): offline docs link checker (#412)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,9 @@ jobs:
       - name: Run VS Code extension unit tests
         run: node --test editors/vscode/*.test.js
 
+      - name: Check documentation links
+        run: sh scripts/check-docs-links.sh
+
       - name: Check example files
         run: sh scripts/check-example-reports.sh
 

--- a/docs/engineering/ci.md
+++ b/docs/engineering/ci.md
@@ -8,6 +8,7 @@ the fastest pre-handoff gate.
 - `scripts/test-go-modules.sh`
 - `scripts/check-root-deps.sh`
 - `scripts/vulncheck-go-modules.sh`
+- `scripts/check-docs-links.sh`
 - `go build ./cmd/gowdk`
 - `node --check editors/vscode/extension.js`
 - `node --check editors/vscode/extension-core.js`
@@ -35,6 +36,36 @@ the fastest pre-handoff gate.
   These commands run from the repository root and rely on the root
   `gowdk.config.go`. Any smoke command run from another directory must pass
   `--config <file>`.
+
+## Documentation Links
+
+`scripts/check-docs-links.sh` runs the stdlib-only `internal/doclint` checker
+over every Markdown file in the repository. It is a targeted gate: a broken
+in-repo link fails CI instead of rotting silently.
+
+It checks only local references and stays offline:
+
+- Relative file and directory links must resolve to an existing path.
+- `#fragment` anchors (same-file or `file.md#fragment`) must resolve to a
+  GitHub-style heading slug in the target Markdown file.
+- External links (`http`, `https`, `mailto`, `tel`, protocol-relative `//`) are
+  skipped — the check never makes network calls.
+- Links inside fenced or inline code are ignored because they are documentation
+  examples, not live references.
+
+Generated, vendored, and local-output directories are excluded by default
+(`.git`, `.gowdk`, `node_modules`, `vendor`, `dist`, `bin`, `tmp`). Override the
+set with `-exclude` and scope a run with `-root`:
+
+```sh
+scripts/check-docs-links.sh -root docs -exclude .git,node_modules
+```
+
+Markdown *style* linting is intentionally not part of this gate. The available
+formatters flagged mostly cosmetic line-wrap and list-indent differences across
+the existing docs — high churn, low signal — so the gate is limited to link and
+anchor correctness, which catches real breakage. Revisit if a style check earns
+its keep without mass reformatting.
 
 ## Cache Maintenance
 

--- a/docs/engineering/release.md
+++ b/docs/engineering/release.md
@@ -68,6 +68,7 @@ below still have to pass before publishing.
 ```sh
 scripts/test-go-modules.sh
 scripts/vulncheck-go-modules.sh
+scripts/check-docs-links.sh
 go build ./cmd/gowdk
 ./gowdk version --json
 node --check editors/vscode/extension.js

--- a/docs/language/components.md
+++ b/docs/language/components.md
@@ -231,6 +231,8 @@ client {
 }
 ```
 
+### WASM Islands
+
 WASM islands are declared on the component:
 
 ```gwdk

--- a/docs/learning/native.md
+++ b/docs/learning/native.md
@@ -62,7 +62,7 @@ Use installed `gowdk` commands inside an initialized app. Use
 ## Lesson 8: Add CSRF
 
 - Generated action adapters wire CSRF by default; see
-  [actions](../language/actions.md#current-contract).
+  [actions](../language/actions.md#production-notes).
 - Run generated endpoint examples with a dev secret after building from
   `examples/endpoints`:
   `GOWDK_CSRF_SECRET=development-endpoints-csrf-secret-32b GOWDK_ADDR=127.0.0.1:8093 bin/endpoints`.

--- a/internal/doclint/doclint_test.go
+++ b/internal/doclint/doclint_test.go
@@ -1,0 +1,154 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeFile(t *testing.T, dir, name, body string) {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestCheckFlagsBrokenLocalLink(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "guide.md", "See the [missing page](./does-not-exist.md).\n")
+
+	problems, err := Check(Config{Root: dir, ExcludedDirs: defaultExclusions})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(problems) != 1 {
+		t.Fatalf("expected 1 problem, got %d: %v", len(problems), problems)
+	}
+	if problems[0].Reason != "missing local file" || problems[0].Target != "./does-not-exist.md" {
+		t.Fatalf("unexpected problem: %+v", problems[0])
+	}
+}
+
+func TestCheckAllowsValidLinksAndAnchors(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "index.md", "Read [setup](sub/setup.md#install-steps) and [top](#overview).\n\n# Overview\n")
+	writeFile(t, dir, "sub/setup.md", "# Setup\n\n## Install steps\n\nDone.\n")
+
+	problems, err := Check(Config{Root: dir, ExcludedDirs: defaultExclusions})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(problems) != 0 {
+		t.Fatalf("expected no problems, got %v", problems)
+	}
+}
+
+func TestCheckFlagsMissingAnchor(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "a.md", "Jump to [other](b.md#no-such-heading).\n")
+	writeFile(t, dir, "b.md", "# Real Heading\n")
+
+	problems, err := Check(Config{Root: dir, ExcludedDirs: defaultExclusions})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(problems) != 1 || problems[0].Reason != "missing heading anchor" {
+		t.Fatalf("expected one missing-anchor problem, got %v", problems)
+	}
+}
+
+func TestCheckSkipsExcludedDirs(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "node_modules/dep/readme.md", "[broken](./nope.md)\n")
+	writeFile(t, dir, ".gowdk/output/page.md", "[broken](./nope.md)\n")
+
+	problems, err := Check(Config{Root: dir, ExcludedDirs: defaultExclusions})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(problems) != 0 {
+		t.Fatalf("expected excluded dirs to be skipped, got %v", problems)
+	}
+}
+
+func TestCheckSkipsExternalLinks(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "ext.md", "[site](https://example.com/missing) and [mail](mailto:a@b.com)\n")
+
+	problems, err := Check(Config{Root: dir, ExcludedDirs: defaultExclusions})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(problems) != 0 {
+		t.Fatalf("expected external links to be skipped, got %v", problems)
+	}
+}
+
+func TestCheckIgnoresLinksInCode(t *testing.T) {
+	dir := t.TempDir()
+	body := "Inline `[x](./missing.md)` is an example.\n\n" +
+		"```\n[y](./also-missing.md)\n```\n"
+	writeFile(t, dir, "code.md", body)
+
+	problems, err := Check(Config{Root: dir, ExcludedDirs: defaultExclusions})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(problems) != 0 {
+		t.Fatalf("expected code-span and fenced links to be ignored, got %v", problems)
+	}
+}
+
+func TestCheckResolvesDirectoryLinks(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "index.md", "Browse the [utils folder](src/utils/).\n")
+	writeFile(t, dir, "src/utils/keep.md", "# keep\n")
+
+	problems, err := Check(Config{Root: dir, ExcludedDirs: defaultExclusions})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(problems) != 0 {
+		t.Fatalf("expected directory link to resolve, got %v", problems)
+	}
+}
+
+func TestCheckReferenceDefinitions(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "ref.md", "See [the spec][spec].\n\n[spec]: ./spec.md\n")
+
+	problems, err := Check(Config{Root: dir, ExcludedDirs: defaultExclusions})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(problems) != 1 || problems[0].Reason != "missing local file" {
+		t.Fatalf("expected the reference definition to be checked, got %v", problems)
+	}
+}
+
+func TestSlugifyMatchesGitHubStyle(t *testing.T) {
+	cases := map[string]string{
+		"Install Steps":          "install-steps",
+		"persist \"local\"":      "persist-local",
+		"Go / WASM Interop":      "go--wasm-interop",
+		"Section 1.2: Overview!": "section-12-overview",
+	}
+	for in, want := range cases {
+		if got := slugify(in); got != want {
+			t.Errorf("slugify(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestHeadingAnchorsDeduplicate(t *testing.T) {
+	anchors := headingAnchors("# Notes\n\n## Notes\n\n## Notes\n")
+	for _, want := range []string{"notes", "notes-1", "notes-2"} {
+		if !anchors[want] {
+			t.Errorf("expected anchor %q in %v", want, anchors)
+		}
+	}
+}

--- a/internal/doclint/main.go
+++ b/internal/doclint/main.go
@@ -1,0 +1,195 @@
+// Command doclint checks local Markdown links and heading anchors across the
+// repository without any network access. It exists so a broken in-repo doc link
+// fails a targeted CI gate (see docs/engineering/ci.md) rather than rotting
+// silently.
+//
+// It deliberately checks only local references:
+//   - relative file/directory links resolve to an existing path, and
+//   - "#fragment" anchors (same-file or "file.md#fragment") resolve to a
+//     GitHub-style heading slug in the target Markdown file.
+//
+// External links (http, https, mailto, protocol-relative) are skipped so the
+// check stays fast and offline. Links inside fenced or inline code are ignored
+// because they are documentation examples, not live references.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+func main() {
+	root := flag.String("root", ".", "repository root to scan for Markdown files")
+	exclude := flag.String("exclude", strings.Join(defaultExclusions, ","),
+		"comma-separated directory names to skip (generated, vendored, or local-output paths)")
+	flag.Parse()
+
+	cfg := Config{Root: *root, ExcludedDirs: splitList(*exclude)}
+	problems, err := Check(cfg)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "doclint: %v\n", err)
+		os.Exit(2)
+	}
+	if len(problems) == 0 {
+		fmt.Println("docs links ok")
+		return
+	}
+	for _, p := range problems {
+		fmt.Fprintln(os.Stderr, p.String())
+	}
+	fmt.Fprintf(os.Stderr, "\ndoclint: %d broken local doc link(s)\n", len(problems))
+	os.Exit(1)
+}
+
+// defaultExclusions are directories that hold generated, vendored, or local
+// build output. Markdown inside them is not authored docs, so it is skipped.
+var defaultExclusions = []string{".git", ".gowdk", "node_modules", "vendor", "dist", "bin", "tmp"}
+
+// Config controls a documentation link scan.
+type Config struct {
+	Root         string
+	ExcludedDirs []string
+}
+
+// Problem is a single broken local reference.
+type Problem struct {
+	File   string // Markdown file containing the link, relative to root.
+	Line   int    // 1-based line number of the link.
+	Target string // The raw link target as written.
+	Reason string
+}
+
+func (p Problem) String() string {
+	return fmt.Sprintf("%s:%d: %s -> %s", p.File, p.Line, p.Reason, p.Target)
+}
+
+// Check scans every Markdown file under cfg.Root and returns one Problem per
+// broken local link, sorted by file then line for stable output.
+func Check(cfg Config) ([]Problem, error) {
+	root := cfg.Root
+	if root == "" {
+		root = "."
+	}
+	excluded := map[string]bool{}
+	for _, name := range cfg.ExcludedDirs {
+		if name != "" {
+			excluded[name] = true
+		}
+	}
+
+	var files []string
+	walkErr := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			if excluded[d.Name()] {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if strings.EqualFold(filepath.Ext(d.Name()), ".md") {
+			files = append(files, path)
+		}
+		return nil
+	})
+	if walkErr != nil {
+		return nil, walkErr
+	}
+	sort.Strings(files)
+
+	// Anchor sets are resolved lazily and cached: a single docs tree links into
+	// the same target files repeatedly.
+	anchorCache := map[string]map[string]bool{}
+	anchorsFor := func(path string) (map[string]bool, error) {
+		if cached, ok := anchorCache[path]; ok {
+			return cached, nil
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			anchorCache[path] = nil
+			return nil, err
+		}
+		set := headingAnchors(string(data))
+		anchorCache[path] = set
+		return set, nil
+	}
+
+	var problems []Problem
+	for _, file := range files {
+		data, err := os.ReadFile(file)
+		if err != nil {
+			return nil, err
+		}
+		for _, link := range extractLinks(string(data)) {
+			rel, _ := filepath.Rel(root, file)
+			if rel == "" {
+				rel = file
+			}
+			if p, ok := checkLink(root, file, rel, link, anchorsFor); ok {
+				problems = append(problems, p)
+			}
+		}
+	}
+	return problems, nil
+}
+
+// link is a Markdown link occurrence: its raw target and source line.
+type link struct {
+	Target string
+	Line   int
+}
+
+func checkLink(root, file, rel string, l link, anchorsFor func(string) (map[string]bool, error)) (Problem, bool) {
+	target := l.Target
+	if target == "" || isExternal(target) {
+		return Problem{}, false
+	}
+
+	pathPart, fragment := splitFragment(target)
+
+	// Pure "#anchor" links point at a heading in the same file.
+	if pathPart == "" {
+		anchors, err := anchorsFor(file)
+		if err != nil {
+			return Problem{File: rel, Line: l.Line, Target: target, Reason: "cannot read file for anchor"}, true
+		}
+		if fragment != "" && !anchors[fragment] {
+			return Problem{File: rel, Line: l.Line, Target: target, Reason: "missing heading anchor"}, true
+		}
+		return Problem{}, false
+	}
+
+	resolved := filepath.Join(filepath.Dir(file), filepath.FromSlash(pathPart))
+	info, err := os.Stat(resolved)
+	if err != nil {
+		return Problem{File: rel, Line: l.Line, Target: target, Reason: "missing local file"}, true
+	}
+
+	// A fragment against a Markdown file must resolve to a heading anchor.
+	if fragment != "" && !info.IsDir() && strings.EqualFold(filepath.Ext(resolved), ".md") {
+		anchors, err := anchorsFor(resolved)
+		if err != nil {
+			return Problem{File: rel, Line: l.Line, Target: target, Reason: "cannot read target for anchor"}, true
+		}
+		if !anchors[fragment] {
+			return Problem{File: rel, Line: l.Line, Target: target, Reason: "missing heading anchor"}, true
+		}
+	}
+	return Problem{}, false
+}
+
+func splitList(s string) []string {
+	var out []string
+	for _, part := range strings.Split(s, ",") {
+		if trimmed := strings.TrimSpace(part); trimmed != "" {
+			out = append(out, trimmed)
+		}
+	}
+	return out
+}

--- a/internal/doclint/parse.go
+++ b/internal/doclint/parse.go
@@ -1,0 +1,296 @@
+package main
+
+import (
+	"strings"
+)
+
+// isExternal reports whether a link target points outside the repository and so
+// should not be resolved on disk. Network schemes are skipped to keep the check
+// offline.
+func isExternal(target string) bool {
+	if strings.HasPrefix(target, "//") {
+		return true
+	}
+	for _, scheme := range []string{"http:", "https:", "mailto:", "tel:", "ftp:", "data:"} {
+		if strings.HasPrefix(strings.ToLower(target), scheme) {
+			return true
+		}
+	}
+	return false
+}
+
+// splitFragment separates "path#fragment" into its path and (decoded) fragment.
+func splitFragment(target string) (path, fragment string) {
+	if i := strings.IndexByte(target, '#'); i >= 0 {
+		return target[:i], target[i+1:]
+	}
+	return target, ""
+}
+
+// extractLinks returns every Markdown link target in src, skipping links inside
+// fenced code blocks and inline code spans (documentation examples, not live
+// references). It recognizes inline links "[text](target)" and reference
+// definitions "[id]: target".
+func extractLinks(src string) []link {
+	var links []link
+	inFence := false
+	var fenceMarker string
+
+	for i, raw := range strings.Split(src, "\n") {
+		lineNo := i + 1
+		trimmed := strings.TrimSpace(raw)
+
+		// Toggle fenced code blocks on ``` or ~~~ runs.
+		if marker := fenceOpener(trimmed); marker != "" {
+			if !inFence {
+				inFence, fenceMarker = true, marker
+			} else if strings.HasPrefix(trimmed, fenceMarker) {
+				inFence, fenceMarker = false, ""
+			}
+			continue
+		}
+		if inFence {
+			continue
+		}
+
+		scrubbed := stripInlineCode(raw)
+
+		// Reference-style definition: "[id]: target [optional title]".
+		if def, ok := referenceDefinition(scrubbed); ok {
+			links = append(links, link{Target: def, Line: lineNo})
+			continue
+		}
+
+		for _, target := range inlineLinkTargets(scrubbed) {
+			links = append(links, link{Target: target, Line: lineNo})
+		}
+	}
+	return links
+}
+
+func fenceOpener(trimmed string) string {
+	switch {
+	case strings.HasPrefix(trimmed, "```"):
+		return "```"
+	case strings.HasPrefix(trimmed, "~~~"):
+		return "~~~"
+	default:
+		return ""
+	}
+}
+
+// stripInlineCode blanks out backtick-delimited spans so links written as
+// examples inside `code` are not treated as live references. Backtick runs of
+// matching length delimit a span (CommonMark rule); an unterminated run is left
+// as-is.
+func stripInlineCode(line string) string {
+	var b strings.Builder
+	runes := []rune(line)
+	for i := 0; i < len(runes); {
+		if runes[i] != '`' {
+			b.WriteRune(runes[i])
+			i++
+			continue
+		}
+		// Measure the opening backtick run.
+		start := i
+		for i < len(runes) && runes[i] == '`' {
+			i++
+		}
+		runLen := i - start
+		// Find a closing run of the same length.
+		closeStart := -1
+		for j := i; j < len(runes); {
+			if runes[j] != '`' {
+				j++
+				continue
+			}
+			cs := j
+			for j < len(runes) && runes[j] == '`' {
+				j++
+			}
+			if j-cs == runLen {
+				closeStart = cs
+				i = j
+				break
+			}
+		}
+		if closeStart == -1 {
+			// Unterminated: emit the backticks literally and stop scrubbing.
+			b.WriteString(strings.Repeat("`", runLen))
+			b.WriteString(string(runes[i:]))
+			return b.String()
+		}
+		// Replace the whole span (including delimiters) with spaces.
+		b.WriteString(strings.Repeat(" ", i-start))
+	}
+	return b.String()
+}
+
+// inlineLinkTargets extracts the URL portion of every "[text](url)" link on a
+// line, ignoring images' leading "!" (images are checked identically). Nested
+// brackets in link text are handled by balancing.
+func inlineLinkTargets(line string) []string {
+	var targets []string
+	runes := []rune(line)
+	for i := 0; i < len(runes); i++ {
+		if runes[i] != '[' {
+			continue
+		}
+		// Balance the link-text brackets.
+		depth, j := 1, i+1
+		for ; j < len(runes) && depth > 0; j++ {
+			switch runes[j] {
+			case '[':
+				depth++
+			case ']':
+				depth--
+			}
+		}
+		if depth != 0 || j >= len(runes) || runes[j] != '(' {
+			continue
+		}
+		// Collect the parenthesized destination.
+		k := j + 1
+		pdepth := 1
+		var dest strings.Builder
+		for ; k < len(runes) && pdepth > 0; k++ {
+			switch runes[k] {
+			case '(':
+				pdepth++
+				dest.WriteRune(runes[k])
+			case ')':
+				pdepth--
+				if pdepth > 0 {
+					dest.WriteRune(runes[k])
+				}
+			default:
+				dest.WriteRune(runes[k])
+			}
+		}
+		if pdepth != 0 {
+			continue
+		}
+		if target := cleanDestination(dest.String()); target != "" {
+			targets = append(targets, target)
+		}
+		i = k - 1
+	}
+	return targets
+}
+
+// cleanDestination normalizes a raw "(...)" destination: trims whitespace,
+// unwraps <...>, and drops an optional "title".
+func cleanDestination(raw string) string {
+	dest := strings.TrimSpace(raw)
+	if dest == "" {
+		return ""
+	}
+	if strings.HasPrefix(dest, "<") {
+		if end := strings.IndexByte(dest, '>'); end >= 0 {
+			return dest[1:end]
+		}
+	}
+	// Destination ends at the first unescaped whitespace; the rest is a title.
+	if idx := strings.IndexAny(dest, " \t"); idx >= 0 {
+		dest = dest[:idx]
+	}
+	return dest
+}
+
+// referenceDefinition matches a link reference definition line, returning its
+// destination. The definition form is "[label]: destination [optional title]".
+func referenceDefinition(line string) (string, bool) {
+	trimmed := strings.TrimSpace(line)
+	if !strings.HasPrefix(trimmed, "[") {
+		return "", false
+	}
+	close := strings.Index(trimmed, "]:")
+	if close < 1 {
+		return "", false
+	}
+	rest := strings.TrimSpace(trimmed[close+2:])
+	if rest == "" {
+		return "", false
+	}
+	return cleanDestination(rest), true
+}
+
+// headingAnchors returns the set of GitHub-style slugs for every ATX heading in
+// src, applying GitHub's duplicate-suffix rule ("-1", "-2", ...). Headings
+// inside fenced code blocks are ignored.
+func headingAnchors(src string) map[string]bool {
+	anchors := map[string]bool{}
+	counts := map[string]int{}
+	inFence := false
+	var fenceMarker string
+
+	for _, raw := range strings.Split(src, "\n") {
+		trimmed := strings.TrimSpace(raw)
+		if marker := fenceOpener(trimmed); marker != "" {
+			if !inFence {
+				inFence, fenceMarker = true, marker
+			} else if strings.HasPrefix(trimmed, fenceMarker) {
+				inFence, fenceMarker = false, ""
+			}
+			continue
+		}
+		if inFence {
+			continue
+		}
+		if !strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		level := 0
+		for level < len(trimmed) && trimmed[level] == '#' {
+			level++
+		}
+		if level == 0 || level > 6 || level >= len(trimmed) || trimmed[level] != ' ' {
+			continue
+		}
+		text := strings.TrimSpace(trimmed[level:])
+		slug := slugify(text)
+		if slug == "" {
+			continue
+		}
+		if n := counts[slug]; n > 0 {
+			anchors[slug+"-"+itoa(n)] = true
+			counts[slug] = n + 1
+		} else {
+			anchors[slug] = true
+			counts[slug] = 1
+		}
+	}
+	return anchors
+}
+
+// slugify converts heading text to a GitHub-style anchor slug: lowercased, with
+// punctuation other than hyphens and underscores removed and spaces converted
+// to hyphens.
+func slugify(text string) string {
+	var b strings.Builder
+	for _, r := range strings.ToLower(text) {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9', r == '-', r == '_':
+			b.WriteRune(r)
+		case r == ' ':
+			b.WriteByte('-')
+		case r >= 0x80:
+			// Keep non-ASCII letters; GitHub lowercases and retains them.
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var digits []byte
+	for n > 0 {
+		digits = append([]byte{byte('0' + n%10)}, digits...)
+		n /= 10
+	}
+	return string(digits)
+}

--- a/scripts/check-docs-links.sh
+++ b/scripts/check-docs-links.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env sh
+set -eu
+
+# Check local Markdown links and heading anchors across the repository. This is
+# offline by design: external (http/https/mailto) links are not fetched. See
+# docs/engineering/ci.md.
+#
+# Pass extra flags through to the checker, e.g.:
+#   scripts/check-docs-links.sh -root docs
+
+repo_root=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+
+cd "${repo_root}"
+exec go run ./internal/doclint "$@"


### PR DESCRIPTION
## Summary

Closes #412. Adds a stdlib-only Markdown link/anchor checker and wires it into CI as a targeted gate, so a broken in-repo doc link fails the build instead of rotting silently.

- `internal/doclint` — scans every `*.md` file and reports broken **local** references:
  - relative file/directory links must resolve to an existing path
  - `#fragment` anchors (same-file or `file.md#fragment`) must resolve to a GitHub-style heading slug
  - external links (`http`/`https`/`mailto`/`tel`/`//`) are skipped — **no network**
  - links inside fenced or inline code are ignored (examples, not live references)
  - generated/vendored/output dirs excluded by default (`.git`, `.gowdk`, `node_modules`, `vendor`, `dist`, `bin`, `tmp`); override via `-exclude`, scope via `-root`
- `scripts/check-docs-links.sh` — wrapper, added to the CI verify job and the release manual-gate list
- Documented in `docs/engineering/ci.md` (incl. why Markdown *style* linting is intentionally out of scope: high churn, low signal)

## Fixes it surfaced on first run

- `docs/learning/native.md` → `actions.md#current-contract` (no such heading) → `#production-notes`
- `docs/learning/native.md` → `components.md#wasm-islands` (no such heading) → added a real `### WASM Islands` section in `components.md`

## Tests

`internal/doclint` unit tests cover broken-link detection, valid links/anchors, missing anchors, excluded dirs, external-link skipping, code-span/fence skipping, directory links, reference definitions, GitHub-style slugging, and duplicate-heading suffixing.

Verified: `go test ./internal/doclint`, `go vet`, `gofmt -l` clean, `scripts/check-root-deps.sh` (stdlib-only — no new module deps), and `scripts/check-docs-links.sh` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)