### PR TITLE
docs(examples): real-world Go interop slice with net/mail + slog (#329)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,16 @@ packages, and tooling contracts may change before 1.0.
 
 ## Unreleased
 
-No changes yet.
+### Implemented
+
+- **Real-world Go interop example (#329).** `examples/go-interop/newsletter.go`
+  + `newsletter-digest.page.gwdk` show a page delegating real behavior to the
+  standard library: subscriber addresses are validated with `net/mail` and the
+  build emits structured `log/slog` logs (kept separate from the JSON payload).
+  Integer build fields render correctly. The example is stdlib-only by design
+  (no new dependency) and the README documents what is real, mocked, and
+  intentionally omitted under the dependency policy. Covered by the
+  `examples/go-interop/*.gwdk` checks in `scripts/check-example-reports.sh`.
 
 ## v0.5.0 - 2026-06-15
 

--- a/examples/go-interop/README.md
+++ b/examples/go-interop/README.md
@@ -38,3 +38,39 @@ test -f /tmp/gowdk-go-interop/go-imported/index.html
 
 Run the command from the repository root so the required root
 `gowdk.config.go` is loaded, or pass an explicit `--config <file>`.
+
+## Real-world slice: validation + structured logging
+
+`newsletter.go` shows a page delegating *serious* behavior to standard-library
+packages instead of inline or generated logic. `SubscriberDigestForBuild`:
+
+- parses and validates a raw subscriber list with **`net/mail`**
+  (`mail.ParseAddress`), so malformed entries are rejected by a real parser;
+- emits **`log/slog`** structured build logs to stderr, which GOWDK keeps
+  separate from the JSON build payload; and
+- returns a digest (`validCount`, `rejectedCount`, `sampleDomains`) that the
+  page interpolates — including integer fields, which render as strings.
+
+What is **real**: the `net/mail` validation, the `log/slog` logging, and the
+stderr/JSON separation are genuine.
+
+What is **mocked**: `rawSubscribers` is a hardcoded slice standing in for a real
+data source (a `database/sql`/`pgx` query, a CRM export, or a drained queue).
+Swap it for your data layer and the `.gwdk` build contract is unchanged.
+
+What is **omitted, on purpose**: this example uses only the standard library so
+it adds no production dependency. Demonstrating `database/sql`, `pgx`, `sqlc`,
+markdown, email-sending, image, or queue packages follows the same import +
+`build {}` pattern, but adding those would need a real dependency reviewed under
+[dependency-policy.md](../../docs/engineering/dependency-policy.md). The root
+module deliberately keeps its direct-dependency surface tiny.
+
+```sh
+go run ./cmd/gowdk check examples/go-interop/newsletter-digest.page.gwdk
+go run ./cmd/gowdk build --out /tmp/gowdk-newsletter examples/go-interop/newsletter-digest.page.gwdk
+grep -F 'Valid subscribers: 3' /tmp/gowdk-newsletter/go-newsletter/index.html
+```
+
+`gowdk check` over `examples/go-interop/*.gwdk` runs in CI
+(`scripts/check-example-reports.sh`), so this page is validated on every build
+and cannot silently rot.

--- a/examples/go-interop/newsletter-digest.page.gwdk
+++ b/examples/go-interop/newsletter-digest.page.gwdk
@@ -1,0 +1,21 @@
+package gointerop
+
+page go.newsletter
+route "/go-newsletter"
+guard public
+
+import interop "github.com/cssbruno/gowdk/examples/go-interop"
+
+build {
+  => interop.SubscriberDigestForBuild()
+}
+
+view {
+  <main>
+    <h1>{title}</h1>
+    <p>{tagline}</p>
+    <p>Valid subscribers: {validCount}</p>
+    <p>Rejected: {rejectedCount}</p>
+    <p>Domains: {sampleDomains}</p>
+  </main>
+}

--- a/examples/go-interop/newsletter.go
+++ b/examples/go-interop/newsletter.go
@@ -1,0 +1,73 @@
+package gointerop
+
+import (
+	"log/slog"
+	"net/mail"
+	"os"
+	"sort"
+	"strings"
+)
+
+// SubscriberDigest is build-time data produced by delegating real work to the
+// standard library: addresses are parsed and validated with net/mail and the
+// build emits structured logs through log/slog. It demonstrates a .gwdk page
+// handing serious behavior to a normal Go package instead of inline or
+// generated business logic.
+type SubscriberDigest struct {
+	Title         string `json:"title"`
+	Tagline       string `json:"tagline"`
+	ValidCount    int    `json:"validCount"`
+	RejectedCount int    `json:"rejectedCount"`
+	SampleDomains string `json:"sampleDomains"`
+}
+
+// rawSubscribers stands in for a real data source — a database/sql or pgx query,
+// a CRM export, or a drained queue. It is intentionally hardcoded so the example
+// adds no production dependency: swap this slice for your data layer and the
+// .gwdk build contract is unchanged.
+var rawSubscribers = []string{
+	"Ada Lovelace <ada@example.com>",
+	"grace@example.org",
+	"not-an-email",
+	"Alan Turing <alan@example.net>",
+	"   ",
+}
+
+// SubscriberDigestForBuild validates rawSubscribers with net/mail, logs the
+// outcome with log/slog (to stderr, which GOWDK keeps separate from the JSON
+// build payload), and returns the digest rendered by the page.
+func SubscriberDigestForBuild() SubscriberDigest {
+	log := slog.New(slog.NewTextHandler(os.Stderr, nil))
+
+	valid, rejected := 0, 0
+	domains := map[string]struct{}{}
+	for _, raw := range rawSubscribers {
+		trimmed := strings.TrimSpace(raw)
+		address, err := mail.ParseAddress(trimmed)
+		if err != nil {
+			rejected++
+			log.Warn("rejected subscriber", "raw", raw, "error", err.Error())
+			continue
+		}
+		valid++
+		if at := strings.LastIndex(address.Address, "@"); at >= 0 {
+			domains[strings.ToLower(address.Address[at+1:])] = struct{}{}
+		}
+	}
+
+	sorted := make([]string, 0, len(domains))
+	for domain := range domains {
+		sorted = append(sorted, domain)
+	}
+	sort.Strings(sorted)
+
+	log.Info("subscriber digest built", "valid", valid, "rejected", rejected, "domains", len(sorted))
+
+	return SubscriberDigest{
+		Title:         "Newsletter digest",
+		Tagline:       "Validated at build time with net/mail; structured logs via log/slog.",
+		ValidCount:    valid,
+		RejectedCount: rejected,
+		SampleDomains: strings.Join(sorted, ", "),
+	}
+}


### PR DESCRIPTION
## Summary

Closes #329. Adds a Go-interop example that delegates *serious* behavior to normal Go packages instead of inline/generated logic — using only the standard library so it adds **no production dependency**.

`examples/go-interop/newsletter.go` + `newsletter-digest.page.gwdk`:
- validates a raw subscriber list with **`net/mail`** (`mail.ParseAddress`) — real parsing, real rejections;
- emits structured **`log/slog`** build logs to stderr, which GOWDK keeps separate from the JSON build payload;
- returns a digest (`validCount`, `rejectedCount`, `sampleDomains`) the page interpolates — including integer fields, which render as strings.

## Acceptance criteria

- [x] At least one example slice using normal Go packages (`net/mail`, `log/slog`).
- [x] Dependency-conscious — stdlib only, no new module deps (the README explains why DB/markdown/queue packages are demonstrated by the same pattern but omitted under `dependency-policy.md`).
- [x] Documents what is intentionally real, mocked, or omitted (README section).
- [x] Check/build commands keep it from going stale — covered by `examples/go-interop/*.gwdk` in `scripts/check-example-reports.sh` (CI).

## Verification

```sh
go run ./cmd/gowdk check examples/go-interop/newsletter-digest.page.gwdk
go run ./cmd/gowdk build --out /tmp/gowdk-newsletter examples/go-interop/newsletter-digest.page.gwdk
grep -F 'Valid subscribers: 3' /tmp/gowdk-newsletter/go-newsletter/index.html
```

`gofmt`/`go vet` clean; the full `scripts/check-example-reports.sh` suite passes with the new page included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)