### PR TITLE
chore: remove dead CLI wrappers and a stale manifest reference

### DIFF
--- a/cmd/gowdk/dev.go
+++ b/cmd/gowdk/dev.go
@@ -546,14 +546,6 @@ func devRuntimePlanLoaded(plan buildOptions, outputDir string) (devRuntime, erro
 	return devRuntime{Enabled: true, AppDir: appDir, BinaryPath: binaryPath}, nil
 }
 
-func devAppAndBinary(args []string, _ string) (string, string, error) {
-	plan, err := loadBuildOptions(args)
-	if err != nil {
-		return "", "", err
-	}
-	return devAppAndBinaryLoaded(plan)
-}
-
 func devAppAndBinaryLoaded(plan buildOptions) (string, string, error) {
 	if len(plan.TargetNames) > 0 {
 		targets, err := selectBuildTargets(plan.Options.Config.Build.Targets, plan.TargetNames)

--- a/cmd/gowdk/dev_loop.go
+++ b/cmd/gowdk/dev_loop.go
@@ -21,14 +21,6 @@ import (
 	"github.com/cssbruno/gowdk/internal/viewmodel"
 )
 
-func buildDevChange(args []string, change inputChange, allowIncremental bool) (bool, error) {
-	plan, err := loadBuildOptions(args)
-	if err != nil {
-		return false, err
-	}
-	return buildDevChangeLoaded(plan, change, allowIncremental)
-}
-
 func buildDevChangeLoaded(plan buildOptions, change inputChange, allowIncremental bool) (bool, error) {
 	if allowIncremental {
 		incremental, err := buildIncrementalSPALoaded(plan, change)
@@ -984,11 +976,6 @@ func uniqueInputPaths(paths []string) []string {
 	}
 	sort.Strings(unique)
 	return unique
-}
-
-func discoverBuildCSSFiles(config gowdk.Config, outputDir string, root string) ([]string, error) {
-	files, _, err := discoverBuildCSSFilesAndDirs(config, outputDir, root)
-	return files, err
 }
 
 func discoverBuildCSSFilesAndDirs(config gowdk.Config, outputDir string, root string) ([]string, []string, error) {

--- a/cmd/gowdk/main.go
+++ b/cmd/gowdk/main.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	"github.com/cssbruno/gowdk"
-	"github.com/cssbruno/gowdk/addons/ssr"
 )
 
 const version = "0.7.0"
@@ -294,21 +293,4 @@ func cleanNames(names []string) []string {
 		cleaned = append(cleaned, name)
 	}
 	return cleaned
-}
-
-func parseOptions(args []string) (cliOptions, []string) {
-	var options cliOptions
-	var paths []string
-	for _, arg := range args {
-		switch arg {
-		case "--ssr":
-			options.Config.Addons = append(options.Config.Addons, ssr.Addon())
-		case "--json":
-			options.JSON = true
-		default:
-			paths = append(paths, arg)
-			continue
-		}
-	}
-	return options, paths
 }

--- a/internal/source/source.go
+++ b/internal/source/source.go
@@ -1,15 +1,14 @@
 // Package source holds the neutral leaf value types shared across the GOWDK
 // compiler packages: source spans, route params, inline scripts, and backend
 // binding metadata. These types carry no behavior and depend on nothing else in
-// the module, so every layer (parser, AST, IR, manifest, generated output) can
-// reference them without creating import cycles or coupling to the manifest
-// page/component model.
+// the module, so every layer (parser, AST, IR, generated output) can reference
+// them without creating import cycles.
 //
-// Historically these lived in internal/manifest, which forced packages that
+// These were originally part of internal/manifest, which forced packages that
 // only needed a SourceSpan to depend on the whole manifest model (and made
-// internal/gwdkir depend on manifest). They were extracted here so the
-// manifest model and the IR can both reference shared leaf types from a neutral
-// home. manifest re-exports them as aliases for backward compatibility.
+// internal/gwdkir depend on manifest). They were extracted into this neutral
+// home so the IR could reference shared leaf types directly; the manifest model
+// itself has since been removed (the manifest→IR migration, #145/#173).
 package source
 
 import (


### PR DESCRIPTION
## What

Cleanup of genuinely-dead/stale code surfaced while auditing for "deprecated code" after the manifest→IR migration (#145/#173). Two independent, low-risk changes:

### 1. Remove dead args-based dev/build wrappers (`cmd/gowdk`)
`parseOptions`, `devAppAndBinary`, `buildDevChange`, and `discoverBuildCSSFiles` were thin wrappers that re-parsed `args` and delegated to a `*Loaded`/`*AndDirs` sibling. All call sites were migrated to the sibling forms, leaving these with **zero references anywhere in the package (including tests)** — verified by grep and `deadcode`. Also drops the now-unused `addons/ssr` import in `main.go` (the other `ssr` uses are in sibling files with their own imports).

### 2. Fix a stale doc comment (`internal/source`)
The `source` package doc still claimed `manifest re-exports them as aliases for backward compatibility`. The `internal/manifest` package was **deleted** by the manifest→IR migration, so that statement is false. Corrected to describe the current state (leaf types live here for the IR directly).

## What this is NOT

While auditing, the `act{}`/`api{}`/`@metadata` "removed syntax" rejection diagnostics were considered for removal but **deliberately kept** — they're live, tested DX (helpful errors + auto-fixes), not dead code. Removing them would only degrade error messages for already-removed syntax.

## Verification
- `go build ./internal/... ./cmd/...` clean.
- `go vet ./internal/source/ ./cmd/gowdk/` clean.
- `go test ./cmd/gowdk/` green (full package, ~82s).
- Comment-only change in `internal/source`; no behavior change.

No public API or diagnostic behavior changes.