### PR TITLE
feat(contracts): true HTML-embedded single-flight for g:command (#493)

### DIFF
--- a/docs/reference/contracts.md
+++ b/docs/reference/contracts.md
@@ -124,9 +124,22 @@ applies a single-flight region refresh: the generated adapter computes which
 `g:query` regions the command's domain events invalidate and names them in the
 `X-GOWDK-Queries` response header, so the submitter's regions update immediately
 without waiting for the realtime fanout that refreshes every other connected
-client. The typed result rides on the `gowdk:command-success` event for optional
+client.
+
+For a parameterless region whose data comes from the page's `load {}`, the
+adapter goes one step further and renders the invalidated region inline — true
+single-flight. It returns a `{ result, patches: [{ query, html }] }` envelope
+(signalled by the `X-GOWDK-Patches` response header) and the client swaps the
+region HTML directly, with no second page fetch. Regions that need route context
+the command request lacks (a dynamic route param) stay in the `X-GOWDK-Queries`
+header only and the client refetches them — the same path used when JavaScript
+re-runs the page render. The raw command result body is preserved whenever no
+region renders, so non-browser callers are unaffected.
+
+The typed result rides on the `gowdk:command-success` event for optional
 optimistic UI. With realtime configured, the same invalidation also fans out over
-SSE to other clients (`g:subscribe` / invalidated `g:query` regions).
+SSE to other clients (`g:subscribe` / invalidated `g:query` regions), reusing the
+client's region-swap routine so the embedded and fanned-out paths converge.
 
 Two caveats the `ssr_command_no_client` warning surfaces. First, with client
 JavaScript disabled a bare submit still navigates to the adapter's JSON — use a

--- a/internal/appgen/appgen_test.go
+++ b/internal/appgen/appgen_test.go
@@ -852,10 +852,178 @@ func TestGenerateWritesRealtimeQueryInvalidationFanout(t *testing.T) {
 		// client which g:query regions to refresh via the X-GOWDK-Queries header.
 		`invalidatedQueries := gowdkcontracts.InvalidatedQueryTypes(realtimeQueryInvalidations, events)`,
 		`response.Header().Set("X-GOWDK-Queries", strings.Join(invalidatedQueries, ","))`,
+		`invalidatedEventIDs := gowdkcontracts.InvalidatedEventIDs(realtimeQueryInvalidations, events)`,
+		`response.Header().Set("X-GOWDK-Events", strings.Join(invalidatedEventIDs, ","))`,
 	} {
 		if !strings.Contains(source, expected) {
 			t.Fatalf("expected generated invalidation source to contain %q:\n%s", expected, source)
 		}
+	}
+	for _, unexpected := range []string{
+		`gowdkssr.RenderInvalidatedRegions`,
+		`X-GOWDK-Patches`,
+		`gowdkssr.CommandEnvelope`,
+	} {
+		if strings.Contains(source, unexpected) {
+			t.Fatalf("did not expect inline patch source without an eligible SSR region %q:\n%s", unexpected, source)
+		}
+	}
+}
+
+func TestGenerateRegistersSingleFlightRegionRenderers(t *testing.T) {
+	root := t.TempDir()
+	outputDir := filepath.Join(root, "dist")
+	appDir := filepath.Join(root, "generated-app")
+	writeTestFile(t, filepath.Join(outputDir, "board", "index.html"), "<main>Board</main>")
+
+	program := &gwdkir.Program{
+		ContractRefs: []gwdkir.ContractReference{{
+			Kind:        gwdkir.ContractCommand,
+			Name:        "patients.CreatePatient",
+			ImportAlias: "patients",
+			ImportPath:  "example.com/app/contracts/patients",
+			Type:        "CreatePatient",
+			Result:      "CreatePatientResult",
+			Method:      http.MethodPost,
+			Path:        "/patients",
+			Status:      gwdkir.ContractBindingBound,
+			Handler:     "HandleCreatePatient",
+			Register:    "Register",
+			OwnerKind:   gwdkir.SourcePage,
+			OwnerID:     "patients",
+		}},
+		QueryInvalidations: []gwdkir.QueryInvalidation{{
+			Query:         "patients.GetPatientPage",
+			QueryType:     "example.com/app/board.GetPatientPage",
+			Event:         "example.com/app/contracts/patients.PatientCreated",
+			EventType:     "example.com/app/contracts/patients.PatientCreated",
+			EventCategory: "domain",
+			Status:        gwdkir.ContractBindingBound,
+			OwnerKind:     gwdkir.SourcePage,
+			OwnerID:       "patients",
+		}},
+	}
+	ssrRoute := SSRRoute{
+		PageID:  "board",
+		Route:   "/board",
+		Render:  gowdk.SSR,
+		Guards:  []string{"public"},
+		HasLoad: true,
+		LoadBinding: source.BackendBinding{
+			Status:       source.BackendBindingBound,
+			ImportPath:   "example.com/app/board",
+			PackageName:  "board",
+			FunctionName: "LoadBoard",
+			Signature:    source.BackendSignatureLoad,
+		},
+		HTML: `<main><section data-gowdk-query-type="example.com/app/board.GetPatientPage"><ul>__GOWDK_SSR_LIST_board__</ul></section></main>`,
+		QueryRegions: []SSRQueryRegion{{
+			QueryType: "example.com/app/board.GetPatientPage",
+			Template:  `<section data-gowdk-query-type="example.com/app/board.GetPatientPage"><ul>__GOWDK_SSR_LIST_board__</ul></section>`,
+			ListSpecs: []SSRListSpec{{Placeholder: "__GOWDK_SSR_LIST_board__", SourcePath: "patients"}},
+		}},
+	}
+
+	result, err := GenerateWithOptions(outputDir, appDir, Options{Config: csrfDisabledConfig(), IR: program, SSR: []SSRRoute{ssrRoute}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload, err := os.ReadFile(result.PackagePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	source := string(payload)
+	for _, expected := range []string{
+		`func init() {`,
+		`gowdkssr.RegisterRegion(gowdkssr.RegionRenderer{QueryType: "example.com/app/board.GetPatientPage"`,
+		`Load: func(request *http.Request) (map[string]any, error)`,
+		`ctx := gowdkruntime.WithRoute(request.Context(), gowdkruntime.RouteMetadata{Kind: "ssr", PageID: "board", Method: "GET", Path: "/board", Render: "ssr", Guards: []string{"public"}, HasLoad: true})`,
+		`pageRequest.Method = http.MethodGet`,
+		`loadContext := gowdkssr.NewLoadContext(request, nil)`,
+		`if request.Header.Get("X-GOWDK-Command") == "1"`,
+		`singleFlightPatches := gowdkssr.RenderInvalidatedRegions(request, invalidatedQueries)`,
+		`response.Header().Set("X-GOWDK-Patches", "1")`,
+		`gowdkssr.CommandEnvelope{Result: result, Patches: singleFlightPatches}`,
+	} {
+		if !strings.Contains(source, expected) {
+			t.Fatalf("expected generated region registration to contain %q:\n%s", expected, source)
+		}
+	}
+}
+
+func TestGenerateSkipsSingleFlightRegionRenderersForGuardedRoutes(t *testing.T) {
+	root := t.TempDir()
+	outputDir := filepath.Join(root, "dist")
+	appDir := filepath.Join(root, "generated-app")
+	writeTestFile(t, filepath.Join(outputDir, "dashboard", "index.html"), "<main>Dashboard</main>")
+
+	program := &gwdkir.Program{
+		ContractRefs: []gwdkir.ContractReference{{
+			Kind:        gwdkir.ContractCommand,
+			Name:        "patients.CreatePatient",
+			ImportAlias: "patients",
+			ImportPath:  "example.com/app/contracts/patients",
+			Type:        "CreatePatient",
+			Result:      "CreatePatientResult",
+			Method:      http.MethodPost,
+			Path:        "/patients",
+			Status:      gwdkir.ContractBindingBound,
+			Handler:     "HandleCreatePatient",
+			Register:    "Register",
+			OwnerKind:   gwdkir.SourcePage,
+			OwnerID:     "patients",
+		}},
+		QueryInvalidations: []gwdkir.QueryInvalidation{{
+			Query:         "patients.GetPatientPage",
+			QueryType:     "example.com/app/dashboard.GetPatientPage",
+			Event:         "example.com/app/contracts/patients.PatientCreated",
+			EventType:     "example.com/app/contracts/patients.PatientCreated",
+			EventCategory: "domain",
+			Status:        gwdkir.ContractBindingBound,
+			OwnerKind:     gwdkir.SourcePage,
+			OwnerID:       "patients",
+		}},
+	}
+	ssrRoute := SSRRoute{
+		PageID:  "dashboard",
+		Route:   "/dashboard",
+		Render:  gowdk.SSR,
+		Guards:  []string{"auth.required"},
+		HasLoad: true,
+		LoadBinding: source.BackendBinding{
+			Status:       source.BackendBindingBound,
+			ImportPath:   "example.com/app/dashboard",
+			PackageName:  "dashboard",
+			FunctionName: "LoadDashboard",
+			Signature:    source.BackendSignatureLoad,
+		},
+		HTML: `<main><section data-gowdk-query-type="example.com/app/dashboard.GetPatientPage"></section></main>`,
+		QueryRegions: []SSRQueryRegion{{
+			QueryType: "example.com/app/dashboard.GetPatientPage",
+			Template:  `<section data-gowdk-query-type="example.com/app/dashboard.GetPatientPage"></section>`,
+		}},
+	}
+
+	result, err := GenerateWithOptions(outputDir, appDir, Options{Config: csrfDisabledConfig(), IR: program, SSR: []SSRRoute{ssrRoute}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload, err := os.ReadFile(result.PackagePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	source := string(payload)
+	for _, unexpected := range []string{
+		`gowdkssr.RegisterRegion`,
+		`gowdkssr.RenderInvalidatedRegions`,
+		`X-GOWDK-Patches`,
+	} {
+		if strings.Contains(source, unexpected) {
+			t.Fatalf("guarded SSR route must not emit inline region patch code %q:\n%s", unexpected, source)
+		}
+	}
+	if !strings.Contains(source, `response.Header().Set("X-GOWDK-Queries", strings.Join(invalidatedQueries, ","))`) {
+		t.Fatalf("guarded route should keep invalidation header fallback:\n%s", source)
 	}
 }
 
@@ -5511,6 +5679,193 @@ func HandleCreatePatient(ctx context.Context, command CreatePatient) (CreatePati
 		t.Fatal("expected X-GOWDK-Events to name the invalidating event ID")
 	} else if parts := strings.Split(got, ","); len(parts) != 1 || strings.TrimSpace(parts[0]) == "" {
 		t.Fatalf("expected one X-GOWDK-Events event ID, got %q", got)
+	}
+}
+
+func TestGeneratedBinaryCommandEmbedsSingleFlightRegionHTML(t *testing.T) {
+	root := t.TempDir()
+	outputDir := filepath.Join(root, "dist")
+	appDir := filepath.Join(root, "generated-app")
+	binaryPath := filepath.Join(root, "site")
+	writeTestFile(t, filepath.Join(outputDir, "board", "index.html"), "<main>Board page</main>")
+
+	program := &gwdkir.Program{
+		ContractRefs: []gwdkir.ContractReference{{
+			Kind:        gwdkir.ContractCommand,
+			Name:        "patients.CreatePatient",
+			ImportAlias: "patients",
+			ImportPath:  "gowdk-generated-app/patients",
+			Type:        "CreatePatient",
+			Result:      "CreatePatientResult",
+			InputFields: []source.BackendInputField{{FieldName: "Name", FormName: "name", Type: "string"}},
+			Method:      http.MethodPost,
+			Path:        "/patients",
+			Status:      gwdkir.ContractBindingBound,
+			Handler:     "HandleCreatePatient",
+			Register:    "Register",
+			OwnerKind:   gwdkir.SourcePage,
+			OwnerID:     "patients",
+		}},
+		QueryInvalidations: []gwdkir.QueryInvalidation{{
+			Query:         "patients.GetPatientPage",
+			QueryType:     "gowdk-generated-app/patients.GetPatientPage",
+			Event:         "gowdk-generated-app/patients.PatientCreated",
+			EventType:     "gowdk-generated-app/patients.PatientCreated",
+			EventCategory: "domain",
+			Status:        gwdkir.ContractBindingBound,
+			OwnerKind:     gwdkir.SourcePage,
+			OwnerID:       "patients",
+		}},
+	}
+	// The board page renders a parameterless g:query region bound to
+	// GetPatientPage. Its standalone render recipe lets the command adapter embed
+	// the refreshed region HTML in its response (true single-flight).
+	ssrRoute := SSRRoute{
+		PageID:  "board",
+		Route:   "/board",
+		Render:  gowdk.SSR,
+		Guards:  []string{"public"},
+		HasLoad: true,
+		LoadBinding: source.BackendBinding{
+			Status:       source.BackendBindingBound,
+			ImportPath:   "gowdk-generated-app/board",
+			PackageName:  "board",
+			FunctionName: "LoadBoard",
+			Signature:    source.BackendSignatureLoad,
+		},
+		HTML: `<main><section data-gowdk-query-type="gowdk-generated-app/patients.GetPatientPage"><ul>__GOWDK_SSR_LIST_board__</ul></section></main>`,
+		ListSpecs: []SSRListSpec{{
+			Placeholder: "__GOWDK_SSR_LIST_board__",
+			SourcePath:  "patients",
+			RowTemplate: "<li>__GOWDK_SSR_FIELD_name__</li>",
+			Fields:      []SSRListField{{Placeholder: "__GOWDK_SSR_FIELD_name__", Path: "Name"}},
+		}},
+		QueryRegions: []SSRQueryRegion{{
+			QueryType: "gowdk-generated-app/patients.GetPatientPage",
+			Template:  `<section data-gowdk-query-type="gowdk-generated-app/patients.GetPatientPage"><ul>__GOWDK_SSR_LIST_board__</ul></section>`,
+			ListSpecs: []SSRListSpec{{
+				Placeholder: "__GOWDK_SSR_LIST_board__",
+				SourcePath:  "patients",
+				RowTemplate: "<li>__GOWDK_SSR_FIELD_name__</li>",
+				Fields:      []SSRListField{{Placeholder: "__GOWDK_SSR_FIELD_name__", Path: "Name"}},
+			}},
+		}},
+	}
+	if _, err := GenerateWithOptions(outputDir, appDir, Options{Config: csrfDisabledConfig(), IR: program, SSR: []SSRRoute{ssrRoute}}); err != nil {
+		t.Fatal(err)
+	}
+	writeTestFile(t, filepath.Join(appDir, "patients", "patients.go"), `package patients
+
+import (
+	"context"
+
+	"github.com/cssbruno/gowdk/runtime/contracts"
+)
+
+type CreatePatient struct {
+	Name string
+}
+
+type CreatePatientResult struct {
+	ID string `+"`json:\"id\"`"+`
+}
+
+type PatientCreated struct {
+	ID string
+}
+
+func Register(registry *contracts.Registry) {
+	contracts.RegisterCommand[CreatePatient, CreatePatientResult](registry, HandleCreatePatient, contracts.RoleWeb)
+}
+
+func HandleCreatePatient(ctx context.Context, command CreatePatient) (CreatePatientResult, error) {
+	if err := contracts.EmitDomain(ctx, PatientCreated{ID: "patient-1"}); err != nil {
+		return CreatePatientResult{}, err
+	}
+	return CreatePatientResult{ID: "patient-1"}, nil
+}
+`)
+	writeTestFile(t, filepath.Join(appDir, "board", "board.go"), `package board
+
+import "github.com/cssbruno/gowdk/runtime/ssr"
+
+func LoadBoard(ctx ssr.LoadContext) map[string]any {
+	return map[string]any{"patients": []map[string]any{{"Name": "Ada"}, {"Name": "Linus"}}}
+}
+`)
+	if _, err := BuildBinary(appDir, binaryPath); err != nil {
+		t.Fatal(err)
+	}
+
+	addr := freeAddr(t)
+	command := exec.Command(binaryPath)
+	command.Env = append(os.Environ(), "GOWDK_ADDR="+addr)
+	if err := command.Start(); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		_ = command.Process.Kill()
+		_, _ = command.Process.Wait()
+	}()
+
+	response, err := waitForHTTPStatus("http://"+addr+"/patients", http.MethodPost, "name=Ada")
+	if err != nil {
+		t.Fatal(err)
+	}
+	bodyBytes, err := io.ReadAll(response.Body)
+	_ = response.Body.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("expected command response status 200, got %d", response.StatusCode)
+	}
+	if got := response.Header.Get("X-GOWDK-Queries"); got != "gowdk-generated-app/patients.GetPatientPage" {
+		t.Fatalf("expected X-GOWDK-Queries to name the invalidated query, got %q", got)
+	}
+	if got := response.Header.Get("X-GOWDK-Patches"); got != "" {
+		t.Fatalf("non-browser command callers must keep raw JSON, got X-GOWDK-Patches=%q", got)
+	}
+	if body := strings.TrimSpace(string(bodyBytes)); body != `{"id":"patient-1"}` {
+		t.Fatalf("non-browser command callers must keep raw result JSON, got %s", body)
+	}
+
+	browserResponse, err := waitForHTTPStatusWithHeaders("http://"+addr+"/patients", http.MethodPost, "name=Ada", map[string]string{
+		"X-GOWDK-Command": "1",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	browserBodyBytes, err := io.ReadAll(browserResponse.Body)
+	_ = browserResponse.Body.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if browserResponse.StatusCode != http.StatusOK {
+		t.Fatalf("expected browser command response status 200, got %d", browserResponse.StatusCode)
+	}
+	if got := browserResponse.Header.Get("X-GOWDK-Queries"); got != "gowdk-generated-app/patients.GetPatientPage" {
+		t.Fatalf("expected browser X-GOWDK-Queries to name the invalidated query, got %q", got)
+	}
+	// The adapter rendered the invalidated region standalone and returned it
+	// inline, signalled by X-GOWDK-Patches. The body is a {result, patches}
+	// envelope carrying the refreshed rows, so the client applies them with no
+	// second page fetch.
+	if got := browserResponse.Header.Get("X-GOWDK-Patches"); got != "1" {
+		t.Fatalf("expected X-GOWDK-Patches header, got %q", got)
+	}
+	body := string(browserBodyBytes)
+	if !strings.Contains(body, `"patches"`) || !strings.Contains(body, `"result"`) {
+		t.Fatalf("expected single-flight envelope body, got %s", body)
+	}
+	if !strings.Contains(body, "gowdk-generated-app/patients.GetPatientPage") {
+		t.Fatalf("expected patch to name the query, got %s", body)
+	}
+	if !strings.Contains(body, "Ada") || !strings.Contains(body, "Linus") {
+		t.Fatalf("expected rendered region rows in patch HTML, got %s", body)
+	}
+	if !strings.Contains(body, `"id":"patient-1"`) {
+		t.Fatalf("expected command result in envelope, got %s", body)
 	}
 }
 

--- a/internal/appgen/auto_routes.go
+++ b/internal/appgen/auto_routes.go
@@ -222,6 +222,7 @@ func ssrRoutes(artifacts []buildgen.SSRArtifact) []SSRRoute {
 			LoadReplacements: append([]SSRLoadReplacement(nil), artifact.LoadReplacements...),
 			ListSpecs:        append([]SSRListSpec(nil), artifact.ListSpecs...),
 			CondSpecs:        append([]SSRCondSpec(nil), artifact.CondSpecs...),
+			QueryRegions:     append([]SSRQueryRegion(nil), artifact.QueryRegions...),
 		})
 	}
 	return routes

--- a/internal/appgen/source.go
+++ b/internal/appgen/source.go
@@ -152,6 +152,9 @@ func runtimeImportMap(options Options) map[string]string {
 	if ssrUsesLoad(ssr) {
 		imports["gowdkssr"] = "github.com/cssbruno/gowdk/runtime/ssr"
 	}
+	if commandPatchRenderingEnabled(options) {
+		imports["gowdkssr"] = "github.com/cssbruno/gowdk/runtime/ssr"
+	}
 	if generatedUsesGuards(options) {
 		imports["gowdkauth"] = "github.com/cssbruno/gowdk/runtime/auth"
 	}
@@ -291,7 +294,7 @@ func appGeneratedDecls(direct Options, full Options) []ast.Decl {
 	decls := actionHandlerDecls(adapter.Actions, csrfEnabled(direct), generatedUsesRateLimit(direct))
 	decls = append(decls, apiFuncDecl(adapter.APIs, csrfEnabled(direct), generatedUsesRateLimit(direct)))
 	decls = append(decls, fragmentFuncDecl(adapter.Fragments, generatedUsesRateLimit(direct)))
-	decls = append(decls, contractHandlerDecls(adapter.ContractExposures, csrfEnabled(direct), generatedUsesRateLimit(direct), generatedRealtimeQueryInvalidationsEnabled(direct))...)
+	decls = append(decls, contractHandlerDecls(adapter.ContractExposures, csrfEnabled(direct), generatedUsesRateLimit(direct), generatedRealtimeQueryInvalidationsEnabled(direct), commandPatchRenderingEnabled(direct))...)
 	decls = append(decls, contractDecoderDecls(adapter.ContractExposures)...)
 	decls = append(decls, contractEventSinkDecls(adapter.ContractExposures, generatedRealtimeEnabled(direct), generatedRealtimeQueryInvalidationsEnabled(direct))...)
 	decls = append(decls, contractRegistryDecls(adapter.ContractExposures)...)
@@ -316,6 +319,9 @@ func appGeneratedDecls(direct Options, full Options) []ast.Decl {
 	decls = append(decls, rateLimitDecls(full)...)
 	decls = append(decls, guardDecls(full)...)
 	decls = append(decls, ssrExactDecl(full.SSR, generatedUsesRateLimit(full), csrf), ssrDynamicDecl(full.SSR, generatedUsesRateLimit(full), csrf))
+	if generatedRealtimeQueryInvalidationsEnabled(direct) {
+		decls = append(decls, ssrRegionRegistrationDecls(full.SSR)...)
+	}
 	return decls
 }
 
@@ -324,7 +330,7 @@ func backendGeneratedDecls(options Options) []ast.Decl {
 	decls := actionHandlerDecls(adapter.Actions, csrfEnabled(options), generatedUsesRateLimit(options))
 	decls = append(decls, apiFuncDecl(adapter.APIs, csrfEnabled(options), generatedUsesRateLimit(options)))
 	decls = append(decls, fragmentFuncDecl(adapter.Fragments, generatedUsesRateLimit(options)))
-	decls = append(decls, contractHandlerDecls(adapter.ContractExposures, csrfEnabled(options), generatedUsesRateLimit(options), generatedRealtimeQueryInvalidationsEnabled(options))...)
+	decls = append(decls, contractHandlerDecls(adapter.ContractExposures, csrfEnabled(options), generatedUsesRateLimit(options), generatedRealtimeQueryInvalidationsEnabled(options), false)...)
 	decls = append(decls, contractDecoderDecls(adapter.ContractExposures)...)
 	decls = append(decls, contractEventSinkDecls(adapter.ContractExposures, generatedRealtimeEnabled(options), generatedRealtimeQueryInvalidationsEnabled(options))...)
 	decls = append(decls, contractRegistryDecls(adapter.ContractExposures)...)

--- a/internal/appgen/source_contracts.go
+++ b/internal/appgen/source_contracts.go
@@ -10,12 +10,12 @@ import (
 	"github.com/cssbruno/gowdk/internal/source"
 )
 
-func contractHandlerDecls(exposures []BackendContractExposure, csrf bool, rateLimit bool, queryInvalidations bool) []ast.Decl {
+func contractHandlerDecls(exposures []BackendContractExposure, csrf bool, rateLimit bool, queryInvalidations bool, commandPatches bool) []ast.Decl {
 	routable := routableContractExposures(exposures)
 	decls := make([]ast.Decl, 0, len(routable))
 	for _, exposure := range routable {
 		if contractExposureExecutable(exposure) {
-			decls = append(decls, executableContractHandlerDecl(exposure, csrf, rateLimit, queryInvalidations))
+			decls = append(decls, executableContractHandlerDecl(exposure, csrf, rateLimit, queryInvalidations, commandPatches))
 			continue
 		}
 		decls = append(decls, fallbackContractHandlerDecl(exposure))
@@ -23,7 +23,7 @@ func contractHandlerDecls(exposures []BackendContractExposure, csrf bool, rateLi
 	return decls
 }
 
-func executableContractHandlerDecl(exposure BackendContractExposure, csrf bool, rateLimit bool, queryInvalidations bool) *ast.FuncDecl {
+func executableContractHandlerDecl(exposure BackendContractExposure, csrf bool, rateLimit bool, queryInvalidations bool, commandPatches bool) *ast.FuncDecl {
 	return funcDecl(contractHandlerName(exposure), []*ast.Field{
 		{Names: []*ast.Ident{id("contractRegistry")}, Type: &ast.StarExpr{X: sel("gowdkcontracts", "Registry")}},
 	}, []*ast.Field{{Type: sel("gowdkruntime", "BackendHandler")}}, []ast.Stmt{
@@ -32,12 +32,12 @@ func executableContractHandlerDecl(exposure BackendContractExposure, csrf bool, 
 				Params:  &ast.FieldList{List: actionParams()},
 				Results: &ast.FieldList{List: boolResults()},
 			},
-			Body: block(executableContractHandlerStmts(exposure, csrf, rateLimit, queryInvalidations)...),
+			Body: block(executableContractHandlerStmts(exposure, csrf, rateLimit, queryInvalidations, commandPatches)...),
 		}}},
 	})
 }
 
-func executableContractHandlerStmts(exposure BackendContractExposure, csrf bool, rateLimit bool, queryInvalidations bool) []ast.Stmt {
+func executableContractHandlerStmts(exposure BackendContractExposure, csrf bool, rateLimit bool, queryInvalidations bool, commandPatches bool) []ast.Stmt {
 	stmts := endpointContextStmts(
 		string(exposure.Endpoint.Kind),
 		exposure.Endpoint.PageID,
@@ -51,7 +51,7 @@ func executableContractHandlerStmts(exposure BackendContractExposure, csrf bool,
 	stmts = append(stmts, contractInputStmts(exposure, csrf)...)
 	if exposure.Endpoint.Kind == BackendEndpointCommand {
 		stmts = append(stmts, executableCommandContractStmts(exposure)...)
-		stmts = append(stmts, commandInvalidationHeaderStmts(queryInvalidations)...)
+		stmts = append(stmts, commandInvalidationHeaderStmts(queryInvalidations, commandPatches)...)
 	} else {
 		stmts = append(stmts, executableQueryContractStmts(exposure)...)
 	}
@@ -100,38 +100,84 @@ func executableCommandContractStmts(exposure BackendContractExposure) []ast.Stmt
 // commandInvalidationHeaderStmts emit the single-flight write path: after a
 // command's events are captured and dispatched, the adapter computes which
 // g:query regions those events invalidate and tells the submitting client via
-// the X-GOWDK-Queries response header. The client uses the header for fallback
-// refreshes when no realtime stream is active; otherwise the generated realtime
-// invalidation owns the refresh. X-GOWDK-Events gives both paths the same event
-// IDs so the browser can dedupe in-flight or already-handled refreshes. The
-// headers ride alongside the unchanged JSON result body, so non-browser callers
-// are unaffected. Only emitted when the build wires query invalidations
-// (realtimeQueryInvalidations exists).
-func commandInvalidationHeaderStmts(queryInvalidations bool) []ast.Stmt {
+// the X-GOWDK-Queries response header. X-GOWDK-Events gives both the direct
+// response and realtime paths the same event IDs so the browser can dedupe
+// in-flight or already-handled refreshes.
+//
+// Browser-enhanced g:command submits identify themselves with X-GOWDK-Command.
+// Only those requests can receive a gowdkssr.CommandEnvelope ({result, patches})
+// signalled by X-GOWDK-Patches; ordinary callers always keep the raw command
+// result JSON. Regions without a standalone renderer remain in X-GOWDK-Queries
+// only and fall back to the client refetch.
+func commandInvalidationHeaderStmts(queryInvalidations bool, commandPatches bool) []ast.Stmt {
 	if !queryInvalidations {
 		return nil
+	}
+	body := []ast.Stmt{
+		exprStmt(call(
+			selExpr(call(selExpr(id("response"), "Header")), "Set"),
+			stringLit("X-GOWDK-Queries"),
+			call(sel("strings", "Join"), id("invalidatedQueries"), stringLit(",")),
+		)),
+		define([]ast.Expr{id("invalidatedEventIDs")}, call(sel("gowdkcontracts", "InvalidatedEventIDs"), id("realtimeQueryInvalidations"), id("events"))),
+		&ast.IfStmt{
+			Cond: &ast.BinaryExpr{X: call(id("len"), id("invalidatedEventIDs")), Op: token.GTR, Y: intLit(0)},
+			Body: block(exprStmt(call(
+				selExpr(call(selExpr(id("response"), "Header")), "Set"),
+				stringLit("X-GOWDK-Events"),
+				call(sel("strings", "Join"), id("invalidatedEventIDs"), stringLit(",")),
+			))),
+		},
+	}
+	if commandPatches {
+		body = append(body, commandPatchEnvelopeStmt())
 	}
 	return []ast.Stmt{
 		define([]ast.Expr{id("invalidatedQueries")}, call(sel("gowdkcontracts", "InvalidatedQueryTypes"), id("realtimeQueryInvalidations"), id("events"))),
 		&ast.IfStmt{
 			Cond: &ast.BinaryExpr{X: call(id("len"), id("invalidatedQueries")), Op: token.GTR, Y: intLit(0)},
-			Body: block(
-				exprStmt(call(
-					selExpr(call(selExpr(id("response"), "Header")), "Set"),
-					stringLit("X-GOWDK-Queries"),
-					call(sel("strings", "Join"), id("invalidatedQueries"), stringLit(",")),
-				)),
-				define([]ast.Expr{id("invalidatedEventIDs")}, call(sel("gowdkcontracts", "InvalidatedEventIDs"), id("realtimeQueryInvalidations"), id("events"))),
-				&ast.IfStmt{
-					Cond: &ast.BinaryExpr{X: call(id("len"), id("invalidatedEventIDs")), Op: token.GTR, Y: intLit(0)},
-					Body: block(exprStmt(call(
-						selExpr(call(selExpr(id("response"), "Header")), "Set"),
-						stringLit("X-GOWDK-Events"),
-						call(sel("strings", "Join"), id("invalidatedEventIDs"), stringLit(",")),
-					))),
-				},
-			),
+			Body: block(body...),
 		},
+	}
+}
+
+func commandPatchEnvelopeStmt() ast.Stmt {
+	return &ast.IfStmt{
+		Cond: &ast.BinaryExpr{
+			X:  call(selExpr(selExpr(id("request"), "Header"), "Get"), stringLit("X-GOWDK-Command")),
+			Op: token.EQL,
+			Y:  stringLit("1"),
+		},
+		Body: block(
+			define([]ast.Expr{id("singleFlightPatches")}, call(sel("gowdkssr", "RenderInvalidatedRegions"), id("request"), id("invalidatedQueries"))),
+			&ast.IfStmt{
+				Cond: &ast.BinaryExpr{X: call(id("len"), id("singleFlightPatches")), Op: token.GTR, Y: intLit(0)},
+				Body: block(
+					exprStmt(call(
+						selExpr(call(selExpr(id("response"), "Header")), "Set"),
+						stringLit("X-GOWDK-Patches"),
+						stringLit("1"),
+					)),
+					define([]ast.Expr{id("singleFlightResult"), id("singleFlightErr")}, call(
+						sel("gowdkresponse", "JSONValue"),
+						sel("http", "StatusOK"),
+						&ast.CompositeLit{Type: sel("gowdkssr", "CommandEnvelope"), Elts: []ast.Expr{
+							keyValue("Result", id("result")),
+							keyValue("Patches", id("singleFlightPatches")),
+						}},
+					)),
+					&ast.IfStmt{
+						Cond: notNil("singleFlightErr"),
+						Body: block(
+							writeNoStoreHandlerJSONErrorExprStmt(id("singleFlightErr"), sel("http", "StatusInternalServerError")),
+							returnBool(true),
+						),
+					},
+					writeNoStoreHTTPStmt(id("singleFlightResult")),
+					returnBool(true),
+				),
+			},
+		),
 	}
 }
 

--- a/internal/appgen/source_ssr_regions.go
+++ b/internal/appgen/source_ssr_regions.go
@@ -1,0 +1,143 @@
+package appgen
+
+import (
+	"go/ast"
+	"go/token"
+
+	"github.com/cssbruno/gowdk/internal/source"
+	"github.com/cssbruno/gowdk/runtime/auth"
+)
+
+// ssrRegionRegistrationDecls generates an init() that registers a runtime region
+// renderer for every eligible g:query region, keyed by query type. A registered
+// renderer lets the single-flight g:command write path render exactly the regions
+// a command invalidated inline in its response, so the submitting client applies
+// them without a second page fetch. Regions that need route context the command
+// request lacks are not registered (the build extractor omits them), so the
+// client refetch remains their fallback.
+func ssrRegionRegistrationDecls(routes []SSRRoute) []ast.Decl {
+	var stmts []ast.Stmt
+	for _, route := range ssrRegionRoutes(routes) {
+		for _, region := range route.QueryRegions {
+			stmts = append(stmts, exprStmt(call(
+				sel("gowdkssr", "RegisterRegion"),
+				regionRendererExpr(route, region),
+			)))
+		}
+	}
+	if len(stmts) == 0 {
+		return nil
+	}
+	return []ast.Decl{funcDecl("init", nil, nil, stmts)}
+}
+
+// ssrRegionRoutes returns the routes whose g:query regions can be rendered
+// standalone at command time: a bound, parameterless load whose data the region
+// resolves against without dynamic route context. Protected and guardless
+// routes are intentionally skipped; their normal page request performs guard
+// checks before load, so inline command patches fall back to a page refetch.
+func ssrRegionRoutes(routes []SSRRoute) []SSRRoute {
+	var eligible []SSRRoute
+	for _, route := range routes {
+		if len(route.QueryRegions) == 0 {
+			continue
+		}
+		if !ssrRegionRouteIsPublic(route) {
+			continue
+		}
+		if !route.HasLoad || route.LoadBinding.Status != source.BackendBindingBound || route.LoadBackendAlias == "" {
+			continue
+		}
+		if len(route.RouteParams) > 0 || len(route.DynamicParams) > 0 {
+			continue
+		}
+		eligible = append(eligible, route)
+	}
+	return eligible
+}
+
+func ssrRegionRouteIsPublic(route SSRRoute) bool {
+	return len(route.Guards) == 1 && auth.IsPublicGuard(route.Guards[0])
+}
+
+func commandPatchRenderingEnabled(options Options) bool {
+	if !generatedRealtimeQueryInvalidationsEnabled(options) {
+		return false
+	}
+	if len(ssrRegionRoutes(options.SSR)) == 0 {
+		return false
+	}
+	return len(executableCommandContractExposures(backendAdapterIR(options).ContractExposures)) > 0
+}
+
+func regionRendererExpr(route SSRRoute, region SSRQueryRegion) ast.Expr {
+	elts := []ast.Expr{
+		keyValue("QueryType", stringLit(region.QueryType)),
+		keyValue("Template", stringLit(region.Template)),
+	}
+	if len(region.ListSpecs) > 0 {
+		elts = append(elts, keyValue("Lists", ssrListSpecsExpr(region.ListSpecs)))
+	}
+	if len(region.CondSpecs) > 0 {
+		elts = append(elts, keyValue("Conds", ssrCondSpecsExpr(region.CondSpecs)))
+	}
+	if len(region.LoadReplacements) > 0 {
+		elts = append(elts, keyValue("LoadFields", regionLoadFieldsExpr(region.LoadReplacements)))
+	}
+	elts = append(elts, keyValue("Load", regionLoadThunk(route)))
+	return &ast.CompositeLit{Type: sel("gowdkssr", "RegionRenderer"), Elts: elts}
+}
+
+func regionLoadFieldsExpr(replacements []SSRLoadReplacement) ast.Expr {
+	elts := make([]ast.Expr, 0, len(replacements))
+	for _, replacement := range replacements {
+		elts = append(elts, &ast.CompositeLit{Type: sel("gowdkssr", "RegionLoadField"), Elts: []ast.Expr{
+			keyValue("Path", stringLit(replacement.Path)),
+			keyValue("Placeholder", stringLit(replacement.Placeholder)),
+		}})
+	}
+	return &ast.CompositeLit{
+		Type: &ast.ArrayType{Elt: sel("gowdkssr", "RegionLoadField")},
+		Elts: elts,
+	}
+}
+
+// regionLoadthunk builds the func(*http.Request) (map[string]any, error)
+// closure that runs a region's page load {} against a synthetic page GET
+// request. This mirrors the normal SSR route context closely enough for
+// parameterless public pages while dynamic or guarded pages stay on fallback.
+func regionLoadThunk(route SSRRoute) ast.Expr {
+	loadCall := call(sel(route.LoadBackendAlias, route.LoadBinding.FunctionName), id("loadContext"))
+	var ret ast.Stmt
+	switch route.LoadBinding.Signature {
+	case source.BackendSignatureLoadError:
+		ret = &ast.ReturnStmt{Results: []ast.Expr{loadCall}}
+	default:
+		ret = &ast.ReturnStmt{Results: []ast.Expr{loadCall, id("nil")}}
+	}
+	stmts := ssrRouteContextStmts(route, false)
+	stmts = append(stmts,
+		define([]ast.Expr{id("pageURL")}, &ast.StarExpr{X: selExpr(id("request"), "URL")}),
+		assign([]ast.Expr{selExpr(id("pageURL"), "Path")}, stringLit(route.Route)),
+		assign([]ast.Expr{selExpr(id("pageURL"), "RawPath")}, stringLit("")),
+		assign([]ast.Expr{selExpr(id("pageURL"), "RawQuery")}, stringLit("")),
+		define([]ast.Expr{id("pageRequest")}, call(selExpr(id("request"), "Clone"), call(selExpr(id("request"), "Context")))),
+		assign([]ast.Expr{selExpr(id("pageRequest"), "Method")}, sel("http", "MethodGet")),
+		assign([]ast.Expr{selExpr(id("pageRequest"), "URL")}, &ast.UnaryExpr{Op: token.AND, X: id("pageURL")}),
+		assign([]ast.Expr{id("request")}, id("pageRequest")),
+		define([]ast.Expr{id("loadContext")}, call(sel("gowdkssr", "NewLoadContext"), id("request"), id("nil"))),
+		ret,
+	)
+	return &ast.FuncLit{
+		Type: &ast.FuncType{
+			Params: &ast.FieldList{List: []*ast.Field{
+				{Names: []*ast.Ident{id("request")}, Type: &ast.StarExpr{X: sel("http", "Request")}},
+			}},
+			Results: &ast.FieldList{List: []*ast.Field{
+				{Type: &ast.MapType{Key: id("string"), Value: id("any")}},
+				{Type: id("error")},
+			}},
+		},
+		Body: block(stmts...),
+	}
+}

--- a/internal/appgen/types.go
+++ b/internal/appgen/types.go
@@ -128,6 +128,7 @@ type SSRRoute struct {
 	LoadReplacements []SSRLoadReplacement
 	ListSpecs        []SSRListSpec
 	CondSpecs        []SSRCondSpec
+	QueryRegions     []SSRQueryRegion
 }
 
 type SSRReplacement = source.SSRReplacement
@@ -139,3 +140,5 @@ type SSRListSpec = source.SSRListSpec
 type SSRCondSpec = source.SSRCondSpec
 
 type SSRListField = source.SSRListField
+
+type SSRQueryRegion = source.SSRQueryRegion

--- a/internal/buildgen/ssr.go
+++ b/internal/buildgen/ssr.go
@@ -32,6 +32,7 @@ type SSRArtifact struct {
 	LoadReplacements []SSRLoadReplacement
 	ListSpecs        []SSRListSpec
 	CondSpecs        []SSRCondSpec
+	QueryRegions     []SSRQueryRegion
 }
 
 type SSRReplacement = source.SSRReplacement
@@ -118,6 +119,7 @@ func ssrArtifact(config gowdk.Config, page gwdkir.Page, components map[string]vi
 	// replacements so the handler does not stringify and substitute a value that
 	// never appears in the output.
 	loadReplacements = usedLoadReplacements(html, loadReplacements)
+	queryRegions := ssrQueryRegions(html, regions.Lists, regions.Conds, loadReplacements, replacements, len(page.DynamicParams()) > 0)
 	return SSRArtifact{
 		PageID:           page.ID,
 		Route:            page.Route,
@@ -135,6 +137,7 @@ func ssrArtifact(config gowdk.Config, page gwdkir.Page, components map[string]vi
 		LoadReplacements: loadReplacements,
 		ListSpecs:        regions.Lists,
 		CondSpecs:        regions.Conds,
+		QueryRegions:     queryRegions,
 	}, nil
 }
 

--- a/internal/buildgen/ssr_regions.go
+++ b/internal/buildgen/ssr_regions.go
@@ -1,0 +1,209 @@
+package buildgen
+
+import (
+	"html"
+	"strings"
+
+	"github.com/cssbruno/gowdk/internal/source"
+)
+
+// SSRQueryRegion is the build-time render recipe for one g:query region. It is
+// lowered by the app generator into a runtime region renderer.
+type SSRQueryRegion = source.SSRQueryRegion
+
+// ssrQueryRegions extracts the standalone render recipe for every g:query region
+// in the rendered page HTML that carries a resolved query type.
+//
+// A region is only emitted when it can be re-rendered without route context the
+// command adapter lacks: the page must declare no dynamic route params (so its
+// load needs none) and the region template must contain no route-param
+// placeholder. Purely static regions (no g:for/g:if and no scalar load field) are
+// skipped because there is nothing to re-render reactively. Regions left out here
+// fall back to the client refetch path, which fetches the live page with its real
+// route context.
+func ssrQueryRegions(htmlSource string, lists []SSRListSpec, conds []SSRCondSpec, loadReplacements []SSRLoadReplacement, paramReplacements []SSRReplacement, hasDynamicParams bool) []SSRQueryRegion {
+	if hasDynamicParams {
+		return nil
+	}
+	raw := extractQueryRegionTemplates(htmlSource)
+	if len(raw) == 0 {
+		return nil
+	}
+	var regions []SSRQueryRegion
+	for _, region := range raw {
+		if region.queryType == "" {
+			continue
+		}
+		if regionUsesParam(region.template, paramReplacements) {
+			continue
+		}
+		listSpecs := specsInTemplate(region.template, lists)
+		condSpecs := condsInTemplate(region.template, conds)
+		regionLoad := loadReplacementsInTemplate(region.template, loadReplacements)
+		if len(listSpecs) == 0 && len(condSpecs) == 0 && len(regionLoad) == 0 {
+			continue
+		}
+		regions = append(regions, SSRQueryRegion{
+			QueryType:        region.queryType,
+			Template:         region.template,
+			ListSpecs:        listSpecs,
+			CondSpecs:        condSpecs,
+			LoadReplacements: regionLoad,
+		})
+	}
+	return regions
+}
+
+type rawQueryRegion struct {
+	queryType string
+	template  string
+}
+
+const queryTypeMarker = `data-gowdk-query-type="`
+
+// extractQueryRegionTemplates scans rendered page HTML for every element that
+// carries a data-gowdk-query-type attribute and returns its outer HTML. Generated
+// HTML is well-formed and HTML-escapes every attribute value and text node, so a
+// raw '<' always opens a tag and a raw '>' always closes one, which makes the
+// element boundary unambiguous.
+func extractQueryRegionTemplates(htmlSource string) []rawQueryRegion {
+	var regions []rawQueryRegion
+	search := 0
+	for {
+		offset := strings.Index(htmlSource[search:], queryTypeMarker)
+		if offset < 0 {
+			break
+		}
+		attrPos := search + offset
+		valueStart := attrPos + len(queryTypeMarker)
+		valueLen := strings.IndexByte(htmlSource[valueStart:], '"')
+		if valueLen < 0 {
+			break
+		}
+		queryType := html.UnescapeString(htmlSource[valueStart : valueStart+valueLen])
+		tagStart := strings.LastIndexByte(htmlSource[:attrPos], '<')
+		if tagStart < 0 {
+			search = valueStart + valueLen
+			continue
+		}
+		outer, ok := elementOuterHTML(htmlSource, tagStart)
+		if !ok {
+			search = valueStart + valueLen
+			continue
+		}
+		regions = append(regions, rawQueryRegion{queryType: queryType, template: outer})
+		search = tagStart + len(outer)
+	}
+	return regions
+}
+
+// elementOuterHTML returns the outer HTML of the element whose opening tag begins
+// at the '<' at tagStart, balancing nested same-name tags.
+func elementOuterHTML(htmlSource string, tagStart int) (string, bool) {
+	name, _, ok := readTagName(htmlSource, tagStart+1)
+	if !ok {
+		return "", false
+	}
+	openEnd := strings.IndexByte(htmlSource[tagStart:], '>')
+	if openEnd < 0 {
+		return "", false
+	}
+	openEnd += tagStart
+	if htmlSource[openEnd-1] == '/' {
+		return htmlSource[tagStart : openEnd+1], true
+	}
+	lower := strings.ToLower(name)
+	depth := 1
+	pos := openEnd + 1
+	for pos < len(htmlSource) {
+		next := strings.IndexByte(htmlSource[pos:], '<')
+		if next < 0 {
+			return "", false
+		}
+		next += pos
+		if next+1 < len(htmlSource) && htmlSource[next+1] == '/' {
+			closeName, closeNameEnd, ok := readTagName(htmlSource, next+2)
+			if ok && strings.ToLower(closeName) == lower {
+				depth--
+				if depth == 0 {
+					gt := strings.IndexByte(htmlSource[closeNameEnd:], '>')
+					if gt < 0 {
+						return "", false
+					}
+					return htmlSource[tagStart : closeNameEnd+gt+1], true
+				}
+			}
+			pos = next + 2
+			continue
+		}
+		openName, _, ok := readTagName(htmlSource, next+1)
+		if ok && strings.ToLower(openName) == lower {
+			gt := strings.IndexByte(htmlSource[next:], '>')
+			if gt < 0 {
+				return "", false
+			}
+			gt += next
+			if htmlSource[gt-1] != '/' {
+				depth++
+			}
+		}
+		pos = next + 1
+	}
+	return "", false
+}
+
+// readTagName reads an HTML tag name starting at start and returns the name, the
+// index just past it, and whether a name was present.
+func readTagName(htmlSource string, start int) (string, int, bool) {
+	end := start
+	for end < len(htmlSource) {
+		char := htmlSource[end]
+		if char == ' ' || char == '\t' || char == '\n' || char == '\r' || char == '>' || char == '/' {
+			break
+		}
+		end++
+	}
+	if end == start {
+		return "", start, false
+	}
+	return htmlSource[start:end], end, true
+}
+
+func regionUsesParam(template string, replacements []SSRReplacement) bool {
+	for _, replacement := range replacements {
+		if strings.Contains(template, replacement.Placeholder) {
+			return true
+		}
+	}
+	return false
+}
+
+func specsInTemplate(template string, specs []SSRListSpec) []SSRListSpec {
+	var out []SSRListSpec
+	for _, spec := range specs {
+		if strings.Contains(template, spec.Placeholder) {
+			out = append(out, spec)
+		}
+	}
+	return out
+}
+
+func condsInTemplate(template string, specs []SSRCondSpec) []SSRCondSpec {
+	var out []SSRCondSpec
+	for _, spec := range specs {
+		if strings.Contains(template, spec.Placeholder) {
+			out = append(out, spec)
+		}
+	}
+	return out
+}
+
+func loadReplacementsInTemplate(template string, replacements []SSRLoadReplacement) []SSRLoadReplacement {
+	var out []SSRLoadReplacement
+	for _, replacement := range replacements {
+		if strings.Contains(template, replacement.Placeholder) {
+			out = append(out, replacement)
+		}
+	}
+	return out
+}

--- a/internal/buildgen/ssr_regions_test.go
+++ b/internal/buildgen/ssr_regions_test.go
@@ -1,0 +1,74 @@
+package buildgen
+
+import "testing"
+
+func TestExtractQueryRegionTemplatesBalancesNestedTags(t *testing.T) {
+	html := `<body><section data-gowdk-query="patients.GetPatientPage" data-gowdk-query-type="example.com/app/patients.GetPatientPage">` +
+		`<div><div>__GOWDK_SSR_LIST_board__</div></div></section><aside>after</aside></body>`
+	regions := extractQueryRegionTemplates(html)
+	if len(regions) != 1 {
+		t.Fatalf("expected 1 region, got %d", len(regions))
+	}
+	if regions[0].queryType != "example.com/app/patients.GetPatientPage" {
+		t.Fatalf("unexpected query type %q", regions[0].queryType)
+	}
+	want := `<section data-gowdk-query="patients.GetPatientPage" data-gowdk-query-type="example.com/app/patients.GetPatientPage"><div><div>__GOWDK_SSR_LIST_board__</div></div></section>`
+	if regions[0].template != want {
+		t.Fatalf("unexpected template:\n got: %q\nwant: %q", regions[0].template, want)
+	}
+}
+
+func TestExtractQueryRegionTemplatesHandlesVoidSiblings(t *testing.T) {
+	html := `<ul data-gowdk-query-type="example.com/app.List"><br><li>__GOWDK_SSR_LIST_x__</li></ul>`
+	regions := extractQueryRegionTemplates(html)
+	if len(regions) != 1 || regions[0].template != html {
+		t.Fatalf("expected whole element, got %+v", regions)
+	}
+}
+
+func TestSSRQueryRegionsPartitionsSpecsByContainment(t *testing.T) {
+	html := `<main>` +
+		`<section data-gowdk-query-type="example.com/app.Board"><ul>__GOWDK_SSR_LIST_board__</ul></section>` +
+		`<section data-gowdk-query-type="example.com/app.Total"><span>__GOWDK_SSR_LOAD_total__</span></section>` +
+		`</main>`
+	lists := []SSRListSpec{{Placeholder: "__GOWDK_SSR_LIST_board__", SourcePath: "patients"}}
+	loadReplacements := []SSRLoadReplacement{{Path: "total", Placeholder: "__GOWDK_SSR_LOAD_total__"}}
+
+	regions := ssrQueryRegions(html, lists, nil, loadReplacements, nil, false)
+	if len(regions) != 2 {
+		t.Fatalf("expected 2 regions, got %d", len(regions))
+	}
+	byType := map[string]SSRQueryRegion{}
+	for _, region := range regions {
+		byType[region.QueryType] = region
+	}
+	board := byType["example.com/app.Board"]
+	if len(board.ListSpecs) != 1 || len(board.LoadReplacements) != 0 {
+		t.Fatalf("board region partition wrong: %+v", board)
+	}
+	total := byType["example.com/app.Total"]
+	if len(total.ListSpecs) != 0 || len(total.LoadReplacements) != 1 {
+		t.Fatalf("total region partition wrong: %+v", total)
+	}
+}
+
+func TestSSRQueryRegionsSkipsParamAndStaticRegions(t *testing.T) {
+	html := `<main>` +
+		`<section data-gowdk-query-type="example.com/app.Static">no placeholders</section>` +
+		`<section data-gowdk-query-type="example.com/app.Param"><span>__GOWDK_SSR_PARAM_page_id__</span><ul>__GOWDK_SSR_LIST_x__</ul></section>` +
+		`</main>`
+	lists := []SSRListSpec{{Placeholder: "__GOWDK_SSR_LIST_x__", SourcePath: "items"}}
+	params := []SSRReplacement{{Param: "id", Placeholder: "__GOWDK_SSR_PARAM_page_id__"}}
+
+	if regions := ssrQueryRegions(html, lists, nil, nil, params, false); len(regions) != 0 {
+		t.Fatalf("expected static and param-bound regions to be skipped, got %+v", regions)
+	}
+}
+
+func TestSSRQueryRegionsSkipsDynamicParamPages(t *testing.T) {
+	html := `<section data-gowdk-query-type="example.com/app.Board"><ul>__GOWDK_SSR_LIST_x__</ul></section>`
+	lists := []SSRListSpec{{Placeholder: "__GOWDK_SSR_LIST_x__", SourcePath: "items"}}
+	if regions := ssrQueryRegions(html, lists, nil, nil, nil, true); regions != nil {
+		t.Fatalf("expected nil for pages with dynamic route params, got %+v", regions)
+	}
+}

--- a/internal/clientrt/assets/gowdk.js
+++ b/internal/clientrt/assets/gowdk.js
@@ -143,15 +143,30 @@
       if (!responseIsJSON(response)) {
         throw await commandResponseError(response, 'command response was not JSON');
       }
-      var result = await parseCommandResult(response);
+      var body = await parseCommandResult(response);
       var queries = parseInvalidatedQueriesHeader(response.headers.get('X-GOWDK-Queries'));
       var eventIDs = parseHeaderList(response.headers.get('X-GOWDK-Events'));
+      // True single-flight: when the adapter rendered the invalidated regions, the
+      // body is a { result, patches } envelope (signalled by X-GOWDK-Patches) and
+      // we apply the region HTML directly. The typed command result is unwrapped so
+      // the success event detail stays identical to the header-only path.
+      var embedded = response.headers.get('X-GOWDK-Patches') === '1' && body && Array.isArray(body.patches);
+      var result = embedded ? body.result : body;
+      var patches = embedded ? body.patches : [];
       form.dispatchEvent(new CustomEvent('gowdk:command-success', {
         detail: { form: form, command: command, result: result, queries: queries, eventIDs: eventIDs }
       }));
+      var refreshEnvelope = { form: form, command: command, eventIDs: eventIDs };
+      var applied = applyCommandPatches(patches, refreshEnvelope);
       if (queries.length) {
-        var refreshEnvelope = { form: form, command: command, eventIDs: eventIDs };
-        refreshInvalidatedQueriesAfterCommand(queries, refreshEnvelope);
+        var remaining = queries.filter(function (query) {
+          return applied.indexOf(query) < 0;
+        });
+        if (!remaining.length) {
+          rememberHandledQueryRefreshEventIDs(eventIDs);
+        } else {
+          refreshInvalidatedQueriesAfterCommand(remaining, refreshEnvelope);
+        }
       }
     } catch (error) {
       form.dispatchEvent(new CustomEvent('gowdk:command-error', {
@@ -298,6 +313,31 @@
       parseError.response = response;
       throw parseError;
     }
+  }
+
+  // applyCommandPatches applies the inline region HTML a single-flight g:command
+  // response carries, reusing the realtime apply routine so the embedded path and
+  // the SSE fanout converge on one swap-and-remount. It returns the query types it
+  // actually applied so the caller can refetch only the regions left uncovered.
+  function applyCommandPatches(patches, envelope) {
+    var applied = [];
+    if (!Array.isArray(patches) || !patches.length) {
+      return applied;
+    }
+    patches.forEach(function (patch) {
+      if (!patch || typeof patch.query !== 'string' || typeof patch.html !== 'string') {
+        return;
+      }
+      var regions = queryRegionsForInvalidation(document, [patch.query]);
+      if (regions.length !== 1) {
+        return;
+      }
+      applyRealtimePatch(regions[0], { op: 'replaceHTML', html: patch.html, swap: 'outerHTML' }, envelope);
+      if (applied.indexOf(patch.query) < 0) {
+        applied.push(patch.query);
+      }
+    });
+    return applied;
   }
 
   var prefetchedDocuments = {};

--- a/internal/clientrt/runtime_dom_test.go
+++ b/internal/clientrt/runtime_dom_test.go
@@ -266,6 +266,13 @@ invalidatedRegion.id = 'invalidated-patients';
 invalidatedRegion.innerHTML = '<p>Stale</p>';
 invalidatedRegion.setAttribute('data-gowdk-query', 'patients.GetPatientPage');
 invalidatedRegion.setAttribute('data-gowdk-query-type', 'gowdk-generated-app/patients.GetPatientPage');
+invalidatedRegion.outerHTMLValue = '<section id="invalidated-patients" data-gowdk-query="patients.GetPatientPage" data-gowdk-query-type="gowdk-generated-app/patients.GetPatientPage"><p>Stale</p></section>';
+const duplicateInvalidatedRegion = new Element('section');
+duplicateInvalidatedRegion.id = 'invalidated-patients-copy';
+duplicateInvalidatedRegion.innerHTML = '<p>Duplicate stale</p>';
+duplicateInvalidatedRegion.setAttribute('data-gowdk-query', 'patients.GetPatientPage');
+duplicateInvalidatedRegion.setAttribute('data-gowdk-query-type', 'gowdk-generated-app/patients.GetPatientPage');
+duplicateInvalidatedRegion.outerHTMLValue = '<section id="invalidated-patients-copy" data-gowdk-query="patients.GetPatientPage" data-gowdk-query-type="gowdk-generated-app/patients.GetPatientPage"><p>Duplicate stale</p></section>';
 const input = new Element('input');
 input.id = 'email';
 
@@ -308,6 +315,20 @@ global.fetch = async function(url, options) {
         status: 200,
         headers: new Headers({ 'Content-Type': 'text/html; charset=utf-8' }),
         text: async () => '<main>Login</main>'
+      };
+    }
+    if (commandMode === 'patch') {
+      return {
+        ok: true,
+        redirected: false,
+        status: 200,
+        headers: new Headers({
+          'Content-Type': 'application/json; charset=utf-8',
+          'X-GOWDK-Queries': 'gowdk-generated-app/patients.GetPatientPage',
+          'X-GOWDK-Events': 'event-patch',
+          'X-GOWDK-Patches': '1'
+        }),
+        text: async () => '{"result":{"id":"patient-1"},"patches":[{"query":"gowdk-generated-app/patients.GetPatientPage","html":"<section id=\\"invalidated-patients\\" data-gowdk-query=\\"patients.GetPatientPage\\" data-gowdk-query-type=\\"gowdk-generated-app/patients.GetPatientPage\\"><p>Patched</p></section>"}]}'
       };
     }
     return {
@@ -456,6 +477,9 @@ async function submit(target = form, submitter = null) {
     requestCount = 0;
     invalidatedRegion.replacedWith = '';
     invalidatedRegion.outerHTMLValue = '';
+    duplicateInvalidatedRegion.replacedWith = '';
+    duplicateInvalidatedRegion.outerHTMLValue = '<section id="invalidated-patients-copy" data-gowdk-query="patients.GetPatientPage" data-gowdk-query-type="gowdk-generated-app/patients.GetPatientPage"><p>Duplicate stale</p></section>';
+    document.queryRegions = [liveRegion, invalidatedRegion];
   }
 
   let commandSubmit = await submit(commandForm, commandSubmitter);
@@ -475,6 +499,36 @@ async function submit(target = form, submitter = null) {
   assert.deepEqual(commandSuccess.queries, ['gowdk-generated-app/patients.GetPatientPage']);
   assert.equal(commandError, null);
   assert.equal(invalidatedRegion.replacedWith, '');
+
+  resetCommandHarness();
+  commandMode = 'patch';
+  await submit(commandForm, commandSubmitter);
+  assert.equal(commandSuccess.result.id, 'patient-1');
+  assert.deepEqual(commandSuccess.eventIDs, ['event-patch']);
+  assert.equal(commandError, null);
+  assert.equal(requestCount, 1);
+  assert.equal(invalidatedRegion.replacedWith, '<section id="invalidated-patients" data-gowdk-query="patients.GetPatientPage" data-gowdk-query-type="gowdk-generated-app/patients.GetPatientPage"><p>Patched</p></section>');
+  assert.deepEqual(islandLifecycle.shift(), ['destroy', 'invalidated-patients', true]);
+  assert.deepEqual(islandLifecycle.shift(), ['mount']);
+  request = null;
+  eventSources[0].emit('gowdk-presentation', {
+    Category: 'presentation',
+    Type: 'gowdk.query.invalidate',
+    Value: {
+      queries: ['gowdk-generated-app/patients.GetPatientPage'],
+      eventIDs: ['event-patch']
+    }
+  });
+  await flushRuntime();
+  assert.equal(request, null);
+
+  resetCommandHarness();
+  commandMode = 'patch';
+  document.queryRegions = [liveRegion, invalidatedRegion, duplicateInvalidatedRegion];
+  await submit(commandForm, commandSubmitter);
+  assert.equal(commandSuccess.result.id, 'patient-1');
+  assert.equal(invalidatedRegion.replacedWith, '');
+  assert.equal(duplicateInvalidatedRegion.replacedWith, '');
 
   resetCommandHarness();
   commandMode = 'html';

--- a/internal/source/source.go
+++ b/internal/source/source.go
@@ -164,6 +164,22 @@ type SSRListField struct {
 	Index       bool
 }
 
+// SSRQueryRegion is the standalone render recipe for one request-time g:query
+// region: the region element's template (with placeholders) plus the subset of
+// the page's g:for/g:if specs and scalar load substitutions that fall inside it.
+// The app generator lowers each into a runtime region renderer keyed by
+// QueryType so a g:command can render exactly the regions it invalidated inline
+// in its response (single-flight) instead of forcing the client to refetch the
+// whole page. Only regions renderable without route context the command request
+// lacks are emitted.
+type SSRQueryRegion struct {
+	QueryType        string
+	Template         string
+	ListSpecs        []SSRListSpec
+	CondSpecs        []SSRCondSpec
+	LoadReplacements []SSRLoadReplacement
+}
+
 // InlineScript records browser module code declared directly inside a .gwdk
 // source file. Path-based script declarations should remain preferred.
 type InlineScript struct {

--- a/runtime/ssr/regions.go
+++ b/runtime/ssr/regions.go
@@ -1,0 +1,286 @@
+package ssr
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+	"strings"
+	"sync"
+
+	gowdkhtml "github.com/cssbruno/gowdk/runtime/html"
+)
+
+// RegionPatch is the rendered HTML for one invalidated g:query region, returned
+// inline in a g:command response so the submitting client applies it without a
+// second page fetch (true single-flight).
+type RegionPatch struct {
+	Query string `json:"query"`
+	HTML  string `json:"html"`
+}
+
+// CommandEnvelope wraps a command result with its single-flight region patches.
+// A g:command adapter only emits this shape (signalled by the X-GOWDK-Patches
+// response header) when it rendered at least one region; otherwise the raw
+// command result body is returned unchanged, so non-browser callers are
+// unaffected.
+type CommandEnvelope struct {
+	Result  any           `json:"result"`
+	Patches []RegionPatch `json:"patches"`
+}
+
+// RegionLoadField is one scalar load {} substitution scoped to a region. It
+// mirrors the page-level SSRLoadReplacement but is applied to a single region's
+// rendered HTML.
+type RegionLoadField struct {
+	Path        string
+	Placeholder string
+}
+
+// RegionRenderer renders one request-time g:query region standalone from its
+// page's load data. The app generator lowers each eligible region into a
+// RegionRenderer and registers it by fully-qualified query type, so a g:command
+// can render exactly the regions it invalidated inline in its response.
+//
+// A region is only registered when it is renderable without route context the
+// command request lacks: its page has no dynamic route params and its template
+// carries no route-param placeholder. Everything else falls back to the client
+// refetch path.
+type RegionRenderer struct {
+	// QueryType is the fully-qualified query type that names this region, matching
+	// the X-GOWDK-Queries header and the region's data-gowdk-query-type attribute.
+	QueryType string
+	// Template is the region element's outer HTML with its region and scalar
+	// placeholders intact, ready for RenderRegions.
+	Template string
+	// Lists and Conds are the page's top-level g:for/g:if specs that fall inside
+	// this region's template.
+	Lists []ListSpec
+	Conds []CondSpec
+	// LoadFields are the scalar load {} substitutions that appear in the template.
+	LoadFields []RegionLoadField
+	// Load runs the region's page load {} against the command request, yielding
+	// the same data a page GET would resolve the region from.
+	Load func(*http.Request) (map[string]any, error)
+}
+
+func (renderer RegionRenderer) render(request *http.Request) (string, bool) {
+	if renderer.Load == nil {
+		return "", false
+	}
+	data, err := renderer.Load(request)
+	if err != nil || data == nil {
+		return "", false
+	}
+	html := RenderRegions(renderer.Template, renderer.Lists, renderer.Conds, data)
+	for _, field := range renderer.LoadFields {
+		value, ok := LoadPath(data, field.Path)
+		if !ok {
+			return "", false
+		}
+		html = strings.ReplaceAll(html, field.Placeholder, gowdkhtml.Escape(fmt.Sprint(value)))
+	}
+	return html, true
+}
+
+type regionEntry struct {
+	renderer  RegionRenderer
+	ambiguous bool
+}
+
+var (
+	regionMu        sync.RWMutex
+	regionRenderers = map[string]regionEntry{}
+)
+
+// RegisterRegion records a region renderer by query type. When two renderers
+// register the same query type (the same query backs regions on more than one
+// parameterless page), the type is marked ambiguous and single-flight falls back
+// to the client refetch for it, since the command request cannot tell which
+// page's region the submitter is viewing.
+func RegisterRegion(renderer RegionRenderer) {
+	if renderer.QueryType == "" || renderer.Load == nil {
+		return
+	}
+	regionMu.Lock()
+	defer regionMu.Unlock()
+	if existing, ok := regionRenderers[renderer.QueryType]; ok {
+		existing.ambiguous = true
+		regionRenderers[renderer.QueryType] = existing
+		return
+	}
+	regionRenderers[renderer.QueryType] = regionEntry{renderer: renderer}
+}
+
+// RenderInvalidatedRegions renders the registered g:query regions for the given
+// invalidated query types, using request for load context. Query types without
+// an eligible, unambiguous renderer (or whose load fails) are skipped so the
+// client refetches them. The returned patches follow the order of queries.
+func RenderInvalidatedRegions(request *http.Request, queries []string) []RegionPatch {
+	if len(queries) == 0 {
+		return nil
+	}
+	var patches []RegionPatch
+	for _, query := range queries {
+		regionMu.RLock()
+		entry, ok := regionRenderers[query]
+		regionMu.RUnlock()
+		if !ok || entry.ambiguous {
+			continue
+		}
+		html, rendered := entry.renderer.render(request)
+		if !rendered {
+			continue
+		}
+		if htmlContainsPostForm(html) {
+			continue
+		}
+		patches = append(patches, RegionPatch{Query: query, HTML: html})
+	}
+	return patches
+}
+
+func htmlContainsPostForm(html string) bool {
+	payload := []byte(html)
+	for _, match := range formStartTagRanges(payload) {
+		if formStartTagHasPostMethod(payload[match[0]:match[1]]) {
+			return true
+		}
+	}
+	return false
+}
+
+func formStartTagRanges(payload []byte) [][2]int {
+	var matches [][2]int
+	for index := 0; index < len(payload); index++ {
+		if payload[index] != '<' || !bytesHasFoldPrefix(payload[index+1:], "form") {
+			continue
+		}
+		afterName := index + len("<form")
+		if afterName < len(payload) && isHTMLNameChar(payload[afterName]) {
+			continue
+		}
+		end := htmlTagEnd(payload, afterName)
+		if end < 0 {
+			break
+		}
+		matches = append(matches, [2]int{index, end + 1})
+		index = end
+	}
+	return matches
+}
+
+func formStartTagHasPostMethod(tag []byte) bool {
+	cursor := len("<form")
+	for cursor < len(tag) {
+		for cursor < len(tag) && isHTMLSpace(tag[cursor]) {
+			cursor++
+		}
+		if cursor >= len(tag) || tag[cursor] == '>' || tag[cursor] == '/' {
+			return false
+		}
+		nameStart := cursor
+		for cursor < len(tag) && !isHTMLSpace(tag[cursor]) && tag[cursor] != '=' && tag[cursor] != '/' && tag[cursor] != '>' {
+			cursor++
+		}
+		name := tag[nameStart:cursor]
+		for cursor < len(tag) && isHTMLSpace(tag[cursor]) {
+			cursor++
+		}
+		if cursor >= len(tag) || tag[cursor] != '=' {
+			continue
+		}
+		cursor++
+		for cursor < len(tag) && isHTMLSpace(tag[cursor]) {
+			cursor++
+		}
+		value, next := htmlAttrValue(tag, cursor)
+		cursor = next
+		if bytes.EqualFold(name, []byte("method")) && strings.EqualFold(string(value), http.MethodPost) {
+			return true
+		}
+	}
+	return false
+}
+
+func htmlTagEnd(payload []byte, cursor int) int {
+	var quote byte
+	for cursor < len(payload) {
+		if quote != 0 {
+			if payload[cursor] == '\\' {
+				cursor += 2
+				continue
+			}
+			if payload[cursor] == quote {
+				quote = 0
+			}
+			cursor++
+			continue
+		}
+		switch payload[cursor] {
+		case '\'', '"':
+			quote = payload[cursor]
+		case '>':
+			return cursor
+		}
+		cursor++
+	}
+	return -1
+}
+
+func htmlAttrValue(tag []byte, cursor int) ([]byte, int) {
+	if cursor >= len(tag) {
+		return nil, cursor
+	}
+	if tag[cursor] == '\'' || tag[cursor] == '"' {
+		quote := tag[cursor]
+		cursor++
+		start := cursor
+		for cursor < len(tag) && tag[cursor] != quote {
+			cursor++
+		}
+		if cursor < len(tag) {
+			return tag[start:cursor], cursor + 1
+		}
+		return tag[start:], cursor
+	}
+	start := cursor
+	for cursor < len(tag) && !isHTMLSpace(tag[cursor]) && tag[cursor] != '/' && tag[cursor] != '>' {
+		cursor++
+	}
+	return tag[start:cursor], cursor
+}
+
+func bytesHasFoldPrefix(value []byte, prefix string) bool {
+	if len(value) < len(prefix) {
+		return false
+	}
+	for index := 0; index < len(prefix); index++ {
+		if asciiLower(value[index]) != prefix[index] {
+			return false
+		}
+	}
+	return true
+}
+
+func asciiLower(char byte) byte {
+	if char >= 'A' && char <= 'Z' {
+		return char + ('a' - 'A')
+	}
+	return char
+}
+
+func isHTMLNameChar(char byte) bool {
+	return (char >= 'A' && char <= 'Z') || (char >= 'a' && char <= 'z') || (char >= '0' && char <= '9') || char == '_' || char == '-'
+}
+
+func isHTMLSpace(char byte) bool {
+	return char == ' ' || char == '\t' || char == '\n' || char == '\r' || char == '\f'
+}
+
+// resetRegions clears the registry. It exists for tests that register renderers
+// into the process-global registry.
+func resetRegions() {
+	regionMu.Lock()
+	defer regionMu.Unlock()
+	regionRenderers = map[string]regionEntry{}
+}

--- a/runtime/ssr/regions_test.go
+++ b/runtime/ssr/regions_test.go
@@ -1,0 +1,100 @@
+package ssr
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func boardRegion(queryType string) RegionRenderer {
+	return RegionRenderer{
+		QueryType: queryType,
+		Template:  `<section data-gowdk-query-type="` + queryType + `"><ul>__LIST__</ul></section>`,
+		Lists: []ListSpec{{
+			Placeholder: "__LIST__",
+			SourcePath:  "patients",
+			RowTemplate: "<li>__NAME__</li>",
+			Fields:      []ListField{{Placeholder: "__NAME__", Path: "Name"}},
+		}},
+		Load: func(*http.Request) (map[string]any, error) {
+			return map[string]any{"patients": []map[string]any{{"Name": "Ada"}, {"Name": "Linus"}}}, nil
+		},
+	}
+}
+
+func TestRenderInvalidatedRegionsRendersRegisteredRegion(t *testing.T) {
+	resetRegions()
+	defer resetRegions()
+	const queryType = "example.com/app/patients.GetPatientPage"
+	RegisterRegion(boardRegion(queryType))
+
+	patches := RenderInvalidatedRegions(httptest.NewRequest(http.MethodPost, "/patients", nil), []string{queryType})
+	if len(patches) != 1 {
+		t.Fatalf("expected 1 patch, got %d", len(patches))
+	}
+	if patches[0].Query != queryType {
+		t.Fatalf("expected patch query %q, got %q", queryType, patches[0].Query)
+	}
+	if !strings.Contains(patches[0].HTML, "<li>Ada</li>") || !strings.Contains(patches[0].HTML, "<li>Linus</li>") {
+		t.Fatalf("expected rendered rows in patch HTML, got %q", patches[0].HTML)
+	}
+}
+
+func TestRenderInvalidatedRegionsSkipsUnregisteredAndAmbiguous(t *testing.T) {
+	resetRegions()
+	defer resetRegions()
+	const single = "example.com/app/patients.GetPatientPage"
+	const ambiguous = "example.com/app/patients.GetDashboard"
+	RegisterRegion(boardRegion(single))
+	// Registering the same query type twice marks it ambiguous: the command
+	// request cannot tell which page's region the submitter is viewing.
+	RegisterRegion(boardRegion(ambiguous))
+	RegisterRegion(boardRegion(ambiguous))
+
+	patches := RenderInvalidatedRegions(httptest.NewRequest(http.MethodPost, "/patients", nil), []string{single, ambiguous, "example.com/app/patients.Unregistered"})
+	if len(patches) != 1 || patches[0].Query != single {
+		t.Fatalf("expected only the unambiguous registered region, got %+v", patches)
+	}
+}
+
+func TestRenderInvalidatedRegionsSkipsOnLoadError(t *testing.T) {
+	resetRegions()
+	defer resetRegions()
+	const queryType = "example.com/app/patients.GetPatientPage"
+	renderer := boardRegion(queryType)
+	renderer.Load = func(*http.Request) (map[string]any, error) {
+		return nil, errors.New("load failed")
+	}
+	RegisterRegion(renderer)
+
+	patches := RenderInvalidatedRegions(httptest.NewRequest(http.MethodPost, "/patients", nil), []string{queryType})
+	if len(patches) != 0 {
+		t.Fatalf("expected no patches when load fails, got %+v", patches)
+	}
+}
+
+func TestRenderInvalidatedRegionsSkipsPostForms(t *testing.T) {
+	resetRegions()
+	defer resetRegions()
+	const queryType = "example.com/app/patients.GetPatientPage"
+	renderer := boardRegion(queryType)
+	renderer.Template = `<section data-gowdk-query-type="` + queryType + `"><form method="POST" action="/patients"><button>Save</button></form></section>`
+	RegisterRegion(renderer)
+
+	patches := RenderInvalidatedRegions(httptest.NewRequest(http.MethodPost, "/patients", nil), []string{queryType})
+	if len(patches) != 0 {
+		t.Fatalf("expected no patches for HTML containing POST forms, got %+v", patches)
+	}
+}
+
+func TestRegisterRegionIgnoresIncomplete(t *testing.T) {
+	resetRegions()
+	defer resetRegions()
+	RegisterRegion(RegionRenderer{QueryType: "", Load: func(*http.Request) (map[string]any, error) { return nil, nil }})
+	RegisterRegion(RegionRenderer{QueryType: "example.com/app.Q", Load: nil})
+	if patches := RenderInvalidatedRegions(httptest.NewRequest(http.MethodPost, "/", nil), []string{"example.com/app.Q"}); len(patches) != 0 {
+		t.Fatalf("expected incomplete renderers to be ignored, got %+v", patches)
+	}
+}


### PR DESCRIPTION
Closes #493. Stacks on #492 (`feat/491-command-single-flight`); review/merge that first.

## What

Collapses the `g:command` write to a single network step. Instead of `POST command → GET page → extract regions`, the command adapter now renders the invalidated `g:query` regions **inline** and the submitting client applies them directly.

```json
{ "result": { "id": "patient-1" }, "patches": [ { "query": "patients.GetPatientPage", "html": "<section …><ul><li>Ada</li></ul></section>" } ] }
```

## How it works

A `g:query` region's SSR data comes from its page's `load {}` (the query type is the reactivity marker). So re-rendering a region standalone = re-run that page's load + expand just that region's template. No per-region query execution, no whole-page render, no client page-path coupling.

- **`runtime/ssr` (`regions.go`)** — a region-renderer registry keyed by fully-qualified query type. `RenderInvalidatedRegions(request, queries)` runs each registered region's `load {}` against the command request and expands its template via the existing `RenderRegions` + scalar load substitution, returning `{query, html}` patches. Ambiguous (same query on >1 page) and load-failing regions are skipped.
- **`internal/buildgen` (`ssr_regions.go`)** — extracts each `g:query` region's element template from the rendered page HTML (tag-balanced; generated HTML escapes `<`/`>` so boundaries are unambiguous) and partitions the page's `g:for`/`g:if` specs and scalar load substitutions into it by placeholder containment. Only **parameterless, dynamic** regions are emitted.
- **`internal/appgen`** — lowers each eligible region into a generated `gowdkssr.RegisterRegion(...)` (with a `load` thunk) inside an `init()`. The command adapter renders the invalidated regions and, when any render, returns a `{result, patches}` envelope signalled by the `X-GOWDK-Patches` header. When none render, the **raw result body is unchanged**, so non-browser callers and existing behavior are unaffected.
- **client (`gowdk.js`)** — `submitCommand` applies embedded patches through the realtime swap routine (`applyRealtimePatch`, `outerHTML`) and refetches only the regions left uncovered, so the embedded and SSE paths converge on one apply routine.

## Fallback (unchanged from #492)

Regions that need route context the command request lacks — a **dynamic route param** — stay in the `X-GOWDK-Queries` header only and the client refetches them via the live page (which has the real params). Same for static regions and ambiguous query types.

## Tests

- `runtime/ssr/regions_test.go` — render, ambiguity, load-error, and incomplete-renderer skipping.
- `internal/buildgen/ssr_regions_test.go` — tag-balanced extraction (nested same-name tags, void siblings), spec/load partitioning, param/static/dynamic-param skipping.
- `internal/appgen` — codegen asserts (`RegisterRegion`, load thunk, single-flight envelope stmts) plus an **end-to-end binary test**: builds a real app, POSTs a command, and asserts the response carries `X-GOWDK-Patches: 1` and a `{result, patches}` envelope with the rendered region rows.

`go test ./internal/... ./runtime/... ./cmd/... .` passes; `gofmt`/`go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)