### PR TITLE
fix(compiler): give g:for row-body diagnostics exact source ranges

### DIFF
--- a/docs/engineering/release-plan.md
+++ b/docs/engineering/release-plan.md
@@ -628,7 +628,11 @@ Every 0.x minor release must have:
   planning.
 - [ ] Add dev tests for failed rebuild recovery and generated app dev flow
   smoke.
-- [ ] Add LSP exact source-range diagnostics once spans are complete.
+- [x] Add LSP exact source-range diagnostics. The LSP consumes
+  `Diagnostic.Range` directly; high-value parser/IR/compiler diagnostics
+  (including `g:for`/`g:key` row bodies) carry exact spans. Remaining
+  file/line-level gaps are listed under "Source Ranges" in
+  `docs/reference/diagnostic-codes.md`.
 - [ ] Add go-to-definition for components, layouts, Go handlers, Go build
   functions, CSS inputs, and assets.
 - [ ] Add hover docs, completions, quick fixes, tree views, graph views, build
@@ -761,7 +765,9 @@ Start with these in order:
 - [x] Add `gowdk generate stubs`.
 - [ ] Stabilize `gowdk check --json`.
 - [ ] Add diagnostic codes.
-- [ ] Add exact source spans where missing.
+- [ ] Add exact source spans where missing. Tracked gaps are listed under
+  "Source Ranges" in `docs/reference/diagnostic-codes.md` (Go contract-scan
+  diagnostics, untyped `withLine` parser errors, `client {}` block columns).
 - [ ] Finish downstream `gwdkir` migration.
 - [ ] Add generated Go golden tests.
 - [ ] Add endpoint IR report.

--- a/docs/reference/diagnostic-codes.md
+++ b/docs/reference/diagnostic-codes.md
@@ -197,10 +197,43 @@ Exact ranges now cover the backend-binding family, which point at the declaring
 block span so both `gowdk check`/build diagnostics and the editor highlight the
 exact declaration.
 
-Known gaps (no precise span available, file/owner-level only): `go_package_error`
-for an unparseable sibling `.go` file or a missing package clause — these arise
-before a Go AST exists, so only the file path is known. Inline `go {}` block
-package errors already carry the block span.
+Exact ranges also cover `g:for` / `g:key` row bodies (`component_field_error`).
+Errors inside a list row — invalid `g:on:` handlers, `g:if` / `g:else-if`
+conditionals, `g:bind:value` / `g:bind:checked` targets, `class:` / `style:`
+toggles, reactive attribute expressions, and `{}` interpolations — point at the
+offending expression or text node. The view-contract collector skips loop
+subtrees, so the list-directive validator is the only source for these and used
+to fall back to the whole `view {}` block; it now maps the parsed
+`viewmodel.Attr` / text offsets through `componentViewBodyOffsetSpan`.
+
+Known gaps (no precise span available; file/owner- or line-level only):
+
+- `go_package_error` for an unparseable sibling `.go` file or a missing package
+  clause — these arise before a Go AST exists, so only the file path is known.
+  Inline `go {}` block package errors already carry the block span.
+- Go contract-scan diagnostics (`contract_handler_*`, `contract_reference_*`,
+  `duplicate_command_owner`, and peers from `internal/contractscan`) carry the
+  registration call's line and column but no end, so the editor marks a point
+  rather than a token range. `contractscan.Diagnostic` records only `Line` /
+  `Column`; an exact range needs the Go AST node end threaded through the scan
+  report model.
+- Untyped parser errors (`parse_error`) wrapped with `withLine` in
+  `internal/parser` (currently three call sites) carry only a line number, so
+  the range is the whole line. Most parser diagnostics are typed via
+  `lineDiagnosticError` and are already exact.
+- Component `client {}` block errors (`component_client_error`) are
+  line-accurate but not column-accurate: `clientlang.Span` carries `StartLine` /
+  `EndLine` only.
+- Interpolation errors inside a list row resolve to the enclosing text node or
+  attribute, not the individual `{expr}`, when several interpolations share one
+  node.
+
+The LSP (`internal/lsp/diagnostics.go`) consumes `Diagnostic.Range` directly and
+only derives a position-based range when `Range` is nil, so there is no
+editor-only range guessing for diagnostics. Cursor-driven features
+(hover, go-to-definition, find-references) still locate the token under the
+caret by scanning, which is inherent to those features and unrelated to
+diagnostic ranges.
 
 ## Adding A Code
 

