### PR TITLE
feat(cli): add gowdk clean; evaluate and reject env/benchmark (#417)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,17 @@ packages, and tooling contracts may change before a stable release.
     island changes a used store (guarded against write-back echo). Surfacing
     state from the Go `uint32` export contract remains the Go-side ABI follow-up.
 
+- **`gowdk clean` command (#417).** Removes the generated build outputs declared
+  by the project config — the top-level `Build.Output` and each configured
+  target's `Output`/`App`/`Binary`/`WASM`/`BackendApp`/`BackendBinary` — plus an
+  optional `--out` directory, scoped with `--target`. It reads `gowdk.config.go`
+  so customized or multi-target outputs are removed correctly, refuses to delete
+  the project root or any path outside it, never touches the source tree, and
+  supports `--dry-run` and `--json`. The `env` and `benchmark` commands were
+  evaluated and intentionally rejected as duplicative of `gowdk doctor`/`go env`
+  and `gowdk build --timings`/`go test -bench` respectively (see
+  `docs/reference/cli.md`).
+
 - Page stores can opt into browser persistence with a `persist "local"` or
   `persist "session"` modifier
   (`store cart ui.CartState = ui.NewCartState() persist "local"`). The generated

--- a/cmd/gowdk/clean.go
+++ b/cmd/gowdk/clean.go
@@ -1,0 +1,211 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/cssbruno/gowdk"
+)
+
+const cleanUsage = "usage: gowdk clean [--config <file>] [--target <name>] [--out <dir>] [--dry-run] [--json]"
+
+// cleanResult is the machine-readable outcome of a clean run.
+type cleanResult struct {
+	Version int      `json:"version"`
+	DryRun  bool     `json:"dryRun"`
+	Removed []string `json:"removed"`
+	Absent  []string `json:"absent"`
+}
+
+// clean removes the generated build outputs declared by the project config
+// (Build.Output and every configured target's output, app, binary, and WASM
+// paths) plus any explicit --out directory. It only ever touches configured
+// output paths inside the project root, never the source tree.
+func clean(args []string) error {
+	var (
+		configPath  string
+		targetNames []string
+		outDir      string
+		dryRun      bool
+		jsonOutput  bool
+	)
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		switch {
+		case arg == "--dry-run":
+			dryRun = true
+		case arg == "--json":
+			jsonOutput = true
+		case arg == "--config":
+			i++
+			if i >= len(args) {
+				return errors.New(cleanUsage)
+			}
+			configPath = args[i]
+		case strings.HasPrefix(arg, "--config="):
+			configPath = strings.TrimPrefix(arg, "--config=")
+		case arg == "--target":
+			i++
+			if i >= len(args) {
+				return errors.New(cleanUsage)
+			}
+			targetNames = appendNames(targetNames, args[i])
+		case strings.HasPrefix(arg, "--target="):
+			targetNames = appendNames(targetNames, strings.TrimPrefix(arg, "--target="))
+		case arg == "--out":
+			i++
+			if i >= len(args) {
+				return errors.New(cleanUsage)
+			}
+			outDir = args[i]
+		case strings.HasPrefix(arg, "--out="):
+			outDir = strings.TrimPrefix(arg, "--out=")
+		default:
+			return fmt.Errorf("unknown clean flag %q\n%s", arg, cleanUsage)
+		}
+	}
+
+	var options cliOptions
+	if err := loadProjectConfig(&options, configPath); err != nil {
+		return err
+	}
+
+	candidates, err := cleanTargets(options.Config, targetNames, outDir)
+	if err != nil {
+		return err
+	}
+
+	result, err := runClean(options.ProjectRoot, candidates, dryRun)
+	if err != nil {
+		return err
+	}
+	return reportClean(result, jsonOutput)
+}
+
+// runClean resolves candidates against root, removes the ones that exist (or
+// reports them under DryRun), and records the rest as absent. Paths that are
+// the project root or escape it are silently dropped by safeRelativeTargets.
+func runClean(root string, candidates []string, dryRun bool) (cleanResult, error) {
+	result := cleanResult{Version: 1, DryRun: dryRun}
+	for _, candidate := range safeRelativeTargets(root, candidates) {
+		absolute := candidate
+		if !filepath.IsAbs(absolute) {
+			absolute = filepath.Join(root, candidate)
+		}
+		if _, statErr := os.Lstat(absolute); statErr != nil {
+			if os.IsNotExist(statErr) {
+				result.Absent = append(result.Absent, candidate)
+				continue
+			}
+			return cleanResult{}, statErr
+		}
+		if !dryRun {
+			if removeErr := os.RemoveAll(absolute); removeErr != nil {
+				return cleanResult{}, fmt.Errorf("clean %s: %w", candidate, removeErr)
+			}
+		}
+		result.Removed = append(result.Removed, candidate)
+	}
+	return result, nil
+}
+
+// cleanTargets gathers the generated output paths from the config and the
+// optional --out override, restricted to --target when given.
+func cleanTargets(config gowdk.Config, targetNames []string, outDir string) ([]string, error) {
+	var targets []string
+	add := func(path string) {
+		if strings.TrimSpace(path) != "" {
+			targets = append(targets, path)
+		}
+	}
+
+	selected := cleanNames(targetNames)
+	if len(selected) == 0 {
+		add(config.Build.Output)
+	}
+
+	wanted := map[string]bool{}
+	for _, name := range selected {
+		wanted[name] = true
+	}
+	seen := map[string]bool{}
+	for _, target := range config.Build.Targets {
+		if len(wanted) > 0 && !wanted[target.Name] {
+			continue
+		}
+		seen[target.Name] = true
+		add(target.Output)
+		add(target.App)
+		add(target.Binary)
+		add(target.WASM)
+		add(target.BackendApp)
+		add(target.BackendBinary)
+	}
+	for _, name := range selected {
+		if !seen[name] {
+			return nil, fmt.Errorf("target %q is not configured", name)
+		}
+	}
+
+	add(outDir)
+	return targets, nil
+}
+
+// safeRelativeTargets resolves candidates against root, drops anything that is
+// the project root itself or escapes it, and de-duplicates while preserving a
+// stable sorted order.
+func safeRelativeTargets(root string, candidates []string) []string {
+	seen := map[string]bool{}
+	var safe []string
+	for _, candidate := range candidates {
+		absolute := candidate
+		if !filepath.IsAbs(absolute) {
+			absolute = filepath.Join(root, candidate)
+		}
+		absolute = filepath.Clean(absolute)
+		rel, err := filepath.Rel(root, absolute)
+		if err != nil {
+			continue
+		}
+		rel = filepath.ToSlash(rel)
+		if rel == "." || rel == ".." || strings.HasPrefix(rel, "../") {
+			// Refuse to remove the project root or anything outside it.
+			continue
+		}
+		if seen[rel] {
+			continue
+		}
+		seen[rel] = true
+		safe = append(safe, rel)
+	}
+	sort.Strings(safe)
+	return safe
+}
+
+func reportClean(result cleanResult, jsonOutput bool) error {
+	if jsonOutput {
+		payload, err := json.MarshalIndent(result, "", "  ")
+		if err != nil {
+			return err
+		}
+		fmt.Println(string(payload))
+		return nil
+	}
+	if len(result.Removed) == 0 {
+		fmt.Println("nothing to clean")
+		return nil
+	}
+	verb := "removed"
+	if result.DryRun {
+		verb = "would remove"
+	}
+	for _, path := range result.Removed {
+		fmt.Printf("%s %s\n", verb, path)
+	}
+	return nil
+}

