### PR TITLE
[codex] Fix routing matrix and request-time layout wiring

### DIFF
--- a/docs/compiler/generated-output.md
+++ b/docs/compiler/generated-output.md
@@ -153,6 +153,9 @@ Implemented today:
   with escaped returned values. Load errors that wrap `ssr.RedirectError`
   become no-store local redirects; other load failures use generated error-page
   output.
+- Request-time SSR and hybrid pages compose declared layouts before rendering
+  the generated response, and load placeholders are shared across page and
+  layout markup. Generated route metadata records the layout stack.
 - Generated embedded apps load optional `404.html` and `500.html` from the
   embedded build output and use those pages for not-found responses and
   generated SSR load failures. SSR routes can also declare

--- a/docs/language/layouts.md
+++ b/docs/language/layouts.md
@@ -71,11 +71,16 @@ page `layout` references by package and declared ID and reports unknown or
 duplicate layout IDs. Duplicate layout IDs are allowed across different GOWDK
 packages and rejected inside the same package. App generation composes declared
 page layouts by replacing each layout's single `<slot />` placeholder with the
-child page or inner layout source before rendering the combined markup once. The
-SSR addon exposes request-aware `LayoutFunc`, `LayoutRegistry`, and
-`ComposeLayouts` contracts that wrap page HTML from innermost to outermost
-layout while passing the request `LoadContext` to each layout. Generated app
-wiring is planned.
+child page or inner layout source before rendering the combined markup once.
+Generated request-time pages use the same composition path for `server {}` and
+hybrid routes, so declared load fields can render in both the page body and its
+layout stack with request-time escaping. Generated request-time route metadata
+also carries the declared layout stack through `runtime/app.Route(ctx)`.
+
+The SSR addon exposes request-aware `LayoutFunc`, `LayoutRegistry`, and
+`ComposeLayouts` contracts for runtime helpers that need to apply the same
+outermost-to-innermost layout order while passing the request `LoadContext` to
+each layout.
 
 Current app-shell layout rules:
 
@@ -94,6 +99,13 @@ Current app-shell layout rules:
 - A layout may not reference itself or form a cyclic inheritance chain.
 - Layout markup is rendered through the same escaped view renderer as
   pages.
+- Request-time layout markup can read fields declared by the page's `server {}`
+  block. Missing fields fail the generated request with the same no-store error
+  policy as page body load failures.
+- Hybrid pages use the same generated request-time layout composition when
+  their render mode is selected by config or IR. This does not make request-time
+  rendering the default; pages still opt in through `server {}`, `go server {}`,
+  or internal hybrid route metadata.
 
 Rules that should remain true as implementation grows:
 

--- a/docs/reference/routing.md
+++ b/docs/reference/routing.md
@@ -36,6 +36,10 @@ Current route rules:
 - Duplicate page route patterns are rejected. `/blog/{slug}` and `/blog/{id}`
   are the same route pattern, and `/docs/{path...}` and `/docs/{rest...}` are
   the same route pattern.
+- Generated app request matching and SPA file lookup reject request paths that
+  contain empty, `.`, or `..` segments before cleaning. Encoded dot segments
+  such as `%2e%2e` therefore return 404 instead of resolving to a different
+  generated route or asset.
 
 ### Rest Params
 
@@ -324,9 +328,11 @@ HTML escaping. Dynamic fragment endpoint params are attached to fragment hook
 contexts. Params can be declared as `{name}`, `{name:type}`, or — as the final
 segment only — `{name...}` (always a string). Supported types are `string`,
 `int`, `int64`, `uint`, `uint64`, `bool`, and `float64`. Generated SSR handlers
-attach route metadata through `runtime/app.Route(ctx)`. Generated SSR and
-fragment handlers attach raw dynamic params through `runtime/app.Params(ctx)`
-and decoded typed params through `runtime/app.TypedParams(ctx)`.
+attach route metadata through `runtime/app.Route(ctx)`, including render mode,
+guard IDs, dynamic params, typed route-param metadata, and declared layouts.
+Generated SSR and fragment handlers attach raw dynamic params through
+`runtime/app.Params(ctx)` and decoded typed params through
+`runtime/app.TypedParams(ctx)`.
 
 There are no generated per-route param struct types yet. Request-time user code
 should use `app.Params(ctx)`, `app.TypedParams(ctx)`, or the `runtime/route`

--- a/internal/appgen/appgen_test.go
+++ b/internal/appgen/appgen_test.go
@@ -4169,6 +4169,99 @@ func TestGeneratedBinaryExecutesInlineSSRScriptLoad(t *testing.T) {
 	}
 }
 
