### PR TITLE
[codex] fix routes endpoint visibility

### DIFF
--- a/cmd/gowdk/lang.go
+++ b/cmd/gowdk/lang.go
@@ -138,6 +138,10 @@ func siteMapJSON(args []string) error {
 }
 
 func routesJSON(args []string) error {
+	if projectCommandHelp(args) {
+		fmt.Println(projectCommandUsage("routes", false))
+		return nil
+	}
 	metadata, err := routeMetadataForCommand(args, "routes")
 	if err != nil {
 		return err
@@ -152,6 +156,10 @@ func routesJSON(args []string) error {
 }
 
 func endpointsJSONCommand(args []string) error {
+	if projectCommandHelp(args) {
+		fmt.Println(projectCommandUsage("endpoints", false))
+		return nil
+	}
 	metadata, err := routeMetadataForCommand(args, "endpoints")
 	if err != nil {
 		return err
@@ -183,6 +191,10 @@ func routeMetadataForCommand(args []string, command string) (compiler.RouteMetad
 	}
 	metadata := compiler.BuildRouteMetadataFromIR(options.Config, ir)
 	return metadata, nil
+}
+
+func projectCommandHelp(args []string) bool {
+	return len(args) == 1 && (args[0] == "-h" || args[0] == "--help")
 }
 
 func printRouteInfos(infos []compiler.RouteInfo) {

--- a/cmd/gowdk/main_test.go
+++ b/cmd/gowdk/main_test.go
@@ -3751,6 +3751,18 @@ func TestRunWithoutArgsPrintsUsage(t *testing.T) {
 	}
 }
 
+func TestRoutesCommandHelpPrintsUsage(t *testing.T) {
+	output, err := captureCLIStdout(t, func() error {
+		return run([]string{"routes", "--help"})
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(output, "usage: gowdk routes") || strings.Contains(output, "unknown routes flag") {
+		t.Fatalf("expected routes usage output, got:\n%s", output)
+	}
+}
+
 func TestContractsCommandReportsGoRegistrations(t *testing.T) {
 	root := t.TempDir()
 	writeCLIFile(t, filepath.Join(root, "patients.go"), `package patients
@@ -4428,8 +4440,8 @@ view {
 	if report.Version != 1 {
 		t.Fatalf("unexpected routes version: %d", report.Version)
 	}
-	if len(report.Routes) != 1 {
-		t.Fatalf("expected only page routes, got %#v", report.Routes)
+	if len(report.Routes) != 2 {
+		t.Fatalf("expected page and action route rows, got %#v", report.Routes)
 	}
 	if len(report.Endpoints) != 1 {
 		t.Fatalf("expected one action endpoint, got %#v", report.Endpoints)
@@ -4441,9 +4453,22 @@ view {
 		PageID:  "newsletter",
 		Handler: `embedded.SPA("pages/newsletter.html")`,
 	})
+	assertRouteBinding(t, report.Routes, routeBindingJSON{
+		Kind:           "action",
+		EndpointSource: "gwdk",
+		Directive:      "act",
+		Method:         "POST",
+		Route:          "/newsletter",
+		PageID:         "newsletter",
+		Symbol:         "Subscribe",
+		CSRF:           true,
+		Handler:        "actions.NewsletterSubscribe",
+		BindingStatus:  "missing",
+	})
 	assertEndpointBinding(t, report.Endpoints, endpointBindingJSON{
 		Kind:           "action",
 		EndpointSource: "gwdk",
+		Directive:      "act",
 		Source:         page,
 		Package:        "app",
 		PackageName:    "app",
@@ -4518,6 +4543,7 @@ view {
 	assertEndpointBinding(t, report.Endpoints, endpointBindingJSON{
 		Kind:           "action",
 		EndpointSource: "gwdk",
+		Directive:      "act",
 		Source:         page,
 		Package:        "app",
 		PackageName:    "app",
@@ -4750,15 +4776,25 @@ view {
 	if err := json.Unmarshal([]byte(output), &report); err != nil {
 		t.Fatalf("invalid routes JSON: %v\n%s", err, output)
 	}
-	if len(report.Routes) != 1 {
-		t.Fatalf("expected status page route only, got %#v", report.Routes)
+	if len(report.Routes) != 2 {
+		t.Fatalf("expected status page and API route rows, got %#v", report.Routes)
 	}
 	if len(report.Endpoints) != 1 {
 		t.Fatalf("expected one API endpoint, got %#v", report.Endpoints)
 	}
+	assertRouteBinding(t, report.Routes, routeBindingJSON{
+		Kind:      "api",
+		Directive: "api",
+		Method:    "GET",
+		Route:     "/api/health",
+		PageID:    "status",
+		Symbol:    "Health",
+		Handler:   "api.StatusHealth",
+	})
 	assertEndpointBinding(t, report.Endpoints, endpointBindingJSON{
 		Kind:           "api",
 		EndpointSource: "gwdk",
+		Directive:      "api",
 		Source:         page,
 		Package:        "app",
 		PackageName:    "app",
@@ -5676,6 +5712,7 @@ func HandleCreatePatient(ctx context.Context, command CreatePatient) (CreatePati
 	assertEndpointBinding(t, report.Endpoints, endpointBindingJSON{
 		Kind:           "command",
 		EndpointSource: "contract",
+		Directive:      "g:command",
 		Source:         page,
 		Package:        "pages",
 		PackagePath:    "",
@@ -5698,6 +5735,17 @@ func HandleCreatePatient(ctx context.Context, command CreatePatient) (CreatePati
 			Handler:     "HandleCreatePatient",
 			Register:    "Register",
 		},
+	})
+	assertRouteBinding(t, report.Routes, routeBindingJSON{
+		Kind:           "command",
+		EndpointSource: "contract",
+		Directive:      "g:command",
+		Method:         "POST",
+		Route:          "/patients",
+		PageID:         "patients",
+		Symbol:         "patients.CreatePatient",
+		CSRF:           true,
+		Handler:        "contracts.command.patients.CreatePatient",
 	})
 	if len(report.Endpoints) != 1 {
 		t.Fatalf("expected one contract endpoint, got %#v", report.Endpoints)
@@ -5763,6 +5811,7 @@ func HandleCreatePatient(ctx context.Context, command CreatePatient) (CreatePati
 	assertEndpointBinding(t, report.Endpoints, endpointBindingJSON{
 		Kind:           "command",
 		EndpointSource: "contract",
+		Directive:      "g:command",
 		Source:         page,
 		Package:        "pages",
 		Symbol:         "patients.CreatePatient",
@@ -5855,6 +5904,35 @@ view {
 	}
 	if _, err := os.Stat(runtimePath); err != nil {
 		t.Fatalf("expected runtime asset to exist: %v", err)
+	}
+	routeManifest, err := os.ReadFile(filepath.Join(outputDir, "gowdk-routes.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var routes struct {
+		Endpoints []struct {
+			Kind      string   `json:"kind"`
+			Directive string   `json:"directive"`
+			Method    string   `json:"method"`
+			Route     string   `json:"route"`
+			PageID    string   `json:"page"`
+			Symbol    string   `json:"symbol"`
+			Handler   string   `json:"handler"`
+			Guards    []string `json:"guards"`
+			CSRF      bool     `json:"csrf"`
+		} `json:"endpoints"`
+	}
+	if err := json.Unmarshal(routeManifest, &routes); err != nil {
+		t.Fatalf("invalid route manifest JSON: %v\n%s", err, routeManifest)
+	}
+	if len(routes.Endpoints) != 1 {
+		t.Fatalf("expected action route in route manifest, got:\n%s", routeManifest)
+	}
+	endpoint := routes.Endpoints[0]
+	if endpoint.Kind != "action" || endpoint.Directive != "act" || endpoint.Method != "POST" || endpoint.Route != "/patients" ||
+		endpoint.PageID != "patients" || endpoint.Symbol != "Refresh" || endpoint.Handler != "actions.PatientsRefresh" ||
+		!endpoint.CSRF || len(endpoint.Guards) != 1 || endpoint.Guards[0] != "public" {
+		t.Fatalf("unexpected route manifest endpoint: %#v", endpoint)
 	}
 }
 
@@ -7264,10 +7342,17 @@ func assertRouteBinding(t *testing.T, routes []routeBindingJSON, expected routeB
 	t.Helper()
 	for _, route := range routes {
 		if route.Kind != expected.Kind ||
+			(expected.EndpointSource != "" && route.EndpointSource != expected.EndpointSource) ||
+			(expected.Directive != "" && route.Directive != expected.Directive) ||
 			route.Method != expected.Method ||
 			route.Route != expected.Route ||
 			route.PageID != expected.PageID ||
+			(expected.Symbol != "" && route.Symbol != expected.Symbol) ||
+			(expected.CSRF && !route.CSRF) ||
 			route.Handler != expected.Handler {
+			continue
+		}
+		if expected.BindingStatus != "" && route.BindingStatus != expected.BindingStatus {
 			continue
 		}
 		return
@@ -7280,6 +7365,7 @@ func assertEndpointBinding(t *testing.T, endpoints []endpointBindingJSON, expect
 	for _, endpoint := range endpoints {
 		if endpoint.Kind != expected.Kind ||
 			endpoint.EndpointSource != expected.EndpointSource ||
+			endpoint.Directive != expected.Directive ||
 			endpoint.Source != expected.Source ||
 			endpoint.Package != expected.Package ||
 			endpoint.PackagePath != expected.PackagePath ||

--- a/cmd/gowdk/project_inputs.go
+++ b/cmd/gowdk/project_inputs.go
@@ -263,6 +263,8 @@ func parseProjectOptions(args []string, command string, allowJSON bool) (cliOpti
 	for i := 0; i < len(args); i++ {
 		arg := args[i]
 		switch {
+		case arg == "-h" || arg == "--help":
+			return options, "", nil, nil, errors.New(usage)
 		case arg == "--ssr":
 			options.Config.Addons = append(options.Config.Addons, ssr.Addon())
 		case arg == "--json" && allowJSON:

--- a/cmd/gowdk/route_report.go
+++ b/cmd/gowdk/route_report.go
@@ -18,20 +18,27 @@ type endpointMetadataReport struct {
 }
 
 type routeBindingJSON struct {
-	Kind          compiler.RouteKind `json:"kind"`
-	Method        string             `json:"method"`
-	Route         string             `json:"route"`
-	PageID        string             `json:"pageId"`
-	Package       string             `json:"package,omitempty"`
-	Render        string             `json:"render,omitempty"`
-	Cache         string             `json:"cache,omitempty"`
-	DynamicParams []string           `json:"dynamicParams,omitempty"`
-	RouteParams   []routeParamJSON   `json:"routeParams,omitempty"`
-	Layouts       []string           `json:"layouts,omitempty"`
-	Guards        []string           `json:"guards,omitempty"`
-	Source        string             `json:"source,omitempty"`
-	SourceSpan    *sourceSpanJSON    `json:"sourceSpan,omitempty"`
-	Handler       string             `json:"handler"`
+	Kind           compiler.RouteKind `json:"kind"`
+	EndpointSource string             `json:"endpointSource,omitempty"`
+	Directive      string             `json:"directive,omitempty"`
+	Method         string             `json:"method"`
+	Route          string             `json:"route"`
+	PageID         string             `json:"pageId"`
+	Package        string             `json:"package,omitempty"`
+	PackagePath    string             `json:"packagePath,omitempty"`
+	PackageName    string             `json:"packageName,omitempty"`
+	Symbol         string             `json:"symbol,omitempty"`
+	Render         string             `json:"render,omitempty"`
+	Cache          string             `json:"cache,omitempty"`
+	DynamicParams  []string           `json:"dynamicParams,omitempty"`
+	RouteParams    []routeParamJSON   `json:"routeParams,omitempty"`
+	Layouts        []string           `json:"layouts,omitempty"`
+	Guards         []string           `json:"guards,omitempty"`
+	CSRF           bool               `json:"csrf,omitempty"`
+	Source         string             `json:"source,omitempty"`
+	SourceSpan     *sourceSpanJSON    `json:"sourceSpan,omitempty"`
+	Handler        string             `json:"handler"`
+	BindingStatus  string             `json:"bindingStatus,omitempty"`
 }
 
 type routeParamJSON struct {
@@ -42,6 +49,7 @@ type routeParamJSON struct {
 type endpointBindingJSON struct {
 	Kind           compiler.EndpointKind `json:"kind"`
 	EndpointSource string                `json:"endpointSource,omitempty"`
+	Directive      string                `json:"directive,omitempty"`
 	Source         string                `json:"source,omitempty"`
 	SourceSpan     *sourceSpanJSON       `json:"sourceSpan,omitempty"`
 	Package        string                `json:"package,omitempty"`
@@ -106,7 +114,7 @@ type routeInfoJSON struct {
 }
 
 func routeMetadataJSON(metadata compiler.RouteMetadata) routeMetadataReport {
-	routes := make([]routeBindingJSON, 0, len(metadata.Routes))
+	routes := make([]routeBindingJSON, 0, len(metadata.Routes)+len(metadata.Endpoints))
 	for _, binding := range metadata.Routes {
 		routes = append(routes, routeBindingJSON{
 			Kind:          binding.Kind,
@@ -126,6 +134,9 @@ func routeMetadataJSON(metadata compiler.RouteMetadata) routeMetadataReport {
 		})
 	}
 	endpoints := endpointsJSON(metadata.Endpoints)
+	for _, endpoint := range endpoints {
+		routes = append(routes, endpointRouteJSON(endpoint))
+	}
 	info := make([]routeInfoJSON, 0, len(metadata.Info))
 	for _, item := range metadata.Info {
 		info = append(info, routeInfoJSON{
@@ -156,6 +167,7 @@ func endpointsJSON(bindings []compiler.EndpointBinding) []endpointBindingJSON {
 		item := endpointBindingJSON{
 			Kind:           binding.Kind,
 			EndpointSource: binding.EndpointSource,
+			Directive:      endpointDirective(binding.Kind),
 			Source:         binding.Source,
 			SourceSpan:     endpointSourceSpanJSON(binding.SourceSpan),
 			Package:        binding.Package,
@@ -204,6 +216,47 @@ func endpointsJSON(bindings []compiler.EndpointBinding) []endpointBindingJSON {
 		endpoints = append(endpoints, item)
 	}
 	return endpoints
+}
+
+func endpointRouteJSON(endpoint endpointBindingJSON) routeBindingJSON {
+	return routeBindingJSON{
+		Kind:           compiler.RouteKind(endpoint.Kind),
+		EndpointSource: endpoint.EndpointSource,
+		Directive:      endpoint.Directive,
+		Method:         endpoint.Method,
+		Route:          endpoint.Route,
+		PageID:         endpoint.PageID,
+		Package:        endpoint.Package,
+		PackagePath:    endpoint.PackagePath,
+		PackageName:    endpoint.PackageName,
+		Symbol:         endpoint.Symbol,
+		Cache:          endpoint.Cache,
+		DynamicParams:  append([]string(nil), endpoint.DynamicParams...),
+		RouteParams:    append([]routeParamJSON(nil), endpoint.RouteParams...),
+		Guards:         append([]string(nil), endpoint.Guards...),
+		CSRF:           endpoint.CSRF,
+		Source:         endpoint.Source,
+		SourceSpan:     endpoint.SourceSpan,
+		Handler:        endpoint.Handler,
+		BindingStatus:  endpoint.BindingStatus,
+	}
+}
+
+func endpointDirective(kind compiler.EndpointKind) string {
+	switch kind {
+	case compiler.EndpointAction:
+		return "act"
+	case compiler.EndpointAPI:
+		return "api"
+	case compiler.EndpointFragment:
+		return "fragment"
+	case compiler.EndpointCommand:
+		return "g:command"
+	case compiler.EndpointQuery:
+		return "g:query"
+	default:
+		return ""
+	}
 }
 
 func routeParamsJSON(params []source.RouteParam) []routeParamJSON {

--- a/cmd/gowdk/testdata/routes_golden/routes.golden.json
+++ b/cmd/gowdk/testdata/routes_golden/routes.golden.json
@@ -23,12 +23,43 @@
         }
       },
       "handler": "embedded.SPA(\"pages/newsletter.html\")"
+    },
+    {
+      "kind": "action",
+      "endpointSource": "gwdk",
+      "directive": "act",
+      "method": "POST",
+      "route": "/newsletter",
+      "pageId": "newsletter",
+      "package": "app",
+      "packagePath": "github.com/cssbruno/gowdk/cmd/gowdk/testdata/routes_golden",
+      "packageName": "app",
+      "symbol": "Subscribe",
+      "cache": "no-store",
+      "guards": [
+        "public"
+      ],
+      "csrf": true,
+      "source": "newsletter.page.gwdk",
+      "sourceSpan": {
+        "start": {
+          "line": 7,
+          "column": 1
+        },
+        "end": {
+          "line": 7,
+          "column": 33
+        }
+      },
+      "handler": "actions.NewsletterSubscribe",
+      "bindingStatus": "missing"
     }
   ],
   "endpoints": [
     {
       "kind": "action",
       "endpointSource": "gwdk",
+      "directive": "act",
       "source": "newsletter.page.gwdk",
       "sourceSpan": {
         "start": {

--- a/docs/compiler/generated-output.md
+++ b/docs/compiler/generated-output.md
@@ -358,6 +358,19 @@ adapters import user feature packages and call exported handlers.
       "route": "/",
       "path": "index.html"
     }
+  ],
+  "endpoints": [
+    {
+      "kind": "action",
+      "directive": "act",
+      "method": "POST",
+      "route": "/login",
+      "page": "login",
+      "symbol": "Login",
+      "handler": "actions.LoginLogin",
+      "guards": ["public"],
+      "csrf": true
+    }
   ]
 }
 ```
@@ -365,7 +378,9 @@ adapters import user feature packages and call exported handlers.
 The `path` field is slash-separated and relative to the selected output
 directory. Dynamic app routes are recorded once for each generated concrete
 route, for example `/blog/{slug}` with `=> { slug: "hello-gowdk" }` is recorded
-as `/blog/hello-gowdk`.
+as `/blog/hello-gowdk`. The optional `endpoints` array records generated
+request-time action, API, fragment, command, and query adapter routes; it does
+not point at static files.
 
 ## Current App Asset Manifest
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -353,15 +353,18 @@ which modules were embedded. Embedded module composition is fixed at build time
 by `Build.Targets` or the selected `--module` flags.
 
 `gowdk routes` prints validated route and endpoint metadata as JSON. The current
-schema is version `1`. The `routes` list is limited to page/file route kinds
-such as `static`, `spa`, `ssr`, and `hybrid`; route records include package,
-render/cache metadata, route params, layouts, guards, source file, source span,
-and planned handler. Backend actions, APIs, fragments, and routable command or
-query contracts appear in the separate `endpoints` list with source path,
-source span, `.gwdk` package, method, path, page ID, route params when
-declared, no-store backend cache policy, inherited guards, CSRF applicability,
-planned adapter handler, and backend or contract binding metadata. Backend
-binding metadata includes the Go
+schema is version `1`. The `routes` list is the generated method/path table:
+it includes page/file route kinds such as `static`, `spa`, `ssr`, and `hybrid`,
+plus generated endpoint rows for actions, APIs, fragments, and routable command
+or query contracts. Route records include package, guards, source file, source
+span, and planned handler. Page rows include render/cache metadata, route
+params, and layouts. Endpoint rows include `endpointSource`, `directive`,
+symbol or contract name, no-store backend cache policy, route params when
+declared, CSRF applicability, and binding status when known.
+
+Backend actions, APIs, fragments, and routable command/query contracts also
+appear in the separate `endpoints` list with detailed backend or contract
+binding metadata. Backend binding metadata includes the Go
 package name, import path when known, handler symbol, signature/input metadata
 when bound, status, and binding message. Non-fatal route-mode notes, such as
 request-time page rendering disabled on a SPA route or static SPA output

--- a/docs/reference/manifest.md
+++ b/docs/reference/manifest.md
@@ -158,8 +158,11 @@ binding details for command/query references.
 
 `gowdk build` also writes a separate SPA route manifest named
 `gowdk-routes.json` in the selected output directory. That generated file records
-emitted page IDs, declared routes, and relative build output paths.
-Dynamic SPA routes are recorded once for each generated concrete route.
+emitted page IDs, declared routes, and relative build output paths under
+`routes`. Dynamic SPA routes are recorded once for each generated concrete
+route. The same file also records generated request-time backend route metadata
+under `endpoints` for actions, APIs, fragments, and routable command/query
+adapters.
 
 SPA builds also write `gowdk-assets.json` in the selected output directory:
 

--- a/docs/reference/routing.md
+++ b/docs/reference/routing.md
@@ -383,26 +383,26 @@ gowdk routes --ssr examples/pages/*.gwdk examples/actions/*.gwdk examples/partia
 gowdk endpoints --ssr examples/actions/*.gwdk examples/api/*.gwdk
 ```
 
-The current JSON schema is version `1`. `routes` contains only page/file route
-kinds such as `static`, `spa`, `ssr`, and `hybrid`. Route records include the
-HTTP method/path, page ID, `.gwdk` package, effective render mode, cache policy
-when declared, dynamic route params, layouts, guards, source file, source span,
-and planned handler. Static generated-output paths stay in `gowdk-routes.json`
-because dynamic SPA paths can expand one source route into multiple concrete
-files.
+The current JSON schema is version `1`. `routes` is the generated route table:
+it includes page/file route kinds such as `static`, `spa`, `ssr`, and `hybrid`,
+plus generated endpoint route rows for actions, APIs, fragments, and routable
+`g:command`/`g:query` contract references. Route records include the HTTP
+method/path, page ID, `.gwdk` package, guards, source file, source span, and
+planned handler. Page rows also include effective render mode, layouts, dynamic
+route params, and cache policy when declared. Endpoint rows include
+`endpointSource`, `directive` (`act`, `api`, `fragment`, `g:command`, or
+`g:query`), symbol/contract name, no-store backend cache policy, CSRF
+applicability, route params when declared, and binding status when known.
 
-`endpoints` contains one framework-neutral endpoint record per action, API,
-fragment declaration, and routable `g:command`/`g:query` contract reference.
-Endpoint records include `endpointSource` (`gwdk`, `go`, or `contract`), source
-file and source span, `.gwdk` package, Go package path/name when known, exact
-declared symbol or contract reference, method, path, no-store backend cache
-policy, inherited guards, CSRF applicability, route params when declared,
-planned adapter handler information, and binding status/message. Backend
-binding details repeat the Go package name, import path when known, handler
-symbol, and supported signature/input metadata when the handler is bound.
-Contract binding details include the contract kind, reference name, binding
-status, local input type, result type, roles, handler, register function, and
-message when known. The
+`endpoints` contains the detailed framework-neutral backend endpoint records
+for the same action, API, fragment, and contract adapter routes. Endpoint
+records repeat the route table fields and add Go package path/name when known,
+backend binding details, and contract binding details. Backend binding details
+repeat the Go package name, import path when known, handler symbol, and
+supported signature/input metadata when the handler is bound. Contract binding
+details include the contract kind, reference name, binding status, local input
+type, result type, roles, handler, register function, and message when known.
+The
 `info` list reports disabled route-mode lanes, for example SSR disabled on a
 SPA route.
 

--- a/internal/buildgen/build.go
+++ b/internal/buildgen/build.go
@@ -81,7 +81,8 @@ func buildFromIR(config gowdk.Config, ir gwdkir.Program, backendBindings []sourc
 		})
 		result.Artifacts = append(result.Artifacts, artifact.Artifact)
 	}
-	manifestPath, err := writeRouteManifest(outputDir, result.Artifacts)
+	endpoints := compiler.BuildRouteMetadataFromIR(config, ir).Endpoints
+	manifestPath, err := writeRouteManifest(outputDir, result.Artifacts, endpoints)
 	if err != nil {
 		return Result{}, reporter.fail("manifest", err)
 	}
@@ -263,7 +264,8 @@ func buildMemoryFromIR(config gowdk.Config, ir gwdkir.Program, backendBindings [
 		})
 	}
 
-	routeManifest, err := routeManifestPayload(outputDir, result.Artifacts)
+	endpoints := compiler.BuildRouteMetadataFromIR(config, ir).Endpoints
+	routeManifest, err := routeManifestPayload(outputDir, result.Artifacts, endpoints)
 	if err != nil {
 		return MemoryResult{}, reporter.fail("manifest", err)
 	}
@@ -739,7 +741,8 @@ func buildIncrementalFromIR(config gowdk.Config, ir gwdkir.Program, backendBindi
 		Data: map[string]string{"changedPages": fmt.Sprint(len(changedPageIDs))},
 	})
 
-	manifestPath, err := writeRouteManifest(outputDir, result.Artifacts)
+	endpoints := compiler.BuildRouteMetadataFromIR(config, ir).Endpoints
+	manifestPath, err := writeRouteManifest(outputDir, result.Artifacts, endpoints)
 	if err != nil {
 		return Result{}, reporter.fail("manifest", err)
 	}

--- a/internal/buildgen/incremental_test.go
+++ b/internal/buildgen/incremental_test.go
@@ -192,6 +192,16 @@ func Subscribe(context.Context) (response.Response, error) {
 	if event.Data["block"] != "Subscribe" || event.Data["status"] != "bound" {
 		t.Fatalf("expected bound Subscribe event, got %#v", event)
 	}
+	routes := readRouteManifest(t, outputDir)
+	if len(routes.Endpoints) != 1 {
+		t.Fatalf("expected action endpoint route in route manifest, got %#v", routes.Endpoints)
+	}
+	endpoint := routes.Endpoints[0]
+	if endpoint.Kind != "action" || endpoint.Directive != "act" || endpoint.Method != "POST" || endpoint.Route != "/newsletter" ||
+		endpoint.PageID != "newsletter" || endpoint.Symbol != "Subscribe" || endpoint.Handler != "actions.NewsletterSubscribe" ||
+		!endpoint.CSRF || len(endpoint.Guards) != 1 || endpoint.Guards[0] != "public" {
+		t.Fatalf("unexpected endpoint route manifest entry: %#v", endpoint)
+	}
 }
 
 func TestBuildIncrementalFromIRRendersChangedPageSources(t *testing.T) {

--- a/internal/buildgen/manifests.go
+++ b/internal/buildgen/manifests.go
@@ -10,12 +10,14 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/cssbruno/gowdk/internal/compiler"
 	runtimeasset "github.com/cssbruno/gowdk/runtime/asset"
 )
 
 type routeManifest struct {
-	Version int                  `json:"version"`
-	Routes  []routeManifestEntry `json:"routes"`
+	Version   int                          `json:"version"`
+	Routes    []routeManifestEntry         `json:"routes"`
+	Endpoints []routeManifestEndpointEntry `json:"endpoints,omitempty"`
 }
 
 type routeManifestEntry struct {
@@ -24,8 +26,20 @@ type routeManifestEntry struct {
 	Path   string `json:"path"`
 }
 
-func writeRouteManifest(outputDir string, artifacts []Artifact) (string, error) {
-	payload, err := routeManifestPayload(outputDir, artifacts)
+type routeManifestEndpointEntry struct {
+	Kind      compiler.EndpointKind `json:"kind"`
+	Directive string                `json:"directive,omitempty"`
+	Method    string                `json:"method"`
+	Route     string                `json:"route"`
+	PageID    string                `json:"page"`
+	Symbol    string                `json:"symbol,omitempty"`
+	Handler   string                `json:"handler"`
+	Guards    []string              `json:"guards,omitempty"`
+	CSRF      bool                  `json:"csrf,omitempty"`
+}
+
+func writeRouteManifest(outputDir string, artifacts []Artifact, endpoints []compiler.EndpointBinding) (string, error) {
+	payload, err := routeManifestPayload(outputDir, artifacts, endpoints)
 	if err != nil {
 		return "", err
 	}
@@ -37,7 +51,7 @@ func writeRouteManifest(outputDir string, artifacts []Artifact) (string, error) 
 	return manifestPath, nil
 }
 
-func routeManifestPayload(outputDir string, artifacts []Artifact) ([]byte, error) {
+func routeManifestPayload(outputDir string, artifacts []Artifact, endpoints []compiler.EndpointBinding) ([]byte, error) {
 	routes := make([]routeManifestEntry, 0, len(artifacts))
 	for _, artifact := range artifacts {
 		rel, err := relativeOutputPath(outputDir, artifact.Path)
@@ -57,12 +71,60 @@ func routeManifestPayload(outputDir string, artifacts []Artifact) ([]byte, error
 		return routes[i].Route < routes[j].Route
 	})
 
-	payload, err := json.MarshalIndent(routeManifest{Version: 1, Routes: routes}, "", "  ")
+	endpointRoutes := routeManifestEndpointEntries(endpoints)
+	payload, err := json.MarshalIndent(routeManifest{Version: 1, Routes: routes, Endpoints: endpointRoutes}, "", "  ")
 	if err != nil {
 		return nil, err
 	}
 	payload = append(payload, '\n')
 	return payload, nil
+}
+
+func routeManifestEndpointEntries(endpoints []compiler.EndpointBinding) []routeManifestEndpointEntry {
+	if len(endpoints) == 0 {
+		return nil
+	}
+	routes := make([]routeManifestEndpointEntry, 0, len(endpoints))
+	for _, endpoint := range endpoints {
+		routes = append(routes, routeManifestEndpointEntry{
+			Kind:      endpoint.Kind,
+			Directive: routeManifestEndpointDirective(endpoint.Kind),
+			Method:    endpoint.Method,
+			Route:     endpoint.Route,
+			PageID:    endpoint.PageID,
+			Symbol:    endpoint.Symbol,
+			Handler:   endpoint.Handler,
+			Guards:    append([]string(nil), endpoint.Guards...),
+			CSRF:      endpoint.CSRF,
+		})
+	}
+	sort.Slice(routes, func(i, j int) bool {
+		if routes[i].Route == routes[j].Route {
+			if routes[i].Method == routes[j].Method {
+				return routes[i].Kind < routes[j].Kind
+			}
+			return routes[i].Method < routes[j].Method
+		}
+		return routes[i].Route < routes[j].Route
+	})
+	return routes
+}
+
+func routeManifestEndpointDirective(kind compiler.EndpointKind) string {
+	switch kind {
+	case compiler.EndpointAction:
+		return "act"
+	case compiler.EndpointAPI:
+		return "api"
+	case compiler.EndpointFragment:
+		return "fragment"
+	case compiler.EndpointCommand:
+		return "g:command"
+	case compiler.EndpointQuery:
+		return "g:query"
+	default:
+		return ""
+	}
 }
 
 func readRouteManifestIfExists(outputDir string) (routeManifest, error) {

--- a/internal/buildgen/test_helpers_test.go
+++ b/internal/buildgen/test_helpers_test.go
@@ -29,6 +29,17 @@ type testRouteManifest struct {
 		Route  string `json:"route"`
 		Path   string `json:"path"`
 	} `json:"routes"`
+	Endpoints []struct {
+		Kind      string   `json:"kind"`
+		Directive string   `json:"directive"`
+		Method    string   `json:"method"`
+		Route     string   `json:"route"`
+		PageID    string   `json:"page"`
+		Symbol    string   `json:"symbol"`
+		Handler   string   `json:"handler"`
+		Guards    []string `json:"guards"`
+		CSRF      bool     `json:"csrf"`
+	} `json:"endpoints"`
 }
 
 func readRouteManifest(t *testing.T, outputDir string) testRouteManifest {


### PR DESCRIPTION
## Summary

Fixes #478.

- Include generated endpoint rows directly in `gowdk routes` so action, API, fragment, `g:command`, and `g:query` routes appear in the method/path table.
- Keep the detailed `endpoints` report, now with a `directive` field for easier source attribution.
- Add generated backend route metadata to `gowdk-routes.json` under an additive `endpoints` array while preserving existing static page `routes` entries.
- Include typed dynamic endpoint params in `gowdk-routes.json`, inspect endpoint nodes, and OpenAPI path parameters.
- Add endpoint route metadata to OpenAPI `x-gowdk` where the IR has it: cache, guards, CSRF, and endpoint source.
- Make top-level and recognized nested `--help` forms print usage successfully instead of falling through to unknown-flag or file-open errors.
- Improve generated-app and `gowdk serve` 405 responses using `gowdk-routes.json` so stale/misdirected POST debugging points at generated endpoints.
- Update tests, golden output, and docs for the expanded report/manifest surfaces.

## Root Cause

The compiler already tracked endpoint metadata, but several public debugging surfaces projected narrower views. `gowdk routes` treated `routes` as page/file routes only and placed backend routes solely in the detailed `endpoints` section. Build output had an even narrower `gowdk-routes.json` shape that only recorded emitted SPA files. Related report surfaces also dropped typed endpoint route params, and many command help paths reached normal argument parsing instead of usage handling.

## Verification

- `go test ./cmd/gowdk ./runtime/app ./internal/buildgen ./internal/inspectreport`
- `go test ./cmd/gowdk ./internal/buildgen -run 'TestRoutesCommand|TestEndpointsCommand|TestBuildCommandPrintsPartialRuntimeAsset|TestBuildIncrementalSourcePathAssemblesBackendBindings|TestRoutesCommandMatchesGoldenFixture|TestBuildWritesSPAHTMLForSimpleRoute'`
- `go test ./runtime/app -run 'TestHandlerMethodNotAllowedSuggestsGeneratedEndpointFromRouteManifest|TestHandlerMetricsRecordDispatchOutcomes'`
- `go test ./internal/buildgen -run 'TestRouteManifestIncludesTypedDynamicEndpointParams|TestBuildOpenAPISpec'`
- `go test ./cmd/gowdk -run 'TestRunHelpPrintsUsage|TestCommandHelpPrintsUsage|TestNestedCommandHelpPrintsUsage|TestOutputFileHandlerUnsupportedMethodMentionsGeneratedEndpointManifest|TestInspectEndpointGraphCommandPrintsEndpointEdges'`
- `go test ./...`
- `go build ./cmd/gowdk`
- `scripts/test-go-modules.sh`
- `go run ./cmd/gowdk routes --help`
- `go run ./cmd/gowdk routes --config cmd/gowdk/testdata/routes_golden/gowdk.config.go cmd/gowdk/testdata/routes_golden/newsletter.page.gwdk`
- `go run ./cmd/gowdk build --config cmd/gowdk/testdata/routes_golden/gowdk.config.go --out /tmp/gowdk-route-endpoints-smoke cmd/gowdk/testdata/routes_golden/newsletter.page.gwdk`
- `go run ./cmd/gowdk build --config gowdk.config.go --out /tmp/gowdk-audit-fragments examples/partials/patients-fragment.page.gwdk`
- `go run ./cmd/gowdk inspect endpoint-graph --config gowdk.config.go --json examples/partials/patients-fragment.page.gwdk`
