### PR TITLE
Fix runtime hardening follow-ups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,28 @@ packages, and tooling contracts may change before 1.0.
 
 ## Unreleased
 
-_No changes yet._
+### Changed
+
+- The client expression runtime now receives its operator and builtin metadata
+  from the Go compiler/runtime spec instead of hardcoded JavaScript tables,
+  reducing Go/JS drift for generated islands.
+
+### Fixed
+
+- Redirect responses now validate unsafe local URLs before writing
+  `Set-Cookie` headers.
+- Enhanced partial forms now include the clicked submit button in submitted
+  `FormData`, and enhanced partial/command forms reject duplicate in-flight
+  submissions.
+- `gowdk:after-swap` is dispatched from live DOM after fragment swaps, so
+  document-level listeners still observe swaps that replace the submitting form.
+- Store subscriber failures are isolated so one throwing listener does not
+  block later subscribers.
+- `gowdk check` now propagates server `g:if` scope into descendants, restoring
+  parity with build-time server-region validation.
+- Request-time URL templates now validate `srcset` per candidate and encode SSR
+  route/load/server-region substitutions when they appear inside URL-bearing
+  attributes.
 
 ## v0.7.0 - 2026-06-17
 

--- a/docs/language/markup.md
+++ b/docs/language/markup.md
@@ -258,8 +258,10 @@ The policy applies to literal URL attributes and to values resolved through
 build data interpolation. `srcset` is checked per URL candidate. Request-time
 route params and `server {}` fields are allowed in URL-bearing attributes only
 inside root-relative URL templates with a stable literal prefix, such as
-`/issue/{issue.id}`. Bare request-time URLs such as `href={website}`,
-request-time-controlled first path segments such as `href="/{slug}"`,
+`/issue/{issue.id}`. During SSR and server-region rendering, accepted
+request-time URL segments are URL-encoded before HTML escaping. Bare
+request-time URLs such as `href={website}`, request-time-controlled first path
+segments such as `href="/{slug}"`,
 protocol-relative URLs, backslashes, control characters, inline handlers,
 `style`, and `srcdoc` are rejected. Custom attributes such as `data-uri` are
 ordinary escaped attributes; the exact HTML `<object data="...">` attribute is

--- a/internal/appgen/appgen_test.go
+++ b/internal/appgen/appgen_test.go
@@ -3075,6 +3075,48 @@ func TestGenerateWritesSSRLoadHandler(t *testing.T) {
 	}
 }
 
