### PR TITLE
chore(release): bump to 0.7.0

### DIFF
--- a/.agents/skills/gowdk-version-bump/SKILL.md
+++ b/.agents/skills/gowdk-version-bump/SKILL.md
@@ -9,7 +9,7 @@ description: Bump the GOWDK release version. Use when updating the CLI version, 
 
 - Source of truth: `const version = "0.x.y"` near the top of
   `cmd/gowdk/main.go` (no `v` prefix). GitHub tags and install snippets use
-  `v0.x.y`. Current line: `const version = "0.6.1"`.
+  `v0.x.y`. Current line: `const version = "0.7.0"`.
 - `editors/vscode/package.json` must match the CLI constant exactly;
   `editors/vscode/scripts/sync-version.js` reads the constant from
   `cmd/gowdk/main.go` and writes/checks `package.json`. Never edit the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,40 @@ packages, and tooling contracts may change before 1.0.
 
 _No changes yet._
 
+## v0.7.0 - 2026-06-17
+
+### Changed
+
+- `gowdk version` and the VS Code extension metadata now report `0.7.0`.
+- Request-time routing, layout wiring, route visibility, and related-route
+  diagnostics were tightened across the compiler and generated reports.
+- Auth addon guard wiring and formatter nesting behavior were hardened.
+- `g:command` client write paths now use single-flight behavior, including the
+  HTML-embedded path, and request-time pages ship the required client runtime.
+
+### Implemented
+
+- Generated binary lifecycle services now have documented contracts and
+  implementation coverage.
+- Route parameter tracing and WASM store support were added across generated
+  output and runtime surfaces.
+- OpenAPI result schemas and AsyncAPI event payload schemas now expand supported
+  local and imported struct fields instead of stopping at shallow named
+  references.
+- Inspect reports now include component composition edges, component cycle
+  diagnostics, structural dispatch nodes, action/command/query dispatch edges,
+  and the same tree projection through the LSP `gowdk/tree` request.
+- Page metadata now supports `robots`, `noindex`, `preload`, and `prefetch`,
+  including generated head output, manifest data, and sitemap exclusion for
+  noindex pages.
+- Accessibility diagnostics now warn on missing image alt text, missing form
+  labels, empty link text, missing button types, and skipped heading levels.
+
+### Known Gaps
+
+- GOWDK remains experimental 0.x software. Public syntax, generated output,
+  runtime packages, and tooling contracts may change before 1.0.
+
 ## v0.6.1 - 2026-06-16
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ curl -fsSL https://raw.githubusercontent.com/cssbruno/GoWDK/main/scripts/install
 Pin the current CLI release:
 
 ```sh
-GOWDK_VERSION=v0.6.1 GOWDK_INSTALL_DIR="$HOME/.local/bin" \
+GOWDK_VERSION=v0.7.0 GOWDK_INSTALL_DIR="$HOME/.local/bin" \
   sh -c "$(curl -fsSL https://raw.githubusercontent.com/cssbruno/GoWDK/main/scripts/install.sh)"
 ```
 

--- a/cmd/gowdk/main.go
+++ b/cmd/gowdk/main.go
@@ -11,7 +11,7 @@ import (
 	"github.com/cssbruno/gowdk/addons/ssr"
 )
 