--- a/internal/compiler/validate_component_lists.go
+++ b/internal/compiler/validate_component_lists.go
@@ -60,7 +60,7 @@ func validateListNodes(nodes []viewmodel.Node, component gwdkir.Component, symbo
 }
 
 func validateListElement(element viewmodel.Element, loopAttr viewmodel.Attr, component gwdkir.Component, symbols map[string]clientlang.ValueType, stateTypes map[string]clientlang.ValueType, handlers map[string]clientlang.Handler, helpers map[string]clientlang.ExprFunction, messages *[]spannedMessage) {
-	loopSpan := viewBodyNeedleSpan(component, loopAttr.Value)
+	loopSpan := attrExprSpan(component, loopAttr, loopAttr.Value)
 	loop, err := viewparse.ParseForDirective(loopAttr.Value)
 	if err != nil {
 		*messages = append(*messages, spannedMessage{Message: err.Error(), Span: loopSpan})
@@ -68,55 +68,74 @@ func validateListElement(element viewmodel.Element, loopAttr viewmodel.Attr, com
 	}
 	collectionType, _, err := clientlang.CheckExpr(loop.Collection, symbols)
 	if err != nil {
-		*messages = append(*messages, spannedMessage{Message: fmt.Sprintf("g:for collection %q is invalid: %v", loop.Collection, err), Span: viewBodyNeedleSpan(component, loop.Collection)})
+		*messages = append(*messages, spannedMessage{Message: fmt.Sprintf("g:for collection %q is invalid: %v", loop.Collection, err), Span: attrExprSpan(component, loopAttr, loop.Collection)})
 		return
 	}
 	if collectionType != clientlang.TypeArray && collectionType != clientlang.TypeUnknown {
-		*messages = append(*messages, spannedMessage{Message: fmt.Sprintf("g:for collection %q must be array, got %s", loop.Collection, collectionType), Span: viewBodyNeedleSpan(component, loop.Collection)})
+		*messages = append(*messages, spannedMessage{Message: fmt.Sprintf("g:for collection %q must be array, got %s", loop.Collection, collectionType), Span: attrExprSpan(component, loopAttr, loop.Collection)})
 		return
 	}
-	keyExpr, ok := elementKeyExpression(element)
-	if !ok {
+	keyAttr, hasKey := elementKeyAttr(element)
+	if !hasKey {
 		*messages = append(*messages, spannedMessage{Message: "g:for requires g:key for mutable lists", Span: loopSpan})
 		return
 	}
+	keyExpr := strings.TrimSpace(keyAttr.Value)
+	keySpan := attrExprSpan(component, keyAttr, keyExpr)
 	loopSymbols := loopSymbols(symbols, loop)
 	keyType, _, err := clientlang.CheckExpr(keyExpr, loopSymbols)
 	if err != nil {
-		*messages = append(*messages, spannedMessage{Message: fmt.Sprintf("g:key %q is invalid: %v", keyExpr, err), Span: viewBodyNeedleSpan(component, keyExpr)})
+		*messages = append(*messages, spannedMessage{Message: fmt.Sprintf("g:key %q is invalid: %v", keyExpr, err), Span: keySpan})
 		return
 	}
 	if keyType == clientlang.TypeArray || keyType == clientlang.TypeObject || keyType == clientlang.TypeNil {
-		*messages = append(*messages, spannedMessage{Message: fmt.Sprintf("g:key %q must be scalar, got %s", keyExpr, keyType), Span: viewBodyNeedleSpan(component, keyExpr)})
+		*messages = append(*messages, spannedMessage{Message: fmt.Sprintf("g:key %q must be scalar, got %s", keyExpr, keyType), Span: keySpan})
 		return
 	}
-	validateLoopElementBody(element, loopSymbols, stateTypes, handlers, helpers, messages)
+	validateLoopElementBody(component, element, loopSymbols, stateTypes, handlers, helpers, messages)
 }
 
-func validateLoopSubtree(node viewmodel.Node, readSymbols map[string]clientlang.ValueType, writeSymbols map[string]clientlang.ValueType, handlers map[string]clientlang.Handler, helpers map[string]clientlang.ExprFunction, messages *[]spannedMessage) {
+// attrExprSpan returns the exact source span of value inside attr, mapped from
+// the component view-body offsets to file line/column. It points a diagnostic at
+// the offending expression rather than the whole attribute or view block.
+func attrExprSpan(component gwdkir.Component, attr viewmodel.Attr, value string) source.SourceSpan {
+	start, end := attrValueOffset(component.Blocks.ViewBody, attr, value)
+	return componentViewBodyOffsetSpan(component, start, end)
+}
+
+func elementKeyAttr(element viewmodel.Element) (viewmodel.Attr, bool) {
+	for _, attr := range element.Attrs {
+		if attr.Name == "g:key" {
+			return attr, true
+		}
+	}
+	return viewmodel.Attr{}, false
+}
+
+func validateLoopSubtree(component gwdkir.Component, node viewmodel.Node, readSymbols map[string]clientlang.ValueType, writeSymbols map[string]clientlang.ValueType, handlers map[string]clientlang.Handler, helpers map[string]clientlang.ExprFunction, messages *[]spannedMessage) {
 	switch typed := node.(type) {
 	case viewmodel.Text:
-		validateInterpolations(typed.Value, readSymbols, messages)
+		validateInterpolations(typed.Value, readSymbols, messages, componentViewBodyOffsetSpan(component, typed.Start, typed.End))
 	case viewmodel.Element:
 		if loopAttr, hasLoop := elementForDirective(typed); hasLoop {
-			validateListElement(typed, loopAttr, gwdkir.Component{}, readSymbols, writeSymbols, handlers, helpers, messages)
+			validateListElement(typed, loopAttr, component, readSymbols, writeSymbols, handlers, helpers, messages)
 			return
 		}
-		validateLoopElementBody(typed, readSymbols, writeSymbols, handlers, helpers, messages)
+		validateLoopElementBody(component, typed, readSymbols, writeSymbols, handlers, helpers, messages)
 	case viewmodel.ComponentCall:
 		for _, attr := range typed.Attrs {
 			if strings.HasPrefix(attr.Name, "g:") {
 				continue
 			}
-			validateInterpolations(attr.Value, readSymbols, messages)
+			validateInterpolations(attr.Value, readSymbols, messages, componentViewBodyOffsetSpan(component, attr.Start, attr.End))
 		}
 		for _, child := range typed.Children {
-			validateLoopSubtree(child, readSymbols, writeSymbols, handlers, helpers, messages)
+			validateLoopSubtree(component, child, readSymbols, writeSymbols, handlers, helpers, messages)
 		}
 	}
 }
 
-func validateLoopElementBody(element viewmodel.Element, readSymbols map[string]clientlang.ValueType, writeSymbols map[string]clientlang.ValueType, handlers map[string]clientlang.Handler, helpers map[string]clientlang.ExprFunction, messages *[]spannedMessage) {
+func validateLoopElementBody(component gwdkir.Component, element viewmodel.Element, readSymbols map[string]clientlang.ValueType, writeSymbols map[string]clientlang.ValueType, handlers map[string]clientlang.Handler, helpers map[string]clientlang.ExprFunction, messages *[]spannedMessage) {
 	for _, attr := range element.Attrs {
 		if attr.Name == "g:for" || attr.Name == "g:key" {
 			continue
@@ -124,40 +143,40 @@ func validateLoopElementBody(element viewmodel.Element, readSymbols map[string]c
 		switch {
 		case strings.HasPrefix(attr.Name, "g:on:"):
 			if err := clientlang.ValidateIslandEventExpressionTypedWithFunctions(attr.Value, readSymbols, writeSymbols, handlers, helpers); err != nil {
-				*messages = append(*messages, spannedMessage{Message: fmt.Sprintf("%s=%q is invalid: %v", attr.Name, attr.Value, err)})
+				*messages = append(*messages, spannedMessage{Message: fmt.Sprintf("%s=%q is invalid: %v", attr.Name, attr.Value, err), Span: attrExprSpan(component, attr, strings.TrimSpace(attr.Value))})
 			}
 		case attr.Name == "g:if" || attr.Name == "g:else-if":
 			if err := clientlang.ValidateIslandBoolExpressionTyped(strings.TrimSpace(attr.Value), readSymbols); err != nil {
-				*messages = append(*messages, spannedMessage{Message: fmt.Sprintf("%s=%q is invalid: %v", attr.Name, attr.Value, err)})
+				*messages = append(*messages, spannedMessage{Message: fmt.Sprintf("%s=%q is invalid: %v", attr.Name, attr.Value, err), Span: attrExprSpan(component, attr, strings.TrimSpace(attr.Value))})
 			}
 		case attr.Name == "g:bind:value":
 			if _, ok := writeSymbols[strings.TrimSpace(attr.Value)]; !ok {
-				*messages = append(*messages, spannedMessage{Message: fmt.Sprintf("g:bind:value target %q must be a state field", strings.TrimSpace(attr.Value))})
+				*messages = append(*messages, spannedMessage{Message: fmt.Sprintf("g:bind:value target %q must be a state field", strings.TrimSpace(attr.Value)), Span: attrExprSpan(component, attr, strings.TrimSpace(attr.Value))})
 			}
 		case attr.Name == "g:bind:checked":
 			if _, ok := writeSymbols[strings.TrimSpace(attr.Value)]; !ok {
-				*messages = append(*messages, spannedMessage{Message: fmt.Sprintf("g:bind:checked target %q must be a state field", strings.TrimSpace(attr.Value))})
+				*messages = append(*messages, spannedMessage{Message: fmt.Sprintf("g:bind:checked target %q must be a state field", strings.TrimSpace(attr.Value)), Span: attrExprSpan(component, attr, strings.TrimSpace(attr.Value))})
 			}
 		case strings.HasPrefix(attr.Name, "class:"):
 			expr := expressionAttrSource(attr.Value)
 			if err := viewvalidation.ValidateClassToggleExpressionTyped(attr.Name, expr, readSymbols); err != nil {
-				*messages = append(*messages, spannedMessage{Message: fmt.Sprintf("%s=%q is invalid: %v", attr.Name, expr, err)})
+				*messages = append(*messages, spannedMessage{Message: fmt.Sprintf("%s=%q is invalid: %v", attr.Name, expr, err), Span: attrExprSpan(component, attr, expr)})
 			}
 		case strings.HasPrefix(attr.Name, "style:"):
 			expr := expressionAttrSource(attr.Value)
 			if err := viewvalidation.ValidateStyleBindingExpressionTyped(attr.Name, expr, readSymbols); err != nil {
-				*messages = append(*messages, spannedMessage{Message: fmt.Sprintf("%s=%q is invalid: %v", attr.Name, expr, err)})
+				*messages = append(*messages, spannedMessage{Message: fmt.Sprintf("%s=%q is invalid: %v", attr.Name, expr, err), Span: attrExprSpan(component, attr, expr)})
 			}
 		case attr.Expression:
 			expr := expressionAttrSource(attr.Value)
 			if err := viewvalidation.ValidateReactiveAttrExpressionTyped(attr.Name, expr, readSymbols); err != nil {
-				*messages = append(*messages, spannedMessage{Message: fmt.Sprintf("%s=%q is invalid: %v", attr.Name, expr, err)})
+				*messages = append(*messages, spannedMessage{Message: fmt.Sprintf("%s=%q is invalid: %v", attr.Name, expr, err), Span: attrExprSpan(component, attr, expr)})
 			}
 		default:
-			validateInterpolations(attr.Value, readSymbols, messages)
+			validateInterpolations(attr.Value, readSymbols, messages, componentViewBodyOffsetSpan(component, attr.Start, attr.End))
 		}
 	}
 	for _, child := range element.Children {
-		validateLoopSubtree(child, readSymbols, writeSymbols, handlers, helpers, messages)
+		validateLoopSubtree(component, child, readSymbols, writeSymbols, handlers, helpers, messages)
 	}
 }

--- a/internal/compiler/validate_component_view.go
+++ b/internal/compiler/validate_component_view.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/cssbruno/gowdk/internal/clientlang"
+	"github.com/cssbruno/gowdk/internal/source"
 	"github.com/cssbruno/gowdk/internal/viewmodel"
 	"github.com/cssbruno/gowdk/internal/viewparse"
 )
@@ -85,20 +86,24 @@ func componentViewReferencesFromNodes(source string, nodes []viewmodel.Node) com
 	return refs
 }
 
-func validateInterpolations(value string, symbols map[string]clientlang.ValueType, messages *[]spannedMessage) {
+// validateInterpolations checks every {expr} in value. enclosing is the source
+// span of the text node or attribute that holds value; it is stamped on each
+// emitted diagnostic so loop-body interpolation errors point at that node
+// instead of falling back to the whole view block.
+func validateInterpolations(value string, symbols map[string]clientlang.ValueType, messages *[]spannedMessage, enclosing source.SourceSpan) {
 	exprs, err := interpolationExpressions(value)
 	if err != nil {
-		*messages = append(*messages, spannedMessage{Message: err.Error()})
+		*messages = append(*messages, spannedMessage{Message: err.Error(), Span: enclosing})
 		return
 	}
 	for _, expr := range exprs {
 		typ, _, err := clientlang.CheckExpr(expr, symbols)
 		if err != nil {
-			*messages = append(*messages, spannedMessage{Message: fmt.Sprintf("interpolation %q is invalid: %v", expr, err)})
+			*messages = append(*messages, spannedMessage{Message: fmt.Sprintf("interpolation %q is invalid: %v", expr, err), Span: enclosing})
 			continue
 		}
 		if typ == clientlang.TypeArray || typ == clientlang.TypeObject {
-			*messages = append(*messages, spannedMessage{Message: fmt.Sprintf("interpolation %q must be scalar, got %s", expr, typ)})
+			*messages = append(*messages, spannedMessage{Message: fmt.Sprintf("interpolation %q must be scalar, got %s", expr, typ), Span: enclosing})
 		}
 	}
 }
@@ -148,15 +153,6 @@ func elementForDirective(element viewmodel.Element) (viewmodel.Attr, bool) {
 		}
 	}
 	return viewmodel.Attr{}, false
-}
-
-func elementKeyExpression(element viewmodel.Element) (string, bool) {
-	for _, attr := range element.Attrs {
-		if attr.Name == "g:key" {
-			return strings.TrimSpace(attr.Value), true
-		}
-	}
-	return "", false
 }
 
 func collectComponentViewReferences(source string, nodes []viewmodel.Node, refs *componentViewRefs) {

--- a/internal/compiler/validate_spans.go
+++ b/internal/compiler/validate_spans.go
@@ -3,7 +3,6 @@ package compiler
 import (
 	"github.com/cssbruno/gowdk/internal/gwdkir"
 	"github.com/cssbruno/gowdk/internal/source"
-	"strings"
 )
 
 func firstSpan(spans ...source.SourceSpan) source.SourceSpan {
@@ -13,36 +12,6 @@ func firstSpan(spans ...source.SourceSpan) source.SourceSpan {
 		}
 	}
 	return source.SourceSpan{}
-}
-
-func viewBodyNeedleSpan(component gwdkir.Component, needle string) source.SourceSpan {
-	needle = strings.TrimSpace(needle)
-	if needle == "" || component.Blocks.ViewBody == "" || !hasSpan(component.Blocks.Spans.View) {
-		return firstSpan(component.Blocks.Spans.View, component.Span)
-	}
-	offset := strings.Index(component.Blocks.ViewBody, needle)
-	if offset < 0 {
-		return firstSpan(component.Blocks.Spans.View, component.Span)
-	}
-	before := component.Blocks.ViewBody[:offset]
-	lineOffset := strings.Count(before, "\n")
-	lastNewline := strings.LastIndex(before, "\n")
-	lineStart := 0
-	if lastNewline >= 0 {
-		lineStart = lastNewline + 1
-	}
-	startColumn := len([]rune(before[lineStart:])) + 1
-	endColumn := startColumn + len([]rune(needle))
-	return source.SourceSpan{
-		Start: source.SourcePosition{
-			Line:   component.Blocks.Spans.View.Start.Line + 1 + lineOffset,
-			Column: startColumn,
-		},
-		End: source.SourcePosition{
-			Line:   component.Blocks.Spans.View.Start.Line + 1 + lineOffset,
-			Column: endColumn,
-		},
-	}
 }
 
 func pageViewBodyOffsetSpan(page gwdkir.Page, start int, end int) source.SourceSpan {

--- a/internal/compiler/validate_test.go
+++ b/internal/compiler/validate_test.go
@@ -2799,6 +2799,70 @@ func TestValidateManifestRejectsUnknownGForItemField(t *testing.T) {
 	}
 }
 
+func TestValidateManifestLoopBodyEventDiagnosticPointsToExpression(t *testing.T) {
+	// An invalid event handler inside a g:for row is validated only by the list
+	// directive validator (the view-contract collector skips loop subtrees), so
+	// this guards that the list validator emits the exact expression span instead
+	// of falling back to the whole view block.
+	app := appFixture{Components: []gwdkir.Component{{
+		Name:    "Nested",
+		Source:  "components/nested.cmp.gwdk",
+		Imports: []gwdkir.Import{{Alias: "ui", Path: "github.com/cssbruno/gowdk/testfixture/islands"}},
+		State: gwdkir.StateContract{
+			Type: gwdkir.GoRef{Alias: "ui", Name: "NestedState"},
+			Init: gwdkir.GoRef{Alias: "ui", Name: "NewNestedState"},
+		},
+		Blocks: gwdkir.Blocks{
+			View:     true,
+			ViewBody: `<ul><li g:for={item in Items} g:key={item.ID} g:on:click={Missing()}>{item.Name}</li></ul>`,
+			Spans: gwdkir.BlockSpans{
+				View: source.SourceSpan{Start: source.SourcePosition{Line: 9, Column: 1}, End: source.SourcePosition{Line: 9, Column: 7}},
+			},
+		},
+	}}}
+
+	err := validateManifest(gowdk.Config{}, app)
+	if err == nil {
+		t.Fatal("expected invalid loop-body event expression diagnostic")
+	}
+	diagnostic := firstDiagnostic(err.(ValidationErrors), "component_field_error")
+	if diagnostic == nil || !strings.Contains(diagnostic.Message, "Missing()") {
+		t.Fatalf("Missing loop-body event diagnostic: %#v", err)
+	}
+	assertSourceSpan(t, diagnostic.Span, 10, 59, 10, 68)
+}
+
+func TestValidateManifestLoopBodyInterpolationDiagnosticPointsToTextNode(t *testing.T) {
+	// An unknown loop-item field used in a {} interpolation inside a g:for row must
+	// point at the offending text node, not the whole view block.
+	app := appFixture{Components: []gwdkir.Component{{
+		Name:    "Nested",
+		Source:  "components/nested.cmp.gwdk",
+		Imports: []gwdkir.Import{{Alias: "ui", Path: "github.com/cssbruno/gowdk/testfixture/islands"}},
+		State: gwdkir.StateContract{
+			Type: gwdkir.GoRef{Alias: "ui", Name: "NestedState"},
+			Init: gwdkir.GoRef{Alias: "ui", Name: "NewNestedState"},
+		},
+		Blocks: gwdkir.Blocks{
+			View:     true,
+			ViewBody: `<ul><li g:for={item in Items} g:key={item.ID}>{item.Missing}</li></ul>`,
+			Spans: gwdkir.BlockSpans{
+				View: source.SourceSpan{Start: source.SourcePosition{Line: 9, Column: 1}, End: source.SourcePosition{Line: 9, Column: 7}},
+			},
+		},
+	}}}
+
+	err := validateManifest(gowdk.Config{}, app)
+	if err == nil {
+		t.Fatal("expected unknown loop-item field diagnostic")
+	}
+	diagnostic := firstDiagnostic(err.(ValidationErrors), "component_field_error")
+	if diagnostic == nil || !strings.Contains(diagnostic.Message, "item.Missing") {
+		t.Fatalf("Missing loop-body interpolation diagnostic: %#v", err)
+	}
+	assertSourceSpan(t, diagnostic.Span, 10, 47, 10, 61)
+}
+
 func TestValidateManifestViewEventDiagnosticPointsToExpression(t *testing.T) {
 	app := appFixture{Components: []gwdkir.Component{{
 		Name:    "Counter",


### PR DESCRIPTION
## Summary

Finish the high-value work in #419 — exact source ranges for editor diagnostics.

- **`g:for` / `g:key` row bodies now get exact ranges (`component_field_error`).**
  Errors inside a list row were validated only by the list-directive validator
  (`validateComponentListDirectives`) because the view-contract collector skips
  loop subtrees — and that validator emitted spanless messages that fell back to
  the whole `view {}` block. The component is now threaded through
  `validateLoopSubtree` / `validateLoopElementBody`, and the parsed
  `viewmodel.Attr` / text offsets are mapped through `componentViewBodyOffsetSpan`
  so invalid `g:on:` handlers, `g:if` / `g:else-if` conditionals, `g:bind:value`
  / `g:bind:checked` targets, `class:` / `style:` toggles, reactive attribute
  expressions, and `{}` interpolations point at the offending expression or text
  node. `g:for` parse errors and collection/key errors point at the directive
  value via `attrValueOffset`.
- **Cleanup:** dropped the now-unused `viewBodyNeedleSpan` substring helper and
  collapsed `elementKeyExpression` into `elementKeyAttr` (single attribute scan).
- **Docs gap list (acceptance criterion):** the "Source Ranges" section of
  `docs/reference/diagnostic-codes.md` now records the new coverage plus a
  complete gap list of diagnostics that are still file/line-level and why (Go
  contract-scan diagnostics, untyped `withLine` parser errors, `client {}` block
  columns, shared-node interpolations), and states that the LSP consumes
  `Diagnostic.Range` directly with no editor-only range guessing.
- Updated the matching `docs/engineering/release-plan.md` checkboxes.

### Acceptance criteria (#419)

- **Gap list identifies diagnostics that still cannot have exact ranges and why** —
  see "Source Ranges" in `docs/reference/diagnostic-codes.md`.
- **High-value editor diagnostics use exact ranges with tests** — `g:for` row
  bodies, covered by `TestValidateManifestLoopBodyEventDiagnosticPointsToExpression`
  and `TestValidateManifestLoopBodyInterpolationDiagnosticPointsToTextNode`
  (backend-binding family was already exact).
- **LSP uses the exact ranges without custom editor-only guesses** — verified:
  `internal/lsp/diagnostics.go` uses `Diagnostic.Range` directly; only
  cursor-driven features (hover/definition/references) scan, which is inherent to
  them and unrelated to diagnostic ranges.

## Issue Closure

Related: #419

## Verification

- [x] I ran the relevant tests, lint, and build commands.
- [x] I ran `scripts/test-go-modules.sh` when Go code or compiler behavior changed.
- [x] I ran `go build ./cmd/gowdk` when CLI, compiler, runtime, addon, or release behavior changed.
- [ ] I ran `node --check editors/vscode/extension.js` when editor files changed. (no editor files changed)
- [x] I updated docs for behavior, setup, or architecture changes.
- [x] I added or updated tests for changed behavior.
- [x] I considered security-sensitive surfaces such as auth, CSRF, redirects,
  request-time handlers, logs, diagnostics, embedded assets, editor commands,
  WASM, contracts, and realtime behavior. (diagnostics-only; spans are derived
  from already-parsed offsets — no new source content reaches messages)

## LLM Assistance

- LLM session summary: Audited every diagnostic emission site across the parser,
  analyzer, compiler, and LSP for range fidelity; found the `g:for` row-body
  path as the clearest high-value owner-level fallback with span machinery
  already available, implemented exact ranges there, and documented the
  remaining gaps.
- Human-reviewed assumptions: `componentViewBodyOffsetSpan` and the
  `viewmodel.Attr` offsets are already trusted in production (used by the
  view-contract validator), so reusing them carries no new risk.
- Follow-up work: capture exact ranges for Go contract-scan diagnostics (thread
  the AST node end through `contractscan.Diagnostic`), type the remaining
  `withLine` parser errors, and add columns to `clientlang.Span` for `client {}`
  block diagnostics — all listed in the diagnostic-codes gap list.
