### PR TITLE
feat(cli): add env file loading

### DIFF
--- a/cmd/gowdk/audit.go
+++ b/cmd/gowdk/audit.go
@@ -20,7 +20,7 @@ import (
 	"github.com/cssbruno/gowdk/internal/securitymanifest"
 )
 
-const auditUsage = "usage: gowdk audit [--config <file>] [--module <name>] [--ssr] [--json] [--emit-tests[=<file>]] [--run] [files...]"
+const auditUsage = "usage: gowdk audit [--config <file>] [--env-file <file>] [--module <name>] [--ssr] [--json] [--emit-tests[=<file>]] [--run] [files...]"
 
 // auditReport is the gowdk audit result: the derived security posture plus the
 // findings from evaluating the built-in baseline and declared policies against

--- a/cmd/gowdk/build.go
+++ b/cmd/gowdk/build.go
@@ -21,7 +21,7 @@ import (
 	"github.com/cssbruno/gowdk/internal/source"
 )
 
-const buildUsage = "usage: gowdk build [--config <file>] [--debug] [--timings[=<file>]] [--ssr] [--allow-missing-backend] [--allow-insecure] [--obfuscate-assets] [--target <name>] [--module <name>] [--out <dir>] [--app <dir>] [--bin <file>] [--docker] [--docker-base <distroless|scratch>] [--deploy-recipe <caddy|nginx|split|static|systemd>] [--wasm <file>] [--backend-app <dir>] [--backend-bin <file>] [files...]"
+const buildUsage = "usage: gowdk build [--config <file>] [--env-file <file>] [--debug] [--timings[=<file>]] [--ssr] [--allow-missing-backend] [--allow-insecure] [--obfuscate-assets] [--target <name>] [--module <name>] [--out <dir>] [--app <dir>] [--bin <file>] [--docker] [--docker-base <distroless|scratch>] [--deploy-recipe <caddy|nginx|split|static|systemd>] [--wasm <file>] [--backend-app <dir>] [--backend-bin <file>] [files...]"
 
 func build(args []string) error {
 	started := time.Now()
@@ -68,6 +68,7 @@ type buildOptions struct {
 	DockerBase        string
 	DeployRecipes     []string
 	ConfigPath        string
+	EnvFilePath       string
 	TargetNames       []string
 	ModuleNames       []string
 	Paths             []string
@@ -746,6 +747,16 @@ func parseBuildOptions(args []string) (buildOptions, error) {
 			plan.ConfigPath = args[i]
 		case len(arg) > len("--config=") && arg[:len("--config=")] == "--config=":
 			plan.ConfigPath = arg[len("--config="):]
+		case arg == "--env-file":
+			i++
+			if i >= len(args) {
+				return buildOptions{}, fmt.Errorf(buildUsage)
+			}
+			plan.EnvFilePath = args[i]
+			plan.Options.EnvFilePath = args[i]
+		case len(arg) > len("--env-file=") && arg[:len("--env-file=")] == "--env-file=":
+			plan.EnvFilePath = arg[len("--env-file="):]
+			plan.Options.EnvFilePath = plan.EnvFilePath
 		case arg == "--target":
 			i++
 			if i >= len(args) {

--- a/cmd/gowdk/dev.go
+++ b/cmd/gowdk/dev.go
@@ -222,7 +222,7 @@ func (state devBuildState) snapshot() (inputSnapshot, error) {
 }
 
 func (state devBuildState) configChanged(change inputChange) bool {
-	return inputChangeTouchesConfig(change, state.plan.ConfigPath)
+	return inputChangeTouchesConfig(change, state.plan.ConfigPath) || inputChangeTouchesEnvFile(change, state.plan.Options.EnvFilePath)
 }
 
 type devServeState struct {

--- a/cmd/gowdk/dev_loop.go
+++ b/cmd/gowdk/dev_loop.go
@@ -59,7 +59,7 @@ func buildIncrementalSPALoaded(plan buildOptions, change inputChange) (bool, err
 	if strings.TrimSpace(plan.AppDir) != "" || strings.TrimSpace(plan.BinaryPath) != "" || strings.TrimSpace(plan.WASMPath) != "" || strings.TrimSpace(plan.BackendAppDir) != "" || strings.TrimSpace(plan.BackendBinaryPath) != "" {
 		return false, nil
 	}
-	if inputChangeTouchesConfig(change, plan.ConfigPath) {
+	if inputChangeTouchesConfig(change, plan.ConfigPath) || inputChangeTouchesEnvFile(change, plan.Options.EnvFilePath) {
 		return false, nil
 	}
 	options := plan.Options
@@ -176,15 +176,36 @@ func inputChangeTouchesConfig(change inputChange, configPath string) bool {
 	return false
 }
 
+func inputChangeTouchesEnvFile(change inputChange, envFilePath string) bool {
+	envAbs, ok := devAbsolutePath(envFilePath)
+	if !ok {
+		return false
+	}
+	for _, paths := range [][]string{change.Changed, change.Added, change.Removed} {
+		for _, changedPath := range paths {
+			if samePath(changedPath, envAbs) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 func devConfigPath(configPath string) (string, bool) {
 	if strings.TrimSpace(configPath) != "" {
-		abs, err := filepath.Abs(configPath)
-		return filepath.Clean(abs), err == nil
+		return devAbsolutePath(configPath)
 	}
 	if _, err := os.Stat("gowdk.config.go"); err != nil {
 		return "", false
 	}
-	abs, err := filepath.Abs("gowdk.config.go")
+	return devAbsolutePath("gowdk.config.go")
+}
+
+func devAbsolutePath(path string) (string, bool) {
+	if strings.TrimSpace(path) == "" {
+		return "", false
+	}
+	abs, err := filepath.Abs(path)
 	return filepath.Clean(abs), err == nil
 }
 
@@ -849,6 +870,10 @@ func buildInputPaths(plan buildOptions) (devInputPaths, error) {
 			inputs.addFiles(configPath)
 			inputs.addParentDirs(configPath)
 		}
+	}
+	if strings.TrimSpace(options.EnvFilePath) != "" {
+		inputs.addFiles(options.EnvFilePath)
+		inputs.addParentDirs(options.EnvFilePath)
 	}
 	return inputs, nil
 }

--- a/cmd/gowdk/doctor.go
+++ b/cmd/gowdk/doctor.go
@@ -15,7 +15,7 @@ import (
 	"github.com/cssbruno/gowdk/internal/lang"
 )
 
-const doctorUsage = "usage: gowdk doctor [--config <file>] [--module <name>] [--ssr] [--json] [files...]"
+const doctorUsage = "usage: gowdk doctor [--config <file>] [--env-file <file>] [--module <name>] [--ssr] [--json] [files...]"
 
 type doctorReport struct {
 	Version     int               `json:"version"`
@@ -33,11 +33,15 @@ type doctorSummary struct {
 }
 
 type doctorEnvironment struct {
-	GOWDKVersion string `json:"gowdkVersion"`
-	WorkingDir   string `json:"workingDir"`
-	ConfigPath   string `json:"configPath,omitempty"`
-	GoVersion    string `json:"goVersion,omitempty"`
-	GoEnvVersion string `json:"goEnvVersion,omitempty"`
+	GOWDKVersion string   `json:"gowdkVersion"`
+	WorkingDir   string   `json:"workingDir"`
+	ConfigPath   string   `json:"configPath,omitempty"`
+	EnvFilePath  string   `json:"envFilePath,omitempty"`
+	EnvFile      string   `json:"envFile,omitempty"`
+	EnvFileVars  []string `json:"envFileVars,omitempty"`
+	ProcessVars  []string `json:"processVars,omitempty"`
+	GoVersion    string   `json:"goVersion,omitempty"`
+	GoEnvVersion string   `json:"goEnvVersion,omitempty"`
 }
 
 type doctorCheck struct {
@@ -225,13 +229,50 @@ func (report *doctorReport) runConfigCheck(options *cliOptions, configPath strin
 		return false
 	}
 	report.Environment.ConfigPath = doctorConfigDisplayPath(configPath)
+	report.Environment.EnvFilePath = doctorEnvFileDisplayPath(*options)
 	report.addCheck(doctorCheck{
 		ID:       "config",
 		Status:   "ok",
 		Severity: "info",
 		Message:  "loaded " + report.Environment.ConfigPath,
 	})
+	report.addEnvFileCheck(options)
 	return true
+}
+
+func (report *doctorReport) addEnvFileCheck(options *cliOptions) {
+	if options.EnvFileLoaded {
+		report.Environment.EnvFilePath = options.EnvFilePath
+		report.Environment.EnvFile = "loaded"
+		report.Environment.EnvFileVars = append([]string(nil), options.EnvFileApplied...)
+		report.Environment.ProcessVars = append([]string(nil), options.EnvFileSkipped...)
+		report.addCheck(doctorCheck{
+			ID:       "env_file",
+			Status:   "ok",
+			Severity: "info",
+			Message:  doctorEnvFileLoadedMessage(options),
+		})
+		return
+	}
+	if options.EnvFileExplicit {
+		report.Environment.EnvFilePath = options.EnvFilePath
+		report.Environment.EnvFile = "missing"
+		report.addCheck(doctorCheck{
+			ID:        "env_file",
+			Status:    "error",
+			Severity:  "error",
+			Message:   "env file was requested but did not load",
+			NextSteps: []string{"Check the --env-file path."},
+		})
+		return
+	}
+	report.Environment.EnvFile = "not_found"
+	report.addCheck(doctorCheck{
+		ID:       "env_file",
+		Status:   "ok",
+		Severity: "info",
+		Message:  "no .env file discovered",
+	})
 }
 
 func (report *doctorReport) runSourcesCheck(config gowdk.Config, moduleNames, paths []string, projectRoot string) ([]string, bool) {
@@ -445,6 +486,28 @@ func doctorConfigDisplayPath(configPath string) string {
 		return configPath
 	}
 	return "gowdk.config.go"
+}
+
+func doctorEnvFileDisplayPath(options cliOptions) string {
+	if strings.TrimSpace(options.EnvFilePath) == "" {
+		return ""
+	}
+	return options.EnvFilePath
+}
+
+func doctorEnvFileLoadedMessage(options *cliOptions) string {
+	message := "loaded " + options.EnvFilePath
+	if len(options.EnvFileApplied) == 0 && len(options.EnvFileSkipped) == 0 {
+		return message
+	}
+	var details []string
+	if len(options.EnvFileApplied) > 0 {
+		details = append(details, fmt.Sprintf("from file: %s", strings.Join(options.EnvFileApplied, ", ")))
+	}
+	if len(options.EnvFileSkipped) > 0 {
+		details = append(details, fmt.Sprintf("process kept: %s", strings.Join(options.EnvFileSkipped, ", ")))
+	}
+	return message + " (" + strings.Join(details, ", ") + ")"
 }
 
 func doctorNodeLooksRelevant() bool {

--- a/cmd/gowdk/doctor_test.go
+++ b/cmd/gowdk/doctor_test.go
@@ -133,6 +133,59 @@ view {
 	}
 }
 
+func TestDoctorCommandReportsLoadedEnvFile(t *testing.T) {
+	root := t.TempDir()
+	source := filepath.Join(root, "home.page.gwdk")
+	secretName := "GOWDK_TEST_DOCTOR_ENV_FILE_SECRET"
+	_ = os.Unsetenv(secretName)
+	t.Cleanup(func() { _ = os.Unsetenv(secretName) })
+	config := writeEnvContractCLIConfig(t, root, secretName, 32)
+	envPath := filepath.Join(root, ".env")
+	writeCLIFile(t, envPath, secretName+"=doctor-secret-value-32-bytes-long\n")
+	writeCLIFile(t, source, `package app
+
+page home
+route "/"
+
+view {
+  <main>Doctor env</main>
+}
+`)
+
+	stdout, stderr, err := captureCLIOutput(t, func() error {
+		return run([]string{"doctor", "--json", "--config", config, source})
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	var decoded struct {
+		Environment struct {
+			EnvFilePath string `json:"envFilePath"`
+			EnvFile     string `json:"envFile"`
+		} `json:"environment"`
+		Checks []struct {
+			ID      string `json:"id"`
+			Status  string `json:"status"`
+			Message string `json:"message"`
+		} `json:"checks"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &decoded); err != nil {
+		t.Fatalf("expected JSON doctor output, got %q: %v", stdout, err)
+	}
+	if decoded.Environment.EnvFilePath != envPath || decoded.Environment.EnvFile != "loaded" {
+		t.Fatalf("expected loaded env file in environment: %#v", decoded.Environment)
+	}
+	if !doctorReportHasCheck(decoded.Checks, "env_file", "ok") {
+		t.Fatalf("expected env_file ok check: %#v", decoded.Checks)
+	}
+	if strings.Contains(stdout, "doctor-secret-value") {
+		t.Fatalf("doctor output must not include secret values:\n%s", stdout)
+	}
+}
+
 func TestDoctorCommandReportsMissingConfig(t *testing.T) {
 	root := t.TempDir()
 	withWorkingDir(t, root, func() {

--- a/cmd/gowdk/fix.go
+++ b/cmd/gowdk/fix.go
@@ -82,7 +82,7 @@ func parseFixOptions(args []string) (fixOptions, error) {
 	return options, nil
 }
 
-const fixUsage = "usage: gowdk fix [--dry-run] [--code <diagnostic-code>] [--config <file>] [--module <name>] [--ssr] [files...]"
+const fixUsage = "usage: gowdk fix [--dry-run] [--code <diagnostic-code>] [--config <file>] [--env-file <file>] [--module <name>] [--ssr] [files...]"
 
 type fileFixes struct {
 	source string

--- a/cmd/gowdk/generate.go
+++ b/cmd/gowdk/generate.go
@@ -19,7 +19,7 @@ import (
 	"github.com/cssbruno/gowdk/internal/source"
 )
 
-const generateUsage = "usage: gowdk generate stubs [--config <file>] [--module <name>] [--ssr] [files...]"
+const generateUsage = "usage: gowdk generate stubs [--config <file>] [--env-file <file>] [--module <name>] [--ssr] [files...]"
 
 func generate(args []string) error {
 	if len(args) == 0 {

--- a/cmd/gowdk/inspect.go
+++ b/cmd/gowdk/inspect.go
@@ -10,7 +10,7 @@ import (
 	"github.com/cssbruno/gowdk/internal/lang"
 )
 
-const inspectUsage = "usage: gowdk inspect ir|tree|endpoint-graph|go-bindings [--config <file>] [--module <name>] [--json] [--ssr] [files...]"
+const inspectUsage = "usage: gowdk inspect ir|tree|endpoint-graph|go-bindings [--config <file>] [--env-file <file>] [--module <name>] [--json] [--ssr] [files...]"
 
 func inspect(args []string) error {
 	if len(args) == 0 {

--- a/cmd/gowdk/main.go
+++ b/cmd/gowdk/main.go
@@ -122,22 +122,22 @@ func usage() {
 	fmt.Println("  add <addon> [--config <file>] [--base-url <url>] | add --list [--registry] [--json]  wire or list addons")
 	fmt.Println("  tokens <file.gwdk>       print language tokens")
 	fmt.Println("  fmt [--write] <files>    format .gwdk files")
-	fmt.Println("  check [--config <file>] [--module <name>] [--json] [--warnings-as-errors] [--ssr] [files...] parse and validate .gwdk files")
-	fmt.Println("  fix [--dry-run] [--code <diagnostic-code>] [--config <file>] [--module <name>] [--ssr] [files...] apply registered safe diagnostic fixes")
-	fmt.Println("  manifest [--config <file>] [--module <name>] [--ssr] [files...] print validated manifest JSON")
-	fmt.Println("  sitemap [--config <file>] [--module <name>] [--ssr] [files...] print editor site-map JSON")
-	fmt.Println("  routes [--config <file>] [--module <name>] [--ssr] [files...] print route and endpoint metadata JSON")
-	fmt.Println("  endpoints [--config <file>] [--module <name>] [--ssr] [files...] print endpoint metadata JSON")
-	fmt.Println("  inspect ir|tree|endpoint-graph|go-bindings [--config <file>] [--module <name>] [--json] [--ssr] [files...] print validated compiler inspection JSON")
-	fmt.Println("  generate stubs [--config <file>] [--module <name>] [--ssr] [files...] write missing action/API Go handler stubs")
+	fmt.Println("  check [--config <file>] [--env-file <file>] [--module <name>] [--json] [--warnings-as-errors] [--ssr] [files...] parse and validate .gwdk files")
+	fmt.Println("  fix [--dry-run] [--code <diagnostic-code>] [--config <file>] [--env-file <file>] [--module <name>] [--ssr] [files...] apply registered safe diagnostic fixes")
+	fmt.Println("  manifest [--config <file>] [--env-file <file>] [--module <name>] [--ssr] [files...] print validated manifest JSON")
+	fmt.Println("  sitemap [--config <file>] [--env-file <file>] [--module <name>] [--ssr] [files...] print editor site-map JSON")
+	fmt.Println("  routes [--config <file>] [--env-file <file>] [--module <name>] [--ssr] [files...] print route and endpoint metadata JSON")
+	fmt.Println("  endpoints [--config <file>] [--env-file <file>] [--module <name>] [--ssr] [files...] print endpoint metadata JSON")
+	fmt.Println("  inspect ir|tree|endpoint-graph|go-bindings [--config <file>] [--env-file <file>] [--module <name>] [--json] [--ssr] [files...] print validated compiler inspection JSON")
+	fmt.Println("  generate stubs [--config <file>] [--env-file <file>] [--module <name>] [--ssr] [files...] write missing action/API Go handler stubs")
 	fmt.Println("  explain [--json] <diagnostic-code> explain a diagnostic code and next steps")
-	fmt.Println("  doctor [--config <file>] [--module <name>] [--ssr] [--json] [files...] check local GOWDK environment and project health")
-	fmt.Println("  audit [--config <file>] [--module <name>] [--ssr] [--json] [--emit-tests[=<file>]] [--run] [files...] check security posture and optional runtime tests")
+	fmt.Println("  doctor [--config <file>] [--env-file <file>] [--module <name>] [--ssr] [--json] [files...] check local GOWDK environment and project health")
+	fmt.Println("  audit [--config <file>] [--env-file <file>] [--module <name>] [--ssr] [--json] [--emit-tests[=<file>]] [--run] [files...] check security posture and optional runtime tests")
 	fmt.Println("  contracts [--json] [dir]  print Go contract registration metadata")
 	fmt.Println("  graph [--json] [dir]      print command/event contract graph")
 	fmt.Println("  trace <contract> [--json] [dir] print one command/query/event/job contract trace")
 	fmt.Println("  list commands|queries|events|jobs [--json] [dir] print filtered contract metadata")
-	fmt.Println("  build [--config <file>] [--debug] [--timings[=<file>]] [--ssr] [--allow-missing-backend] [--allow-insecure] [--obfuscate-assets] [--target <name>] [--module <name>] [--out <dir>] [--app <dir>] [--bin <file>] [--docker] [--docker-base <distroless|scratch>] [--deploy-recipe <caddy|nginx|split|static|systemd>] [--wasm <file>] [--backend-app <dir>] [--backend-bin <file>] [files...] compile .gwdk files into build output")
+	fmt.Println("  build [--config <file>] [--env-file <file>] [--debug] [--timings[=<file>]] [--ssr] [--allow-missing-backend] [--allow-insecure] [--obfuscate-assets] [--target <name>] [--module <name>] [--out <dir>] [--app <dir>] [--bin <file>] [--docker] [--docker-base <distroless|scratch>] [--deploy-recipe <caddy|nginx|split|static|systemd>] [--wasm <file>] [--backend-app <dir>] [--backend-bin <file>] [files...] compile .gwdk files into build output")
 	fmt.Println("  clean [--config <file>] [--target <name>] [--out <dir>] [--dry-run] [--json] remove configured build outputs")
 	fmt.Println("  dev [--addr <addr>] [--interval <duration>] [build flags...] build, serve, rebuild, and live reload")
 	fmt.Println("  preview [--addr <addr>] [--hot] [build flags...] build and serve a local deploy preview")
@@ -155,6 +155,11 @@ type cliOptions struct {
 	AllowInsecure       bool
 	ObfuscateAssets     bool
 	WarningsAsErrors    bool
+	EnvFilePath         string
+	EnvFileLoaded       bool
+	EnvFileExplicit     bool
+	EnvFileApplied      []string
+	EnvFileSkipped      []string
 }
 
 func appendModuleNames(moduleNames []string, value string) []string {

--- a/cmd/gowdk/main_test.go
+++ b/cmd/gowdk/main_test.go
@@ -53,6 +53,64 @@ view {
 	}
 }
 
+func TestCheckCommandLoadsExplicitEnvFile(t *testing.T) {
+	root := t.TempDir()
+	source := filepath.Join(root, "home.page.gwdk")
+	secretName := "GOWDK_TEST_ENV_FILE_SECRET_EXPLICIT"
+	_ = os.Unsetenv(secretName)
+	t.Cleanup(func() { _ = os.Unsetenv(secretName) })
+	config := writeEnvContractCLIConfig(t, root, secretName, 32)
+	envPath := filepath.Join(root, ".env.dev")
+	writeCLIFile(t, envPath, secretName+"=development-secret-value-32-bytes-long\n")
+	writeCLIFile(t, source, `package app
+
+page home
+route "/"
+
+view {
+  <main>Env file</main>
+}
+`)
+
+	stdout, stderr, err := captureCLIOutput(t, func() error {
+		return run([]string{"check", "--config", config, "--env-file", envPath, source})
+	})
+	if err != nil {
+		t.Fatalf("expected check to load env file, got err=%v stderr=%s", err, stderr)
+	}
+	if strings.TrimSpace(stdout) != "ok" || stderr != "" {
+		t.Fatalf("unexpected check output stdout=%q stderr=%q", stdout, stderr)
+	}
+}
+
+func TestCheckCommandKeepsProcessEnvOverEnvFile(t *testing.T) {
+	root := t.TempDir()
+	source := filepath.Join(root, "home.page.gwdk")
+	secretName := "GOWDK_TEST_ENV_FILE_SECRET_PROCESS"
+	t.Setenv(secretName, "process-secret-value-32-bytes-long")
+	config := writeEnvContractCLIConfig(t, root, secretName, 32)
+	writeCLIFile(t, filepath.Join(root, ".env"), secretName+"=short\n")
+	writeCLIFile(t, source, `package app
+
+page home
+route "/"
+
+view {
+  <main>Process env</main>
+}
+`)
+
+	stdout, stderr, err := captureCLIOutput(t, func() error {
+		return run([]string{"check", "--config", config, source})
+	})
+	if err != nil {
+		t.Fatalf("expected process env to win over short file value, got err=%v stderr=%s", err, stderr)
+	}
+	if strings.TrimSpace(stdout) != "ok" || stderr != "" {
+		t.Fatalf("unexpected check output stdout=%q stderr=%q", stdout, stderr)
+	}
+}
+
 func TestBuildCommandPrerendersSupportedStaticSlice(t *testing.T) {
 	root := t.TempDir()
 	page := filepath.Join(root, "docs.page.gwdk")
@@ -6848,6 +6906,24 @@ import "github.com/cssbruno/gowdk"
 var Config = gowdk.Config{}
 `)
 	return path
+}
+
+func writeEnvContractCLIConfig(t *testing.T, root string, secretName string, minBytes int) string {
+	t.Helper()
+	config := filepath.Join(root, "gowdk.config.go")
+	writeCLIFile(t, config, fmt.Sprintf(`package app
+
+import "github.com/cssbruno/gowdk"
+
+var Config = gowdk.Config{
+	Env: gowdk.EnvConfig{
+		Secrets: []gowdk.SecretEnv{
+			{Name: %q, Required: true, MinBytes: %d},
+		},
+	},
+}
+`, secretName, minBytes))
+	return config
 }
 
 func writeCLITestModule(t *testing.T, root string, modulePath string) {

--- a/cmd/gowdk/project_inputs.go
+++ b/cmd/gowdk/project_inputs.go
@@ -11,6 +11,7 @@ import (
 	"github.com/cssbruno/gowdk/addons/ssr"
 	"github.com/cssbruno/gowdk/internal/discover"
 	"github.com/cssbruno/gowdk/internal/project"
+	"github.com/cssbruno/gowdk/runtime/envfile"
 )
 
 func loadBuildConfig(options *cliOptions, configPath string) error {
@@ -22,6 +23,9 @@ func loadProjectConfig(options *cliOptions, configPath string) error {
 	obfuscateAssets := options.ObfuscateAssets
 	projectRoot, err := resolveProjectRoot(configPath)
 	if err != nil {
+		return err
+	}
+	if err := loadProjectEnvFile(options, projectRoot); err != nil {
 		return err
 	}
 	config, err := project.LoadConfig(configPath)
@@ -40,6 +44,26 @@ func loadProjectConfig(options *cliOptions, configPath string) error {
 	options.ProjectRoot = projectRoot
 	options.AllowMissingBackend = allowMissingBackend
 	options.ObfuscateAssets = obfuscateAssets
+	return nil
+}
+
+func loadProjectEnvFile(options *cliOptions, projectRoot string) error {
+	path, explicit, err := envfile.LookupPath(projectRoot, options.EnvFilePath)
+	if err != nil {
+		return err
+	}
+	result, err := envfile.LoadIntoEnv(path, explicit)
+	if err != nil {
+		if explicit {
+			return fmt.Errorf("load env file %q: %w", path, err)
+		}
+		return fmt.Errorf("load discovered env file %q: %w", path, err)
+	}
+	options.EnvFilePath = result.Path
+	options.EnvFileLoaded = result.Loaded
+	options.EnvFileExplicit = result.Explicit
+	options.EnvFileApplied = append([]string(nil), result.Applied...)
+	options.EnvFileSkipped = append([]string(nil), result.Skipped...)
 	return nil
 }
 
@@ -232,6 +256,7 @@ func outputExcludePattern(root, outputDir string) string {
 func parseProjectOptions(args []string, command string, allowJSON bool) (cliOptions, string, []string, []string, error) {
 	var options cliOptions
 	var configPath string
+	var envFilePath string
 	var moduleNames []string
 	var paths []string
 	usage := projectCommandUsage(command, allowJSON)
@@ -257,6 +282,16 @@ func parseProjectOptions(args []string, command string, allowJSON bool) (cliOpti
 			configPath = args[i]
 		case strings.HasPrefix(arg, "--config="):
 			configPath = strings.TrimPrefix(arg, "--config=")
+		case arg == "--env-file":
+			i++
+			if i >= len(args) {
+				return options, "", nil, nil, errors.New(usage)
+			}
+			envFilePath = args[i]
+			options.EnvFilePath = envFilePath
+		case strings.HasPrefix(arg, "--env-file="):
+			envFilePath = strings.TrimPrefix(arg, "--env-file=")
+			options.EnvFilePath = envFilePath
 		case arg == "--module":
 			i++
 			if i >= len(args) {
@@ -271,6 +306,7 @@ func parseProjectOptions(args []string, command string, allowJSON bool) (cliOpti
 			paths = append(paths, arg)
 		}
 	}
+	options.EnvFilePath = envFilePath
 	return options, configPath, moduleNames, paths, nil
 }
 
@@ -280,7 +316,7 @@ func projectCommandUsage(command string, allowJSON bool) string {
 		if command == "check" {
 			warningsFlag = " [--warnings-as-errors]"
 		}
-		return fmt.Sprintf("usage: gowdk %s [--config <file>] [--module <name>] [--json]%s [--ssr] [files...]", command, warningsFlag)
+		return fmt.Sprintf("usage: gowdk %s [--config <file>] [--env-file <file>] [--module <name>] [--json]%s [--ssr] [files...]", command, warningsFlag)
 	}
-	return fmt.Sprintf("usage: gowdk %s [--config <file>] [--module <name>] [--ssr] [files...]", command)
+	return fmt.Sprintf("usage: gowdk %s [--config <file>] [--env-file <file>] [--module <name>] [--ssr] [files...]", command)
 }

--- a/docs/engineering/env-file-loading-plan.md
+++ b/docs/engineering/env-file-loading-plan.md
@@ -1,0 +1,66 @@
+# Implementation Plan: Env File Loading
+
+## Context
+
+Spec: `docs/product/env-file-loading-spec.md`
+Issue: https://github.com/cssbruno/GoWDK/issues/467
+
+## Assumptions
+
+- Local env files are a developer convenience, not a production secret manager.
+- Process env precedence is required for CI and deployment safety.
+- `serve` stays outside scope because it does not load project config.
+
+## Proposed Changes
+
+- Add dependency-free `runtime/envfile` parsing and loading helpers.
+- Load env files from shared CLI project config loading before
+  `project.LoadConfig`.
+- Add `--env-file` parsing to project-aware commands and build flags.
+- Generate env-file loading into generated apps before env/CSRF validation.
+- Add doctor metadata for loaded env files without values.
+- Update CLI/config/deployment docs.
+
+## Files Expected To Change
+
+- `runtime/envfile/`
+- `cmd/gowdk/project_inputs.go`, `build.go`, `doctor.go`, `dev.go`,
+  `dev_loop.go`, `main.go`
+- `internal/appgen/source_env.go`, `source.go`, `source_backend_app.go`
+- CLI/generated app tests and docs
+
+## Data And API Impact
+
+- New public runtime package: `github.com/cssbruno/gowdk/runtime/envfile`.
+- New CLI flag: `--env-file <path>` for project-aware commands and build flags.
+- New generated-binary env var: `GOWDK_ENV_FILE`.
+
+## Tests
+
+- Unit: dotenv parser behavior and process-env precedence.
+- Integration: `gowdk check --env-file`, auto `.env`, doctor JSON metadata.
+- End-to-end: generated binary loads `GOWDK_ENV_FILE`.
+- Manual: run `gowdk check --env-file .env.dev` in a project with `EnvConfig`.
+
+## Verification Commands
+
+```sh
+gofmt -w runtime/envfile/*.go cmd/gowdk/*.go internal/appgen/*.go
+go test ./runtime/envfile ./cmd/gowdk ./internal/appgen
+go test ./...
+go build ./cmd/gowdk
+```
+
+## Rollback Plan
+
+- Remove env-file loading calls and the generated helper.
+- Remove `--env-file` parsing and docs.
+- Keep existing process-env validation behavior unchanged.
+
+## Risks
+
+- Accidentally overriding CI env values; mitigated by process-env precedence.
+- Leaking values in diagnostics; mitigated by name/count-only reporting.
+- Generated binaries loading unintended `.env` from the current working
+  directory; explicit process env values still win and production should use
+  platform env variables.

--- a/docs/product/env-file-loading-spec.md
+++ b/docs/product/env-file-loading-spec.md
@@ -1,0 +1,80 @@
+# Feature Spec: Env File Loading
+
+## Problem
+
+Projects can declare required runtime secrets in `EnvConfig`, but CLI commands
+and generated binaries only checked the process environment. Local development
+required shell-side exports or third-party tools before `gowdk check`, `build`,
+`dev`, `doctor`, or a generated binary could pass the same env contract.
+
+## Goals
+
+- Let project-aware CLI commands load a local env file before env validation.
+- Preserve process environment precedence so CI and production behavior stays
+  unchanged.
+- Let generated binaries load an explicit env file for direct local runs.
+- Keep diagnostics and doctor output value-free.
+
+## Non-Goals
+
+- Managing production secrets.
+- Expanding dotenv syntax beyond simple `NAME=value` files.
+- Making `gowdk serve` load project config; it remains static output serving.
+
+## Users And Permissions
+
+- Primary users: local developers and operators testing generated binaries.
+- Roles or permissions: no new app permissions.
+- Data visibility rules: commands may report env variable names and file paths,
+  never values.
+
+## User Flow
+
+1. Developer writes `.env` or `.env.dev` in the project root.
+2. Developer runs `gowdk check --env-file .env.dev` or sets `GOWDK_ENV=dev`.
+3. GOWDK loads missing process values from the file and validates `EnvConfig`.
+4. For generated binaries, the developer sets `GOWDK_ENV_FILE=/path/to/.env`
+   or starts the binary from a directory containing `.env`.
+
+## Requirements
+
+### Functional
+
+- `--env-file <path>` loads before `gowdk.config.go` env validation.
+- Without `--env-file`, `.env.<GOWDK_ENV>` is discovered before `.env`.
+- Process env values override file values.
+- Generated binaries load `GOWDK_ENV_FILE` or discovered `.env` before startup
+  env and CSRF secret checks.
+- `doctor --json` reports the loaded env-file path and counts, not values.
+
+### Non-Functional
+
+- Performance: parse small env files once per command/build cycle.
+- Reliability: malformed env files fail the command before validation proceeds.
+- Accessibility: not applicable.
+- Security/privacy: never print secret values; keep production env precedence.
+- Observability: `doctor` exposes whether a file was loaded.
+
+## Acceptance Criteria
+
+- [x] `gowdk check --env-file <file>` satisfies a required secret from the file.
+- [x] Process env wins when the same name appears in the file.
+- [x] Auto-discovered `.env` satisfies the same validation path.
+- [x] Generated binaries can load an explicit env file with `GOWDK_ENV_FILE`.
+- [x] `doctor --json` reports the env file without leaking values.
+
+## Edge Cases
+
+- Explicit missing or malformed env files fail fast.
+- Blank required values still fail after file loading.
+- Empty optional values remain valid unless a secret `MinBytes` check applies.
+
+## Dependencies
+
+- Internal: `runtime/envfile`, CLI project config loading, generated app output.
+- External: none.
+
+## Open Questions
+
+- Should a future production deploy recipe emit examples for platform-specific
+  secret managers instead of env files?

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -13,22 +13,22 @@ gowdk add <addon> [--config <file>] [--base-url <url>]
 gowdk add --list [--registry] [--json]
 gowdk tokens <file.gwdk>
 gowdk fmt [--write] <files>
-gowdk check [--config <file>] [--module <name>] [--json] [--warnings-as-errors] [--ssr] [files...]
-gowdk fix [--dry-run] [--code <diagnostic-code>] [--config <file>] [--module <name>] [--ssr] [files...]
-gowdk manifest [--config <file>] [--module <name>] [--ssr] [files...]
-gowdk sitemap [--config <file>] [--module <name>] [--ssr] [files...]
-gowdk routes [--config <file>] [--module <name>] [--ssr] [files...]
-gowdk endpoints [--config <file>] [--module <name>] [--ssr] [files...]
-gowdk inspect ir|tree|endpoint-graph|go-bindings [--config <file>] [--module <name>] [--json] [--ssr] [files...]
-gowdk generate stubs [--config <file>] [--module <name>] [--ssr] [files...]
+gowdk check [--config <file>] [--env-file <file>] [--module <name>] [--json] [--warnings-as-errors] [--ssr] [files...]
+gowdk fix [--dry-run] [--code <diagnostic-code>] [--config <file>] [--env-file <file>] [--module <name>] [--ssr] [files...]
+gowdk manifest [--config <file>] [--env-file <file>] [--module <name>] [--ssr] [files...]
+gowdk sitemap [--config <file>] [--env-file <file>] [--module <name>] [--ssr] [files...]
+gowdk routes [--config <file>] [--env-file <file>] [--module <name>] [--ssr] [files...]
+gowdk endpoints [--config <file>] [--env-file <file>] [--module <name>] [--ssr] [files...]
+gowdk inspect ir|tree|endpoint-graph|go-bindings [--config <file>] [--env-file <file>] [--module <name>] [--json] [--ssr] [files...]
+gowdk generate stubs [--config <file>] [--env-file <file>] [--module <name>] [--ssr] [files...]
 gowdk explain [--json] <diagnostic-code>
-gowdk doctor [--config <file>] [--module <name>] [--ssr] [--json] [files...]
-gowdk audit [--config <file>] [--module <name>] [--ssr] [--json] [--emit-tests[=<file>]] [--run] [files...]
+gowdk doctor [--config <file>] [--env-file <file>] [--module <name>] [--ssr] [--json] [files...]
+gowdk audit [--config <file>] [--env-file <file>] [--module <name>] [--ssr] [--json] [--emit-tests[=<file>]] [--run] [files...]
 gowdk contracts [--json] [dir]
 gowdk graph [--json] [dir]
 gowdk trace <contract> [--json] [dir]
 gowdk list commands|queries|events|jobs [--json] [dir]
-gowdk build [--config <file>] [--debug] [--timings[=<file>]] [--ssr] [--allow-missing-backend] [--allow-insecure] [--obfuscate-assets] [--target <name>] [--module <name>] [--out <dir>] [--app <dir>] [--bin <file>] [--docker] [--docker-base <distroless|scratch>] [--deploy-recipe <caddy|nginx|split|static|systemd>] [--wasm <file>] [--backend-app <dir>] [--backend-bin <file>] [files...]
+gowdk build [--config <file>] [--env-file <file>] [--debug] [--timings[=<file>]] [--ssr] [--allow-missing-backend] [--allow-insecure] [--obfuscate-assets] [--target <name>] [--module <name>] [--out <dir>] [--app <dir>] [--bin <file>] [--docker] [--docker-base <distroless|scratch>] [--deploy-recipe <caddy|nginx|split|static|systemd>] [--wasm <file>] [--backend-app <dir>] [--backend-bin <file>] [files...]
 gowdk clean [--config <file>] [--target <name>] [--out <dir>] [--dry-run] [--json]
 gowdk dev [--addr <addr>] [--interval <duration>] [build flags...]
 gowdk preview [--addr <addr>] [--hot] [build flags...]
@@ -86,6 +86,15 @@ gowdk lsp [--ssr]
   `routes`, `endpoints`, `inspect`, `generate stubs`, and `build`; selects the
   config file. Compile commands load a literal config subset from the given
   path instead of the required default `gowdk.config.go`.
+- `--env-file`: supported by project-aware compile/report commands that load
+  `gowdk.config.go`, including `check`, `doctor`, `audit`, `manifest`,
+  `sitemap`, `routes`, `endpoints`, `inspect`, `generate stubs`, and `build`;
+  forwarded through `dev` and `preview` as a build flag. Values from the file
+  are applied only when the process environment does not already define the
+  name. Without the flag, commands auto-load `.env.<GOWDK_ENV>` from the
+  project root when `GOWDK_ENV` is set and that file exists, otherwise `.env`
+  when present. Secret values are never printed; `doctor --json` reports only
+  the env-file path and variable names for file/process sources.
 - `--debug`: supported by `build` and forwarded by `dev`; prints the structured SPA build report to stderr while generated paths remain on stdout.
 - `--timings[=<file>]`: supported by `build`; writes a separate versioned JSON
   timing report. Without an explicit file, the report is written to
@@ -147,6 +156,7 @@ go run ./cmd/gowdk add ssr actions partial
 go run ./cmd/gowdk add seo --base-url https://example.com
 go run ./cmd/gowdk check examples/pages/home.page.gwdk
 go run ./cmd/gowdk check --config gowdk.config.go
+go run ./cmd/gowdk check --env-file .env.dev --config gowdk.config.go
 go run ./cmd/gowdk check --warnings-as-errors --config gowdk.config.go
 go run ./cmd/gowdk fix --dry-run --code old_action_block_syntax --config gowdk.config.go
 go run ./cmd/gowdk check --ssr examples/ssr/dashboard.page.gwdk

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -282,12 +282,27 @@ or blank in the host environment fail with a direct diagnostic such as
 treated as satisfied by the default. Secrets have no `Default` or value field by
 type; `Default` and `Value` are rejected in literal config parsing too.
 
+Project-aware CLI commands can load local env files before validation:
+
+```sh
+gowdk check --env-file .env.dev
+gowdk build --env-file .env.production
+```
+
+If `--env-file` is omitted, GOWDK auto-loads `.env.<GOWDK_ENV>` from the
+project root when `GOWDK_ENV` is set and the file exists, otherwise `.env` when
+present. Process environment values always win over file values. The file is
+only a value source for the same validation contract; it does not bypass
+`Required` or `MinBytes`.
+
 The same name cannot appear in both `Vars` and `Secrets`. Secret-looking var
 names ending in `_SECRET`, `_TOKEN`, `_PASSWORD`, or `_KEY` are rejected and
 must move to `Secrets`. Diagnostics print names only and never print values.
 
 Generated app binaries repeat the required env check before serving requests.
-This is a startup redundancy layer only. It does not replace backend
+For direct binary runs, set `GOWDK_ENV_FILE=/path/to/.env` or place `.env` in
+the process working directory. This is a startup redundancy layer only. It does
+not replace backend
 authorization, handler validation, database checks, deployment secrets, or
 runtime-specific security controls.
 

--- a/docs/reference/deployment.md
+++ b/docs/reference/deployment.md
@@ -220,7 +220,9 @@ binaries, and all Dockerfile generation rejects non-ELF binaries with guidance
 to build with `GOOS=linux`.
 
 Pass app secrets, CSRF secrets, database URLs, and service credentials as
-runtime environment variables owned by your deployment platform.
+runtime environment variables owned by your deployment platform. For local
+generated-binary runs, `GOWDK_ENV_FILE=/path/to/.env` can point the binary at a
+dotenv file; host environment values still take precedence over file values.
 
 ## CSRF Secret Rotation
 

--- a/internal/appgen/appgen_test.go
+++ b/internal/appgen/appgen_test.go
@@ -1631,8 +1631,14 @@ func TestGenerateWiresEnvContractValidation(t *testing.T) {
 	source := string(payload)
 	for _, expected := range []string{
 		`errors`,
+		`gowdkenvfile "github.com/cssbruno/gowdk/runtime/envfile"`,
 		`os`,
 		`strings`,
+		`if err := loadEnvFile(); err != nil {`,
+		`func loadEnvFile() error`,
+		`explicit := strings.TrimSpace(os.Getenv("GOWDK_ENV_FILE"))`,
+		`path, _, err := gowdkenvfile.LookupPath("", explicit)`,
+		`_, err = gowdkenvfile.LoadIntoEnv(path, explicit != "")`,
 		`if err := validateEnvContract(); err != nil {`,
 		`func validateEnvContract() error`,
 		`value := os.Getenv("GOWDK_TEST_BACKEND_ORIGIN")`,
@@ -3711,6 +3717,55 @@ func TestGeneratedBinaryFailsFastWhenRequiredEnvIsMissing(t *testing.T) {
 		if !strings.Contains(string(output), expected) {
 			t.Fatalf("expected generated binary output to contain %q:\n%s", expected, output)
 		}
+	}
+}
+
+func TestGeneratedBinaryLoadsExplicitEnvFile(t *testing.T) {
+	root := t.TempDir()
+	outputDir := filepath.Join(root, "dist")
+	appDir := filepath.Join(root, "generated-app")
+	binaryPath := filepath.Join(root, "site")
+	writeTestFile(t, filepath.Join(outputDir, "index.html"), "<main>Home</main>")
+
+	if _, err := GenerateWithOptions(outputDir, appDir, Options{
+		Config: gowdk.Config{Env: gowdk.EnvConfig{
+			Vars: []gowdk.EnvVar{
+				{Name: "GOWDK_TEST_BACKEND_ORIGIN", Required: true},
+			},
+			Secrets: []gowdk.SecretEnv{
+				{Name: "GOWDK_TEST_DATABASE_URL", Required: true, MinBytes: 32},
+			},
+		}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := BuildBinary(appDir, binaryPath); err != nil {
+		t.Fatal(err)
+	}
+	envPath := filepath.Join(root, ".env.runtime")
+	writeTestFile(t, envPath, "GOWDK_TEST_BACKEND_ORIGIN=http://backend.test\nGOWDK_TEST_DATABASE_URL=runtime-secret-value-32-bytes-long\n")
+	addr := freeAddr(t)
+	command := exec.Command(binaryPath)
+	command.Env = append(
+		withoutEnv(os.Environ(), "GOWDK_TEST_BACKEND_ORIGIN", "GOWDK_TEST_DATABASE_URL"),
+		"GOWDK_ADDR="+addr,
+		"GOWDK_ENV_FILE="+envPath,
+	)
+	if err := command.Start(); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if command.Process != nil {
+			_ = command.Process.Kill()
+			_, _ = command.Process.Wait()
+		}
+	}()
+	body, err := waitForHTTP("http://" + addr + "/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.TrimSpace(body) != "<main>Home</main>" {
+		t.Fatalf("unexpected response body:\n%s", body)
 	}
 }
 

--- a/internal/appgen/source.go
+++ b/internal/appgen/source.go
@@ -42,6 +42,11 @@ func runtimeImportMap(options Options) map[string]string {
 		"gowdkruntime": "github.com/cssbruno/gowdk/runtime/app",
 		"sync":         "sync",
 	}
+	if generatedEnvFileLoadRequired(options) {
+		imports["gowdkenvfile"] = "github.com/cssbruno/gowdk/runtime/envfile"
+		imports["os"] = "os"
+		imports["strings"] = "strings"
+	}
 	if envRuntimeValidationRequired(options.Config.Env) {
 		imports["errors"] = "errors"
 		imports["os"] = "os"
@@ -254,6 +259,7 @@ func appShellDecls(options Options) []ast.Decl {
 		handlerDecl(),
 		serveMuxDecl(options, true),
 	)
+	decls = append(decls, loadEnvFileDecl(options)...)
 	decls = append(decls, validateEnvContractDecl(options.Config.Env)...)
 	return decls
 }
@@ -268,6 +274,7 @@ func backendShellDecls(options Options) []ast.Decl {
 		handlerDecl(),
 		serveMuxDecl(options, false),
 	)
+	decls = append(decls, loadEnvFileDecl(options)...)
 	decls = append(decls, validateEnvContractDecl(options.Config.Env)...)
 	return decls
 }
@@ -391,6 +398,7 @@ func handlerDecl() ast.Decl {
 
 func serveMuxDecl(options Options, embedded bool) ast.Decl {
 	stmts := []ast.Stmt{}
+	stmts = append(stmts, loadEnvFileStmt(options)...)
 	stmts = append(stmts, validateEnvContractStmt(options.Config.Env)...)
 	if embedded {
 		stmts = append(stmts,

--- a/internal/appgen/source_backend_app.go
+++ b/internal/appgen/source_backend_app.go
@@ -21,6 +21,11 @@ func backendRuntimeImportMap(options Options) map[string]string {
 	contractExposures := adapter.ContractExposures
 	routableContracts := routableContractExposures(contractExposures)
 	executableContracts := executableContractExposures(contractExposures)
+	if generatedEnvFileLoadRequired(options) {
+		imports["gowdkenvfile"] = "github.com/cssbruno/gowdk/runtime/envfile"
+		imports["os"] = "os"
+		imports["strings"] = "strings"
+	}
 	if envRuntimeValidationRequired(options.Config.Env) {
 		imports["errors"] = "errors"
 		imports["os"] = "os"

--- a/internal/appgen/source_env.go
+++ b/internal/appgen/source_env.go
@@ -22,6 +22,38 @@ func envRuntimeValidationRequired(config gowdk.EnvConfig) bool {
 	return false
 }
 
+func generatedEnvFileLoadRequired(options Options) bool {
+	return envRuntimeValidationRequired(options.Config.Env) || csrfEnabled(options)
+}
+
+func loadEnvFileDecl(options Options) []ast.Decl {
+	if !generatedEnvFileLoadRequired(options) {
+		return nil
+	}
+	stmts := []ast.Stmt{
+		define([]ast.Expr{id("explicit")}, call(sel("strings", "TrimSpace"), call(sel("os", "Getenv"), stringLit("GOWDK_ENV_FILE")))),
+		define([]ast.Expr{id("path"), id("_"), id("err")}, call(sel("gowdkenvfile", "LookupPath"), stringLit(""), id("explicit"))),
+		&ast.IfStmt{
+			Cond: notNil("err"),
+			Body: block(&ast.ReturnStmt{Results: []ast.Expr{id("err")}}),
+		},
+		assign([]ast.Expr{id("_"), id("err")}, call(sel("gowdkenvfile", "LoadIntoEnv"), id("path"), &ast.BinaryExpr{X: id("explicit"), Op: token.NEQ, Y: stringLit("")})),
+		&ast.ReturnStmt{Results: []ast.Expr{id("err")}},
+	}
+	return []ast.Decl{funcDecl("loadEnvFile", nil, []*ast.Field{{Type: id("error")}}, stmts)}
+}
+
+func loadEnvFileStmt(options Options) []ast.Stmt {
+	if !generatedEnvFileLoadRequired(options) {
+		return nil
+	}
+	return []ast.Stmt{&ast.IfStmt{
+		Init: define([]ast.Expr{id("err")}, call(id("loadEnvFile"))),
+		Cond: notNil("err"),
+		Body: block(&ast.ReturnStmt{Results: []ast.Expr{id("nil"), id("err")}}),
+	}}
+}
+
 func validateEnvContractDecl(config gowdk.EnvConfig) []ast.Decl {
 	if !envRuntimeValidationRequired(config) {
 		return nil

--- a/internal/appgen/testdata/generated_go_golden/app.go.golden
+++ b/internal/appgen/testdata/generated_go_golden/app.go.golden
@@ -9,6 +9,7 @@ import (
 	gowdkactions "github.com/cssbruno/gowdk/addons/actions"
 	gowdkruntime "github.com/cssbruno/gowdk/runtime/app"
 	gowdkcontracts "github.com/cssbruno/gowdk/runtime/contracts"
+	gowdkenvfile "github.com/cssbruno/gowdk/runtime/envfile"
 	gowdkform "github.com/cssbruno/gowdk/runtime/form"
 	gowdkresponse "github.com/cssbruno/gowdk/runtime/response"
 	"io/fs"
@@ -46,6 +47,9 @@ func Handler() (http.Handler, error) {
 	return ServeMux()
 }
 func ServeMux() (*http.ServeMux, error) {
+	if err := loadEnvFile(); err != nil {
+		return nil, err
+	}
 	root, err := fs.Sub(embeddedFiles, "app")
 	if err != nil {
 		return nil, err
@@ -63,6 +67,15 @@ func ServeMux() (*http.ServeMux, error) {
 	mux := http.NewServeMux()
 	mux.Handle("/", gowdkruntime.ApplyMiddlewares(&gowdkruntime.Handler{Root: root, Identity: gowdkruntime.InstanceIdentity(), Assets: gowdkruntime.LoadAssetManifest(root), ErrorPages: gowdkruntime.LoadErrorPages(root), Backend: backendRouter.HandlerFunc(), CSRF: csrfTokenSource, SSRExact: ssrExact, SSRDynamic: ssrDynamic, RequestTimeout: gowdkruntime.DefaultRequestTimeout}, registeredMiddlewares()...))
 	return mux, nil
+}
+func loadEnvFile() error {
+	explicit := strings.TrimSpace(os.Getenv("GOWDK_ENV_FILE"))
+	path, _, err := gowdkenvfile.LookupPath("", explicit)
+	if err != nil {
+		return err
+	}
+	_, err = gowdkenvfile.LoadIntoEnv(path, explicit != "")
+	return err
 }
 func action(response http.ResponseWriter, request *http.Request) bool {
 	requestPath := actionRequestPath(request.URL.Path)

--- a/runtime/envfile/envfile.go
+++ b/runtime/envfile/envfile.go
@@ -1,0 +1,233 @@
+// Package envfile loads simple dotenv-style files without overriding process
+// environment values.
+package envfile
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+)
+
+// LoadResult describes one env-file load without exposing values.
+type LoadResult struct {
+	Path     string
+	Loaded   bool
+	Applied  []string
+	Skipped  []string
+	Explicit bool
+}
+
+var (
+	appliedMu     sync.Mutex
+	appliedByFile = map[string]bool{}
+)
+
+// LookupPath resolves the env file for a project root. explicit wins. Without
+// an explicit path, .env.<GOWDK_ENV> wins over .env when it exists.
+func LookupPath(projectRoot string, explicit string) (string, bool, error) {
+	if strings.TrimSpace(explicit) != "" {
+		path, err := resolvePath(projectRoot, explicit)
+		if err != nil {
+			return "", false, err
+		}
+		return path, true, nil
+	}
+	if projectRoot == "" {
+		var err error
+		projectRoot, err = os.Getwd()
+		if err != nil {
+			return "", false, err
+		}
+	}
+	if name := strings.TrimSpace(os.Getenv("GOWDK_ENV")); name != "" {
+		candidate := filepath.Join(projectRoot, ".env."+name)
+		if fileExists(candidate) {
+			return candidate, false, nil
+		}
+	}
+	candidate := filepath.Join(projectRoot, ".env")
+	if fileExists(candidate) {
+		return candidate, false, nil
+	}
+	return "", false, nil
+}
+
+// LoadIntoEnv loads path and sets only names that are not already present in
+// the process environment. Existing process values always win.
+func LoadIntoEnv(path string, explicit bool) (LoadResult, error) {
+	appliedMu.Lock()
+	defer appliedMu.Unlock()
+
+	result := LoadResult{Path: path, Explicit: explicit}
+	if strings.TrimSpace(path) == "" {
+		return result, nil
+	}
+	values, err := ParseFile(path)
+	if err != nil {
+		return result, err
+	}
+	result.Loaded = true
+	for _, entry := range values {
+		if _, ok := os.LookupEnv(entry.Name); ok && !appliedByFile[entry.Name] {
+			result.Skipped = append(result.Skipped, entry.Name)
+			continue
+		}
+		if err := os.Setenv(entry.Name, entry.Value); err != nil {
+			return result, err
+		}
+		appliedByFile[entry.Name] = true
+		result.Applied = append(result.Applied, entry.Name)
+	}
+	return result, nil
+}
+
+// Entry is one parsed env-file assignment.
+type Entry struct {
+	Name  string
+	Value string
+}
+
+// ParseFile parses KEY=value and export KEY=value lines. Values may be quoted
+// with single or double quotes. Blank lines and # comments are ignored.
+func ParseFile(path string) ([]Entry, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	var entries []Entry
+	scanner := bufio.NewScanner(file)
+	lineNumber := 0
+	for scanner.Scan() {
+		lineNumber++
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		entry, ok, err := parseLine(line)
+		if err != nil {
+			return nil, fmt.Errorf("%s:%d: %w", path, lineNumber, err)
+		}
+		if ok {
+			entries = append(entries, entry)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	return entries, nil
+}
+
+func parseLine(line string) (Entry, bool, error) {
+	line = strings.TrimSpace(line)
+	line = strings.TrimPrefix(line, "\ufeff")
+	if strings.HasPrefix(line, "export ") {
+		line = strings.TrimSpace(strings.TrimPrefix(line, "export "))
+	}
+	name, value, ok := strings.Cut(line, "=")
+	if !ok {
+		return Entry{}, false, fmt.Errorf("expected NAME=value")
+	}
+	name = strings.TrimSpace(name)
+	if !validName(name) {
+		return Entry{}, false, fmt.Errorf("invalid env name %q", name)
+	}
+	value, err := parseValue(strings.TrimSpace(value))
+	if err != nil {
+		return Entry{}, false, err
+	}
+	return Entry{Name: name, Value: value}, true, nil
+}
+
+func parseValue(value string) (string, error) {
+	if value == "" {
+		return "", nil
+	}
+	switch value[0] {
+	case '\'':
+		return quotedValue(value, '\'')
+	case '"':
+		quoted, err := quotedValue(value, '"')
+		if err != nil {
+			return "", err
+		}
+		replacer := strings.NewReplacer(`\n`, "\n", `\r`, "\r", `\t`, "\t", `\"`, `"`, `\\`, `\`)
+		return replacer.Replace(quoted), nil
+	default:
+		return strings.TrimSpace(stripInlineComment(value)), nil
+	}
+}
+
+func quotedValue(value string, quote byte) (string, error) {
+	if len(value) < 2 {
+		return "", fmt.Errorf("unterminated quoted value")
+	}
+	var builder strings.Builder
+	escaped := false
+	for i := 1; i < len(value); i++ {
+		ch := value[i]
+		if escaped {
+			builder.WriteByte('\\')
+			builder.WriteByte(ch)
+			escaped = false
+			continue
+		}
+		if ch == '\\' && quote == '"' {
+			escaped = true
+			continue
+		}
+		if ch == quote {
+			if strings.TrimSpace(value[i+1:]) != "" && !strings.HasPrefix(strings.TrimSpace(value[i+1:]), "#") {
+				return "", fmt.Errorf("unexpected text after quoted value")
+			}
+			return builder.String(), nil
+		}
+		builder.WriteByte(ch)
+	}
+	return "", fmt.Errorf("unterminated quoted value")
+}
+
+func stripInlineComment(value string) string {
+	for i := 0; i < len(value); i++ {
+		if value[i] == '#' && (i == 0 || value[i-1] == ' ' || value[i-1] == '\t') {
+			return value[:i]
+		}
+	}
+	return value
+}
+
+func validName(name string) bool {
+	if name == "" {
+		return false
+	}
+	for i, ch := range name {
+		if ch == '_' || ch >= 'A' && ch <= 'Z' || ch >= 'a' && ch <= 'z' || i > 0 && ch >= '0' && ch <= '9' {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+func resolvePath(projectRoot string, path string) (string, error) {
+	if filepath.IsAbs(path) {
+		return filepath.Clean(path), nil
+	}
+	if projectRoot == "" {
+		var err error
+		projectRoot, err = os.Getwd()
+		if err != nil {
+			return "", err
+		}
+	}
+	return filepath.Join(projectRoot, path), nil
+}
+
+func fileExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && !info.IsDir()
+}

--- a/runtime/envfile/envfile_test.go
+++ b/runtime/envfile/envfile_test.go
@@ -1,0 +1,142 @@
+package envfile
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestParseFileReadsDotenvAssignments(t *testing.T) {
+	path := filepath.Join(t.TempDir(), ".env")
+	if err := os.WriteFile(path, []byte(`
+# comment
+PLAIN=value
+export EXPORTED=from-export
+SPACED = value with spaces # comment
+HASH=abc#def
+SINGLE='quoted # value'
+DOUBLE="line\nvalue"
+EMPTY=
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	entries, err := ParseFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := map[string]string{}
+	for _, entry := range entries {
+		got[entry.Name] = entry.Value
+	}
+	want := map[string]string{
+		"PLAIN":    "value",
+		"EXPORTED": "from-export",
+		"SPACED":   "value with spaces",
+		"HASH":     "abc#def",
+		"SINGLE":   "quoted # value",
+		"DOUBLE":   "line\nvalue",
+		"EMPTY":    "",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected entries:\n got %#v\nwant %#v", got, want)
+	}
+}
+
+func TestParseFileRejectsInvalidLine(t *testing.T) {
+	path := filepath.Join(t.TempDir(), ".env")
+	if err := os.WriteFile(path, []byte("BAD LINE\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := ParseFile(path)
+	if err == nil || !strings.Contains(err.Error(), "expected NAME=value") {
+		t.Fatalf("expected parse error, got %v", err)
+	}
+}
+
+func TestLoadIntoEnvPreservesProcessValues(t *testing.T) {
+	path := filepath.Join(t.TempDir(), ".env")
+	if err := os.WriteFile(path, []byte("GOWDK_TEST_FILE_ONLY=file\nGOWDK_TEST_PROCESS=from-file\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("GOWDK_TEST_PROCESS", "from-process")
+	t.Cleanup(func() {
+		_ = os.Unsetenv("GOWDK_TEST_FILE_ONLY")
+	})
+
+	result, err := LoadIntoEnv(path, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if os.Getenv("GOWDK_TEST_FILE_ONLY") != "file" {
+		t.Fatalf("expected file value to be applied")
+	}
+	if os.Getenv("GOWDK_TEST_PROCESS") != "from-process" {
+		t.Fatalf("expected process value to win")
+	}
+	if !reflect.DeepEqual(result.Applied, []string{"GOWDK_TEST_FILE_ONLY"}) ||
+		!reflect.DeepEqual(result.Skipped, []string{"GOWDK_TEST_PROCESS"}) {
+		t.Fatalf("unexpected load result: %#v", result)
+	}
+}
+
+func TestLoadIntoEnvUpdatesValuesItPreviouslyApplied(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, ".env")
+	name := "GOWDK_TEST_FILE_RELOAD"
+	_ = os.Unsetenv(name)
+	t.Cleanup(func() {
+		_ = os.Unsetenv(name)
+		appliedMu.Lock()
+		delete(appliedByFile, name)
+		appliedMu.Unlock()
+	})
+
+	if err := os.WriteFile(path, []byte(name+"=first\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := LoadIntoEnv(path, false); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(name+"=second\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := LoadIntoEnv(path, false); err != nil {
+		t.Fatal(err)
+	}
+	if got := os.Getenv(name); got != "second" {
+		t.Fatalf("expected file-applied value to update, got %q", got)
+	}
+}
+
+func TestLookupPathUsesExplicitThenGOWDKEnvThenDefault(t *testing.T) {
+	root := t.TempDir()
+	write := func(name string) {
+		t.Helper()
+		if err := os.WriteFile(filepath.Join(root, name), []byte("A=B\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write(".env")
+	write(".env.dev")
+	t.Setenv("GOWDK_ENV", "dev")
+
+	path, explicit, err := LookupPath(root, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if path != filepath.Join(root, ".env.dev") || explicit {
+		t.Fatalf("expected .env.dev discovery, got path=%q explicit=%v", path, explicit)
+	}
+
+	path, explicit, err = LookupPath(root, "custom.env")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if path != filepath.Join(root, "custom.env") || !explicit {
+		t.Fatalf("expected explicit path, got path=%q explicit=%v", path, explicit)
+	}
+}


### PR DESCRIPTION
## Summary

- Add dependency-free dotenv parsing/loading with process-env precedence.
- Wire `--env-file` and `.env` / `.env.<GOWDK_ENV>` discovery into project-aware CLI config loading and dev input tracking.
- Generate runtime env-file loading for generated apps before env-contract and CSRF secret validation.
- Document the feature, add a product spec/implementation plan, and cover CLI/generated-app behavior with tests.

## Issue Closure

Closes #467

## Verification

- [x] I ran the relevant tests, lint, and build commands.
- [x] I ran `scripts/test-go-modules.sh` when Go code or compiler behavior changed.
- [x] I ran `go build ./cmd/gowdk` when CLI, compiler, runtime, addon, or release behavior changed.
- [ ] I ran `node --check editors/vscode/extension.js` when editor files changed.
- [x] I updated docs for behavior, setup, or architecture changes.
- [x] I added or updated tests for changed behavior.
- [x] I considered security-sensitive surfaces such as auth, CSRF, redirects, request-time handlers, logs, diagnostics, embedded assets, editor commands, WASM, contracts, and realtime behavior.

Commands run:

```sh
go test ./runtime/envfile
go test ./cmd/gowdk
go test ./internal/appgen
go test ./...
go build ./cmd/gowdk
scripts/test-go-modules.sh
```

## LLM Assistance

- LLM session summary: Implemented env-file loading for CLI validation and generated app startup, added docs/spec/plan, and verified with focused and broad Go test gates.
- Human-reviewed assumptions: `gowdk serve` remains static-output-only and does not load project config; generated binaries use `GOWDK_ENV_FILE` for explicit env-file selection.
- Follow-up work: None required for this issue.