-const version = "0.6.1"
+const version = "0.7.0"
 
 var (
 	defaultSourceIncludes = []string{"**/*.gwdk"}

--- a/docs/engineering/release-notes-v0.7.md
+++ b/docs/engineering/release-notes-v0.7.md
@@ -1,0 +1,108 @@
+# Experimental 0.x Release: GOWDK v0.7.0
+
+GOWDK v0.7.0 is an experimental 0.x compiler/runtime release.
+
+Not production-ready. Public syntax, generated output, runtime packages, and
+tooling contracts may change before 1.0.
+
+## Implemented
+
+- Generated binary lifecycle services now have documented contracts and
+  implementation coverage.
+- Route parameter tracing and WASM store support were added across generated
+  output and runtime surfaces.
+- OpenAPI result schemas and AsyncAPI event payload schemas now expand supported
+  local and imported struct fields instead of stopping at shallow named
+  references.
+- Inspect reports now include component composition edges, component cycle
+  diagnostics, structural dispatch nodes, action/command/query dispatch edges,
+  and the same tree projection through the LSP `gowdk/tree` request.
+- Page metadata now supports `robots`, `noindex`, `preload`, and `prefetch`,
+  including generated head output, manifest data, and sitemap exclusion for
+  noindex pages.
+- Accessibility diagnostics now warn on missing image alt text, missing form
+  labels, empty link text, missing button types, and skipped heading levels.
+
+## Changed
+
+- `gowdk version` and the VS Code extension metadata report `0.7.0`.
+- Request-time routing, layout wiring, route visibility, and related-route
+  diagnostics were tightened across the compiler and generated reports.
+- Auth addon guard wiring and formatter nesting behavior were hardened.
+- `g:command` client write paths now use single-flight behavior, including the
+  HTML-embedded path, and request-time pages ship the required client runtime.
+
+## Planned
+
+- Continue hardening generated-output compatibility contracts before any 1.0
+  production-readiness claim.
+- Keep expanding language-server and inspect graph coverage as the language
+  surface stabilizes.
+
+## Intentionally Out Of Scope
+
+- Production-readiness claims.
+- Mandatory full-page SSR.
+- Full-page hydration as the default browser model.
+- User-written JavaScript as the normal app contract.
+- Mandatory Tailwind, npm, Gin, Echo, Fiber, Redis, NATS, or another optional
+  framework/tool dependency.
+
+## Known Gaps
+
+- Generated output is pre-1.0. Treat generated Go, generated JavaScript,
+  manifests, and build reports as unstable unless a reference doc explicitly
+  marks a surface as stable.
+- Release artifact availability depends on the GitHub `Release` workflow
+  finishing successfully for tag `v0.7.0`.
+
+## Required Verification
+
+Required local gates:
+
+```sh
+node editors/vscode/scripts/sync-version.js --check
+go test ./cmd/gowdk -run Version
+go run ./cmd/gowdk version --json
+node --check editors/vscode/extension.js
+node --check editors/vscode/extension-core.js
+node --test editors/vscode/*.test.js
+go test ./...
+```
+
+The release workflow also runs the repository release gates in
+`.github/workflows/release.yml` before uploading artifacts.
+
+## Artifact Verification
+
+Download the CLI artifact for your platform and `checksums.txt` from the GitHub
+release.
+
+```sh
+grep ' <artifact>$' checksums.txt | sha256sum -c -
+```
+
+On macOS, use:
+
+```sh
+shasum -a 256 <artifact>
+```
+
+Verify GitHub artifact attestations:
+
+```sh
+gh attestation verify <artifact> -R cssbruno/GOWDK
+```
+
+## VS Code Extension
+
+Install the packaged `.vsix` manually when the release includes one:
+
+```sh
+code --install-extension gowdk-vscode-0.7.0.vsix
+```
+
+## Tool Versions
+
+- Go: `1.26.4`
+- Node.js for extension checks: `24`

--- a/docs/engineering/release.md
+++ b/docs/engineering/release.md
@@ -6,7 +6,7 @@ visible normal GitHub releases with downloadable assets from `v*` tags or a
 manual workflow dispatch. VS Code Marketplace publishing lives in
 `.github/workflows/vscode-extension-publish.yml`.
 
-The current CLI version is `0.6.1`, but this is not a production-readiness
+The current CLI version is `0.7.0`, but this is not a production-readiness
 claim. It identifies the current development line while the compiler, generated
 runtime, and docs continue through the 0.x line. Public release notes must keep
 the build experimental and not production-ready until the 1.0 release gates are
@@ -14,7 +14,7 @@ satisfied.
 
 Use `docs/engineering/v0.2-release-checklist.md` for the historical v0.2
 Public Truth and Release Trust checklist.
-Use `docs/engineering/release-notes-v0.6.md` as the draft v0.6 release notes.
+Use `docs/engineering/release-notes-v0.7.md` as the draft v0.7 release notes.
 Use `docs/engineering/release-plan.md` for the open-ended 0.x hardening
 checklist. It does not make any minor version a production-readiness target.
 Use `.github/release-note-template.md` for future 0.x release bodies.
@@ -90,14 +90,14 @@ After those gates pass on the release commit, run the release workflow manually
 for the current CLI line or push the corresponding tag:
 
 ```sh
-gh workflow run release.yml -f version=v0.6.1
+gh workflow run release.yml -f version=v0.7.0
 ```
 
 After the release workflow completes, smoke the published artifacts for each
 supported OS artifact:
 
 ```sh
-gh workflow run release-smoke.yml -f version=v0.6.1
+gh workflow run release-smoke.yml -f version=v0.7.0
 ```
 
 ## Artifacts
@@ -108,7 +108,7 @@ gh workflow run release-smoke.yml -f version=v0.6.1
 - `gowdk-darwin-arm64`
 - `gowdk-windows-amd64.exe`
 - `checksums.txt`
-- `gowdk-vscode-0.6.1.vsix`
+- `gowdk-vscode-0.7.0.vsix`
 
 ## Install Script
 
@@ -121,7 +121,7 @@ platform before binary download, verifies the binary SHA-256, and writes
 Pinned install:
 
 ```sh
-GOWDK_VERSION=v0.6.1 GOWDK_INSTALL_DIR="$HOME/.local/bin" \
+GOWDK_VERSION=v0.7.0 GOWDK_INSTALL_DIR="$HOME/.local/bin" \
   sh -c "$(curl -fsSL https://raw.githubusercontent.com/cssbruno/GoWDK/main/scripts/install.sh)"
 ```
 
@@ -142,7 +142,7 @@ gh attestation verify <artifact> -R <owner>/<repo>
 ## Extension Publishing
 
 The release workflow packages the extension into a `.vsix` named from
-`editors/vscode/package.json`, currently `gowdk-vscode-0.6.1.vsix`.
+`editors/vscode/package.json`, currently `gowdk-vscode-0.7.0.vsix`.
 Marketplace publishing is handled by the `Publish VS Code Extension` workflow.
 It is manual-only so CLI/runtime releases do not accidentally republish an
 extension version that already exists on the Marketplace.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -21,7 +21,7 @@ gowdk version
 Pin the current CLI release or install into a user-writable directory:
 
 ```sh
-GOWDK_VERSION=v0.6.1 GOWDK_INSTALL_DIR="$HOME/.local/bin" \
+GOWDK_VERSION=v0.7.0 GOWDK_INSTALL_DIR="$HOME/.local/bin" \
   sh -c "$(curl -fsSL https://raw.githubusercontent.com/cssbruno/GoWDK/main/scripts/install.sh)"
 ```
 
@@ -96,7 +96,7 @@ Direct artifact names:
 Manual Linux install:
 
 ```sh
-version=v0.6.1
+version=v0.7.0
 curl -fsSLO "https://github.com/cssbruno/GoWDK/releases/download/$version/gowdk-linux-amd64"
 curl -fsSLO "https://github.com/cssbruno/GoWDK/releases/download/$version/checksums.txt"
 grep ' gowdk-linux-amd64$' checksums.txt | sha256sum -c -
@@ -109,7 +109,7 @@ gowdk version
 Manual macOS Intel install:
 
 ```sh
-version=v0.6.1
+version=v0.7.0
 curl -fsSLO "https://github.com/cssbruno/GoWDK/releases/download/$version/gowdk-darwin-amd64"
 curl -fsSLO "https://github.com/cssbruno/GoWDK/releases/download/$version/checksums.txt"
 expected="$(awk '$2 == "gowdk-darwin-amd64" { print $1 }' checksums.txt)"
@@ -124,7 +124,7 @@ gowdk version
 Manual macOS ARM install:
 
 ```sh
-version=v0.6.1
+version=v0.7.0
 curl -fsSLO "https://github.com/cssbruno/GoWDK/releases/download/$version/gowdk-darwin-arm64"
 curl -fsSLO "https://github.com/cssbruno/GoWDK/releases/download/$version/checksums.txt"
 expected="$(awk '$2 == "gowdk-darwin-arm64" { print $1 }' checksums.txt)"
@@ -139,7 +139,7 @@ gowdk version
 Manual Windows install from PowerShell:
 
 ```powershell
-$version = "v0.6.1"
+$version = "v0.7.0"
 Invoke-WebRequest "https://github.com/cssbruno/GoWDK/releases/download/$version/gowdk-windows-amd64.exe" -OutFile "gowdk.exe"
 Invoke-WebRequest "https://github.com/cssbruno/GoWDK/releases/download/$version/checksums.txt" -OutFile "checksums.txt"
 $expected = (Select-String -Path checksums.txt -Pattern "gowdk-windows-amd64.exe").Line.Split(" ")[0]
@@ -158,7 +158,7 @@ Install the VS Code extension package from a release when a `.vsix` is
 published:
 
 ```sh
-code --install-extension gowdk-vscode-0.6.1.vsix
+code --install-extension gowdk-vscode-0.7.0.vsix
 ```
 
 ## Build From Source

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "gowdk-vscode",
   "displayName": "GOWDK",
   "description": "Language tools for portable .gwdk files.",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "publisher": "gowdk",
   "license": "MIT",
   "icon": "icons/gowdk.png",


### PR DESCRIPTION
## Summary

- Bump GOWDK CLI and VS Code extension metadata to 0.7.0.
- Update install snippets, release docs, and release workflow references to v0.7.0.
- Add v0.7 changelog and release notes so release.yml publishes a non-template body.

## Validation

- `node editors/vscode/scripts/sync-version.js --check`
- `go test ./cmd/gowdk -run Version`
- `go run ./cmd/gowdk version --json`
- `node --check editors/vscode/extension.js && node --check editors/vscode/extension-core.js && node --test editors/vscode/*.test.js`
- `go test ./...`
- `go build ./cmd/gowdk`