--- a/cmd/gowdk/clean_test.go
+++ b/cmd/gowdk/clean_test.go
@@ -1,0 +1,132 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cssbruno/gowdk"
+)
+
+func TestCleanTargetsCollectsConfiguredOutputs(t *testing.T) {
+	config := gowdk.Config{
+		Build: gowdk.BuildConfig{
+			Output: "gowdk_cache",
+			Targets: []gowdk.BuildTargetConfig{
+				{Name: "site", Output: ".gowdk/output/site", App: ".gowdk/app/site", Binary: "bin/site", WASM: "bin/site.wasm"},
+			},
+		},
+	}
+	targets, err := cleanTargets(config, nil, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"gowdk_cache", ".gowdk/output/site", ".gowdk/app/site", "bin/site", "bin/site.wasm"} {
+		if !contains(targets, want) {
+			t.Fatalf("expected %q in targets %v", want, targets)
+		}
+	}
+}
+
+func TestCleanTargetsFiltersByTargetName(t *testing.T) {
+	config := gowdk.Config{
+		Build: gowdk.BuildConfig{
+			Output: "gowdk_cache",
+			Targets: []gowdk.BuildTargetConfig{
+				{Name: "site", Output: "out/site"},
+				{Name: "admin", Output: "out/admin"},
+			},
+		},
+	}
+	targets, err := cleanTargets(config, []string{"admin"}, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if contains(targets, "out/site") || contains(targets, "gowdk_cache") {
+		t.Fatalf("expected only the admin target, got %v", targets)
+	}
+	if !contains(targets, "out/admin") {
+		t.Fatalf("expected the admin output, got %v", targets)
+	}
+}
+
+func TestCleanTargetsRejectsUnknownTarget(t *testing.T) {
+	config := gowdk.Config{Build: gowdk.BuildConfig{Targets: []gowdk.BuildTargetConfig{{Name: "site"}}}}
+	if _, err := cleanTargets(config, []string{"missing"}, ""); err == nil {
+		t.Fatal("expected an error for an unknown target")
+	}
+}
+
+func TestCleanTargetsAddsOutOverride(t *testing.T) {
+	targets, err := cleanTargets(gowdk.Config{}, nil, "custom-out")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !contains(targets, "custom-out") {
+		t.Fatalf("expected the --out override, got %v", targets)
+	}
+}
+
+func TestSafeRelativeTargetsRejectsRootAndEscapes(t *testing.T) {
+	root := t.TempDir()
+	safe := safeRelativeTargets(root, []string{".", "..", "../escape", root, "gowdk_cache", "gowdk_cache"})
+	if len(safe) != 1 || safe[0] != "gowdk_cache" {
+		t.Fatalf("expected only the in-project path, got %v", safe)
+	}
+}
+
+func TestRunCleanRemovesExistingAndReportsAbsent(t *testing.T) {
+	root := t.TempDir()
+	outputDir := filepath.Join(root, "gowdk_cache")
+	if err := os.MkdirAll(filepath.Join(outputDir, "nested"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := runClean(root, []string{"gowdk_cache", "bin/site"}, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !contains(result.Removed, "gowdk_cache") {
+		t.Fatalf("expected gowdk_cache removed, got %+v", result)
+	}
+	if !contains(result.Absent, "bin/site") {
+		t.Fatalf("expected bin/site reported absent, got %+v", result)
+	}
+	if _, statErr := os.Stat(outputDir); !os.IsNotExist(statErr) {
+		t.Fatalf("expected %s to be removed", outputDir)
+	}
+}
+
+func TestRunCleanDryRunKeepsFiles(t *testing.T) {
+	root := t.TempDir()
+	outputDir := filepath.Join(root, "gowdk_cache")
+	if err := os.MkdirAll(outputDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := runClean(root, []string{"gowdk_cache"}, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.DryRun || !contains(result.Removed, "gowdk_cache") {
+		t.Fatalf("expected dry-run to list gowdk_cache, got %+v", result)
+	}
+	if _, statErr := os.Stat(outputDir); statErr != nil {
+		t.Fatalf("dry-run must not remove %s: %v", outputDir, statErr)
+	}
+}
+
+func TestCleanCommandRejectsUnknownFlag(t *testing.T) {
+	if err := clean([]string{"--nope"}); err == nil {
+		t.Fatal("expected an error for an unknown flag")
+	}
+}
+
+func contains(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/gowdk/main.go
+++ b/cmd/gowdk/main.go
@@ -76,6 +76,8 @@ func run(args []string) error {
 		return listContracts(args[1:])
 	case "build":
 		return build(args[1:])
+	case "clean":
+		return clean(args[1:])
 	case "dev":
 		return dev(args[1:])
 	case "preview":
@@ -136,6 +138,7 @@ func usage() {
 	fmt.Println("  trace <contract> [--json] [dir] print one command/query/event/job contract trace")
 	fmt.Println("  list commands|queries|events|jobs [--json] [dir] print filtered contract metadata")
 	fmt.Println("  build [--config <file>] [--debug] [--timings[=<file>]] [--ssr] [--allow-missing-backend] [--allow-insecure] [--obfuscate-assets] [--target <name>] [--module <name>] [--out <dir>] [--app <dir>] [--bin <file>] [--docker] [--docker-base <distroless|scratch>] [--deploy-recipe <caddy|nginx|split|static|systemd>] [--wasm <file>] [--backend-app <dir>] [--backend-bin <file>] [files...] compile .gwdk files into build output")
+	fmt.Println("  clean [--config <file>] [--target <name>] [--out <dir>] [--dry-run] [--json] remove configured build outputs")
 	fmt.Println("  dev [--addr <addr>] [--interval <duration>] [build flags...] build, serve, rebuild, and live reload")
 	fmt.Println("  preview [--addr <addr>] [--hot] [build flags...] build and serve a local deploy preview")
 	fmt.Println("  playground policy|export|run inspect sandbox policy, export projects, or run an opt-in sandbox build")

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -29,6 +29,7 @@ gowdk graph [--json] [dir]
 gowdk trace <contract> [--json] [dir]
 gowdk list commands|queries|events|jobs [--json] [dir]
 gowdk build [--config <file>] [--debug] [--timings[=<file>]] [--ssr] [--allow-missing-backend] [--allow-insecure] [--obfuscate-assets] [--target <name>] [--module <name>] [--out <dir>] [--app <dir>] [--bin <file>] [--docker] [--docker-base <distroless|scratch>] [--deploy-recipe <caddy|nginx|split|static|systemd>] [--wasm <file>] [--backend-app <dir>] [--backend-bin <file>] [files...]
+gowdk clean [--config <file>] [--target <name>] [--out <dir>] [--dry-run] [--json]
 gowdk dev [--addr <addr>] [--interval <duration>] [build flags...]
 gowdk preview [--addr <addr>] [--hot] [build flags...]
 gowdk serve --dir <dir> [--addr <addr>]
@@ -51,7 +52,7 @@ gowdk lsp [--ssr]
 - `--base-url`: supported by `add seo`; writes the required
   `seo.Options.BaseURL` value. The value must be an absolute `http` or
   `https` URL.
-- `--json`: supported by `check`, `doctor`, `audit`, `explain`, `inspect`, `contracts`, `graph`, `trace`, `list`, `playground policy`, and `playground export`; prints
+- `--json`: supported by `check`, `doctor`, `audit`, `explain`, `inspect`, `contracts`, `graph`, `trace`, `list`, `clean`, `playground policy`, and `playground export`; prints
   editor/tooling-friendly JSON. Contract JSON includes same-file handler
   signature diagnostics when available. `gowdk check --json` uses diagnostic
   schema version `1`. `gowdk inspect` emits JSON by default; `--json` is
@@ -76,8 +77,9 @@ gowdk lsp [--ssr]
   posture alone to a non-served `.gowdk/reports/<output-name>/gowdk-security.json`
   path outside the selected output directory.
 - `--write`: supported by `fmt`; overwrites formatted files.
-- `--dry-run`: supported by `fix`; prints files with available registered fixes
-  without writing changes.
+- `--dry-run`: supported by `fix` and `clean`; for `fix` it prints files with
+  available registered fixes without writing changes, and for `clean` it lists
+  the build outputs that would be removed without deleting anything.
 - `--code`: supported by `fix`; limits rewrites to one diagnostic code that has
   a registered fix.
 - `--config`: supported by `add`, `check`, `doctor`, `audit`, `manifest`, `sitemap`,
@@ -103,12 +105,12 @@ gowdk lsp [--ssr]
   that build, records transformed assets in `gowdk-assets.json`, and writes
   `asset_obfuscation` / `asset_obfuscated` build-report events. This is an
   optimization/hardening option, not a security boundary.
-- `--target`: supported by `build`; may be repeated or comma-separated, and runs selected `Build.Targets` entries.
+- `--target`: supported by `build` and `clean`; may be repeated or comma-separated. For `build` it runs the selected `Build.Targets` entries; for `clean` it restricts removal to the selected targets' outputs.
 - `--module`: supported by `check`, `doctor`, `audit`, `manifest`, `sitemap`, `routes`,
   `endpoints`, `inspect`, `generate stubs`, and `build`; may be repeated or
   comma-separated, and limits discovery to selected configured modules when no
   explicit file list is passed.
-- `--out`: supported by `build`; selects the output directory and overrides `Build.Output`. `playground export` uses `--out` as the archive path. `playground run` uses `--out` as the generated output directory and never writes build output into the source project.
+- `--out`: supported by `build` and `clean`; for `build` it selects the output directory and overrides `Build.Output`, and for `clean` it adds an extra output directory to remove alongside the configured outputs. `playground export` uses `--out` as the archive path. `playground run` uses `--out` as the generated output directory and never writes build output into the source project.
 - `--app`: supported by `build`; writes generated Go app source that embeds the selected output directory.
 - `--bin`: supported by `build`; requires `--app` and compiles the generated app with `go build -o <file>`.
 - `--docker`: supported by `build`; requires `--bin` and emits `Dockerfile`
@@ -261,6 +263,25 @@ module, app, binary, or explicit file arguments are passed; `gowdk build
 --target <name>` runs selected targets. `--target` cannot be combined with
 `--module`, `--out`, `--app`, `--bin`, `--wasm`, or explicit files. The ad hoc
 flags remain useful for one-off builds.
+
+`clean` removes the generated build outputs declared by the project config: the
+top-level `Build.Output` directory and, when `Build.Targets` are configured,
+each target's `Output`, `App`, `Binary`, `WASM`, `BackendApp`, and
+`BackendBinary` paths. `--target` restricts removal to selected targets and
+`--out` adds an extra directory. It only ever deletes configured output paths
+inside the project root — it refuses to remove the project root itself or any
+path that resolves outside it, and it never touches the source tree. Use
+`--dry-run` to list what would be removed and `--json` for tooling. This is more
+than `rm -rf`: it reads `gowdk.config.go` so the right paths are removed even
+when outputs are customized or spread across targets.
+
+`env` and `benchmark` were considered and intentionally **not** added. `env`
+would duplicate `gowdk doctor` (which already reports the resolved Go toolchain,
+CLI version, config, and tool availability, with `--json`) and Go's own
+`go env`. `benchmark` would duplicate `gowdk build --timings`, which already
+writes per-phase compiler timings, and Go's native `go test -bench`; broader
+performance work is tracked in issue #414. Adding either would split one source
+of truth across redundant commands.
 
 `doctor` checks the local GOWDK environment and current project without writing
 files. It verifies the Go toolchain, CLI version, config loading, source


### PR DESCRIPTION
## Summary

Closes #417. Evaluates the proposed `clean`, `env`, and `benchmark` CLI commands and acts on each.

### `clean` — accepted and implemented

`gowdk clean [--config <file>] [--target <name>] [--out <dir>] [--dry-run] [--json]`

Removes the generated build outputs declared by the project config:
- top-level `Build.Output`, and
- each configured target's `Output` / `App` / `Binary` / `WASM` / `BackendApp` / `BackendBinary`,
- plus an optional `--out` directory, scoped with `--target`.

It reads `gowdk.config.go` so the right paths are removed even when outputs are customized or spread across targets — more than a blind `rm -rf`. Safety: it refuses to remove the project root or any path that resolves outside it, and it never touches the source tree. `--dry-run` lists what would be removed; `--json` is machine-readable.

### `env` — rejected

Duplicates `gowdk doctor --json` (already reports the resolved Go toolchain, CLI version, config, and tool availability) and Go's own `go env`.

### `benchmark` — rejected / deferred

Duplicates `gowdk build --timings` (already writes per-phase compiler timings) and Go's native `go test -bench`. Broader performance work is tracked in #414.

## Acceptance criteria

- [x] Each command is specified with usage/output/tests (`clean`) or explicitly rejected with rationale (`env`, `benchmark`).
- [x] No design-only accepted command left dangling — `clean` is fully implemented, so no follow-up issue is needed.
- [x] CLI docs and help output stay synchronized (`usage()` in `main.go` + `docs/reference/cli.md` both updated; rationale also in `CHANGELOG.md`).

## Tests

`cmd/gowdk/clean_test.go`: target collection from config, `--target` filtering, unknown-target error, `--out` override, the root/escape safety guard, real removal + absent reporting, dry-run keeps files, and unknown-flag rejection.

Verified: `go build ./cmd/gowdk`, `go vet`, `gofmt -l` clean, `go test ./cmd/gowdk` green, and a manual `gowdk clean --dry-run --json` against the repo config.
