### PR TITLE
feat(fmt): move gowdk fmt to parser-backed formatting

### DIFF
--- a/cmd/gowdk/lang.go
+++ b/cmd/gowdk/lang.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -33,34 +34,63 @@ func tokens(args []string) error {
 
 func format(args []string) error {
 	write := false
+	checkMode := false
 	var paths []string
 	for _, arg := range args {
-		if arg == "--write" {
+		switch arg {
+		case "--write":
 			write = true
-			continue
+		case "--check":
+			checkMode = true
+		default:
+			paths = append(paths, arg)
 		}
-		paths = append(paths, arg)
 	}
 	if len(paths) == 0 {
-		return fmt.Errorf("usage: gowdk fmt [--write] <files>")
+		return fmt.Errorf("usage: gowdk fmt [--write] [--check] <files>")
 	}
 
+	skipped := false
+	needsFormat := false
 	for _, path := range paths {
 		source, err := os.ReadFile(path)
 		if err != nil {
 			return err
 		}
-		formatted := lang.Format(source)
-		if write {
+		formatted, parsed := lang.FormatChecked(source)
+		// Refuse to rewrite source that does not parse so malformed files are
+		// preserved rather than normalized through text heuristics. The
+		// conservative fallback is still printed for inspection without --write.
+		if !parsed && (write || checkMode) {
+			fmt.Fprintf(os.Stderr, "fmt: skipping %s: source has syntax errors; run `gowdk check %s`\n", path, path)
+			skipped = true
+			continue
+		}
+		switch {
+		case checkMode:
+			if !bytes.Equal(formatted, source) {
+				fmt.Println(path)
+				needsFormat = true
+			}
+		case write:
+			if bytes.Equal(formatted, source) {
+				continue
+			}
 			if err := os.WriteFile(path, formatted, 0o644); err != nil {
 				return err
 			}
-			continue
+		default:
+			if len(paths) > 1 {
+				fmt.Printf("==> %s <==\n", path)
+			}
+			fmt.Print(string(formatted))
 		}
-		if len(paths) > 1 {
-			fmt.Printf("==> %s <==\n", path)
-		}
-		fmt.Print(string(formatted))
+	}
+	if skipped {
+		return fmt.Errorf("fmt: some files were skipped because of syntax errors")
+	}
+	if checkMode && needsFormat {
+		return fmt.Errorf("fmt: some files need formatting")
 	}
 	return nil
 }

--- a/cmd/gowdk/main.go
+++ b/cmd/gowdk/main.go
@@ -151,7 +151,7 @@ func commandUsage(command string) (string, bool) {
 	case "tokens":
 		return "usage: gowdk tokens <file.gwdk>", true
 	case "fmt":
-		return "usage: gowdk fmt [--write] <files>", true
+		return "usage: gowdk fmt [--write] [--check] <files>", true
 	case "check":
 		return projectCommandUsage("check", true), true
 	case "fix":
@@ -228,7 +228,7 @@ func usage() {
 	fmt.Println("  init [--force] [--tests] [--template <site|minimal>] [dir] scaffold a starter GOWDK project")
 	fmt.Println("  add <addon> [--config <file>] [--base-url <url>] | add --list [--registry] [--json]  wire or list addons")
 	fmt.Println("  tokens <file.gwdk>       print language tokens")
-	fmt.Println("  fmt [--write] <files>    format .gwdk files")
+	fmt.Println("  fmt [--write] [--check] <files>  format .gwdk files (--check reports files that need formatting)")
 	fmt.Println("  check [--config <file>] [--env-file <file>] [--module <name>] [--json] [--warnings-as-errors] [--ssr] [files...] parse and validate .gwdk files")
 	fmt.Println("  fix [--dry-run] [--code <diagnostic-code>] [--config <file>] [--env-file <file>] [--module <name>] [--ssr] [files...] apply registered safe diagnostic fixes")
 	fmt.Println("  manifest [--config <file>] [--env-file <file>] [--module <name>] [--ssr] [files...] print validated manifest JSON")

--- a/cmd/gowdk/main_test.go
+++ b/cmd/gowdk/main_test.go
@@ -8006,3 +8006,62 @@ func TestLiveReloadBrokerNotifyIsNoOpOnNilBroker(t *testing.T) {
 	broker.notify("reload")
 	broker.notifyData("build-error", "boom")
 }
+
+func TestFmtCommandWritesFormatsAndChecks(t *testing.T) {
+	root := t.TempDir()
+	unformatted := "page home\nroute \"/\"\nguard public\n\nview {\n<main>\n<h1>Home</h1>\n</main>\n}\n"
+	formatted := "page home\nroute \"/\"\nguard public\n\nview {\n  <main>\n    <h1>Home</h1>\n  </main>\n}\n"
+
+	path := filepath.Join(root, "home.page.gwdk")
+	if err := os.WriteFile(path, []byte(unformatted), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// --check on an unformatted file reports it and fails.
+	out, err := captureCLIStdout(t, func() error { return run([]string{"fmt", "--check", path}) })
+	if err == nil {
+		t.Fatalf("expected --check to fail for an unformatted file")
+	}
+	if !strings.Contains(out, path) {
+		t.Fatalf("expected --check to list %q, got:\n%s", path, out)
+	}
+
+	// --write rewrites the file to its formatted form.
+	if err := run([]string{"fmt", "--write", path}); err != nil {
+		t.Fatalf("fmt --write: %v", err)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != formatted {
+		t.Fatalf("unexpected written output:\n--- got ---\n%s--- want ---\n%s", got, formatted)
+	}
+
+	// --check now passes because the file is already formatted.
+	if err := run([]string{"fmt", "--check", path}); err != nil {
+		t.Fatalf("expected --check to pass for a formatted file, got %v", err)
+	}
+}
+
+func TestFmtCommandRefusesToRewriteUnparseableSource(t *testing.T) {
+	root := t.TempDir()
+	// A view body with an HTML comment is not supported by the view parser, so
+	// the formatter must refuse to rewrite the file and leave the source intact.
+	original := "page home\nroute \"/\"\nguard public\n\nview {\n<main>\n<!-- keep -->\n<h1>Home</h1>\n</main>\n}\n"
+	path := filepath.Join(root, "broken.page.gwdk")
+	if err := os.WriteFile(path, []byte(original), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := run([]string{"fmt", "--write", path}); err == nil {
+		t.Fatalf("expected fmt --write to refuse unparseable source")
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != original {
+		t.Fatalf("fmt --write must not rewrite unparseable source:\n--- got ---\n%s--- want ---\n%s", got, original)
+	}
+}

--- a/docs/engineering/release-plan.md
+++ b/docs/engineering/release-plan.md
@@ -316,8 +316,11 @@ Every 0.x minor release must have:
   Tailwind command. Implemented suggestion surfaces are documented in
   `docs/reference/diagnostics.md`; remaining suggestion expansion is deferred to
   #250.
-- [x] Add formatter idempotence and comment preservation tests. Parser-backed
-  formatting beyond the current line-oriented formatter is deferred to #250.
+- [x] Add formatter idempotence and comment preservation tests. `gowdk fmt` is
+  now parser-backed (#472): block kinds come from the parser and view markup is
+  indented from the parsed view node tree, with a conservative line-oriented
+  fallback that preserves unparseable source. Remaining unsupported formatting
+  families are listed in `docs/language/formatting.md`.
 - [x] Add malformed syntax tests. Current parser/check fixtures cover malformed
   metadata, imports, `use`, endpoint migration, and unsupported build syntax;
   broader recovery-driven malformed syntax coverage is deferred to #250.

--- a/docs/language/formatting.md
+++ b/docs/language/formatting.md
@@ -1,26 +1,70 @@
 # Formatting
 
-The current formatter normalizes whitespace for line-oriented `.gwdk` files:
+`gowdk fmt` formats `.gwdk` source from the parsed syntax tree. The CLI and the
+language server share one implementation (`internal/lang.Format`), so editor
+formatting and `gowdk fmt` produce identical output.
 
-- Trims trailing spaces and tabs.
-- Removes repeated blank lines except where one blank line separates meaningful sections.
-- Keeps metadata declarations grouped without blank lines between adjacent declarations.
-- Indents lines by brace depth using two spaces.
-- Emits a final newline.
+```sh
+gowdk fmt <files>            # print formatted source to stdout
+gowdk fmt --write <files>    # rewrite files in place
+gowdk fmt --check <files>    # list files that are not formatted (non-zero exit)
+```
 
-The formatter does not parse markup or statements yet. It counts braces in text, so future parser-backed formatting must replace this for nested markup, comments, attributes, expressions, and block bodies.
+## Parser-backed formatting
 
-Current hardening coverage:
+When a file parses, the formatter is driven by the parsed structure rather than
+line-by-line text heuristics:
 
-- Supported page, component, endpoint, comment, and nested-markup shapes are
-  checked for idempotence.
+- Top-level declarations, comments, and blank lines keep their content; only
+  indentation and blank-line grouping are normalized.
+- Block kinds and boundaries come from the parser, so `style`, `client`, `go`,
+  `go ssr`, `go client`, `go addon.*`, `server`, and the record/contract blocks
+  are each indented by brace depth using the parser's string/comment-aware
+  scanner. Braces inside string literals, comments, and template literals do not
+  skew indentation.
+- View markup is indented from the parsed view node tree. Nested elements,
+  component calls, interpolations, and multi-line open tags are indented from
+  structure, so a multi-line tag indents its attribute continuation lines one
+  level deeper than the tag and places the closing `>` / `/>` back at the tag's
+  level.
+- Comments are preserved. Top-level `//` comments keep their position and are
+  re-indented in place.
+- Two-space indentation; a single trailing newline.
+
+The formatter normalizes whitespace only — it never rewrites the textual content
+of a line, so expressions, attribute values, CSS, JavaScript, and Go block
+bodies are preserved exactly.
+
+## Malformed or unsupported source
+
+If a file does not parse, the formatter falls back to a conservative
+line-oriented pass that only normalizes whitespace and never drops user source:
+
+- `gowdk fmt` and the editor still print best-effort formatted output.
+- `gowdk fmt --write` and `gowdk fmt --check` refuse the file (non-zero exit)
+  rather than rewriting source the parser cannot model. Run `gowdk check
+  <file>` to see the underlying diagnostics.
+
+## Unsupported formatting families
+
+These shapes are formatted by the conservative fallback (whitespace only),
+because the parser cannot model them precisely. They are preserved without data
+loss, but their internal structure is not re-derived:
+
+- View bodies containing HTML comments (`<!-- ... -->`). The view parser does not
+  model HTML comments, so such views take the fallback path. Inline `{...}`
+  interpolations and component calls are supported on the parser-backed path.
+- Any file with parse-level syntax errors or unsupported/legacy block syntax
+  (for example old `act {}` / `api {}` blocks). These keep their content and
+  surface their diagnostics through `gowdk check`.
+- Go, CSS, and JavaScript block bodies are indented by brace depth, not
+  reformatted by a language-specific formatter. Run `gofmt` (or the relevant
+  tool) for canonical formatting of those bodies.
+
+## Hardening coverage
+
+- Page, component, endpoint, comment, nested-markup, multi-line-attribute, and
+  per-block-family shapes are covered by golden and idempotence tests.
 - Formatting a file with parser-level migration errors does not hide those
-  errors; validation still reports the parser diagnostic after formatting.
-
-Unsupported formatting cases:
-
-- The formatter does not validate syntax.
-- The formatter does not preserve semantic indentation inside markup yet.
-- Braces inside strings, comments, JavaScript, CSS, or arbitrary Go block
-  bodies can affect indentation because the current implementation counts
-  braces line by line.
+  errors; validation still reports the diagnostic after formatting.
+- The fallback path is covered by a test that asserts no source line is dropped.

--- a/internal/lang/format.go
+++ b/internal/lang/format.go
@@ -1,16 +1,192 @@
 package lang
 
 import (
+	"sort"
 	"strings"
 
+	"github.com/cssbruno/gowdk/internal/gwdkast"
 	"github.com/cssbruno/gowdk/internal/parser"
+	"github.com/cssbruno/gowdk/internal/viewmodel"
 )
 
-// Format normalizes whitespace for top-level .gwdk metadata and blocks. Brace
-// depth is tracked with the parser's string/comment-aware scanner so braces
-// inside string literals, comments, and template literals do not skew
-// indentation (for example `title "a { b"` or `// note about }`).
+// Format normalizes whitespace for .gwdk source. When the file parses, it
+// formats from the parsed structure: block kinds and boundaries come from the
+// parser and view markup indentation comes from the parsed view node tree, so
+// nested markup, multi-line attributes, and interpolations are indented from
+// structure rather than line-by-line tag heuristics. When the file does not
+// parse, it falls back to the conservative line-oriented formatter so malformed
+// source is preserved instead of being rewritten destructively.
 func Format(source []byte) []byte {
+	formatted, _ := FormatChecked(source)
+	return formatted
+}
+
+// FormatChecked formats source and reports whether the file was formatted from
+// its parsed structure. ok is false when the syntax does not parse; in that case
+// the returned bytes come from the conservative line-oriented fallback, which
+// only normalizes whitespace and never drops user source. Callers that must not
+// rewrite malformed files (for example `gowdk fmt --write`) gate on ok.
+func FormatChecked(source []byte) (formatted []byte, ok bool) {
+	if out, parsed := formatStructured(source); parsed {
+		return out, true
+	}
+	return formatLegacy(source), false
+}
+
+// formatStructured formats source from the typed syntax tree. It returns
+// ok=false when the source cannot be parsed so the caller can fall back without
+// touching content.
+func formatStructured(source []byte) ([]byte, bool) {
+	file, err := parser.ParseSyntax(source)
+	if err != nil {
+		return nil, false
+	}
+	viewDepths := viewMarkupDepths(file)
+
+	var out []string
+	blankPending := false
+	depth := 0
+	braces := parser.NewBraceDepth()
+
+	for index, raw := range strings.Split(string(source), "\n") {
+		line := strings.TrimSpace(raw)
+		if line == "" {
+			blankPending = true
+			continue
+		}
+
+		if len(out) > 0 && blankPending && shouldKeepBlank(out[len(out)-1], line) {
+			out = append(out, "")
+		}
+		blankPending = false
+
+		// A line that is textually a closing brace dedents itself, unless we are
+		// inside a multi-line literal/comment where that "}" is body content.
+		inMultiline := braces.InMultiline()
+		indent := depth
+		if !inMultiline && strings.HasPrefix(line, "}") && indent > 0 {
+			indent--
+		}
+		// View body lines are indented by their parsed markup depth on top of the
+		// block's brace depth. The block's closing "}" is not a view body line and
+		// is handled by the brace-depth path above.
+		if markup, isViewBody := viewDepths[index+1]; isViewBody && !strings.HasPrefix(line, "}") {
+			out = append(out, strings.Repeat("  ", indent+markup)+line)
+		} else {
+			out = append(out, strings.Repeat("  ", indent)+line)
+		}
+		depth += braces.Delta(line)
+		if depth < 0 {
+			depth = 0
+		}
+	}
+
+	return []byte(strings.Join(out, "\n") + "\n"), true
+}
+
+// viewMarkupDepths maps a 1-based source line to its markup nesting depth for
+// every view block in the file. Depths are derived from the parsed view node
+// tree rather than scanning tags line by line.
+func viewMarkupDepths(file gwdkast.File) map[int]int {
+	depths := map[int]int{}
+	for _, block := range file.Blocks {
+		if block.Kind != "view" || len(block.View) == 0 {
+			continue
+		}
+		assignViewMarkupDepths(depths, block)
+	}
+	return depths
+}
+
+// assignViewMarkupDepths records the markup nesting depth of each source line in
+// one view block. Node offsets are rune offsets into the trimmed block body, and
+// block.BodyStart.Line is the source line of the body's first rune, so a body
+// line index maps directly to a source line.
+func assignViewMarkupDepths(depths map[int]int, block gwdkast.Block) {
+	body := []rune(block.Body)
+	var newlines []int
+	for offset, r := range body {
+		if r == '\n' {
+			newlines = append(newlines, offset)
+		}
+	}
+	baseLine := block.BodyStart.Line
+
+	// bodyLine returns the 0-based body line index containing the given rune
+	// offset (the count of newlines before it).
+	bodyLine := func(offset int) int {
+		if offset < 0 {
+			offset = 0
+		}
+		if offset > len(body) {
+			offset = len(body)
+		}
+		return sort.SearchInts(newlines, offset)
+	}
+	// set records depth for a body line unless an earlier (left-most) construct
+	// already claimed it, so a line is indented by its first construct.
+	set := func(bodyLineIndex, depth int) {
+		line := baseLine + bodyLineIndex
+		if _, exists := depths[line]; !exists {
+			depths[line] = depth
+		}
+	}
+	// container assigns depths for an element or component: the open tag line at
+	// depth, any multi-line attribute continuation lines one level deeper, and a
+	// separate close tag line back at depth.
+	container := func(start, end int, attrs []viewmodel.Attr, depth int) {
+		openLine := bodyLine(start)
+		set(openLine, depth)
+		tagEnd := openLine
+		for _, attr := range attrs {
+			if line := bodyLine(maxInt(attr.Start, attr.End-1)); line > tagEnd {
+				tagEnd = line
+			}
+		}
+		for line := openLine + 1; line <= tagEnd; line++ {
+			set(line, depth+1)
+		}
+		if closeLine := bodyLine(maxInt(start, end-1)); closeLine != openLine {
+			set(closeLine, depth)
+		}
+	}
+
+	var walk func(nodes []viewmodel.Node, depth int)
+	walk = func(nodes []viewmodel.Node, depth int) {
+		for _, node := range nodes {
+			switch typed := node.(type) {
+			case viewmodel.Element:
+				container(typed.Start, typed.End, typed.Attrs, depth)
+				walk(typed.Children, depth+1)
+			case viewmodel.ComponentCall:
+				container(typed.Start, typed.End, typed.Attrs, depth)
+				walk(typed.Children, depth+1)
+			case viewmodel.Text:
+				start := bodyLine(typed.Start)
+				end := bodyLine(maxInt(typed.Start, typed.End-1))
+				for line := start; line <= end; line++ {
+					set(line, depth)
+				}
+			}
+		}
+	}
+	walk(block.View, 0)
+}
+
+func maxInt(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+// formatLegacy is the conservative line-oriented fallback used when source does
+// not parse. It tracks brace depth with the parser's string/comment-aware
+// scanner so braces inside string literals, comments, and template literals do
+// not skew indentation (for example `title "a { b"` or `// note about }`), and
+// it indents view markup with a line-by-line tag scanner. It only normalizes
+// whitespace and never changes line content.
+func formatLegacy(source []byte) []byte {
 	var out []string
 	blankPending := false
 	depth := 0

--- a/internal/lang/format_test.go
+++ b/internal/lang/format_test.go
@@ -31,6 +31,85 @@ func TestFormatGoldenPreservesCommentsAndNestedMarkup(t *testing.T) {
 	}
 }
 
+// TestFormatParserBackedGolden exercises the parser-backed path across the block
+// families called out by the formatter scope: comments, nested markup,
+// multi-line attributes, interpolations, and style, client, go, go ssr, go
+// client, and go addon.* bodies.
+func TestFormatParserBackedGolden(t *testing.T) {
+	source, err := os.ReadFile(filepath.FromSlash("testdata/format_parser_backed/input.gwdk"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected, err := os.ReadFile(filepath.FromSlash("testdata/format_parser_backed/expected.gwdk"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	formatted, ok := FormatChecked(source)
+	if !ok {
+		t.Fatalf("expected parser-backed formatting, got conservative fallback for:\n%s", source)
+	}
+	if string(formatted) != string(expected) {
+		t.Fatalf("parser-backed golden mismatch\nexpected:\n%s\nactual:\n%s", expected, formatted)
+	}
+	// The formatted golden must be a fixed point of the formatter.
+	if twice := Format(expected); string(twice) != string(expected) {
+		t.Fatalf("parser-backed golden is not idempotent\nonce:\n%s\ntwice:\n%s", expected, twice)
+	}
+}
+
+// TestFormatStructuredIndentsMultiLineAttributes locks the parser-backed
+// behavior the line-by-line fallback cannot reproduce: a multi-line open tag
+// indents its attribute continuation lines one level deeper than the tag, with
+// the self-closing terminator back at the tag's level.
+func TestFormatStructuredIndentsMultiLineAttributes(t *testing.T) {
+	source := []byte("view {\n<input\ntype=\"text\"\nvalue={email}\n/>\n}\n")
+	formatted, ok := FormatChecked(source)
+	if !ok {
+		t.Fatalf("expected parser-backed formatting, got fallback")
+	}
+	want := "view {\n  <input\n    type=\"text\"\n    value={email}\n  />\n}\n"
+	if string(formatted) != want {
+		t.Fatalf("multi-line attribute indentation mismatch:\n--- got ---\n%s--- want ---\n%s", formatted, want)
+	}
+}
+
+// TestFormatCheckedReportsParseability reports the parser-backed path for
+// parseable source and the conservative fallback for source the parser rejects.
+func TestFormatCheckedReportsParseability(t *testing.T) {
+	if _, ok := FormatChecked([]byte("page home\nroute \"/\"\n\nview {\n<main>Home</main>\n}\n")); !ok {
+		t.Fatalf("expected ok=true for parseable source")
+	}
+	// View bodies with HTML comments are not supported by the view parser, so the
+	// formatter preserves the source through the conservative fallback.
+	if _, ok := FormatChecked([]byte("view {\n<main>\n<!-- note -->\n</main>\n}\n")); ok {
+		t.Fatalf("expected ok=false for view markup the parser cannot parse")
+	}
+}
+
+// TestFormatPreservesUnsupportedViewSyntaxWithoutDroppingSource verifies the
+// fallback never drops user source: every non-blank line survives a format of a
+// view the parser cannot handle, and the result is idempotent.
+func TestFormatPreservesUnsupportedViewSyntaxWithoutDroppingSource(t *testing.T) {
+	source := []byte("page home\nroute \"/\"\n\nview {\n<main>\n<!-- keep this comment -->\n<h1>{title}</h1>\n</main>\n}\n")
+	formatted, ok := FormatChecked(source)
+	if ok {
+		t.Fatalf("expected conservative fallback for unsupported view syntax")
+	}
+	for _, line := range strings.Split(string(source), "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			continue
+		}
+		if !strings.Contains(string(formatted), trimmed) {
+			t.Fatalf("fallback dropped source line %q from:\n%s", trimmed, formatted)
+		}
+	}
+	if twice := Format(formatted); string(twice) != string(formatted) {
+		t.Fatalf("fallback is not idempotent\nonce:\n%s\ntwice:\n%s", formatted, twice)
+	}
+}
+
 func TestFormatPreservesNestedViewMarkupDepth(t *testing.T) {
 	source := []byte(`view {
 <main class="shell">

--- a/internal/lang/testdata/format_parser_backed/expected.gwdk
+++ b/internal/lang/testdata/format_parser_backed/expected.gwdk
@@ -1,0 +1,78 @@
+package app
+
+page dashboard
+route "/dashboard"
+guard public
+
+// Top-level comment kept above imports.
+import "time"
+
+// Use comment kept above the declaration.
+use widgets "components"
+
+// Store comment kept above the declaration.
+store Session app.NewSession
+
+style {
+  .panel {
+    color: red;
+  }
+  .panel .title {
+    font-weight: bold;
+  }
+}
+
+// View comment kept above the block.
+view {
+  <main class="shell">
+    <section class="panel">
+      <h1 class="title">{title}</h1>
+      <p>Welcome, {user.Name}</p>
+      <form g:post={Save}>
+        <input
+          type="text"
+          name="email"
+          value={email}
+        />
+        <button g:if={ready}>Save</button>
+      </form>
+      <ul>
+        <li g:for={item in items} g:key={item.ID}>{item.Name}</li>
+      </ul>
+    </section>
+    <Footer year={year} />
+  </main>
+}
+
+client {
+  function setup() {
+    const handlers = {
+      save: () => submit(),
+    }
+    return handlers
+  }
+}
+
+go {
+  func Save(ctx app.Context) error {
+    return nil
+  }
+}
+
+go ssr {
+  func Load(ctx app.Context) error {
+    return nil
+  }
+}
+
+go client {
+  func boot() {
+    println("client")
+  }
+}
+
+go addon.counter {
+  func Increment() int {
+    return 1
+  }
+}

--- a/internal/lang/testdata/format_parser_backed/input.gwdk
+++ b/internal/lang/testdata/format_parser_backed/input.gwdk
@@ -1,0 +1,78 @@
+package app
+
+page dashboard
+route "/dashboard"
+guard public
+
+// Top-level comment kept above imports.
+import "time"
+
+// Use comment kept above the declaration.
+use widgets "components"
+
+// Store comment kept above the declaration.
+store Session app.NewSession
+
+style {
+.panel {
+color: red;
+}
+.panel .title {
+font-weight: bold;
+}
+}
+
+// View comment kept above the block.
+view {
+<main class="shell">
+<section class="panel">
+<h1 class="title">{title}</h1>
+<p>Welcome, {user.Name}</p>
+<form g:post={Save}>
+<input
+type="text"
+name="email"
+value={email}
+/>
+<button g:if={ready}>Save</button>
+</form>
+<ul>
+<li g:for={item in items} g:key={item.ID}>{item.Name}</li>
+</ul>
+</section>
+<Footer year={year} />
+</main>
+}
+
+client {
+function setup() {
+const handlers = {
+save: () => submit(),
+}
+return handlers
+}
+}
+
+go {
+func Save(ctx app.Context) error {
+return nil
+}
+}
+
+go ssr {
+func Load(ctx app.Context) error {
+return nil
+}
+}
+
+go client {
+func boot() {
+println("client")
+}
+}
+
+go addon.counter {
+func Increment() int {
+return 1
+}
+}


### PR DESCRIPTION
## Summary

- `gowdk fmt` now formats from the parsed syntax tree instead of the line-oriented brace-counting heuristic. When a file parses, block kinds/boundaries come from the parser and **view markup is indented from the parsed view node tree**, so nested markup, multi-line open tags (attribute continuation lines indent one level deeper than the tag), component calls, and `{...}` interpolations are indented from structure rather than a tag-by-tag line scan. Comments and all line content are preserved — only indentation and blank-line grouping are normalized.
- Unparseable source falls back to a conservative line-oriented pass that **never drops user source**. New `FormatChecked` reports parseability, and the CLI uses it: `gowdk fmt --write` and the new `gowdk fmt --check` **refuse** files the parser cannot model (non-zero exit) instead of rewriting them, while plain `gowdk fmt` still prints best-effort output for inspection.
- The **LSP shares the same engine** (`internal/lang.Format`), so editor formatting matches the CLI with no editor-only path.
- Per the scope's "conservative fallback with diagnostics," the remaining unsupported families are documented rather than force-formatted (gap list below).

Design notes:
- The proven brace-aware forward pass is kept for `style`/`client`/`go`/`go ssr`/`go client`/`go addon.*`/`server`/record bodies (indented by brace depth, not language-reformatted). The parser-backed change replaces the heuristic view-markup indentation with node-tree-derived depths and gates the whole pass on a successful parse.
- Documented unsupported families (whitespace-only fallback, preserved without loss): HTML comments in view bodies (`<!-- -->` is not modeled by the view parser), legacy/invalid block syntax, and language-specific reformatting of Go/CSS/JS bodies.

## Issue Closure

Closes #472

## Verification

- [x] I ran the relevant tests, lint, and build commands.
- [x] I ran `scripts/test-go-modules.sh` when Go code or compiler behavior changed.
- [x] I ran `go build ./cmd/gowdk` when CLI, compiler, runtime, addon, or release behavior changed.
- [ ] I ran `node --check editors/vscode/extension.js` when editor files changed. (No editor files changed.)
- [x] I updated docs for behavior, setup, or architecture changes.
- [x] I added or updated tests for changed behavior.
- [x] I considered security-sensitive surfaces such as auth, CSRF, redirects, request-time handlers, logs, diagnostics, embedded assets, editor commands, WASM, contracts, and realtime behavior. (Formatter is whitespace-only and never rewrites line content; `--write` refuses unparseable source.)

Commands run (all green): `go build ./cmd/gowdk`, `go test ./internal/lang/ ./internal/lsp/ ./cmd/gowdk/`, `scripts/test-go-modules.sh` (exit 0), `gofmt -l`, `go vet`.

Tests added: comprehensive golden (`testdata/format_parser_backed/`) covering comments, nested/multi-line markup, expressions, and `style`/`client`/`go`/`go ssr`/`go client`/`go addon.*` bodies; focused tests for multi-line attribute indentation, parseability reporting, and the no-source-dropped fallback; CLI tests for `--check` and refuse-on-malformed `--write`.

## LLM Assistance

- LLM session summary: Mapped the existing formatter/LSP/parser surfaces, then rebuilt `internal/lang.Format` as a parse-gated structured pass with view depths from the parsed `viewmodel.Node` tree and a conservative fallback; wired `FormatChecked` into the CLI; added goldens/tests and docs.
- Human-reviewed assumptions: comments are dropped by the AST (so the formatter normalizes structure over preserved line content rather than regenerating from the AST); view bodies with HTML comments are unsupported by `viewparse` and intentionally take the fallback; `--write`/`--check` refusing unparseable source is the chosen "refuses or preserves" behavior.
- Follow-up work: optional language-aware reformatting of Go/CSS/JS block internals; view-parser support for HTML comments would let those views take the parser-backed path.