+func TestGenerateWritesURLAwareSSRLoadReplacements(t *testing.T) {
+	root := t.TempDir()
+	outputDir := filepath.Join(root, "dist")
+	appDir := filepath.Join(root, "generated-app")
+	writeTestFile(t, filepath.Join(outputDir, "index.html"), "<main>App</main>")
+
+	result, err := GenerateWithOptions(outputDir, appDir, Options{SSR: []SSRRoute{{
+		PageID:  "profile",
+		Route:   "/profile",
+		Guards:  []string{"public"},
+		HasLoad: true,
+		LoadBinding: source.BackendBinding{
+			Status:       source.BackendBindingBound,
+			ImportPath:   "example.com/app/profile",
+			PackageName:  "profile",
+			FunctionName: "LoadProfile",
+			Signature:    source.BackendSignatureLoadError,
+		},
+		HTML: `<main><a href="/user/__SLUG_URL__">__SLUG__</a></main>`,
+		LoadReplacements: []SSRLoadReplacement{
+			{Path: "user.slug", Placeholder: "__SLUG__"},
+			{Path: "user.slug", Placeholder: "__SLUG_URL__", URL: true},
+		},
+	}}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload, err := os.ReadFile(result.PackagePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	source := string(payload)
+	for _, expected := range []string{
+		`strings.ReplaceAll(html, "__SLUG__", gowdkhtml.Escape(fmt.Sprint(loadValue0)))`,
+		`strings.ReplaceAll(html, "__SLUG_URL__", gowdkhtml.EscapeURL(fmt.Sprint(loadValue1)))`,
+	} {
+		if !strings.Contains(source, expected) {
+			t.Fatalf("expected generated main.go to contain %q:\n%s", expected, source)
+		}
+	}
+}
+
 func TestGenerateKeepsActionHandlersIndependentFromSSRLoad(t *testing.T) {
 	root := t.TempDir()
 	outputDir := filepath.Join(root, "dist")
@@ -3171,6 +3213,40 @@ func TestGenerateWritesDynamicSSRHandler(t *testing.T) {
 		`request = request.WithContext(ctx)`,
 		`strings.ReplaceAll(html, "__SLUG__", gowdkhtml.Escape(params["slug"]))`,
 		`gowdkresponse.WriteNoStoreHTML(response, request, html)`,
+	} {
+		if !strings.Contains(source, expected) {
+			t.Fatalf("expected generated main.go to contain %q:\n%s", expected, source)
+		}
+	}
+}
+
+func TestGenerateWritesURLAwareSSRReplacements(t *testing.T) {
+	root := t.TempDir()
+	outputDir := filepath.Join(root, "dist")
+	appDir := filepath.Join(root, "generated-app")
+	writeTestFile(t, filepath.Join(outputDir, "index.html"), "<main>App</main>")
+
+	result, err := GenerateWithOptions(outputDir, appDir, Options{SSR: []SSRRoute{{
+		PageID: "blog.post",
+		Route:  "/blog/{slug}",
+		Guards: []string{"public"},
+		HTML:   `<main><a href="/blog/__SLUG_URL__">__SLUG__</a></main>`,
+		Replacements: []SSRReplacement{
+			{Param: "slug", Placeholder: "__SLUG__"},
+			{Param: "slug", Placeholder: "__SLUG_URL__", URL: true},
+		},
+	}}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload, err := os.ReadFile(result.PackagePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	source := string(payload)
+	for _, expected := range []string{
+		`strings.ReplaceAll(html, "__SLUG__", gowdkhtml.Escape(params["slug"]))`,
+		`strings.ReplaceAll(html, "__SLUG_URL__", gowdkhtml.EscapeURL(params["slug"]))`,
 	} {
 		if !strings.Contains(source, expected) {
 			t.Fatalf("expected generated main.go to contain %q:\n%s", expected, source)

--- a/internal/appgen/source_ssr.go
+++ b/internal/appgen/source_ssr.go
@@ -105,11 +105,15 @@ func ssrRouteBodyStmts(route SSRRoute, includeParams bool, rateLimit bool, csrf 
 	body = append(body, ssrLoadFetchStmts(route, trace)...)
 	body = append(body, ssrRegionRenderStmts(route)...)
 	for _, replacement := range route.Replacements {
+		value := call(sel("gowdkhtml", "Escape"), &ast.IndexExpr{X: id("params"), Index: stringLit(replacement.Param)})
+		if replacement.URL {
+			value = call(sel("gowdkhtml", "EscapeURL"), &ast.IndexExpr{X: id("params"), Index: stringLit(replacement.Param)})
+		}
 		body = append(body, assign([]ast.Expr{id("html")}, call(
 			sel("strings", "ReplaceAll"),
 			id("html"),
 			stringLit(replacement.Placeholder),
-			call(sel("gowdkhtml", "Escape"), &ast.IndexExpr{X: id("params"), Index: stringLit(replacement.Param)}),
+			value,
 		)))
 	}
 	body = append(body, ssrLoadScalarReplaceStmts(route)...)
@@ -271,6 +275,10 @@ func ssrLoadScalarReplaceStmts(route SSRRoute) []ast.Stmt {
 	for index, replacement := range route.LoadReplacements {
 		valueName := id("loadValue" + intIdentSuffix(index))
 		okName := id("loadOK" + intIdentSuffix(index))
+		replacementValue := call(sel("gowdkhtml", "Escape"), call(sel("fmt", "Sprint"), valueName))
+		if replacement.URL {
+			replacementValue = call(sel("gowdkhtml", "EscapeURL"), call(sel("fmt", "Sprint"), valueName))
+		}
 		stmts = append(stmts,
 			define([]ast.Expr{valueName, okName}, call(sel("gowdkssr", "LoadPath"), id("loadData"), stringLit(replacement.Path))),
 			&ast.IfStmt{
@@ -284,7 +292,7 @@ func ssrLoadScalarReplaceStmts(route SSRRoute) []ast.Stmt {
 				sel("strings", "ReplaceAll"),
 				id("html"),
 				stringLit(replacement.Placeholder),
-				call(sel("gowdkhtml", "Escape"), call(sel("fmt", "Sprint"), valueName)),
+				replacementValue,
 			)),
 		)
 	}
@@ -382,6 +390,9 @@ func ssrListFieldsExpr(fields []SSRListField) ast.Expr {
 			fieldElts = append(fieldElts, keyValue("Index", id("true")))
 		} else {
 			fieldElts = append(fieldElts, keyValue("Path", stringLit(field.Path)))
+		}
+		if field.URL {
+			fieldElts = append(fieldElts, keyValue("URL", id("true")))
 		}
 		elts = append(elts, &ast.CompositeLit{Type: sel("gowdkssr", "ListField"), Elts: fieldElts})
 	}

--- a/internal/appgen/source_ssr_regions.go
+++ b/internal/appgen/source_ssr_regions.go
@@ -91,10 +91,14 @@ func regionRendererExpr(route SSRRoute, region SSRQueryRegion) ast.Expr {
 func regionLoadFieldsExpr(replacements []SSRLoadReplacement) ast.Expr {
 	elts := make([]ast.Expr, 0, len(replacements))
 	for _, replacement := range replacements {
-		elts = append(elts, &ast.CompositeLit{Type: sel("gowdkssr", "RegionLoadField"), Elts: []ast.Expr{
+		fieldElts := []ast.Expr{
 			keyValue("Path", stringLit(replacement.Path)),
 			keyValue("Placeholder", stringLit(replacement.Placeholder)),
-		}})
+		}
+		if replacement.URL {
+			fieldElts = append(fieldElts, keyValue("URL", id("true")))
+		}
+		elts = append(elts, &ast.CompositeLit{Type: sel("gowdkssr", "RegionLoadField"), Elts: fieldElts})
 	}
 	return &ast.CompositeLit{
 		Type: &ast.ArrayType{Elt: sel("gowdkssr", "RegionLoadField")},

--- a/internal/appgen/validate_ssr.go
+++ b/internal/appgen/validate_ssr.go
@@ -106,18 +106,18 @@ func validateSSRReplacements(route SSRRoute) error {
 	for _, param := range ssrRoutePatternParams(route.Route) {
 		routeParams[param] = true
 	}
-	seen := map[string]bool{}
+	seenPlaceholders := map[string]bool{}
 	for _, replacement := range route.Replacements {
 		if !routeParams[replacement.Param] {
 			return fmt.Errorf("generated SSR %s replacement param %q is not declared by route %q", route.PageID, replacement.Param, route.Route)
 		}
-		if seen[replacement.Param] {
-			return fmt.Errorf("generated SSR %s declares duplicate replacement param %q", route.PageID, replacement.Param)
-		}
 		if strings.TrimSpace(replacement.Placeholder) == "" {
 			return fmt.Errorf("generated SSR %s replacement for %q has empty placeholder", route.PageID, replacement.Param)
 		}
-		seen[replacement.Param] = true
+		if seenPlaceholders[replacement.Placeholder] {
+			return fmt.Errorf("generated SSR %s declares duplicate replacement placeholder %q", route.PageID, replacement.Placeholder)
+		}
+		seenPlaceholders[replacement.Placeholder] = true
 	}
 	return nil
 }

--- a/internal/buildgen/render.go
+++ b/internal/buildgen/render.go
@@ -139,6 +139,7 @@ func convertSSRListFields(fields []view.SSRListField) []source.SSRListField {
 			Placeholder: field.Placeholder,
 			Path:        field.Path,
 			Index:       field.Index,
+			URL:         field.URL,
 		})
 	}
 	return out

--- a/internal/buildgen/ssr.go
+++ b/internal/buildgen/ssr.go
@@ -114,10 +114,13 @@ func ssrArtifact(config gowdk.Config, page gwdkir.Page, components map[string]vi
 	if !regions.empty() && !page.Blocks.Server {
 		return SSRArtifact{}, fmt.Errorf("%s: g:for and g:if over server data require a server {} block", page.ID)
 	}
+	html, replacements, loadReplacements = markPageURLPlaceholders(html, replacements, loadReplacements)
+	regions = markRegionURLPlaceholders(regions)
 	// A load field consumed only by g:for/g:if (resolved by the runtime region
 	// renderer) leaves no scalar placeholder in the HTML. Drop those request-time
 	// replacements so the handler does not stringify and substitute a value that
 	// never appears in the output.
+	replacements = usedSSRReplacements(html, replacements)
 	loadReplacements = usedLoadReplacements(html, loadReplacements)
 	queryRegions := ssrQueryRegions(html, regions.Lists, regions.Conds, loadReplacements, replacements, len(page.DynamicParams()) > 0)
 	return SSRArtifact{

--- a/internal/buildgen/ssr_list_test.go
+++ b/internal/buildgen/ssr_list_test.go
@@ -30,7 +30,7 @@ func toRuntimeListSpecs(specs []source.SSRListSpec) []gowdkssr.ListSpec {
 func toRuntimeListFields(fields []source.SSRListField) []gowdkssr.ListField {
 	out := make([]gowdkssr.ListField, 0, len(fields))
 	for _, field := range fields {
-		out = append(out, gowdkssr.ListField{Placeholder: field.Placeholder, Path: field.Path, Index: field.Index})
+		out = append(out, gowdkssr.ListField{Placeholder: field.Placeholder, Path: field.Path, Index: field.Index, URL: field.URL})
 	}
 	return out
 }
@@ -135,23 +135,37 @@ func TestSSRArtifactServerListEndToEnd(t *testing.T) {
 func TestSSRArtifactServerListRootRelativeURLTemplate(t *testing.T) {
 	view := `<main><a g:for={issue in issues} href="/issue/{issue.id}">{issue.title}</a></main>`
 	artifact := buildSSRRegionArtifact(t, `=> { issues }`, view)
+	if len(artifact.ListSpecs) != 1 {
+		t.Fatalf("expected one list spec, got %#v", artifact.ListSpecs)
+	}
+	urlField := false
+	for _, field := range artifact.ListSpecs[0].Fields {
+		if field.Path == "id" && field.URL {
+			urlField = true
+		}
+	}
+	if !urlField {
+		t.Fatalf("expected issue id field to be marked as a URL substitution, got %#v", artifact.ListSpecs[0].Fields)
+	}
 
 	html := gowdkssr.RenderRegions(artifact.HTML, toRuntimeListSpecs(artifact.ListSpecs), toRuntimeCondSpecs(artifact.CondSpecs), map[string]any{
 		"issues": []any{
 			map[string]any{"id": "T-1", "title": "Wire <auth>"},
 			map[string]any{"id": `bad" onclick="x`, "title": "Injected"},
+			map[string]any{"id": `\\evil.com`, "title": "Backslash"},
 		},
 	})
 
 	for _, want := range []string{
 		`href="/issue/T-1">Wire &lt;auth&gt;`,
-		`href="/issue/bad&#34; onclick=&#34;x">Injected`,
+		`href="/issue/bad%22%20onclick=%22x">Injected`,
+		`href="/issue/%5C%5Cevil.com">Backslash`,
 	} {
 		if !strings.Contains(html, want) {
 			t.Fatalf("rendered HTML missing %q\n%s", want, html)
 		}
 	}
-	if strings.Contains(html, `onclick="x"`) {
+	if strings.Contains(html, `onclick`) && !strings.Contains(html, `bad%22%20onclick=%22x`) {
 		t.Fatalf("server row URL interpolation escaped out of the href attribute:\n%s", html)
 	}
 }

--- a/internal/buildgen/ssr_test.go
+++ b/internal/buildgen/ssr_test.go
@@ -373,13 +373,27 @@ func TestSSRArtifactsRenderDynamicSSRPageWithPlaceholders(t *testing.T) {
 	if len(artifact.DynamicParams) != 1 || artifact.DynamicParams[0] != "slug" || len(artifact.Guards) != 1 || artifact.Guards[0] != "auth.required" {
 		t.Fatalf("unexpected route metadata: %#v", artifact)
 	}
-	if len(artifact.Replacements) != 1 || artifact.Replacements[0].Param != "slug" {
+	if len(artifact.Replacements) != 2 {
 		t.Fatalf("unexpected replacements: %#v", artifact.Replacements)
 	}
-	if !strings.Contains(artifact.HTML, artifact.Replacements[0].Placeholder) {
-		t.Fatalf("expected SSR HTML placeholder %q in %s", artifact.Replacements[0].Placeholder, artifact.HTML)
+	var textReplacement, urlReplacement SSRReplacement
+	for _, replacement := range artifact.Replacements {
+		if replacement.Param != "slug" {
+			t.Fatalf("unexpected replacement param: %#v", artifact.Replacements)
+		}
+		if replacement.URL {
+			urlReplacement = replacement
+		} else {
+			textReplacement = replacement
+		}
 	}
-	if !strings.Contains(artifact.HTML, `href="/blog/`+artifact.Replacements[0].Placeholder+`"`) {
+	if textReplacement.Placeholder == "" || urlReplacement.Placeholder == "" {
+		t.Fatalf("expected text and URL route replacements, got %#v", artifact.Replacements)
+	}
+	if !strings.Contains(artifact.HTML, `data-slug="`+textReplacement.Placeholder+`"`) || !strings.Contains(artifact.HTML, `<p>`+textReplacement.Placeholder+`</p>`) {
+		t.Fatalf("expected text SSR placeholder %q in %s", textReplacement.Placeholder, artifact.HTML)
+	}
+	if !strings.Contains(artifact.HTML, `href="/blog/`+urlReplacement.Placeholder+`"`) {
 		t.Fatalf("expected route-param URL template in SSR HTML:\n%s", artifact.HTML)
 	}
 }
@@ -444,6 +458,56 @@ func TestSSRArtifactsRenderLoadPlaceholders(t *testing.T) {
 	}
 	if !paths["user.name"] || !paths["account.plan"] {
 		t.Fatalf("expected dotted load paths, got %#v", artifact.LoadReplacements)
+	}
+}
+
+func TestSSRArtifactsMarkLoadURLPlaceholders(t *testing.T) {
+	outputDir := t.TempDir()
+	app := gwdkanalysis.Sources{Pages: []gwdkir.Page{{
+		ID:     "profile",
+		Route:  "/profile",
+		Render: gowdk.SSR,
+		Blocks: gwdkir.Blocks{
+			Server:     true,
+			ServerBody: `=> { user.slug, user.avatar }`,
+			View:       true,
+			ViewBody:   `<main><a href="/user/{user.slug}">{user.slug}</a><img srcset="/avatar/{user.avatar} 1x, /avatar/{user.avatar} 2x" /></main>`,
+		},
+	}}}
+
+	artifacts, err := SSRArtifacts(gowdk.Config{Addons: []gowdk.Addon{gowdk.NewAddon("ssr", gowdk.FeatureSSR)}}, app, outputDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(artifacts) != 1 {
+		t.Fatalf("expected one artifact, got %#v", artifacts)
+	}
+	artifact := artifacts[0]
+	if len(artifact.LoadReplacements) != 3 {
+		t.Fatalf("expected text slug, URL slug, and URL avatar replacements, got %#v", artifact.LoadReplacements)
+	}
+	var slugText, slugURL, avatarURL SSRLoadReplacement
+	for _, replacement := range artifact.LoadReplacements {
+		switch {
+		case replacement.Path == "user.slug" && replacement.URL:
+			slugURL = replacement
+		case replacement.Path == "user.slug":
+			slugText = replacement
+		case replacement.Path == "user.avatar" && replacement.URL:
+			avatarURL = replacement
+		}
+	}
+	if slugText.Placeholder == "" || slugURL.Placeholder == "" || avatarURL.Placeholder == "" {
+		t.Fatalf("expected URL-aware load replacements, got %#v", artifact.LoadReplacements)
+	}
+	if !strings.Contains(artifact.HTML, `href="/user/`+slugURL.Placeholder+`"`) {
+		t.Fatalf("expected slug URL placeholder in href:\n%s", artifact.HTML)
+	}
+	if !strings.Contains(artifact.HTML, `>`+slugText.Placeholder+`</a>`) {
+		t.Fatalf("expected slug text placeholder in link text:\n%s", artifact.HTML)
+	}
+	if strings.Count(artifact.HTML, avatarURL.Placeholder) != 2 {
+		t.Fatalf("expected avatar URL placeholder to be reused per srcset candidate:\n%s", artifact.HTML)
 	}
 }
 

--- a/internal/buildgen/ssr_url_placeholders.go
+++ b/internal/buildgen/ssr_url_placeholders.go
@@ -1,0 +1,290 @@
+package buildgen
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/cssbruno/gowdk/internal/source"
+)
+
+func markPageURLPlaceholders(html string, replacements []SSRReplacement, loadReplacements []SSRLoadReplacement) (string, []SSRReplacement, []SSRLoadReplacement) {
+	next := 0
+	html, replacements, loadReplacements, _ = markURLPlaceholdersInHTML(html, replacements, loadReplacements, nil, &next)
+	return html, replacements, loadReplacements
+}
+
+func markRegionURLPlaceholders(regions ssrRegions) ssrRegions {
+	next := 0
+	regions.Lists = markSSRListSpecsURLPlaceholders(regions.Lists, &next)
+	regions.Conds = markSSRCondSpecsURLPlaceholders(regions.Conds, &next)
+	return regions
+}
+
+func markSSRListSpecsURLPlaceholders(specs []source.SSRListSpec, next *int) []source.SSRListSpec {
+	if len(specs) == 0 {
+		return specs
+	}
+	out := make([]source.SSRListSpec, 0, len(specs))
+	for _, spec := range specs {
+		spec.RowTemplate, _, _, spec.Fields = markURLPlaceholdersInHTML(spec.RowTemplate, nil, nil, spec.Fields, next)
+		spec.Fields = usedSSRListFields(spec.RowTemplate, spec.Fields)
+		spec.Lists = markSSRListSpecsURLPlaceholders(spec.Lists, next)
+		spec.Conds = markSSRCondSpecsURLPlaceholders(spec.Conds, next)
+		out = append(out, spec)
+	}
+	return out
+}
+
+func markSSRCondSpecsURLPlaceholders(specs []source.SSRCondSpec, next *int) []source.SSRCondSpec {
+	if len(specs) == 0 {
+		return specs
+	}
+	out := make([]source.SSRCondSpec, 0, len(specs))
+	for _, spec := range specs {
+		spec.Template, _, _, spec.Fields = markURLPlaceholdersInHTML(spec.Template, nil, nil, spec.Fields, next)
+		spec.Fields = usedSSRListFields(spec.Template, spec.Fields)
+		spec.Lists = markSSRListSpecsURLPlaceholders(spec.Lists, next)
+		spec.Conds = markSSRCondSpecsURLPlaceholders(spec.Conds, next)
+		out = append(out, spec)
+	}
+	return out
+}
+
+func markURLPlaceholdersInHTML(html string, replacements []SSRReplacement, loadReplacements []SSRLoadReplacement, fields []source.SSRListField, next *int) (string, []SSRReplacement, []SSRLoadReplacement, []source.SSRListField) {
+	if html == "" {
+		return html, replacements, loadReplacements, fields
+	}
+	ranges := urlAttrValueRanges(html)
+	if len(ranges) == 0 {
+		return html, replacements, loadReplacements, fields
+	}
+
+	routeURLs := map[string]string{}
+	loadURLs := map[string]string{}
+	fieldURLs := map[string]string{}
+	var out strings.Builder
+	last := 0
+	for _, valueRange := range ranges {
+		if valueRange.start < last || valueRange.end > len(html) {
+			continue
+		}
+		out.WriteString(html[last:valueRange.start])
+		value := html[valueRange.start:valueRange.end]
+		value, replacements, loadReplacements, fields = markURLPlaceholdersInValue(value, replacements, loadReplacements, fields, routeURLs, loadURLs, fieldURLs, next)
+		out.WriteString(value)
+		last = valueRange.end
+	}
+	out.WriteString(html[last:])
+	return out.String(), replacements, loadReplacements, fields
+}
+
+func markURLPlaceholdersInValue(value string, replacements []SSRReplacement, loadReplacements []SSRLoadReplacement, fields []source.SSRListField, routeURLs, loadURLs, fieldURLs map[string]string, next *int) (string, []SSRReplacement, []SSRLoadReplacement, []source.SSRListField) {
+	routeCount := len(replacements)
+	for index := 0; index < routeCount; index++ {
+		replacement := replacements[index]
+		if replacement.URL || !strings.Contains(value, replacement.Placeholder) {
+			continue
+		}
+		placeholder, ok := routeURLs[replacement.Placeholder]
+		if !ok {
+			placeholder = urlPlaceholder(replacement.Placeholder, next)
+			routeURLs[replacement.Placeholder] = placeholder
+			replacement.Placeholder = placeholder
+			replacement.URL = true
+			replacements = append(replacements, replacement)
+		}
+		value = strings.ReplaceAll(value, replacements[index].Placeholder, placeholder)
+	}
+
+	loadCount := len(loadReplacements)
+	for index := 0; index < loadCount; index++ {
+		replacement := loadReplacements[index]
+		if replacement.URL || !strings.Contains(value, replacement.Placeholder) {
+			continue
+		}
+		placeholder, ok := loadURLs[replacement.Placeholder]
+		if !ok {
+			placeholder = urlPlaceholder(replacement.Placeholder, next)
+			loadURLs[replacement.Placeholder] = placeholder
+			replacement.Placeholder = placeholder
+			replacement.URL = true
+			loadReplacements = append(loadReplacements, replacement)
+		}
+		value = strings.ReplaceAll(value, loadReplacements[index].Placeholder, placeholder)
+	}
+
+	fieldCount := len(fields)
+	for index := 0; index < fieldCount; index++ {
+		field := fields[index]
+		if field.URL || !strings.Contains(value, field.Placeholder) {
+			continue
+		}
+		placeholder, ok := fieldURLs[field.Placeholder]
+		if !ok {
+			placeholder = urlPlaceholder(field.Placeholder, next)
+			fieldURLs[field.Placeholder] = placeholder
+			field.Placeholder = placeholder
+			field.URL = true
+			fields = append(fields, field)
+		}
+		value = strings.ReplaceAll(value, fields[index].Placeholder, placeholder)
+	}
+	return value, replacements, loadReplacements, fields
+}
+
+func urlPlaceholder(base string, next *int) string {
+	*next = *next + 1
+	suffix := "_URL_" + strconv.Itoa(*next)
+	if strings.HasSuffix(base, "__") {
+		return strings.TrimSuffix(base, "__") + suffix + "__"
+	}
+	return base + suffix
+}
+
+func usedSSRReplacements(html string, replacements []SSRReplacement) []SSRReplacement {
+	if len(replacements) == 0 {
+		return replacements
+	}
+	used := make([]SSRReplacement, 0, len(replacements))
+	for _, replacement := range replacements {
+		if strings.Contains(html, replacement.Placeholder) {
+			used = append(used, replacement)
+		}
+	}
+	return used
+}
+
+func usedSSRListFields(template string, fields []source.SSRListField) []source.SSRListField {
+	if len(fields) == 0 {
+		return fields
+	}
+	used := make([]source.SSRListField, 0, len(fields))
+	for _, field := range fields {
+		if strings.Contains(template, field.Placeholder) {
+			used = append(used, field)
+		}
+	}
+	return used
+}
+
+type attrValueRange struct {
+	start int
+	end   int
+}
+
+func urlAttrValueRanges(html string) []attrValueRange {
+	var ranges []attrValueRange
+	for index := 0; index < len(html); index++ {
+		if html[index] != '<' {
+			continue
+		}
+		end := htmlTagEnd(html, index+1)
+		if end < 0 {
+			break
+		}
+		ranges = append(ranges, tagURLAttrValueRanges(html, index+1, end)...)
+		index = end
+	}
+	return ranges
+}
+
+func htmlTagEnd(html string, cursor int) int {
+	var quote byte
+	for cursor < len(html) {
+		if quote != 0 {
+			if html[cursor] == quote {
+				quote = 0
+			}
+			cursor++
+			continue
+		}
+		switch html[cursor] {
+		case '\'', '"':
+			quote = html[cursor]
+		case '>':
+			return cursor
+		}
+		cursor++
+	}
+	return -1
+}
+
+func tagURLAttrValueRanges(html string, cursor, end int) []attrValueRange {
+	var ranges []attrValueRange
+	if cursor >= end || html[cursor] == '/' || html[cursor] == '!' || html[cursor] == '?' {
+		return nil
+	}
+	for cursor < end && !isHTMLSpace(html[cursor]) && html[cursor] != '/' {
+		cursor++
+	}
+	for cursor < end {
+		for cursor < end && isHTMLSpace(html[cursor]) {
+			cursor++
+		}
+		if cursor >= end || html[cursor] == '/' {
+			return ranges
+		}
+		nameStart := cursor
+		for cursor < end && !isHTMLSpace(html[cursor]) && html[cursor] != '=' && html[cursor] != '/' {
+			cursor++
+		}
+		name := html[nameStart:cursor]
+		for cursor < end && isHTMLSpace(html[cursor]) {
+			cursor++
+		}
+		if cursor >= end || html[cursor] != '=' {
+			continue
+		}
+		cursor++
+		for cursor < end && isHTMLSpace(html[cursor]) {
+			cursor++
+		}
+		valueStart, valueEnd, next := htmlAttrValueRange(html, cursor, end)
+		cursor = next
+		if urlBearingSSRAttr(name) {
+			ranges = append(ranges, attrValueRange{start: valueStart, end: valueEnd})
+		}
+	}
+	return ranges
+}
+
+func htmlAttrValueRange(html string, cursor, end int) (int, int, int) {
+	if cursor >= end {
+		return cursor, cursor, cursor
+	}
+	if html[cursor] == '\'' || html[cursor] == '"' {
+		quote := html[cursor]
+		cursor++
+		start := cursor
+		for cursor < end && html[cursor] != quote {
+			cursor++
+		}
+		if cursor < end {
+			return start, cursor, cursor + 1
+		}
+		return start, cursor, cursor
+	}
+	start := cursor
+	for cursor < end && !isHTMLSpace(html[cursor]) && html[cursor] != '/' {
+		cursor++
+	}
+	return start, cursor, cursor
+}
+
+func isHTMLSpace(char byte) bool {
+	switch char {
+	case ' ', '\n', '\r', '\t', '\f':
+		return true
+	default:
+		return false
+	}
+}
+
+func urlBearingSSRAttr(name string) bool {
+	switch strings.ToLower(strings.TrimSpace(name)) {
+	case "href", "src", "srcset", "action", "formaction", "poster", "cite", "data", "longdesc", "manifest", "xlink:href":
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/buildgen/store_persist_runtime_test.go
+++ b/internal/buildgen/store_persist_runtime_test.go
@@ -57,6 +57,7 @@ const localStorage = makeStorage();
 const sessionStorage = makeStorage();
 let storageListeners = [];
 let warnings = [];
+let errors = [];
 
 // Harness-controlled seed and persist attributes, read fresh on every boot.
 let seedJSON = '{"Count":0,"Open":false}';
@@ -76,7 +77,7 @@ function makeNode() {
   };
 }
 
-global.console = { warn: (m) => warnings.push(m), error: (m) => warnings.push(m), log: console.log };
+global.console = { warn: (m) => warnings.push(m), error: (m) => errors.push(m), log: console.log };
 global.document = { querySelectorAll: () => [makeNode()] };
 
 function boot() {
@@ -320,10 +321,23 @@ let bulkCleared = null;
 r.subscribe("cart", (next) => { bulkCleared = next; });
 storageListeners[0]({ key: null, oldValue: null, newValue: null, storageArea: sessionStorage });
 assert.equal(r.get("cart").Count, 6, "a clear() of a different storage area is ignored");
-storageListeners[0]({ key: null, oldValue: null, newValue: null, storageArea: localStorage });
-assert.equal(r.get("cart").Count, 0, "a cross-tab localStorage.clear() resets local stores to seed");
-assert.ok(bulkCleared && bulkCleared.Count === 0, "a bulk clear notifies subscribers");
+	storageListeners[0]({ key: null, oldValue: null, newValue: null, storageArea: localStorage });
+	assert.equal(r.get("cart").Count, 0, "a cross-tab localStorage.clear() resets local stores to seed");
+	assert.ok(bulkCleared && bulkCleared.Count === 0, "a bulk clear notifies subscribers");
 
-console.log("OK");
-`
+	// 17. A broken subscriber must not block later subscribers or escape store
+	// operations. The runtime reports the failure and keeps notifying.
+	errors = [];
+	let firstSubscriber = null;
+	let thirdSubscriber = null;
+	r.subscribe("cart", (next) => { firstSubscriber = next.Count; });
+	r.subscribe("cart", () => { throw new Error("subscriber failed"); });
+	r.subscribe("cart", (next) => { thirdSubscriber = next.Count; });
+	assert.doesNotThrow(() => r.set("cart", { Count: 11 }), "subscriber failure must not escape set()");
+	assert.equal(firstSubscriber, 11, "subscriber before the thrower ran");
+	assert.equal(thirdSubscriber, 11, "subscriber after the thrower still ran");
+	assert.ok(errors.some((m) => m.includes("store subscriber")), "subscriber failure is reported");
+
+	console.log("OK");
+	`
 }

--- a/internal/clientrt/assets/gowdk.js
+++ b/internal/clientrt/assets/gowdk.js
@@ -5,15 +5,18 @@
       return;
     }
 
-    var target = document.querySelector(form.dataset.gowdkTarget);
+    if (formInFlight(form)) {
+      event.preventDefault();
+      return;
+    }
+
+    var targetSelector = form.dataset.gowdkTarget;
+    var target = document.querySelector(targetSelector);
     if (!target) {
       return;
     }
 
-    var before = new CustomEvent('gowdk:before-request', {
-      cancelable: true,
-      detail: { form: form, target: target }
-    });
+    var before = gowdkEvent('gowdk:before-request', { cancelable: true, detail: { form: form, target: target } });
     if (!form.dispatchEvent(before)) {
       event.preventDefault();
       return;
@@ -25,15 +28,16 @@
     }
 
     event.preventDefault();
+    markFormInFlight(form);
     form.setAttribute('aria-busy', 'true');
     var focused = focusTarget(document.activeElement);
     try {
       var response = await traceFetch(form.getAttribute('action') || window.location.href, {
         method: (form.getAttribute('method') || 'POST').toUpperCase(),
-        body: new FormData(form),
+        body: formDataWithSubmitter(form, event.submitter || null),
         headers: {
           'X-GOWDK-Partial': '1',
-          'X-GOWDK-Target': form.dataset.gowdkTarget,
+          'X-GOWDK-Target': targetSelector,
           'X-GOWDK-Swap': form.dataset.gowdkSwap || ''
         }
       }, { name: 'partial submit', lane: 'fragment' });
@@ -49,8 +53,10 @@
       if (typeof window !== 'undefined' && window.__gowdkDestroyIslands) {
         window.__gowdkDestroyIslands(target, swap === 'outerHTML');
       }
+      var liveTarget = target;
       if (swap === 'outerHTML') {
         target.outerHTML = html;
+        liveTarget = targetSelector ? document.querySelector(targetSelector) : null;
       } else {
         target.innerHTML = html;
       }
@@ -65,11 +71,13 @@
       }
       ensureRealtime();
       restoreFocus(focused);
-      form.dispatchEvent(new CustomEvent('gowdk:after-swap', {
-        detail: { form: form, target: target, swap: swap }
+      var liveForm = connectedNode(form);
+      liveTarget = connectedNode(liveTarget);
+      eventDispatchTarget(liveForm, liveTarget).dispatchEvent(gowdkEvent('gowdk:after-swap', {
+        detail: { form: liveForm, target: liveTarget, swap: swap }
       }));
     } catch (error) {
-      form.dispatchEvent(new CustomEvent('gowdk:request-error', {
+      form.dispatchEvent(gowdkEvent('gowdk:request-error', {
         detail: {
           form: form,
           target: target,
@@ -81,6 +89,7 @@
       }));
     } finally {
       form.removeAttribute('aria-busy');
+      clearFormInFlight(form);
     }
   }
 
@@ -88,7 +97,7 @@
     if (typeof form.checkValidity !== 'function' || form.checkValidity()) {
       return true;
     }
-    form.dispatchEvent(new CustomEvent('gowdk:validation-blocked', {
+    form.dispatchEvent(gowdkEvent('gowdk:validation-blocked', {
       detail: { form: form, target: target }
     }));
     if (typeof form.reportValidity === 'function') {
@@ -121,7 +130,13 @@
       return;
     }
 
+    if (formInFlight(form)) {
+      event.preventDefault();
+      return;
+    }
+
     event.preventDefault();
+    markFormInFlight(form);
     form.setAttribute('aria-busy', 'true');
     var command = form.dataset.gowdkCommand || '';
     try {
@@ -153,7 +168,7 @@
       var embedded = response.headers.get('X-GOWDK-Patches') === '1' && body && Array.isArray(body.patches);
       var result = embedded ? body.result : body;
       var patches = embedded ? body.patches : [];
-      form.dispatchEvent(new CustomEvent('gowdk:command-success', {
+      form.dispatchEvent(gowdkEvent('gowdk:command-success', {
         detail: { form: form, command: command, result: result, queries: queries, eventIDs: eventIDs }
       }));
       var refreshEnvelope = { form: form, command: command, eventIDs: eventIDs };
@@ -169,7 +184,7 @@
         }
       }
     } catch (error) {
-      form.dispatchEvent(new CustomEvent('gowdk:command-error', {
+      form.dispatchEvent(gowdkEvent('gowdk:command-error', {
         detail: {
           form: form,
           command: command,
@@ -181,6 +196,7 @@
       }));
     } finally {
       form.removeAttribute('aria-busy');
+      clearFormInFlight(form);
     }
   }
 
@@ -188,7 +204,7 @@
     if (typeof form.checkValidity !== 'function' || form.checkValidity()) {
       return true;
     }
-    form.dispatchEvent(new CustomEvent('gowdk:validation-blocked', {
+    form.dispatchEvent(gowdkEvent('gowdk:validation-blocked', {
       detail: { form: form }
     }));
     if (typeof form.reportValidity === 'function') {
@@ -274,6 +290,58 @@
     });
   }
 
+  function gowdkEvent(type, options) {
+    options = options || {};
+    options.bubbles = true;
+    return new CustomEvent(type, options);
+  }
+
+  function formInFlight(form) {
+    if (!form) {
+      return false;
+    }
+    if (inFlightForms) {
+      return inFlightForms.has(form);
+    }
+    return !!form.__gowdkInFlight;
+  }
+
+  function markFormInFlight(form) {
+    if (!form) {
+      return;
+    }
+    if (inFlightForms) {
+      inFlightForms.add(form);
+      return;
+    }
+    form.__gowdkInFlight = true;
+  }
+
+  function clearFormInFlight(form) {
+    if (!form) {
+      return;
+    }
+    if (inFlightForms) {
+      inFlightForms.delete(form);
+      return;
+    }
+    form.__gowdkInFlight = false;
+  }
+
+  function connectedNode(node) {
+    if (!node) {
+      return null;
+    }
+    if (typeof node.isConnected === 'boolean') {
+      return node.isConnected ? node : null;
+    }
+    return node;
+  }
+
+  function eventDispatchTarget(primary, fallback) {
+    return connectedNode(primary) || connectedNode(fallback) || document;
+  }
+
   async function commandResponseError(response, message) {
     var body = '';
     try {
@@ -354,6 +422,7 @@
   var realtimeSource = null;
   var traceEndpoint = '/_gowdk/traces/browser';
   var traceStack = [];
+  var inFlightForms = typeof WeakSet !== 'undefined' ? new WeakSet() : null;
 
   installTraceBridge();
   document.addEventListener('submit', submitPartial);
@@ -390,7 +459,7 @@
     if (url.hash && url.pathname === window.location.pathname && url.search === window.location.search) {
       return;
     }
-    var before = new CustomEvent('gowdk:before-navigate', {
+    var before = gowdkEvent('gowdk:before-navigate', {
       cancelable: true,
       detail: { link: link, url: url.href }
     });
@@ -402,7 +471,7 @@
     try {
       await loadDocument(url.href, true, link);
     } catch (error) {
-      document.dispatchEvent(new CustomEvent('gowdk:navigate-error', {
+      document.dispatchEvent(gowdkEvent('gowdk:navigate-error', {
         detail: { link: link, url: url.href, error: error }
       }));
       window.location.href = url.href;
@@ -562,7 +631,7 @@
       } else if (window.scrollTo) {
         window.scrollTo(0, 0);
       }
-      document.dispatchEvent(new CustomEvent('gowdk:after-navigate', {
+      document.dispatchEvent(gowdkEvent('gowdk:after-navigate', {
         detail: { url: url, source: source || null }
       }));
     } finally {
@@ -596,13 +665,13 @@
     }
     if (active) {
       document.documentElement.setAttribute('data-gowdk-navigating', 'true');
-      document.dispatchEvent(new CustomEvent('gowdk:navigate-start', {
+      document.dispatchEvent(gowdkEvent('gowdk:navigate-start', {
         detail: { source: source || null }
       }));
       return;
     }
     document.documentElement.removeAttribute('data-gowdk-navigating');
-    document.dispatchEvent(new CustomEvent('gowdk:navigate-end', {
+    document.dispatchEvent(gowdkEvent('gowdk:navigate-end', {
       detail: { source: source || null }
     }));
   }
@@ -1017,7 +1086,7 @@
     }
     ensureRealtime();
     restoreFocus(focused);
-    document.dispatchEvent(new CustomEvent('gowdk:query-refresh', {
+    document.dispatchEvent(gowdkEvent('gowdk:query-refresh', {
       detail: { queries: queries, envelope: envelope }
     }));
   }
@@ -1162,13 +1231,13 @@
       window.__gowdkMountClientGoBlocks();
     }
     restoreFocus(focused);
-    region.dispatchEvent(new CustomEvent('gowdk:realtime-patch', {
+    eventDispatchTarget(region, null).dispatchEvent(gowdkEvent('gowdk:realtime-patch', {
       detail: { region: region, patch: patch, envelope: envelope }
     }));
   }
 
   function dispatchRealtimeError(error, detail) {
-    document.dispatchEvent(new CustomEvent('gowdk:realtime-error', {
+    document.dispatchEvent(gowdkEvent('gowdk:realtime-error', {
       detail: Object.assign({ error: error }, detail || {})
     }));
   }

--- a/internal/clientrt/assets/store.js
+++ b/internal/clientrt/assets/store.js
@@ -79,7 +79,15 @@
   };
 
   const notify = (name) => {
-    (registry.listeners[name] || []).slice().forEach((listener) => listener(registry.get(name)));
+    (registry.listeners[name] || []).slice().forEach((listener) => {
+      try {
+        listener(registry.get(name));
+      } catch (error) {
+        if (typeof console !== "undefined" && console.error) {
+          console.error("GOWDK: store subscriber for \"" + name + "\" failed; continuing notification.", error);
+        }
+      }
+    });
   };
 
   registry.init = (name, state, persist) => {

--- a/internal/clientrt/runtime_dom_test.go
+++ b/internal/clientrt/runtime_dom_test.go
@@ -31,13 +31,15 @@ func domHarnessScript(runtime string) string {
 const assert = require('node:assert/strict');
 
 class CustomEvent {
-  constructor(type, options = {}) {
-    this.type = type;
-    this.cancelable = !!options.cancelable;
-    this.detail = options.detail || {};
-    this.defaultPrevented = false;
-    this.target = null;
-  }
+	  constructor(type, options = {}) {
+	    this.type = type;
+	    this.bubbles = !!options.bubbles;
+	    this.cancelable = !!options.cancelable;
+	    this.detail = options.detail || {};
+	    this.defaultPrevented = false;
+	    this.target = null;
+	    this.currentTarget = null;
+	  }
   preventDefault() {
     if (this.cancelable) {
       this.defaultPrevented = true;
@@ -52,14 +54,27 @@ class EventTarget {
   addEventListener(type, handler) {
     (this.listeners[type] ||= []).push(handler);
   }
-  dispatchEvent(event) {
-    event.target ||= this;
-    for (const handler of this.listeners[event.type] || []) {
-      handler(event);
-    }
-    return !event.defaultPrevented;
-  }
-}
+	  dispatchEvent(event) {
+	    event.target ||= this;
+	    event.currentTarget = this;
+	    for (const handler of this.listeners[event.type] || []) {
+	      handler(event);
+	    }
+	    if (event.bubbles && this.parentNode) {
+	      this.parentNode.dispatchEvent(event);
+	    }
+	    return !event.defaultPrevented;
+	  }
+	}
+
+	function disconnectTree(node) {
+	  if (!node) return;
+	  node.isConnected = false;
+	  for (const child of node.children || []) {
+	    disconnectTree(child);
+	  }
+	  node.parentNode = null;
+	}
 
 class Element extends EventTarget {
   constructor(tagName) {
@@ -76,10 +91,13 @@ class Element extends EventTarget {
     this.action = '';
     this.disabled = false;
     this.replacedWith = '';
-    this.outerHTMLValue = '';
-    this.valid = true;
-    this.reported = false;
-  }
+	    this.outerHTMLValue = '';
+	    this.valid = true;
+	    this.reported = false;
+	    this.parentNode = null;
+	    this.children = [];
+	    this.isConnected = true;
+	  }
   closest(selector) {
     if (selector === 'form[data-gowdk-target]' && this.tagName === 'FORM' && this.dataset.gowdkTarget) {
       return this;
@@ -108,13 +126,19 @@ class Element extends EventTarget {
     this.reported = true;
     return this.valid;
   }
-  focus() {
-    document.activeElement = this;
-  }
-  set outerHTML(value) {
-    this.replacedWith = value;
-    this.outerHTMLValue = value;
-  }
+	  focus() {
+	    document.activeElement = this;
+	  }
+	  appendChild(child) {
+	    child.parentNode = this;
+	    child.isConnected = this.isConnected;
+	    this.children.push(child);
+	  }
+	  set outerHTML(value) {
+	    this.replacedWith = value;
+	    this.outerHTMLValue = value;
+	    disconnectTree(this);
+	  }
   get outerHTML() {
     return this.outerHTMLValue || this.replacedWith;
   }
@@ -123,13 +147,16 @@ class Element extends EventTarget {
 class Document extends EventTarget {
   constructor() {
     super();
-    this.body = new Element('body');
-    this.activeElement = this.body;
-    this.bySelector = {};
-    this.byID = {};
-    this.realtimeRegions = [];
-    this.queryRegions = [];
-  }
+	    this.body = new Element('body');
+	    this.body.parentNode = this;
+	    this.activeElement = this.body;
+	    this.bySelector = {};
+	    this.byID = {};
+	    this.realtimeRegions = [];
+	    this.queryRegions = [];
+	    this.parentNode = null;
+	    this.isConnected = true;
+	  }
   querySelector(selector) {
     if (selector === '[data-gowdk-subscribe], [data-gowdk-query-type]') {
       return this.realtimeRegions[0] || this.queryRegions[0] || null;
@@ -234,16 +261,20 @@ global.FormData = class {
   }
 };
 
-const form = new Element('form');
-form.method = 'post';
-form.action = '/newsletter';
-form.setAttribute('method', 'post');
-form.setAttribute('action', '/newsletter');
-form.dataset.gowdkTarget = '#newsletter';
-form.dataset.gowdkSwap = 'innerHTML';
-const commandForm = new Element('form');
-commandForm.method = 'post';
-commandForm.action = '/commands/create';
+	const form = new Element('form');
+	form.method = 'post';
+	form.action = '/newsletter';
+	form.setAttribute('method', 'post');
+	form.setAttribute('action', '/newsletter');
+	form.dataset.gowdkTarget = '#newsletter';
+	form.dataset.gowdkSwap = 'innerHTML';
+	form.fields = [{ name: 'email', value: 'ada@example.test' }];
+	const partialSubmitter = new Element('button');
+	partialSubmitter.name = 'intent';
+	partialSubmitter.value = 'save';
+	const commandForm = new Element('form');
+	commandForm.method = 'post';
+	commandForm.action = '/commands/create';
 commandForm.setAttribute('method', 'post');
 commandForm.setAttribute('action', '/commands/create');
 commandForm.dataset.gowdkCommand = 'patients.CreatePatient';
@@ -251,9 +282,12 @@ commandForm.fields = [{ name: 'name', value: 'Ada' }];
 const commandSubmitter = new Element('button');
 commandSubmitter.name = 'intent';
 commandSubmitter.value = 'publish';
-const target = new Element('section');
-target.id = 'newsletter';
-target.innerHTML = '<p>Old</p>';
+	const target = new Element('section');
+	target.id = 'newsletter';
+	target.innerHTML = '<p>Old</p>';
+	target.appendChild(form);
+	target.parentNode = document;
+	commandForm.parentNode = document;
 const liveRegion = new Element('section');
 liveRegion.id = 'live-patients';
 liveRegion.innerHTML = '<p>Waiting</p>';
@@ -292,13 +326,18 @@ let requestCount = 0;
 let swap = 'innerHTML';
 let fail = false;
 let reload = false;
-let commandMode = 'success';
-let refreshFail = false;
-global.fetch = async function(url, options) {
-  requestCount++;
-  request = { url, options };
-  requests.push(request);
-  if (url === '/commands/create') {
+	let commandMode = 'success';
+	let refreshFail = false;
+	let holdRequests = false;
+	let heldFetchResolvers = [];
+	global.fetch = async function(url, options) {
+	  requestCount++;
+	  request = { url, options };
+	  requests.push(request);
+	  if (holdRequests) {
+	    await new Promise(resolve => heldFetchResolvers.push(resolve));
+	  }
+	  if (url === '/commands/create') {
     if (commandMode === 'redirect') {
       return {
         ok: true,
@@ -376,21 +415,33 @@ global.fetch = async function(url, options) {
 
 ` + runtime + `
 
-async function flushRuntime() {
-  await new Promise(resolve => setImmediate(resolve));
-  await new Promise(resolve => setImmediate(resolve));
-}
+	async function flushRuntime() {
+	  await new Promise(resolve => setImmediate(resolve));
+	  await new Promise(resolve => setImmediate(resolve));
+	}
 
-async function submit(target = form, submitter = null) {
-  const event = new CustomEvent('submit', { cancelable: true });
-  event.target = target;
-  if (submitter) {
-    event.submitter = submitter;
-  }
-  document.dispatchEvent(event);
-  await flushRuntime();
-  return event;
-}
+	function dispatchSubmit(target = form, submitter = null) {
+	  const event = new CustomEvent('submit', { cancelable: true });
+	  event.target = target;
+	  if (submitter) {
+	    event.submitter = submitter;
+	  }
+	  document.dispatchEvent(event);
+	  return event;
+	}
+
+	async function submit(target = form, submitter = null) {
+	  const event = dispatchSubmit(target, submitter);
+	  await flushRuntime();
+	  return event;
+	}
+
+	function releaseHeldFetches() {
+	  const resolvers = heldFetchResolvers.slice();
+	  heldFetchResolvers = [];
+	  holdRequests = false;
+	  resolvers.forEach(resolve => resolve());
+	}
 
 (async function() {
   assert.equal(eventSources.length, 1);
@@ -467,9 +518,9 @@ async function submit(target = form, submitter = null) {
   commandForm.addEventListener('gowdk:command-error', event => {
     commandError = event.detail;
   });
-  function resetCommandHarness() {
-    commandSuccess = null;
-    commandError = null;
+	  function resetCommandHarness() {
+	    commandSuccess = null;
+	    commandError = null;
     realtimeError = null;
     queryRefresh = null;
     request = null;
@@ -479,12 +530,25 @@ async function submit(target = form, submitter = null) {
     invalidatedRegion.outerHTMLValue = '';
     duplicateInvalidatedRegion.replacedWith = '';
     duplicateInvalidatedRegion.outerHTMLValue = '<section id="invalidated-patients-copy" data-gowdk-query="patients.GetPatientPage" data-gowdk-query-type="gowdk-generated-app/patients.GetPatientPage"><p>Duplicate stale</p></section>';
-    document.queryRegions = [liveRegion, invalidatedRegion];
-  }
+	    document.queryRegions = [liveRegion, invalidatedRegion];
+	  }
 
-  let commandSubmit = await submit(commandForm, commandSubmitter);
-  assert.equal(commandSubmit.defaultPrevented, true);
-  assert.equal(requestCount, 1);
+	  resetCommandHarness();
+	  holdRequests = true;
+	  const firstHeldCommand = dispatchSubmit(commandForm, commandSubmitter);
+	  const duplicateHeldCommand = dispatchSubmit(commandForm, commandSubmitter);
+	  assert.equal(firstHeldCommand.defaultPrevented, true);
+	  assert.equal(duplicateHeldCommand.defaultPrevented, true);
+	  assert.equal(requestCount, 1, "duplicate command submit should not issue a second request");
+	  releaseHeldFetches();
+	  await flushRuntime();
+	  assert.equal(commandSuccess.result.id, 'patient-1');
+	  assert.equal(commandForm.attributes['aria-busy'], undefined);
+	  resetCommandHarness();
+
+	  let commandSubmit = await submit(commandForm, commandSubmitter);
+	  assert.equal(commandSubmit.defaultPrevented, true);
+	  assert.equal(requestCount, 1);
   assert.equal(request.url, '/commands/create');
   assert.equal(request.options.method, 'POST');
   assert.equal(request.options.redirect, 'manual');
@@ -566,10 +630,14 @@ async function submit(target = form, submitter = null) {
   requests = [];
   requestCount = 0;
 
-  let afterSwap;
-  form.addEventListener('gowdk:after-swap', event => {
-    afterSwap = event.detail;
-  });
+	  let afterSwap;
+	  form.addEventListener('gowdk:after-swap', event => {
+	    afterSwap = event.detail;
+	  });
+	  let documentAfterSwap;
+	  document.addEventListener('gowdk:after-swap', event => {
+	    documentAfterSwap = event.detail;
+	  });
 
   let validationBlocked;
   form.addEventListener('gowdk:validation-blocked', event => {
@@ -585,14 +653,33 @@ async function submit(target = form, submitter = null) {
   assert.equal(validationBlocked.form, form);
   assert.equal(validationBlocked.target, target);
   assert.equal(form.attributes['aria-busy'], undefined);
-  form.valid = true;
-  form.reported = false;
+	  form.valid = true;
+	  form.reported = false;
 
-  const inner = await submit();
-  assert.equal(inner.defaultPrevented, true);
-  assert.equal(request.url, '/newsletter');
-  assert.equal(request.options.method, 'POST');
-  assert.equal(request.options.headers['X-GOWDK-Partial'], '1');
+	  holdRequests = true;
+	  const firstHeldPartial = dispatchSubmit(form, partialSubmitter);
+	  const duplicateHeldPartial = dispatchSubmit(form, partialSubmitter);
+	  assert.equal(firstHeldPartial.defaultPrevented, true);
+	  assert.equal(duplicateHeldPartial.defaultPrevented, true);
+	  assert.equal(requestCount, 1, "duplicate partial submit should not issue a second request");
+	  releaseHeldFetches();
+	  await flushRuntime();
+	  assert.equal(form.attributes['aria-busy'], undefined);
+	  assert.equal(target.innerHTML, '<p>Updated</p>');
+	  assert.deepEqual(islandLifecycle.shift(), ['destroy', 'newsletter', false]);
+	  assert.deepEqual(islandLifecycle.shift(), ['mount']);
+	  request = null;
+	  requests = [];
+	  requestCount = 0;
+	  target.innerHTML = '<p>Old</p>';
+
+	  const inner = await submit(form, partialSubmitter);
+	  assert.equal(inner.defaultPrevented, true);
+	  assert.equal(request.url, '/newsletter');
+	  assert.equal(request.options.method, 'POST');
+	  assert.equal(request.options.body.getAll('email')[0], 'ada@example.test');
+	  assert.deepEqual(request.options.body.getAll('intent'), ['save']);
+	  assert.equal(request.options.headers['X-GOWDK-Partial'], '1');
   assert.equal(request.options.headers['X-GOWDK-Target'], '#newsletter');
   assert.equal(request.options.headers['X-GOWDK-Swap'], 'innerHTML');
   assert.equal(target.innerHTML, '<p>Updated</p>');
@@ -600,17 +687,26 @@ async function submit(target = form, submitter = null) {
   assert.deepEqual(islandLifecycle.shift(), ['mount']);
   assert.equal(form.attributes['aria-busy'], undefined);
   assert.equal(document.activeElement, input);
-  assert.equal(afterSwap.form, form);
-  assert.equal(afterSwap.target, target);
-  assert.equal(afterSwap.swap, 'innerHTML');
+	  assert.equal(afterSwap.form, form);
+	  assert.equal(afterSwap.target, target);
+	  assert.equal(afterSwap.swap, 'innerHTML');
+	  assert.equal(documentAfterSwap.form, form);
+	  assert.equal(documentAfterSwap.target, target);
+	  assert.equal(documentAfterSwap.swap, 'innerHTML');
 
-  swap = 'outerHTML';
-  form.dataset.gowdkSwap = 'outerHTML';
-  await submit();
-  assert.equal(request.options.headers['X-GOWDK-Swap'], 'outerHTML');
-  assert.deepEqual(islandLifecycle.shift(), ['destroy', 'newsletter', true]);
-  assert.deepEqual(islandLifecycle.shift(), ['mount']);
-  assert.equal(target.replacedWith, '<p>Updated</p>');
+	  swap = 'outerHTML';
+	  form.dataset.gowdkSwap = 'outerHTML';
+	  afterSwap = null;
+	  documentAfterSwap = null;
+	  await submit();
+	  assert.equal(request.options.headers['X-GOWDK-Swap'], 'outerHTML');
+	  assert.deepEqual(islandLifecycle.shift(), ['destroy', 'newsletter', true]);
+	  assert.deepEqual(islandLifecycle.shift(), ['mount']);
+	  assert.equal(target.replacedWith, '<p>Updated</p>');
+	  assert.equal(afterSwap, null);
+	  assert.equal(documentAfterSwap.form, null);
+	  assert.equal(documentAfterSwap.target, null);
+	  assert.equal(documentAfterSwap.swap, 'outerHTML');
 
   let requestError;
   form.addEventListener('gowdk:request-error', event => {

--- a/internal/compiler/validate_page_lists.go
+++ b/internal/compiler/validate_page_lists.go
@@ -24,7 +24,7 @@ func validatePageServerLists(page gwdkir.Page) []ValidationError {
 	loads := collectPageLoads(page)
 	var diagnostics []ValidationError
 	validateServerLoadFieldConflicts(page, loads, &diagnostics)
-	walkPageListNodes(page, nodes, loads, nil, &diagnostics)
+	walkPageListNodes(page, nodes, loads, nil, false, &diagnostics)
 	return diagnostics
 }
 
@@ -77,17 +77,17 @@ func collectPageLoads(page gwdkir.Page) pageLoads {
 	return loads
 }
 
-func walkPageListNodes(page gwdkir.Page, nodes []viewmodel.Node, loads pageLoads, eachVars []string, diagnostics *[]ValidationError) {
+func walkPageListNodes(page gwdkir.Page, nodes []viewmodel.Node, loads pageLoads, eachVars []string, inServerRegion bool, diagnostics *[]ValidationError) {
 	for _, node := range nodes {
 		element, ok := node.(viewmodel.Element)
 		if !ok {
 			if call, isCall := node.(viewmodel.ComponentCall); isCall {
-				if len(eachVars) > 0 {
+				if inServerRegion || len(eachVars) > 0 {
 					*diagnostics = append(*diagnostics, pageListDiagnostic(page, "server_region_directive",
 						fmt.Sprintf("%s: server-lane g:for rows and g:if branches cannot contain component calls; render request-time markup with static elements, g:for, and g:if", page.ID)))
 					continue
 				}
-				walkPageListNodes(page, call.Children, loads, eachVars, diagnostics)
+				walkPageListNodes(page, call.Children, loads, eachVars, inServerRegion, diagnostics)
 			}
 			continue
 		}
@@ -109,8 +109,9 @@ func walkPageListNodes(page gwdkir.Page, nodes []viewmodel.Node, loads pageLoads
 		if !serverBranch && len(childVars) == len(eachVars) {
 			serverRegionVars = eachVars
 		}
-		validatePageServerRegionElement(page, element, loads, serverBranch || len(childVars) > len(eachVars), serverRegionVars, diagnostics)
-		walkPageListNodes(page, element.Children, loads, childVars, diagnostics)
+		currentServerRegion := inServerRegion || serverBranch || len(childVars) > len(eachVars)
+		validatePageServerRegionElement(page, element, loads, currentServerRegion, serverRegionVars, diagnostics)
+		walkPageListNodes(page, element.Children, loads, childVars, currentServerRegion, diagnostics)
 	}
 }
 
@@ -343,6 +344,27 @@ func allowRequestTimeURLAttrTemplate(name, value string) bool {
 	if !urlBearingRequestTimeAttr(name) {
 		return false
 	}
+	value = strings.TrimSpace(value)
+	if strings.EqualFold(strings.TrimSpace(name), "srcset") {
+		return allowRequestTimeSrcsetURLAttrTemplate(value)
+	}
+	return allowSingleRequestTimeURLAttrTemplate(value)
+}
+
+func allowRequestTimeSrcsetURLAttrTemplate(value string) bool {
+	for _, candidate := range strings.Split(value, ",") {
+		fields := strings.Fields(strings.TrimSpace(candidate))
+		if len(fields) == 0 || !strings.Contains(fields[0], "{") {
+			continue
+		}
+		if !allowSingleRequestTimeURLAttrTemplate(fields[0]) {
+			return false
+		}
+	}
+	return true
+}
+
+func allowSingleRequestTimeURLAttrTemplate(value string) bool {
 	value = strings.TrimSpace(value)
 	if value == "" || value[0] != '/' {
 		return false

--- a/internal/compiler/validate_page_lists_test.go
+++ b/internal/compiler/validate_page_lists_test.go
@@ -253,6 +253,38 @@ func TestValidateAcceptsRequestTimeURLTemplateInsideServerRow(t *testing.T) {
 	}
 }
 
+func TestValidateRejectsRequestTimeSrcsetCandidateWithoutStablePrefix(t *testing.T) {
+	report := validatePageListsFor(t, gwdkir.Page{
+		Blocks: gwdkir.Blocks{
+			Server:     true,
+			ServerBody: `=> { issues }`,
+			View:       true,
+			ViewBody:   `<main><img g:for={issue in issues} srcset="/safe.png 1x, {issue.image} 2x" /></main>`,
+		},
+	})
+	diag, ok := findCode(report, "server_url_tainted")
+	if !ok {
+		t.Fatalf("expected server_url_tainted for tainted srcset candidate, got %v", report)
+	}
+	if !strings.Contains(diag.Message, `"srcset"`) {
+		t.Fatalf("diagnostic should name srcset: %q", diag.Message)
+	}
+}
+
+func TestValidateAcceptsRequestTimeSrcsetCandidatesWithStablePrefixes(t *testing.T) {
+	report := validatePageListsFor(t, gwdkir.Page{
+		Blocks: gwdkir.Blocks{
+			Server:     true,
+			ServerBody: `=> { issues }`,
+			View:       true,
+			ViewBody:   `<main><img g:for={issue in issues} srcset="/image/{issue.image} 1x, /image/{issue.image} 2x" /></main>`,
+		},
+	})
+	if _, ok := findCode(report, "server_url_tainted"); ok {
+		t.Fatalf("root-relative srcset URL templates should be accepted, got %v", report)
+	}
+}
+
 func TestValidateRejectsRequestTimeURLAttributeControlledByServerRow(t *testing.T) {
 	report := validatePageListsFor(t, gwdkir.Page{
 		Blocks: gwdkir.Blocks{
@@ -329,5 +361,52 @@ func TestValidateRejectsComponentInsideServerRow(t *testing.T) {
 	})
 	if _, ok := findCode(report, "server_region_directive"); !ok {
 		t.Fatalf("expected server_region_directive for component call, got %v", report)
+	}
+}
+
+func TestValidateRejectsDirectiveInsideTopLevelServerIf(t *testing.T) {
+	report := validatePageListsFor(t, gwdkir.Page{
+		Blocks: gwdkir.Blocks{
+			Server:     true,
+			ServerBody: `=> { found }`,
+			Actions:    []gwdkir.Action{{Name: "Open", Method: "POST", Route: "/open"}},
+			View:       true,
+			ViewBody:   `<main><section g:if={found}><form g:post={Open}></form></section></main>`,
+		},
+	})
+	diag, ok := findCode(report, "server_region_directive")
+	if !ok {
+		t.Fatalf("expected server_region_directive inside server g:if, got %v", report)
+	}
+	if !strings.Contains(diag.Message, `"g:post"`) {
+		t.Fatalf("diagnostic should name the unsupported directive: %q", diag.Message)
+	}
+}
+
+func TestValidateRejectsComponentInsideTopLevelServerIf(t *testing.T) {
+	report := validatePageListsFor(t, gwdkir.Page{
+		Blocks: gwdkir.Blocks{
+			Server:     true,
+			ServerBody: `=> { found }`,
+			View:       true,
+			ViewBody:   `<main><section g:if={found}><IssueCard /></section></main>`,
+		},
+	})
+	if _, ok := findCode(report, "server_region_directive"); !ok {
+		t.Fatalf("expected server_region_directive for component call inside server g:if, got %v", report)
+	}
+}
+
+func TestValidateRejectsRequestTimeURLInsideTopLevelServerIf(t *testing.T) {
+	report := validatePageListsFor(t, gwdkir.Page{
+		Blocks: gwdkir.Blocks{
+			Server:     true,
+			ServerBody: `=> { found, website }`,
+			View:       true,
+			ViewBody:   `<main><section g:if={found}><a href="{website}">Profile</a></section></main>`,
+		},
+	})
+	if _, ok := findCode(report, "server_url_tainted"); !ok {
+		t.Fatalf("expected server_url_tainted inside server g:if, got %v", report)
 	}
 }

--- a/internal/source/source.go
+++ b/internal/source/source.go
@@ -119,6 +119,7 @@ type RouteParam struct {
 type SSRReplacement struct {
 	Param       string
 	Placeholder string
+	URL         bool
 }
 
 // SSRLoadReplacement maps a generated placeholder back to a request-time load
@@ -126,6 +127,7 @@ type SSRReplacement struct {
 type SSRLoadReplacement struct {
 	Path        string
 	Placeholder string
+	URL         bool
 }
 
 // SSRListSpec describes one server-rendered g:for list for a request-time
@@ -162,6 +164,7 @@ type SSRListField struct {
 	Placeholder string
 	Path        string
 	Index       bool
+	URL         bool
 }
 
 // SSRQueryRegion is the standalone render recipe for one request-time g:query

--- a/internal/viewrender/interpolate.go
+++ b/internal/viewrender/interpolate.go
@@ -98,6 +98,27 @@ func allowRequestTimeURLAttrTemplate(name string, value string) bool {
 		return false
 	}
 	value = strings.TrimSpace(decodeSourceTextEntities(value))
+	if strings.EqualFold(strings.TrimSpace(name), "srcset") {
+		return allowRequestTimeSrcsetURLAttrTemplate(value)
+	}
+	return allowSingleRequestTimeURLAttrTemplate(value)
+}
+
+func allowRequestTimeSrcsetURLAttrTemplate(value string) bool {
+	for _, candidate := range strings.Split(value, ",") {
+		fields := strings.Fields(strings.TrimSpace(candidate))
+		if len(fields) == 0 || !strings.Contains(fields[0], "{") {
+			continue
+		}
+		if !allowSingleRequestTimeURLAttrTemplate(fields[0]) {
+			return false
+		}
+	}
+	return true
+}
+
+func allowSingleRequestTimeURLAttrTemplate(value string) bool {
+	value = strings.TrimSpace(value)
 	if value == "" || value[0] != '/' {
 		return false
 	}

--- a/internal/viewrender/server_list.go
+++ b/internal/viewrender/server_list.go
@@ -46,6 +46,7 @@ type SSRListField struct {
 	Placeholder string
 	Path        string
 	Index       bool
+	URL         bool
 }
 
 // serverScope tracks the active server-lane g:for row or g:if branch while

--- a/internal/viewrender/view_test.go
+++ b/internal/viewrender/view_test.go
@@ -1467,6 +1467,21 @@ func TestRenderRejectsTaintedLoadFieldInDangerousAttribute(t *testing.T) {
 	}
 }
 
+func TestRenderRejectsTaintedSrcsetCandidateWithoutStablePrefix(t *testing.T) {
+	_, err := RenderWithOptions(`<img srcset="/safe.png 1x, {user.avatar} 2x" />`, nil, map[string]string{
+		"user.avatar": "https://evil.example/avatar.png",
+	}, Options{Tainted: map[string]bool{"user.avatar": true}})
+	if err == nil || !strings.Contains(err.Error(), `is not allowed in "srcset" attributes`) {
+		t.Fatalf("expected tainted srcset candidate to be rejected, got %v", err)
+	}
+
+	if _, err := RenderWithOptions(`<img srcset="/avatar/{user.avatar} 1x, /avatar/{user.avatar} 2x" />`, nil, map[string]string{
+		"user.avatar": "ada.png",
+	}, Options{Tainted: map[string]bool{"user.avatar": true}}); err != nil {
+		t.Fatalf("root-relative srcset candidates should render: %v", err)
+	}
+}
+
 func TestRenderSPAAllowsSafeURLAttributes(t *testing.T) {
 	source := `<main><a href="/docs?q=go&sort=new">Docs</a><a href="https://example.com">External</a><a href="mailto:team@example.com">Mail</a><img srcset="/img.png 1x, https://cdn.example.com/img@2x.png 2x" data-uri="data:text/plain,ok" /></main>`
 	got, err := RenderSPA(source)

--- a/runtime/html/html.go
+++ b/runtime/html/html.go
@@ -3,12 +3,19 @@ package html
 import (
 	stdhtml "html"
 	htmltemplate "html/template"
+	"net/url"
 	"strings"
 )
 
 // Escape escapes text for safe HTML output.
 func Escape(value string) string {
 	return stdhtml.EscapeString(value)
+}
+
+// EscapeURL escapes a request-time interpolation segment before it is placed
+// inside a URL-bearing HTML attribute.
+func EscapeURL(value string) string {
+	return stdhtml.EscapeString(url.PathEscape(value))
 }
 
 // Attr renders an escaped HTML attribute when value is non-empty.

--- a/runtime/html/html_test.go
+++ b/runtime/html/html_test.go
@@ -11,6 +11,12 @@ func TestEscapeEscapesHTMLText(t *testing.T) {
 	}
 }
 
+func TestEscapeURLEncodesBeforeHTMLEscaping(t *testing.T) {
+	if got := EscapeURL(`\\evil.example/x?q="bad"&ok=1`); got != `%5C%5Cevil.example%2Fx%3Fq=%22bad%22&amp;ok=1` {
+		t.Fatalf("unexpected escaped URL segment: %q", got)
+	}
+}
+
 func TestAttrOmitsEmptyValuesAndEscapesNonEmptyValues(t *testing.T) {
 	if got := Attr("href", ""); got != "" {
 		t.Fatalf("expected empty attr to be omitted, got %q", got)

--- a/runtime/response/response.go
+++ b/runtime/response/response.go
@@ -204,18 +204,19 @@ func ValidationHTML(result validation.Result) string {
 // WriteHTTP writes a runtime response envelope to net/http.
 func WriteHTTP(writer http.ResponseWriter, result Response) error {
 	status := statusOrDefault(result)
+	if result.Kind == Redirect {
+		if err := ValidateLocalRedirect(result.URL); err != nil {
+			// Fail closed before writing any side-effect headers. This matches the
+			// guard and SSR redirect lanes, which only allow local absolute paths.
+			http.Error(writer, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+			return err
+		}
+	}
 	for _, cookie := range result.Cookies {
 		http.SetCookie(writer, &cookie)
 	}
 	switch result.Kind {
 	case Redirect:
-		if err := ValidateLocalRedirect(result.URL); err != nil {
-			// Fail closed: never emit an attacker-influenced Location header.
-			// This matches the guard and SSR redirect lanes, which only allow
-			// local absolute paths.
-			http.Error(writer, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
-			return err
-		}
 		writer.Header().Set("Location", result.URL)
 		writer.WriteHeader(status)
 	case Reload:

--- a/runtime/response/response_test.go
+++ b/runtime/response/response_test.go
@@ -158,6 +158,30 @@ func TestWriteHTTPRejectsOpenRedirect(t *testing.T) {
 	}
 }
 
+func TestWriteHTTPRejectsUnsafeRedirectBeforeCookies(t *testing.T) {
+	recorder := httptest.NewRecorder()
+	result := WithCookie(RedirectTo("//evil.com"), http.Cookie{
+		Name:     "gowdk_session",
+		Value:    "signed",
+		Path:     "/",
+		HttpOnly: true,
+	})
+
+	err := WriteHTTP(recorder, result)
+	if err == nil {
+		t.Fatal("expected unsafe redirect error")
+	}
+	if recorder.Code != http.StatusInternalServerError {
+		t.Fatalf("unexpected status: %d", recorder.Code)
+	}
+	if location := recorder.Header().Get("Location"); location != "" {
+		t.Fatalf("unsafe redirect leaked Location header: %q", location)
+	}
+	if setCookie := recorder.Header().Get("Set-Cookie"); setCookie != "" {
+		t.Fatalf("unsafe redirect leaked Set-Cookie header: %q", setCookie)
+	}
+}
+
 func TestValidateLocalRedirect(t *testing.T) {
 	for _, ok := range []string{"/", "/dashboard", "/a/b?c=1#d"} {
 		if err := ValidateLocalRedirect(ok); err != nil {

--- a/runtime/ssr/list.go
+++ b/runtime/ssr/list.go
@@ -66,6 +66,8 @@ type ListField struct {
 	Path string
 	// Index is true when this field substitutes the zero-based row index.
 	Index bool
+	// URL is true when this field is substituted into a URL-bearing attribute.
+	URL bool
 }
 
 // RenderRegions expands every top-level g:for list and g:if conditional in
@@ -124,11 +126,17 @@ func condHolds(container any, cond CondSpec) bool {
 
 func listFieldValue(field ListField, container any, index int) string {
 	if field.Index {
+		if field.URL {
+			return gowdkhtml.EscapeURL(strconv.Itoa(index))
+		}
 		return gowdkhtml.Escape(strconv.Itoa(index))
 	}
 	value, ok := ElementPath(container, field.Path)
 	if !ok || value == nil {
 		return ""
+	}
+	if field.URL {
+		return gowdkhtml.EscapeURL(fmt.Sprint(value))
 	}
 	return gowdkhtml.Escape(fmt.Sprint(value))
 }

--- a/runtime/ssr/list_test.go
+++ b/runtime/ssr/list_test.go
@@ -35,6 +35,24 @@ func TestRenderRegionsEscapesFields(t *testing.T) {
 	}
 }
 
+func TestRenderRegionsEscapesURLFields(t *testing.T) {
+	specs := []ListSpec{{
+		Placeholder: "@LIST@",
+		SourcePath:  "items",
+		RowTemplate: `<a href="/issue/@ID@">@TITLE@</a>`,
+		Fields: []ListField{
+			{Placeholder: "@ID@", Path: "id", URL: true},
+			{Placeholder: "@TITLE@", Path: "title"},
+		},
+	}}
+	data := map[string]any{"items": []any{map[string]any{"id": `\\evil.com`, "title": `<bad>`}}}
+	got := RenderRegions("@LIST@", specs, nil, data)
+	want := `<a href="/issue/%5C%5Cevil.com">&lt;bad&gt;</a>`
+	if got != want {
+		t.Fatalf("got %q want %q", got, want)
+	}
+}
+
 func TestRenderRegionsIndexField(t *testing.T) {
 	specs := []ListSpec{{
 		Placeholder: "@LIST@",

--- a/runtime/ssr/regions.go
+++ b/runtime/ssr/regions.go
@@ -34,6 +34,7 @@ type CommandEnvelope struct {
 type RegionLoadField struct {
 	Path        string
 	Placeholder string
+	URL         bool
 }
 
 // RegionRenderer renders one request-time g:query region standalone from its
@@ -76,6 +77,10 @@ func (renderer RegionRenderer) render(request *http.Request) (string, bool) {
 		value, ok := LoadPath(data, field.Path)
 		if !ok {
 			return "", false
+		}
+		if field.URL {
+			html = strings.ReplaceAll(html, field.Placeholder, gowdkhtml.EscapeURL(fmt.Sprint(value)))
+			continue
 		}
 		html = strings.ReplaceAll(html, field.Placeholder, gowdkhtml.Escape(fmt.Sprint(value)))
 	}

--- a/runtime/ssr/regions_test.go
+++ b/runtime/ssr/regions_test.go
@@ -42,6 +42,29 @@ func TestRenderInvalidatedRegionsRendersRegisteredRegion(t *testing.T) {
 	}
 }
 
+func TestRegionRendererEscapesURLLoadFields(t *testing.T) {
+	renderer := RegionRenderer{
+		QueryType: "example.com/app/profile.Load",
+		Template:  `<a href="/user/__SLUG__">Profile</a>`,
+		LoadFields: []RegionLoadField{{
+			Path:        "slug",
+			Placeholder: "__SLUG__",
+			URL:         true,
+		}},
+		Load: func(*http.Request) (map[string]any, error) {
+			return map[string]any{"slug": `\\evil.com`}, nil
+		},
+	}
+	got, ok := renderer.render(httptest.NewRequest(http.MethodPost, "/profile", nil))
+	if !ok {
+		t.Fatal("expected region to render")
+	}
+	const want = `<a href="/user/%5C%5Cevil.com">Profile</a>`
+	if got != want {
+		t.Fatalf("got %q want %q", got, want)
+	}
+}
+
 func TestRenderInvalidatedRegionsSkipsUnregisteredAndAmbiguous(t *testing.T) {
 	resetRegions()
 	defer resetRegions()


### PR DESCRIPTION
## Summary
- Validate redirect URLs before writing cookies and isolate store subscriber failures.
- Harden enhanced form submissions: include submitter values, reject duplicate in-flight partial/command submits, and dispatch swap events from live DOM.
- Restore check/build parity for server `g:if` descendants and make request-time URL templates srcset-aware with URL-encoded SSR substitutions.
- Update the unreleased changelog and URL-template docs.

Closes #524
Closes #525
Closes #526
Closes #527
Closes #528
Closes #529
Closes #531
Closes #532

## Verification
- `go test ./...`
- `go build ./cmd/gowdk`
- `scripts/test-go-modules.sh`