+func TestGeneratedBinaryRendersRequestAwareHybridLayouts(t *testing.T) {
+	root := t.TempDir()
+	outputDir := filepath.Join(root, "dist")
+	appDir := filepath.Join(root, "generated-app")
+	binaryPath := filepath.Join(root, "site")
+	sourceDir := filepath.Join(root, "src")
+	if err := os.MkdirAll(sourceDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeTestFile(t, filepath.Join(outputDir, "index.html"), "<main>Home</main>")
+
+	config := gowdk.Config{Addons: []gowdk.Addon{gowdk.NewAddon("ssr", gowdk.FeatureSSR)}}
+	app := gwdkanalysis.Sources{
+		Pages: []gwdkir.Page{{
+			ID:      "dashboard",
+			Package: "pages",
+			Source:  filepath.Join(sourceDir, "dashboard.page.gwdk"),
+			Route:   "/dashboard",
+			Render:  gowdk.Hybrid,
+			Layouts: []string{"shell"},
+			Guards:  []string{"public"},
+			Imports: []gwdkir.Import{{
+				Alias: "ssr",
+				Path:  "github.com/cssbruno/gowdk/runtime/ssr",
+			}},
+			Blocks: gwdkir.Blocks{
+				Server:     true,
+				ServerBody: `=> { request.path }`,
+				View:       true,
+				ViewBody:   `<main>{request.path}</main>`,
+				GoBlocks: []gwdkir.GoBlock{{
+					Target: "server",
+					Body: `func LoadDashboard(ctx ssr.LoadContext) (map[string]any, error) {
+	return map[string]any{
+		"request": map[string]any{"path": ctx.Request.URL.Path},
+	}, nil
+}`,
+				}},
+			},
+		}},
+		Layouts: []gwdkir.Layout{{
+			ID:      "shell",
+			Package: "pages",
+			Blocks: gwdkir.Blocks{
+				View:     true,
+				ViewBody: `<section><header>{request.path}</header><slot /></section>`,
+			},
+		}},
+	}
+	ir := gwdkanalysis.BuildProgram(config, app)
+	compiler.BindBackendHandlers(&ir)
+
+	result, err := GenerateWithOptions(outputDir, appDir, Options{AutoRoutes: true, Config: config, IR: &ir})
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload, err := os.ReadFile(result.PackagePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	source := string(payload)
+	for _, expected := range []string{
+		`Render: "hybrid"`,
+		`Layouts: []string{"shell"}`,
+	} {
+		if !strings.Contains(source, expected) {
+			t.Fatalf("expected generated app source to contain %q:\n%s", expected, source)
+		}
+	}
+	if _, err := BuildBinary(appDir, binaryPath); err != nil {
+		t.Fatal(err)
+	}
+
+	addr := freeAddr(t)
+	command := exec.Command(binaryPath)
+	command.Env = append(os.Environ(), "GOWDK_ADDR="+addr)
+	if err := command.Start(); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		_ = command.Process.Kill()
+		_, _ = command.Process.Wait()
+	}()
+
+	body, _, err := waitForHTTPResponse("http://" + addr + "/dashboard")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(body, "<section><header>/dashboard</header><main>/dashboard</main></section>") {
+		t.Fatalf("expected request-aware hybrid layout response, got:\n%s", body)
+	}
+}
+
 func TestGenerateWritesStaticInlineGoBlockPackages(t *testing.T) {
 	root := t.TempDir()
 	outputDir := filepath.Join(root, "dist")

--- a/internal/appgen/auto_routes.go
+++ b/internal/appgen/auto_routes.go
@@ -213,6 +213,7 @@ func ssrRoutes(artifacts []buildgen.SSRArtifact) []SSRRoute {
 			ErrorPage:        artifact.ErrorPage,
 			DynamicParams:    append([]string(nil), artifact.DynamicParams...),
 			RouteParams:      append([]source.RouteParam(nil), artifact.RouteParams...),
+			Layouts:          append([]string(nil), artifact.Layouts...),
 			Guards:           append([]string(nil), artifact.Guards...),
 			HasLoad:          artifact.HasLoad,
 			LoadBinding:      artifact.LoadBinding,

--- a/internal/appgen/source_ssr.go
+++ b/internal/appgen/source_ssr.go
@@ -357,6 +357,9 @@ func ssrRouteContextStmts(route SSRRoute, includeParams bool) []ast.Stmt {
 	if len(route.RouteParams) > 0 {
 		metadata = append(metadata, keyValue("RouteParams", routeParamMetadataExpr(route.RouteParams)))
 	}
+	if len(route.Layouts) > 0 {
+		metadata = append(metadata, keyValue("Layouts", stringSliceExpr(route.Layouts)))
+	}
 	if len(route.Guards) > 0 {
 		metadata = append(metadata, keyValue("Guards", stringSliceExpr(route.Guards)))
 	}

--- a/internal/appgen/types.go
+++ b/internal/appgen/types.go
@@ -116,6 +116,7 @@ type SSRRoute struct {
 	ErrorPage        string
 	DynamicParams    []string
 	RouteParams      []source.RouteParam
+	Layouts          []string
 	Guards           []string
 	HasLoad          bool
 	LoadBinding      source.BackendBinding

--- a/internal/buildgen/ssr.go
+++ b/internal/buildgen/ssr.go
@@ -23,6 +23,7 @@ type SSRArtifact struct {
 	ErrorPage        string
 	DynamicParams    []string
 	RouteParams      []source.RouteParam
+	Layouts          []string
 	Guards           []string
 	HasLoad          bool
 	LoadBinding      source.BackendBinding
@@ -123,6 +124,7 @@ func ssrArtifact(config gowdk.Config, page gwdkir.Page, components map[string]vi
 		ErrorPage:        page.ErrorPage,
 		DynamicParams:    page.DynamicParams(),
 		RouteParams:      append([]source.RouteParam(nil), page.TypedRouteParams()...),
+		Layouts:          append([]string(nil), page.Layouts...),
 		Guards:           append([]string(nil), page.Guards...),
 		HasLoad:          page.Blocks.Server,
 		LoadBinding:      sourceBackendBinding(page.LoadBinding),

--- a/internal/buildgen/ssr_test.go
+++ b/internal/buildgen/ssr_test.go
@@ -372,6 +372,9 @@ func TestSSRArtifactsComposePageLoadThroughLayouts(t *testing.T) {
 	if len(artifact.LoadReplacements) != 1 || artifact.LoadReplacements[0].Path != "user.name" {
 		t.Fatalf("expected page load replacement to be shared with layout, got %#v", artifact.LoadReplacements)
 	}
+	if len(artifact.Layouts) != 1 || artifact.Layouts[0] != "shell" {
+		t.Fatalf("expected artifact layout stack, got %#v", artifact.Layouts)
+	}
 	placeholder := artifact.LoadReplacements[0].Placeholder
 	if strings.Count(artifact.HTML, placeholder) != 2 {
 		t.Fatalf("expected page load placeholder in layout and page body, got:\n%s", artifact.HTML)

--- a/runtime/app/app.go
+++ b/runtime/app/app.go
@@ -719,6 +719,9 @@ func (handler Handler) SPAFile(requestPath string) ([]byte, fs.FileInfo, string,
 }
 
 func SPACandidates(requestPath string) []string {
+	if unsafeRequestPath(requestPath) {
+		return nil
+	}
 	clean := path.Clean("/" + requestPath)
 	if strings.HasSuffix(requestPath, "/") {
 		return []string{strings.TrimPrefix(path.Join(clean, "index.html"), "/")}
@@ -758,4 +761,17 @@ func readSPAFile(root fs.FS, name string) ([]byte, fs.FileInfo, bool) {
 
 func unsafeSPAFile(name string) bool {
 	return strings.EqualFold(path.Base(name), "gowdk-security.json")
+}
+
+func unsafeRequestPath(requestPath string) bool {
+	trimmed := strings.Trim(requestPath, "/")
+	if trimmed == "" {
+		return false
+	}
+	for _, segment := range strings.Split(trimmed, "/") {
+		if segment == "" || segment == "." || segment == ".." {
+			return true
+		}
+	}
+	return false
 }

--- a/runtime/app/app_test.go
+++ b/runtime/app/app_test.go
@@ -375,6 +375,39 @@ func TestHandlerDoesNotServeSecurityManifest(t *testing.T) {
 	}
 }
 
+func TestHandlerRejectsUnsafeStaticRequestPaths(t *testing.T) {
+	handler := Handler{
+		Root: fstest.MapFS{
+			"admin/index.html":     {Data: []byte("<main>Admin</main>")},
+			"assets/app/main.css":  {Data: []byte("body{}")},
+			"blog/post/index.html": {Data: []byte("<main>Post</main>")},
+		},
+		Identity: Identity{AppID: "clinic", ModuleName: "frontend", InstanceID: "frontend-1"},
+		Assets:   asset.Manifest{Version: 1, Files: map[string]string{}},
+	}
+	for _, requestPath := range []string{
+		"/blog/%2e%2e/admin",
+		"/blog/../admin",
+		"/blog/./post",
+		"/assets/app/../app/main.css",
+		"/blog//post",
+	} {
+		t.Run(requestPath, func(t *testing.T) {
+			recorder := httptest.NewRecorder()
+			request := httptest.NewRequest(http.MethodGet, requestPath, nil)
+
+			handler.ServeHTTP(recorder, request)
+
+			if recorder.Code != http.StatusNotFound {
+				t.Fatalf("expected unsafe path to 404, got %d with body %s", recorder.Code, recorder.Body.String())
+			}
+			if strings.Contains(recorder.Body.String(), "Admin") || strings.Contains(recorder.Body.String(), "Post") || strings.Contains(recorder.Body.String(), "body{}") {
+				t.Fatalf("unsafe path resolved to generated asset: %s", recorder.Body.String())
+			}
+		})
+	}
+}
+
 func TestHandlerRedirectsTrailingSlashGETToCanonicalPath(t *testing.T) {
 	handler := Handler{
 		Root:     fstest.MapFS{"blog/hello/index.html": {Data: []byte("<main>Hello</main>")}},

--- a/runtime/app/context.go
+++ b/runtime/app/context.go
@@ -29,6 +29,7 @@ type RouteMetadata struct {
 	ErrorPage     string
 	DynamicParams []string
 	RouteParams   []RouteParamMetadata
+	Layouts       []string
 	Guards        []string
 	HasLoad       bool
 }
@@ -125,6 +126,7 @@ func Session(ctx context.Context) any {
 func WithRoute(ctx context.Context, route RouteMetadata) context.Context {
 	route.DynamicParams = copyStrings(route.DynamicParams)
 	route.RouteParams = copyRouteParamMetadata(route.RouteParams)
+	route.Layouts = copyStrings(route.Layouts)
 	route.Guards = copyStrings(route.Guards)
 	return context.WithValue(ctx, routeContextKey, route)
 }
@@ -135,6 +137,7 @@ func Route(ctx context.Context) (RouteMetadata, bool) {
 	route, ok := ctx.Value(routeContextKey).(RouteMetadata)
 	route.DynamicParams = copyStrings(route.DynamicParams)
 	route.RouteParams = copyRouteParamMetadata(route.RouteParams)
+	route.Layouts = copyStrings(route.Layouts)
 	route.Guards = copyStrings(route.Guards)
 	return route, ok
 }

--- a/runtime/route/route.go
+++ b/runtime/route/route.go
@@ -11,6 +11,9 @@ import (
 // final "{name...}" rest segment matches one or more remaining request
 // segments; the captured value is those segments joined with "/".
 func Match(pattern, requestPath string) (map[string]string, bool) {
+	if hasUnsafeRequestSegment(requestPath) {
+		return nil, false
+	}
 	patternParts := splitPath(pattern)
 	requestParts := splitPath(requestPath)
 	rest := len(patternParts) > 0 && isRestSegment(patternParts[len(patternParts)-1])
@@ -61,6 +64,19 @@ func Match(pattern, requestPath string) (map[string]string, bool) {
 		}
 	}
 	return params, true
+}
+
+func hasUnsafeRequestSegment(requestPath string) bool {
+	trimmed := strings.Trim(requestPath, "/")
+	if trimmed == "" {
+		return false
+	}
+	for _, value := range strings.Split(trimmed, "/") {
+		if value == "" || value == "." || value == ".." {
+			return true
+		}
+	}
+	return false
 }
 
 func isRestSegment(part string) bool {

--- a/runtime/route/route_test.go
+++ b/runtime/route/route_test.go
@@ -127,6 +127,18 @@ func TestMatchRejectsUnsafeParamValues(t *testing.T) {
 	}
 }
 
+func TestMatchRejectsNonCanonicalDynamicPaths(t *testing.T) {
+	for _, requestPath := range []string{
+		"/blog/a/../b",
+		"/blog/./b",
+		"/blog//b",
+	} {
+		if _, ok := Match("/blog/{slug}", requestPath); ok {
+			t.Fatalf("expected non-canonical dynamic path %q not to match", requestPath)
+		}
+	}
+}
+
 func TestTypedParamHelpersDecodeScalars(t *testing.T) {
 	params := map[string]string{
 		"slug":  "hello",


### PR DESCRIPTION
## Summary
- reject unsafe generated-app request paths before path cleaning so encoded dot segments, dot segments, and doubled segments cannot resolve to another generated asset or dynamic route
- carry request-time layout stacks into generated route metadata
- add generated-binary coverage for request-aware hybrid layout rendering and focused runtime request-matrix tests
- update routing, layout, and generated-output docs

Fixes #252.
Fixes #253.

## Validation
- go test ./internal/appgen ./internal/buildgen ./internal/compiler ./runtime/app ./runtime/route
- go build ./cmd/gowdk
- scripts/test-go-modules.sh