### PR TITLE
feat(addons): document lifecycle contract; add version handshake (#416)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,18 @@ packages, and tooling contracts may change before 1.0.
 
 ## Unreleased
 
-No changes yet.
+### Implemented
+
+- **Addon lifecycle contract and version handshake (#416).**
+  `docs/reference/addons.md` now documents the four-phase addon lifecycle
+  (config loading → compiler validation → generated output → runtime hook
+  registration), the addon category taxonomy (marker, compiler, CSS processor,
+  build-time provider, runtime), the feature and version handshake, and the
+  failure modes for unsupported/stale addons. The registry gains a computed
+  version handshake — `addonregistry.Entry.SupportsVersion` and
+  `Registry.UnsupportedFor` check a CLI version against an entry's
+  `minGOWDK`/`maxGOWDK` bounds (supported/unsupported/unknown) — with tests.
+  Build-time auto-enforcement of the bound remains a deliberate follow-up.
 
 ## v0.5.0 - 2026-06-15
 

--- a/docs/reference/addons.md
+++ b/docs/reference/addons.md
@@ -14,6 +14,86 @@ importable Go module, the loader uses an executable config bridge so
 GitHub-hosted addons can return real `gowdk.Addon` values and preserve supported
 extension interfaces.
 
+## Addon Lifecycle
+
+An addon participates in up to four ordered phases. Each phase corresponds to a
+specific interface, and an addon implements only the interfaces for the phases
+it needs. The base `gowdk.Addon` (`Name()`, `Features()`) is always required;
+the rest are opt-in extension points.
+
+1. **Config loading** — `gowdk.Addon`. The loader resolves the constructor from
+   `gowdk.config.go` (Go AST for built-ins, executable bridge for external
+   modules) and reads `Features()`. Feature IDs gate compiler and generator
+   logic through `Config.HasFeature`.
+2. **Compiler validation** — `gowdk.GoBlockConsumer.ValidateGoBlock` validates
+   `go addon.<name> {}` blocks and may return addon-owned diagnostics. Built-in
+   feature gates also run here (for example, a page using `load {}` or
+   `go ssr {}` requires the `ssr` feature).
+3. **Generated output** — build-time emitters run while writing output:
+   `gowdk.CSSProcessor.ProcessCSS` (CSS), `gowdk.SEOProvider.SEOOptions`
+   (`sitemap.xml`/`robots.txt`), and `gowdk.GoBlockConsumer.GeneratedGo` (files
+   relative to the generated app directory, formatted before writing).
+4. **Runtime hook registration** — generated apps register runtime hooks from
+   user-owned Go in the generated package, for example
+   `RegisterRateLimiter(*ratelimit.Limiter)`, `GOWDKAuthProvider() auth.Provider`,
+   or `RegisterContractEventSink(...)`. GOWDK never calls third-party runtime
+   code implicitly; the app wires it.
+
+### Addon categories
+
+The contract distinguishes addon categories by which interfaces they implement.
+The registry records this in each entry's `publicInterfaces`:
+
+| Category | Interface(s) | Phase |
+| --- | --- | --- |
+| Marker / feature addon | `gowdk.Addon` only | config loading (feature gate) |
+| Compiler addon | `gowdk.GoBlockConsumer` | compiler validation + generated output |
+| CSS processor | `gowdk.CSSProcessor` | generated output |
+| Build-time provider | `gowdk.SEOProvider` | generated output |
+| Runtime addon | generated-app registration hooks | runtime hook registration |
+
+A single addon can span categories (for example `addons/css` implements both
+`gowdk.Addon` and `gowdk.CSSProcessor`).
+
+## Version and Feature Handshake
+
+Addons declare what they target two ways:
+
+- **Feature handshake.** `Features()` declares feature IDs (see below).
+  `Config.HasFeature` gates the matching compiler and generator logic; a page
+  that uses a capability without its feature addon is reported by a diagnostic
+  (for example `missing_ssr_addon`).
+- **Version handshake.** A registry entry declares the GOWDK line it supports
+  with `minGOWDK` and optional `maxGOWDK`. `addonregistry.Entry.SupportsVersion`
+  checks a concrete CLI version against those inclusive bounds and returns
+  `VersionSupported`, `VersionUnsupported`, or `VersionUnknown` (when a bound or
+  the queried version is unset or unparseable, so tooling warns rather than
+  wrongly blocking). `Registry.UnsupportedFor(version)` lists entries a given
+  CLI version excludes. The curated `compatibility` field
+  (`compatible`/`incompatible`/`unknown`) is the human-reviewed signal that
+  complements the computed bound check. Both are covered by
+  `internal/addonregistry` tests.
+
+## Failure Modes
+
+- **Unsupported addon go block** — `go addon.<name> {}` targeting an enabled
+  addon that does not implement `gowdk.GoBlockConsumer`, or whose
+  `GoBlockTargets` omits the exact target, fails `gowdk check` and builds with
+  `unsupported_addon_go_block_target`.
+- **Missing required external tool** — an addon that shells out to a tool (for
+  example `addons/tailwind`) fails the build with an install-required error when
+  the tool is absent; GOWDK does not download it.
+- **Missing feature addon** — using a capability without enabling its addon is a
+  compiler diagnostic, not a silent no-op.
+- **Version-incompatible addon** — `SupportsVersion` returns `VersionUnsupported`
+  for a CLI version outside an entry's `minGOWDK`/`maxGOWDK`. Tooling can surface
+  this; build-time auto-enforcement of the version bound remains a deliberate
+  follow-up (see Discovery Policy).
+- **Deprecated or experimental lifecycle** — surfaced in `gowdk add --list
+  --registry` output so users see stability before wiring an addon.
+- **External addon resolution** — external addons resolve through normal Go
+  module tooling; missing modules surface as ordinary Go build errors.
+
 Current feature IDs:
 
 - `spa`
@@ -114,12 +194,16 @@ non-addable built-in distinctions such as `addons/tailwind`. The schema and CLI
 table are ready for documented external, deprecated, and incompatible entries
 when the project has real entries to publish.
 
-Until that metadata, trust policy, and compatibility check exist, GOWDK must not
-scan GitHub or module proxies for addons, execute unknown constructors to build
-a list, download hidden dependencies, auto-add external modules, or enable an
-external addon that is not already present in project Go code. Remote registry
-sync and automatic compatibility enforcement remain out of scope for the local
-registry slice.
+The registry now provides a computed version handshake
+(`addonregistry.Entry.SupportsVersion` / `Registry.UnsupportedFor`, see
+[Version and Feature Handshake](#version-and-feature-handshake)) on top of the
+curated `compatibility` field. Even so, GOWDK must not scan GitHub or module
+proxies for addons, execute unknown constructors to build a list, download
+hidden dependencies, auto-add external modules, or enable an external addon that
+is not already present in project Go code. Remote registry sync and *build-time*
+automatic compatibility enforcement (failing a build on an out-of-range
+`minGOWDK`) remain out of scope for the local registry slice; the handshake is
+available for tooling to warn.
 
 `gowdk.NewAddon(name, features...)` creates a marker addon for feature checks.
 It does not by itself make the compiler, app generator, or runtime call

--- a/internal/addonregistry/handshake.go
+++ b/internal/addonregistry/handshake.go
@@ -1,0 +1,112 @@
+package addonregistry
+
+import (
+	"strconv"
+	"strings"
+)
+
+// VersionSupport is the result of checking a registry entry's declared
+// GOWDK-version bounds against a concrete CLI version.
+type VersionSupport int
+
+const (
+	// VersionUnknown means the bounds or the queried version could not be
+	// compared (an unset or unparseable bound), so compatibility cannot be
+	// proven either way. Callers should warn, not hard-fail.
+	VersionUnknown VersionSupport = iota
+	// VersionSupported means the queried version is within the declared bounds.
+	VersionSupported
+	// VersionUnsupported means the queried version is below MinGOWDK or above
+	// MaxGOWDK.
+	VersionUnsupported
+)
+
+// SupportsVersion reports whether the queried GOWDK version satisfies the
+// entry's declared [MinGOWDK, MaxGOWDK] bounds. This is the version handshake:
+// an addon declares the versions it targets and tooling can check a concrete
+// CLI version against it before wiring or trusting the addon.
+//
+// Bounds are inclusive. An unset bound is open on that side. If either relevant
+// bound or the queried version cannot be parsed as a dotted numeric version,
+// the result is VersionUnknown so a caller warns rather than wrongly blocking.
+func (e Entry) SupportsVersion(version string) VersionSupport {
+	target, ok := parseVersion(version)
+	if !ok {
+		return VersionUnknown
+	}
+
+	if strings.TrimSpace(e.MinGOWDK) != "" {
+		min, ok := parseVersion(e.MinGOWDK)
+		if !ok {
+			return VersionUnknown
+		}
+		if compareVersion(target, min) < 0 {
+			return VersionUnsupported
+		}
+	}
+	if strings.TrimSpace(e.MaxGOWDK) != "" {
+		max, ok := parseVersion(e.MaxGOWDK)
+		if !ok {
+			return VersionUnknown
+		}
+		if compareVersion(target, max) > 0 {
+			return VersionUnsupported
+		}
+	}
+	return VersionSupported
+}
+
+// UnsupportedFor returns the entries whose declared version bounds exclude the
+// queried version. Entries with unknown (unparseable or unset) bounds are not
+// reported, because their incompatibility cannot be proven.
+func (r Registry) UnsupportedFor(version string) []Entry {
+	var unsupported []Entry
+	for _, entry := range r.Addons {
+		if entry.SupportsVersion(version) == VersionUnsupported {
+			unsupported = append(unsupported, entry)
+		}
+	}
+	return unsupported
+}
+
+// parseVersion parses a "major.minor.patch" string, tolerating a leading "v"
+// and a trailing pre-release/build suffix (for example "1.2.0-rc1"). Missing
+// minor/patch components default to zero.
+func parseVersion(version string) ([3]int, bool) {
+	trimmed := strings.TrimSpace(version)
+	trimmed = strings.TrimPrefix(trimmed, "v")
+	if trimmed == "" {
+		return [3]int{}, false
+	}
+	// Drop any pre-release/build metadata so "0.5.0-rc1" compares as 0.5.0.
+	if cut := strings.IndexAny(trimmed, "-+"); cut >= 0 {
+		trimmed = trimmed[:cut]
+	}
+	parts := strings.Split(trimmed, ".")
+	if len(parts) > 3 {
+		return [3]int{}, false
+	}
+	var out [3]int
+	for i, part := range parts {
+		n, err := strconv.Atoi(part)
+		if err != nil || n < 0 {
+			return [3]int{}, false
+		}
+		out[i] = n
+	}
+	return out, true
+}
+
+// compareVersion returns -1, 0, or 1 as a is less than, equal to, or greater
+// than b.
+func compareVersion(a, b [3]int) int {
+	for i := 0; i < 3; i++ {
+		switch {
+		case a[i] < b[i]:
+			return -1
+		case a[i] > b[i]:
+			return 1
+		}
+	}
+	return 0
+}

--- a/internal/addonregistry/handshake_test.go
+++ b/internal/addonregistry/handshake_test.go
@@ -1,0 +1,65 @@
+package addonregistry
+
+import "testing"
+
+func TestEntrySupportsVersion(t *testing.T) {
+	cases := []struct {
+		name    string
+		entry   Entry
+		version string
+		want    VersionSupport
+	}{
+		{"within min only", Entry{MinGOWDK: "0.3.0"}, "0.5.0", VersionSupported},
+		{"equals min", Entry{MinGOWDK: "0.3.0"}, "0.3.0", VersionSupported},
+		{"below min", Entry{MinGOWDK: "0.3.0"}, "0.2.9", VersionUnsupported},
+		{"within range", Entry{MinGOWDK: "0.3.0", MaxGOWDK: "0.9.0"}, "0.5.0", VersionSupported},
+		{"above max", Entry{MinGOWDK: "0.3.0", MaxGOWDK: "0.4.0"}, "0.5.0", VersionUnsupported},
+		{"equals max", Entry{MaxGOWDK: "0.5.0"}, "0.5.0", VersionSupported},
+		{"no bounds", Entry{}, "0.5.0", VersionSupported},
+		{"leading v and prerelease", Entry{MinGOWDK: "0.3.0"}, "v0.5.0-rc1", VersionSupported},
+		{"unparseable version", Entry{MinGOWDK: "0.3.0"}, "latest", VersionUnknown},
+		{"unparseable bound", Entry{MinGOWDK: "next"}, "0.5.0", VersionUnknown},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.entry.SupportsVersion(tc.version); got != tc.want {
+				t.Fatalf("SupportsVersion(%q) = %v, want %v", tc.version, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestRegistryUnsupportedFor(t *testing.T) {
+	registry := Registry{Addons: []Entry{
+		{Name: "ok", MinGOWDK: "0.3.0"},
+		{Name: "too-new", MinGOWDK: "0.9.0"},
+		{Name: "too-old", MaxGOWDK: "0.4.0"},
+		{Name: "unknown-bound", MinGOWDK: "next"},
+	}}
+	unsupported := registry.UnsupportedFor("0.5.0")
+	if len(unsupported) != 2 {
+		t.Fatalf("expected 2 unsupported entries, got %d: %+v", len(unsupported), unsupported)
+	}
+	names := map[string]bool{}
+	for _, entry := range unsupported {
+		names[entry.Name] = true
+	}
+	if !names["too-new"] || !names["too-old"] {
+		t.Fatalf("expected too-new and too-old, got %v", names)
+	}
+	if names["unknown-bound"] {
+		t.Fatal("entries with unparseable bounds must not be reported as unsupported")
+	}
+}
+
+func TestBundledRegistrySupportsCurrentLine(t *testing.T) {
+	registry, err := Bundled()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Every bundled built-in declares minGOWDK 0.3.0, so the current 0.x line
+	// must not report any of them as version-incompatible.
+	if unsupported := registry.UnsupportedFor("0.5.0"); len(unsupported) != 0 {
+		t.Fatalf("bundled registry should support 0.5.0, got unsupported: %+v", unsupported)
+	}
+}


### PR DESCRIPTION
## Summary

Closes #416. Defines the addon lifecycle contract, documents the version/feature handshake and failure modes, and adds a computed, tested version handshake to the registry.

### Documentation (`docs/reference/addons.md`)
- **Addon lifecycle** — the four ordered phases (config loading → compiler validation → generated output → runtime hook registration), each mapped to the interface that participates (`gowdk.Addon`, `gowdk.GoBlockConsumer`, `gowdk.CSSProcessor`, `gowdk.SEOProvider`, generated-app registration hooks).
- **Addon categories** — a taxonomy table distinguishing marker/feature, compiler, CSS processor, build-time provider, and runtime addons (mirrors each registry entry's `publicInterfaces`).
- **Version and feature handshake** — how `Features()` + `Config.HasFeature` gate logic, and how `minGOWDK`/`maxGOWDK` + the new computed check declare a supported GOWDK line.
- **Failure modes** — unsupported go-block target, missing external tool, missing feature addon, version-incompatible addon, deprecated/experimental lifecycle, external resolution errors.

### Implementation (`internal/addonregistry`)
- `Entry.SupportsVersion(version)` → `VersionSupported` / `VersionUnsupported` / `VersionUnknown` against inclusive `minGOWDK`/`maxGOWDK` bounds (tolerates a leading `v` and pre-release suffixes; unknown when a bound or version is unparseable so callers warn rather than wrongly block).
- `Registry.UnsupportedFor(version)` lists entries a given CLI version excludes.

## Acceptance criteria
- [x] Contract distinguishes compiler addons, runtime addons, CSS processors, and generated-app hooks (category table + lifecycle phases).
- [x] Version/feature handshake documented **and tested where implemented** (`handshake_test.go`, incl. bundled built-ins supporting the current 0.x line).
- [x] Existing built-in addons comply — all are registered in `registry.json` with `minGOWDK` and `publicInterfaces`; `TestBundledRegistrySupportsCurrentLine` asserts none are version-incompatible.

## Verification
`go test ./internal/addonregistry`, `go vet`, `gofmt -l` clean; doc anchor links pass `doclint`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)