### PR TITLE
chore(release): bump to 0.6.1

### DIFF
--- a/.agents/skills/gowdk-version-bump/SKILL.md
+++ b/.agents/skills/gowdk-version-bump/SKILL.md
@@ -9,7 +9,7 @@ description: Bump the GOWDK release version. Use when updating the CLI version, 
 
 - Source of truth: `const version = "0.x.y"` near the top of
   `cmd/gowdk/main.go` (no `v` prefix). GitHub tags and install snippets use
-  `v0.x.y`. Current line: `const version = "0.5.0"`.
+  `v0.x.y`. Current line: `const version = "0.6.1"`.
 - `editors/vscode/package.json` must match the CLI constant exactly;
   `editors/vscode/scripts/sync-version.js` reads the constant from
   `cmd/gowdk/main.go` and writes/checks `package.json`. Never edit the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ packages, and tooling contracts may change before 1.0.
 
 ## Unreleased
 
+_No changes yet._
+
+## v0.6.1 - 2026-06-16
+
 ### Changed
 
 - **Split addon registration from request-time runtime helpers (#428).**

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ curl -fsSL https://raw.githubusercontent.com/cssbruno/GoWDK/main/scripts/install
 Pin the current CLI release:
 
 ```sh
-GOWDK_VERSION=v0.6.0 GOWDK_INSTALL_DIR="$HOME/.local/bin" \
+GOWDK_VERSION=v0.6.1 GOWDK_INSTALL_DIR="$HOME/.local/bin" \
   sh -c "$(curl -fsSL https://raw.githubusercontent.com/cssbruno/GoWDK/main/scripts/install.sh)"
 ```
 

--- a/cmd/gowdk/main.go
+++ b/cmd/gowdk/main.go
@@ -11,7 +11,7 @@ import (
 	"github.com/cssbruno/gowdk/addons/ssr"
 )
 
-const version = "0.6.0"
+const version = "0.6.1"
 
 var (
 	defaultSourceIncludes = []string{"**/*.gwdk"}

--- a/docs/engineering/release-notes-v0.6.md
+++ b/docs/engineering/release-notes-v0.6.md
@@ -33,7 +33,12 @@ tooling contracts may change before 1.0.
 
 ## Changed
 
-- `gowdk version` and the VS Code extension metadata report `0.6.0`.
+- `gowdk version` and the VS Code extension metadata report `0.6.1`.
+- Generated apps import request-time helpers from `runtime/actions`,
+  `runtime/api`, `runtime/partial`, `runtime/ratelimit`, `runtime/realtime`, and
+  `runtime/ssr` instead of the corresponding `addons/*` packages. The addon
+  packages remain the config-facing packages and re-export their runtime helpers
+  for 0.x compatibility.
 
 ## Implemented
 

--- a/docs/engineering/release.md
+++ b/docs/engineering/release.md
@@ -6,7 +6,7 @@ visible normal GitHub releases with downloadable assets from `v*` tags or a
 manual workflow dispatch. VS Code Marketplace publishing lives in
 `.github/workflows/vscode-extension-publish.yml`.
 
-The current CLI version is `0.6.0`, but this is not a production-readiness
+The current CLI version is `0.6.1`, but this is not a production-readiness
 claim. It identifies the current development line while the compiler, generated
 runtime, and docs continue through the 0.x line. Public release notes must keep
 the build experimental and not production-ready until the 1.0 release gates are
@@ -90,14 +90,14 @@ After those gates pass on the release commit, run the release workflow manually
 for the current CLI line or push the corresponding tag:
 
 ```sh
-gh workflow run release.yml -f version=v0.6.0
+gh workflow run release.yml -f version=v0.6.1
 ```
 
 After the release workflow completes, smoke the published artifacts for each
 supported OS artifact:
 
 ```sh
-gh workflow run release-smoke.yml -f version=v0.6.0
+gh workflow run release-smoke.yml -f version=v0.6.1
 ```
 
 ## Artifacts
@@ -108,7 +108,7 @@ gh workflow run release-smoke.yml -f version=v0.6.0
 - `gowdk-darwin-arm64`
 - `gowdk-windows-amd64.exe`
 - `checksums.txt`
-- `gowdk-vscode-0.6.0.vsix`
+- `gowdk-vscode-0.6.1.vsix`
 
 ## Install Script
 
@@ -121,7 +121,7 @@ platform before binary download, verifies the binary SHA-256, and writes
 Pinned install:
 
 ```sh
-GOWDK_VERSION=v0.6.0 GOWDK_INSTALL_DIR="$HOME/.local/bin" \
+GOWDK_VERSION=v0.6.1 GOWDK_INSTALL_DIR="$HOME/.local/bin" \
   sh -c "$(curl -fsSL https://raw.githubusercontent.com/cssbruno/GoWDK/main/scripts/install.sh)"
 ```
 
@@ -142,7 +142,7 @@ gh attestation verify <artifact> -R <owner>/<repo>
 ## Extension Publishing
 
 The release workflow packages the extension into a `.vsix` named from
-`editors/vscode/package.json`, currently `gowdk-vscode-0.6.0.vsix`.
+`editors/vscode/package.json`, currently `gowdk-vscode-0.6.1.vsix`.
 Marketplace publishing is handled by the `Publish VS Code Extension` workflow.
 It is manual-only so CLI/runtime releases do not accidentally republish an
 extension version that already exists on the Marketplace.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -21,7 +21,7 @@ gowdk version
 Pin the current CLI release or install into a user-writable directory:
 
 ```sh
-GOWDK_VERSION=v0.5.0 GOWDK_INSTALL_DIR="$HOME/.local/bin" \
+GOWDK_VERSION=v0.6.1 GOWDK_INSTALL_DIR="$HOME/.local/bin" \
   sh -c "$(curl -fsSL https://raw.githubusercontent.com/cssbruno/GoWDK/main/scripts/install.sh)"
 ```
 
@@ -96,7 +96,7 @@ Direct artifact names:
 Manual Linux install:
 
 ```sh
-version=v0.5.0
+version=v0.6.1
 curl -fsSLO "https://github.com/cssbruno/GoWDK/releases/download/$version/gowdk-linux-amd64"
 curl -fsSLO "https://github.com/cssbruno/GoWDK/releases/download/$version/checksums.txt"
 grep ' gowdk-linux-amd64$' checksums.txt | sha256sum -c -
@@ -109,7 +109,7 @@ gowdk version
 Manual macOS Intel install:
 
 ```sh
-version=v0.5.0
+version=v0.6.1
 curl -fsSLO "https://github.com/cssbruno/GoWDK/releases/download/$version/gowdk-darwin-amd64"
 curl -fsSLO "https://github.com/cssbruno/GoWDK/releases/download/$version/checksums.txt"
 expected="$(awk '$2 == "gowdk-darwin-amd64" { print $1 }' checksums.txt)"
@@ -124,7 +124,7 @@ gowdk version
 Manual macOS ARM install:
 
 ```sh
-version=v0.5.0
+version=v0.6.1
 curl -fsSLO "https://github.com/cssbruno/GoWDK/releases/download/$version/gowdk-darwin-arm64"
 curl -fsSLO "https://github.com/cssbruno/GoWDK/releases/download/$version/checksums.txt"
 expected="$(awk '$2 == "gowdk-darwin-arm64" { print $1 }' checksums.txt)"
@@ -139,7 +139,7 @@ gowdk version
 Manual Windows install from PowerShell:
 
 ```powershell
-$version = "v0.5.0"
+$version = "v0.6.1"
 Invoke-WebRequest "https://github.com/cssbruno/GoWDK/releases/download/$version/gowdk-windows-amd64.exe" -OutFile "gowdk.exe"
 Invoke-WebRequest "https://github.com/cssbruno/GoWDK/releases/download/$version/checksums.txt" -OutFile "checksums.txt"
 $expected = (Select-String -Path checksums.txt -Pattern "gowdk-windows-amd64.exe").Line.Split(" ")[0]
@@ -158,7 +158,7 @@ Install the VS Code extension package from a release when a `.vsix` is
 published:
 
 ```sh
-code --install-extension gowdk-vscode-0.5.0.vsix
+code --install-extension gowdk-vscode-0.6.1.vsix
 ```
 
 ## Build From Source

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "gowdk-vscode",
   "displayName": "GOWDK",
   "description": "Language tools for portable .gwdk files.",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "publisher": "gowdk",
   "license": "MIT",
   "icon": "icons/gowdk.png",


### PR DESCRIPTION
## Summary

- Bump the CLI and VS Code extension metadata to `0.6.1`.
- Move the current changelog entry into `v0.6.1 - 2026-06-16` and update the v0.6 release notes for the patch release.
- Refresh pinned install snippets and release workflow examples to `v0.6.1`.

## Release Execution

- Published release: https://github.com/cssbruno/GoWDK/releases/tag/v0.6.1
- Release workflow: https://github.com/cssbruno/GoWDK/actions/runs/27639142970
- Artifact smoke workflow: https://github.com/cssbruno/GoWDK/actions/runs/27639703953

## Verification

- [x] `node editors/vscode/scripts/sync-version.js --check`
- [x] `go test ./cmd/gowdk -run Version`
- [x] `go run ./cmd/gowdk version --json`
- [x] `go build ./cmd/gowdk`
- [x] `git diff --check`
- [x] Documented local release gates from `docs/engineering/release.md`
- [x] `gh workflow run release.yml --ref codex/release-0.6.1 -f version=v0.6.1`
- [x] `gh workflow run release-smoke.yml --ref codex/release-0.6.1 -f version=v0.6.1`

## LLM Assistance

- Session summary: Codex prepared the 0.6.1 release metadata bump in a separate worktree, synced extension metadata from the CLI version constant, verified the release-bump checks, ran the documented local release gates, published `v0.6.1`, and verified release artifacts across Linux, macOS Intel, macOS ARM, and Windows.
- Human-reviewed assumptions: This is a patch release for the current 0.6 line and remains framed as experimental 0.x software, with no production-readiness claim.
- Follow-up work: Merge this PR so `main` reflects the published 0.6.1 release metadata.