### PR TITLE
fix: security & correctness hardening batch (#535-#545)

### DIFF
--- a/cmd/gowdk/clean.go
+++ b/cmd/gowdk/clean.go
@@ -89,9 +89,14 @@ func clean(args []string) error {
 
 // runClean resolves candidates against root, removes the ones that exist (or
 // reports them under DryRun), and records the rest as absent. Paths that are
-// the project root or escape it are silently dropped by safeRelativeTargets.
+// the project root, escape it lexically, or escape it through a symlink are
+// silently dropped.
 func runClean(root string, candidates []string, dryRun bool) (cleanResult, error) {
 	result := cleanResult{Version: 1, DryRun: dryRun}
+	realRoot, err := filepath.EvalSymlinks(root)
+	if err != nil {
+		realRoot = filepath.Clean(root)
+	}
 	for _, candidate := range safeRelativeTargets(root, candidates) {
 		absolute := candidate
 		if !filepath.IsAbs(absolute) {
@@ -103,6 +108,13 @@ func runClean(root string, candidates []string, dryRun bool) (cleanResult, error
 				continue
 			}
 			return cleanResult{}, statErr
+		}
+		// safeRelativeTargets only checks containment lexically, but
+		// os.RemoveAll follows intermediate symlinks. Re-check against the
+		// symlink-resolved path so a configured target reached through a
+		// symlinked directory cannot delete files outside the project.
+		if !withinRoot(realRoot, absolute) {
+			continue
 		}
 		if !dryRun {
 			if removeErr := os.RemoveAll(absolute); removeErr != nil {
@@ -185,6 +197,28 @@ func safeRelativeTargets(root string, candidates []string) []string {
 	}
 	sort.Strings(safe)
 	return safe
+}
+
+// withinRoot reports whether absolute resolves inside realRoot after following
+// symlinks in its parent directory. Only the parent is resolved so that a
+// target that is itself a symlink is removed as a link (os.RemoveAll does not
+// follow a leaf symlink) rather than escaping through it.
+func withinRoot(realRoot, absolute string) bool {
+	parent := filepath.Dir(absolute)
+	realParent, err := filepath.EvalSymlinks(parent)
+	if err != nil {
+		realParent = filepath.Clean(parent)
+	}
+	resolved := filepath.Join(realParent, filepath.Base(absolute))
+	rel, err := filepath.Rel(realRoot, resolved)
+	if err != nil {
+		return false
+	}
+	rel = filepath.ToSlash(rel)
+	if rel == "." || rel == ".." || strings.HasPrefix(rel, "../") {
+		return false
+	}
+	return true
 }
 
 func reportClean(result cleanResult, jsonOutput bool) error {

--- a/cmd/gowdk/clean_test.go
+++ b/cmd/gowdk/clean_test.go
@@ -116,6 +116,31 @@ func TestRunCleanDryRunKeepsFiles(t *testing.T) {
 	}
 }
 
+func TestRunCleanDoesNotFollowSymlinkOutsideRoot(t *testing.T) {
+	root := t.TempDir()
+	outside := t.TempDir()
+	external := filepath.Join(outside, "keep.txt")
+	if err := os.WriteFile(external, []byte("keep"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// "link" inside the project points at the external directory; the
+	// configured clean target reaches a file through that intermediate symlink.
+	if err := os.Symlink(outside, filepath.Join(root, "link")); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	result, err := runClean(root, []string{"link/keep.txt"}, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if contains(result.Removed, "link/keep.txt") {
+		t.Fatalf("expected symlinked external path to be refused, got %+v", result)
+	}
+	if _, statErr := os.Stat(external); statErr != nil {
+		t.Fatalf("external file must survive clean: %v", statErr)
+	}
+}
+
 func TestCleanCommandRejectsUnknownFlag(t *testing.T) {
 	if err := clean([]string{"--nope"}); err == nil {
 		t.Fatal("expected an error for an unknown flag")

--- a/cmd/gowdk/dev.go
+++ b/cmd/gowdk/dev.go
@@ -244,23 +244,29 @@ func (serve *devServeState) apply(state devBuildState, absDir string) error {
 	if state.runtime.Enabled {
 		return serve.useRuntime(state.runtime)
 	}
-	serve.useStatic(absDir)
-	return nil
+	return serve.useStatic(absDir)
 }
 
-func (serve *devServeState) useStatic(absDir string) {
+func (serve *devServeState) useStatic(absDir string) error {
 	if serve.process != nil {
 		serve.process.stop()
 		serve.process = nil
 	}
 	if serve.server != nil && serve.staticDir == absDir {
-		return
+		return nil
 	}
 	if serve.server != nil {
 		stopDevStaticServer(serve.server)
+		serve.server = nil
+		serve.staticDir = ""
 	}
-	serve.server = startDevStaticServer(serve.addr, absDir, serve.reload)
+	server, err := startDevStaticServer(serve.addr, absDir, serve.reload)
+	if err != nil {
+		return err
+	}
+	serve.server = server
 	serve.staticDir = absDir
+	return nil
 }
 
 func (serve *devServeState) useRuntime(runtime devRuntime) error {
@@ -277,7 +283,11 @@ func (serve *devServeState) useRuntime(runtime devRuntime) error {
 		if err != nil {
 			return err
 		}
-		serve.server = startDevRuntimeProxy(serve.addr, targetAddr, serve.reload)
+		server, err := startDevRuntimeProxy(serve.addr, targetAddr, serve.reload)
+		if err != nil {
+			return err
+		}
+		serve.server = server
 		serve.staticDir = ""
 		if serve.process == nil {
 			serve.process = &devRuntimeProcess{addr: targetAddr}
@@ -335,7 +345,7 @@ func (serve *devServeState) close() {
 	}
 }
 
-func startDevStaticServer(addr, absDir string, reload *liveReloadBroker) *http.Server {
+func startDevStaticServer(addr, absDir string, reload *liveReloadBroker) (*http.Server, error) {
 	server := &http.Server{
 		Addr:              addr,
 		Handler:           liveReloadFileHandler(absDir, reload),
@@ -345,15 +355,22 @@ func startDevStaticServer(addr, absDir string, reload *liveReloadBroker) *http.S
 		IdleTimeout:       60 * time.Second,
 		MaxHeaderBytes:    1 << 20,
 	}
+	// Bind synchronously so a failure (e.g. the address is already in use) is
+	// returned to the caller instead of being logged from a goroutine while
+	// dev keeps running and reports that it is serving.
+	listener, err := net.Listen("tcp", addr)
+	if err != nil {
+		return nil, err
+	}
 	go func() {
-		if err := server.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		if err := server.Serve(listener); err != nil && !errors.Is(err, http.ErrServerClosed) {
 			fmt.Fprintln(os.Stderr, err)
 		}
 	}()
-	return server
+	return server, nil
 }
 
-func startDevRuntimeProxy(addr, targetAddr string, reload *liveReloadBroker) *http.Server {
+func startDevRuntimeProxy(addr, targetAddr string, reload *liveReloadBroker) (*http.Server, error) {
 	server := &http.Server{
 		Addr:              addr,
 		Handler:           devRuntimeProxyHandler(targetAddr, reload),
@@ -363,12 +380,18 @@ func startDevRuntimeProxy(addr, targetAddr string, reload *liveReloadBroker) *ht
 		IdleTimeout:       60 * time.Second,
 		MaxHeaderBytes:    1 << 20,
 	}
+	// Bind synchronously so a failure on the public address is returned to the
+	// caller instead of being logged from a goroutine.
+	listener, err := net.Listen("tcp", addr)
+	if err != nil {
+		return nil, err
+	}
 	go func() {
-		if err := server.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		if err := server.Serve(listener); err != nil && !errors.Is(err, http.ErrServerClosed) {
 			fmt.Fprintln(os.Stderr, err)
 		}
 	}()
-	return server
+	return server, nil
 }
 
 func stopDevStaticServer(server *http.Server) {
@@ -377,6 +400,11 @@ func stopDevStaticServer(server *http.Server) {
 	}
 }
 
+// freeDevRuntimeAddr returns a free loopback address for the generated app to
+// bind. The probe listener is closed before the address is handed back, so a
+// brief TOCTOU window remains in which another process could claim the port
+// before the generated binary binds it. Fully closing it requires handing the
+// bound listener to the child process (socket activation), tracked separately.
 func freeDevRuntimeAddr() (string, error) {
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {

--- a/internal/clientlang/expr_parser.go
+++ b/internal/clientlang/expr_parser.go
@@ -139,7 +139,7 @@ func (parser *exprParser) parsePostfix() (Expr, error) {
 			expr = MemberExpr{X: expr, Name: token.value, Span: mergeExprSpans(ExprSpan(expr), tokenSpan(token))}
 		case tokenLBracket:
 			parser.consume()
-			index, err := parser.parseOr()
+			index, err := parser.parseConditional()
 			if err != nil {
 				return nil, err
 			}
@@ -214,7 +214,7 @@ func (parser *exprParser) parsePrimary() (Expr, error) {
 	case tokenNil:
 		return LiteralExpr{Type: TypeNil, Value: token.value, Span: tokenSpan(token)}, nil
 	case tokenLParen:
-		expr, err := parser.parseOr()
+		expr, err := parser.parseConditional()
 		if err != nil {
 			return nil, err
 		}

--- a/internal/clientlang/expr_test.go
+++ b/internal/clientlang/expr_test.go
@@ -155,6 +155,31 @@ func TestCheckExprParsesGoishConditionalExpression(t *testing.T) {
 	}
 }
 
+func TestCheckExprParsesConditionalInParenthesesAndIndex(t *testing.T) {
+	typ, _, err := CheckExpr(`(if Open { Count } else { 0 })`, map[string]ValueType{
+		"Open":  TypeBool,
+		"Count": TypeInt,
+	})
+	if err != nil {
+		t.Fatalf("parenthesized conditional: %v", err)
+	}
+	if typ != TypeInt {
+		t.Fatalf("expected int type for parenthesized conditional, got %s", typ)
+	}
+
+	typ, _, err = CheckExpr(`Items[if First { 0 } else { 1 }]`, map[string]ValueType{
+		"Items":   TypeArray,
+		"Items[]": TypeString,
+		"First":   TypeBool,
+	})
+	if err != nil {
+		t.Fatalf("conditional index: %v", err)
+	}
+	if typ != TypeString {
+		t.Fatalf("expected string type for conditional index, got %s", typ)
+	}
+}
+
 func TestCheckExprWithFunctionsParsesHelperCalls(t *testing.T) {
 	typ, fields, err := CheckExprWithFunctions(`Next(Count) + Double(step)`, map[string]ValueType{
 		"Count": TypeInt,

--- a/runtime/contracts/events.go
+++ b/runtime/contracts/events.go
@@ -161,6 +161,14 @@ func OutboxCommandEventSink(outbox Outbox) CommandEventSink {
 
 // CompositeCommandEventSink returns a sink that sends the same captured event
 // batch to each sink in order. Nil sinks are ignored.
+//
+// Dispatch is sequential and not transactional: if an earlier sink commits
+// (for example storing to an outbox or publishing to a broker) and a later
+// sink fails, the earlier side effects remain while the command handler
+// returns the error and the client may retry the mutation. Order sinks so the
+// durable, replayable sink (typically the outbox) runs first, and make
+// downstream sinks idempotent — keyed by EventEnvelope.ID — so a retry does
+// not duplicate effects.
 func CompositeCommandEventSink(sinks ...CommandEventSink) CommandEventSink {
 	copied := make([]CommandEventSink, 0, len(sinks))
 	for _, sink := range sinks {

--- a/runtime/contracts/sse/sse.go
+++ b/runtime/contracts/sse/sse.go
@@ -21,7 +21,20 @@ const (
 type Hub struct {
 	mu         sync.Mutex
 	bufferSize int
-	clients    map[chan []byte]bool
+	clients    map[*sseClient]bool
+}
+
+// sseClient is one connected browser. disconnect is closed (once) to ask the
+// streaming goroutine to drop the connection so the browser's EventSource
+// reconnects and resynchronizes.
+type sseClient struct {
+	queue      chan []byte
+	disconnect chan struct{}
+	once       sync.Once
+}
+
+func (client *sseClient) drop() {
+	client.once.Do(func() { close(client.disconnect) })
 }
 
 // Option configures a Hub.
@@ -41,7 +54,7 @@ func WithBufferSize(size int) Option {
 func New(options ...Option) *Hub {
 	hub := &Hub{
 		bufferSize: defaultBufferSize,
-		clients:    map[chan []byte]bool{},
+		clients:    map[*sseClient]bool{},
 	}
 	for _, option := range options {
 		if option != nil {
@@ -64,7 +77,10 @@ func (hub *Hub) ServeHTTP(response http.ResponseWriter, request *http.Request) {
 	response.Header().Set("Connection", "keep-alive")
 	response.Header().Set("X-Accel-Buffering", "no")
 
-	client := make(chan []byte, hub.bufferSize)
+	client := &sseClient{
+		queue:      make(chan []byte, hub.bufferSize),
+		disconnect: make(chan struct{}),
+	}
 	hub.add(client)
 	defer hub.remove(client)
 
@@ -75,7 +91,9 @@ func (hub *Hub) ServeHTTP(response http.ResponseWriter, request *http.Request) {
 		select {
 		case <-request.Context().Done():
 			return
-		case payload := <-client:
+		case <-client.disconnect:
+			return
+		case payload := <-client.queue:
 			if _, err := response.Write([]byte("event: gowdk-presentation\n")); err != nil {
 				return
 			}
@@ -114,14 +132,24 @@ func (hub *Hub) SendPresentationEvents(ctx context.Context, events []contracts.E
 		return nil
 	}
 	hub.mu.Lock()
-	defer hub.mu.Unlock()
+	var slow []*sseClient
 	for client := range hub.clients {
+	queueLoop:
 		for _, payload := range payloads {
 			select {
-			case client <- payload:
+			case client.queue <- payload:
 			default:
+				// The client cannot keep up. Drop it so the browser reconnects
+				// and resynchronizes, rather than silently missing events (for
+				// example a query invalidation) and leaving the UI stale.
+				slow = append(slow, client)
+				break queueLoop
 			}
 		}
+	}
+	hub.mu.Unlock()
+	for _, client := range slow {
+		client.drop()
 	}
 	return nil
 }
@@ -133,17 +161,20 @@ func (hub *Hub) ClientCount() int {
 	return len(hub.clients)
 }
 
-func (hub *Hub) add(client chan []byte) {
+func (hub *Hub) add(client *sseClient) {
 	hub.mu.Lock()
 	defer hub.mu.Unlock()
 	hub.clients[client] = true
 }
 
-func (hub *Hub) remove(client chan []byte) {
+func (hub *Hub) remove(client *sseClient) {
 	hub.mu.Lock()
-	defer hub.mu.Unlock()
 	delete(hub.clients, client)
-	close(client)
+	hub.mu.Unlock()
+	// The queue channel is intentionally left for the garbage collector: the
+	// sender only ever holds it under the lock, so once the client is removed
+	// no send can reach it. Closing it here could race a concurrent send.
+	client.drop()
 }
 
 // ErrNoHub is returned by helpers that require a hub but receive nil.

--- a/runtime/contracts/sse/sse_test.go
+++ b/runtime/contracts/sse/sse_test.go
@@ -85,9 +85,12 @@ func TestHubStreamsPresentationEvents(t *testing.T) {
 	}
 }
 
-func TestHubDropsWhenClientBufferIsFull(t *testing.T) {
+func TestHubDisconnectsSlowClient(t *testing.T) {
 	hub := New(WithBufferSize(1))
-	client := make(chan []byte, 1)
+	client := &sseClient{
+		queue:      make(chan []byte, 1),
+		disconnect: make(chan struct{}),
+	}
 	hub.add(client)
 	defer hub.remove(client)
 
@@ -99,8 +102,12 @@ func TestHubDropsWhenClientBufferIsFull(t *testing.T) {
 	if err != nil {
 		t.Fatalf("send presentation events: %v", err)
 	}
-	if got := len(client); got != 1 {
-		t.Fatalf("client buffer length = %d, want 1", got)
+	// A client whose buffer overflows is disconnected so the browser
+	// reconnects and resynchronizes, instead of silently dropping events.
+	select {
+	case <-client.disconnect:
+	default:
+		t.Fatal("expected the slow client to be disconnected on buffer overflow")
 	}
 }
 

--- a/runtime/contracts/websocketfanout/websocketfanout.go
+++ b/runtime/contracts/websocketfanout/websocketfanout.go
@@ -18,8 +18,21 @@ const defaultBufferSize = 16
 type Hub struct {
 	mu         sync.Mutex
 	bufferSize int
-	clients    map[*websocket.Conn]chan []byte
+	clients    map[*websocket.Conn]*wsClient
 	accept     *websocket.AcceptOptions
+}
+
+// wsClient is one connected browser. disconnect is closed (once) to ask the
+// streaming goroutine to drop the connection so the browser reconnects and
+// resynchronizes.
+type wsClient struct {
+	queue      chan []byte
+	disconnect chan struct{}
+	once       sync.Once
+}
+
+func (client *wsClient) drop() {
+	client.once.Do(func() { close(client.disconnect) })
 }
 
 // Option configures a Hub.
@@ -46,7 +59,7 @@ func WithAcceptOptions(options websocket.AcceptOptions) Option {
 func New(options ...Option) *Hub {
 	hub := &Hub{
 		bufferSize: defaultBufferSize,
-		clients:    map[*websocket.Conn]chan []byte{},
+		clients:    map[*websocket.Conn]*wsClient{},
 	}
 	for _, option := range options {
 		if option != nil {
@@ -65,7 +78,10 @@ func (hub *Hub) ServeHTTP(response http.ResponseWriter, request *http.Request) {
 	defer conn.Close(websocket.StatusNormalClosure, "")
 
 	ctx := conn.CloseRead(request.Context())
-	client := make(chan []byte, hub.bufferSize)
+	client := &wsClient{
+		queue:      make(chan []byte, hub.bufferSize),
+		disconnect: make(chan struct{}),
+	}
 	hub.add(conn, client)
 	defer hub.remove(conn)
 
@@ -73,7 +89,9 @@ func (hub *Hub) ServeHTTP(response http.ResponseWriter, request *http.Request) {
 		select {
 		case <-ctx.Done():
 			return
-		case payload := <-client:
+		case <-client.disconnect:
+			return
+		case payload := <-client.queue:
 			if err := conn.Write(ctx, websocket.MessageText, payload); err != nil {
 				return
 			}
@@ -102,14 +120,24 @@ func (hub *Hub) SendPresentationEvents(ctx context.Context, events []contracts.E
 		return nil
 	}
 	hub.mu.Lock()
-	defer hub.mu.Unlock()
+	var slow []*wsClient
 	for _, client := range hub.clients {
+	queueLoop:
 		for _, payload := range payloads {
 			select {
-			case client <- payload:
+			case client.queue <- payload:
 			default:
+				// The client cannot keep up. Drop it so the browser reconnects
+				// and resynchronizes, rather than silently missing events (for
+				// example a query invalidation) and leaving the UI stale.
+				slow = append(slow, client)
+				break queueLoop
 			}
 		}
+	}
+	hub.mu.Unlock()
+	for _, client := range slow {
+		client.drop()
 	}
 	return nil
 }
@@ -121,7 +149,7 @@ func (hub *Hub) ClientCount() int {
 	return len(hub.clients)
 }
 
-func (hub *Hub) add(conn *websocket.Conn, client chan []byte) {
+func (hub *Hub) add(conn *websocket.Conn, client *wsClient) {
 	hub.mu.Lock()
 	defer hub.mu.Unlock()
 	hub.clients[conn] = client
@@ -129,9 +157,12 @@ func (hub *Hub) add(conn *websocket.Conn, client chan []byte) {
 
 func (hub *Hub) remove(conn *websocket.Conn) {
 	hub.mu.Lock()
-	defer hub.mu.Unlock()
-	if client, ok := hub.clients[conn]; ok {
-		delete(hub.clients, conn)
-		close(client)
+	client, ok := hub.clients[conn]
+	delete(hub.clients, conn)
+	hub.mu.Unlock()
+	// The queue channel is left for the garbage collector: the sender only
+	// holds it under the lock, so no send can reach a removed client.
+	if ok {
+		client.drop()
 	}
 }

--- a/runtime/envfile/envfile.go
+++ b/runtime/envfile/envfile.go
@@ -20,9 +20,11 @@ type LoadResult struct {
 	Explicit bool
 }
 
+// appliedValues records the value this loader last wrote for each name, so a
+// reload can tell its own previous value apart from an external override.
 var (
 	appliedMu     sync.Mutex
-	appliedByFile = map[string]bool{}
+	appliedValues = map[string]string{}
 )
 
 // LookupPath resolves the env file for a project root. explicit wins. Without
@@ -56,7 +58,9 @@ func LookupPath(projectRoot string, explicit string) (string, bool, error) {
 }
 
 // LoadIntoEnv loads path and sets only names that are not already present in
-// the process environment. Existing process values always win.
+// the process environment. Existing process values always win, including a
+// value changed with os.Setenv after a previous load: a reload only overwrites
+// a name whose current value is still the one this loader last applied.
 func LoadIntoEnv(path string, explicit bool) (LoadResult, error) {
 	appliedMu.Lock()
 	defer appliedMu.Unlock()
@@ -71,14 +75,20 @@ func LoadIntoEnv(path string, explicit bool) (LoadResult, error) {
 	}
 	result.Loaded = true
 	for _, entry := range values {
-		if _, ok := os.LookupEnv(entry.Name); ok && !appliedByFile[entry.Name] {
-			result.Skipped = append(result.Skipped, entry.Name)
-			continue
+		if current, ok := os.LookupEnv(entry.Name); ok {
+			// A value already in the environment wins, unless this loader set
+			// it on a previous load and nothing has changed it since. If the
+			// current value differs from what we last applied, it is an
+			// external/manual override and must not be clobbered.
+			if applied, mine := appliedValues[entry.Name]; !mine || applied != current {
+				result.Skipped = append(result.Skipped, entry.Name)
+				continue
+			}
 		}
 		if err := os.Setenv(entry.Name, entry.Value); err != nil {
 			return result, err
 		}
-		appliedByFile[entry.Name] = true
+		appliedValues[entry.Name] = entry.Value
 		result.Applied = append(result.Applied, entry.Name)
 	}
 	return result, nil

--- a/runtime/envfile/envfile_test.go
+++ b/runtime/envfile/envfile_test.go
@@ -91,7 +91,7 @@ func TestLoadIntoEnvUpdatesValuesItPreviouslyApplied(t *testing.T) {
 	t.Cleanup(func() {
 		_ = os.Unsetenv(name)
 		appliedMu.Lock()
-		delete(appliedByFile, name)
+		delete(appliedValues, name)
 		appliedMu.Unlock()
 	})
 
@@ -109,6 +109,45 @@ func TestLoadIntoEnvUpdatesValuesItPreviouslyApplied(t *testing.T) {
 	}
 	if got := os.Getenv(name); got != "second" {
 		t.Fatalf("expected file-applied value to update, got %q", got)
+	}
+}
+
+func TestLoadIntoEnvDoesNotOverrideManualValueAfterLoad(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, ".env")
+	name := "GOWDK_TEST_MANUAL_OVERRIDE"
+	_ = os.Unsetenv(name)
+	t.Cleanup(func() {
+		_ = os.Unsetenv(name)
+		appliedMu.Lock()
+		delete(appliedValues, name)
+		appliedMu.Unlock()
+	})
+
+	if err := os.WriteFile(path, []byte(name+"=from-file\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := LoadIntoEnv(path, false); err != nil {
+		t.Fatal(err)
+	}
+	if got := os.Getenv(name); got != "from-file" {
+		t.Fatalf("expected initial file value, got %q", got)
+	}
+
+	// Override the value manually after the initial file load.
+	if err := os.Setenv(name, "manual"); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := LoadIntoEnv(path, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := os.Getenv(name); got != "manual" {
+		t.Fatalf("expected manual override to survive reload, got %q", got)
+	}
+	if !reflect.DeepEqual(result.Skipped, []string{name}) {
+		t.Fatalf("expected %q skipped on reload, got %#v", name, result)
 	}
 }
 

--- a/runtime/route/route.go
+++ b/runtime/route/route.go
@@ -67,6 +67,14 @@ func Match(pattern, requestPath string) (map[string]string, bool) {
 }
 
 func hasUnsafeRequestSegment(requestPath string) bool {
+	// Consecutive slashes anywhere — including a leading "//" or trailing
+	// "//" — are non-canonical. path.Clean would collapse them, letting
+	// "//admin" or "/admin//" match "/admin" while a fronting proxy, cache,
+	// or authorization layer may treat them as different paths. Reject them
+	// outright so matching cannot disagree with what sits in front of it.
+	if strings.Contains(requestPath, "//") {
+		return true
+	}
 	trimmed := strings.Trim(requestPath, "/")
 	if trimmed == "" {
 		return false

--- a/runtime/route/route_test.go
+++ b/runtime/route/route_test.go
@@ -118,6 +118,20 @@ func TestMatchRestRouteTypedHelpers(t *testing.T) {
 	}
 }
 
+func TestMatchRejectsDuplicateSlashes(t *testing.T) {
+	if _, ok := Match("/admin", "/admin"); !ok {
+		t.Fatal("expected /admin to match /admin")
+	}
+	for _, requestPath := range []string{"//admin", "/admin//", "///admin"} {
+		if _, ok := Match("/admin", requestPath); ok {
+			t.Fatalf("expected duplicate-slash path %q to be rejected", requestPath)
+		}
+	}
+	if _, ok := Match("/blog/post", "/blog//post"); ok {
+		t.Fatal("expected interior duplicate slash to be rejected")
+	}
+}
+
 func TestMatchRejectsUnsafeParamValues(t *testing.T) {
 	if _, ok := Match("/blog/{slug}", "/blog/."); ok {
 		t.Fatal("expected dot param not to match")

--- a/runtime/ssr/load.go
+++ b/runtime/ssr/load.go
@@ -77,10 +77,21 @@ func loadPathValue(value any, field string) (any, bool) {
 }
 
 func loadMapField(value reflect.Value, field string) (any, bool) {
-	if value.Type().Key().Kind() != reflect.String {
+	keyType := value.Type().Key()
+	if keyType.Kind() != reflect.String {
 		return nil, false
 	}
-	found := value.MapIndex(reflect.ValueOf(field))
+	key := reflect.ValueOf(field)
+	if key.Type() != keyType {
+		// The map may be keyed by a named string type (e.g. type ID string),
+		// which a plain string is not assignable to. Convert the key so
+		// MapIndex does not panic.
+		if !key.Type().ConvertibleTo(keyType) {
+			return nil, false
+		}
+		key = key.Convert(keyType)
+	}
+	found := value.MapIndex(key)
 	if !found.IsValid() {
 		return nil, false
 	}

--- a/runtime/ssr/regions.go
+++ b/runtime/ssr/regions.go
@@ -146,6 +146,82 @@ func htmlContainsPostForm(html string) bool {
 			return true
 		}
 	}
+	// A nominally GET form can still POST through a submit control that
+	// overrides the method, e.g. <button formmethod="post">. Scan every start
+	// tag for that override so such a form is not embedded in a patch without a
+	// freshly generated CSRF token.
+	for _, match := range startTagRanges(payload) {
+		if tagHasPostFormmethod(payload[match[0]:match[1]]) {
+			return true
+		}
+	}
+	return false
+}
+
+// startTagRanges returns the byte ranges of every HTML start tag in payload.
+func startTagRanges(payload []byte) [][2]int {
+	var matches [][2]int
+	for index := 0; index < len(payload); index++ {
+		if payload[index] != '<' {
+			continue
+		}
+		nameStart := index + 1
+		if nameStart >= len(payload) || !isHTMLNameChar(payload[nameStart]) {
+			// Not a start tag: a closing tag, comment, or stray '<'.
+			continue
+		}
+		end := htmlTagEnd(payload, nameStart)
+		if end < 0 {
+			break
+		}
+		matches = append(matches, [2]int{index, end + 1})
+		index = end
+	}
+	return matches
+}
+
+// tagHasPostFormmethod reports whether the start tag carries formmethod="post".
+func tagHasPostFormmethod(tag []byte) bool {
+	return tagAttrMatch(tag, func(name, value []byte) bool {
+		return bytes.EqualFold(name, []byte("formmethod")) && strings.EqualFold(string(value), http.MethodPost)
+	})
+}
+
+// tagAttrMatch walks the attributes of an HTML start tag (the slice must begin
+// at '<') and reports whether want returns true for any name/value pair.
+func tagAttrMatch(tag []byte, want func(name, value []byte) bool) bool {
+	cursor := 1
+	for cursor < len(tag) && !isHTMLSpace(tag[cursor]) && tag[cursor] != '>' && tag[cursor] != '/' {
+		cursor++
+	}
+	for cursor < len(tag) {
+		for cursor < len(tag) && isHTMLSpace(tag[cursor]) {
+			cursor++
+		}
+		if cursor >= len(tag) || tag[cursor] == '>' || tag[cursor] == '/' {
+			return false
+		}
+		nameStart := cursor
+		for cursor < len(tag) && !isHTMLSpace(tag[cursor]) && tag[cursor] != '=' && tag[cursor] != '/' && tag[cursor] != '>' {
+			cursor++
+		}
+		name := tag[nameStart:cursor]
+		for cursor < len(tag) && isHTMLSpace(tag[cursor]) {
+			cursor++
+		}
+		if cursor >= len(tag) || tag[cursor] != '=' {
+			continue
+		}
+		cursor++
+		for cursor < len(tag) && isHTMLSpace(tag[cursor]) {
+			cursor++
+		}
+		value, next := htmlAttrValue(tag, cursor)
+		cursor = next
+		if want(name, value) {
+			return true
+		}
+	}
 	return false
 }
 

--- a/runtime/ssr/regions_test.go
+++ b/runtime/ssr/regions_test.go
@@ -89,6 +89,21 @@ func TestRenderInvalidatedRegionsSkipsPostForms(t *testing.T) {
 	}
 }
 
+func TestRenderInvalidatedRegionsSkipsFormmethodPostControls(t *testing.T) {
+	resetRegions()
+	defer resetRegions()
+	const queryType = "example.com/app/patients.GetPatientPage"
+	renderer := boardRegion(queryType)
+	// A nominally GET form that POSTs via a submit button override.
+	renderer.Template = `<section data-gowdk-query-type="` + queryType + `"><form method="get"><button formmethod="post">Save</button></form></section>`
+	RegisterRegion(renderer)
+
+	patches := RenderInvalidatedRegions(httptest.NewRequest(http.MethodPost, "/patients", nil), []string{queryType})
+	if len(patches) != 0 {
+		t.Fatalf("expected no patches for HTML with formmethod=post controls, got %+v", patches)
+	}
+}
+
 func TestRegisterRegionIgnoresIncomplete(t *testing.T) {
 	resetRegions()
 	defer resetRegions()

--- a/runtime/ssr/ssr_test.go
+++ b/runtime/ssr/ssr_test.go
@@ -69,6 +69,17 @@ func TestLoadPathResolvesNestedMapsAndStructs(t *testing.T) {
 	}
 }
 
+func TestLoadPathResolvesNamedStringKeyedMap(t *testing.T) {
+	type key string
+	data := map[string]any{
+		"labels": map[key]string{"greeting": "hi"},
+	}
+	value, ok := LoadPath(data, "labels.greeting")
+	if !ok || value != "hi" {
+		t.Fatalf("LoadPath(labels.greeting) = %#v, %v; want \"hi\", true", value, ok)
+	}
+}
+
 func TestLoadPathRejectsMissingOrInvalidPaths(t *testing.T) {
 	data := map[string]any{
 		"user": map[string]any{"name": "Ada"},


### PR DESCRIPTION
## Summary

Hardening batch addressing the audited defects filed as #535–#545. Each fix is small, scoped to one subsystem, and covered by a test.

This branch is based on `main` and contains **only** these fixes — unrelated in-progress work in the tree was deliberately left out.

## Fixes

| Issue | Fix | File |
|---|---|---|
| #535 | `gowdk clean` now resolves symlinks on the target's parent and refuses to remove a path that escapes the project through an intermediate symlink (lexical check alone was insufficient since `os.RemoveAll` follows symlinks). | [clean.go](cmd/gowdk/clean.go) |
| #536 | `loadMapField` converts the lookup key to the map's actual key type before `MapIndex`, so a `map[NamedString]T` no longer panics. | [load.go](runtime/ssr/load.go) |
| #537 | On buffer overflow the SSE/WebSocket hub now **disconnects** the slow client (via a per-client `disconnect` signal) instead of silently dropping the event, so the browser reconnects and resynchronizes. | [sse.go](runtime/contracts/sse/sse.go), [websocketfanout.go](runtime/contracts/websocketfanout/websocketfanout.go) |
| #539 | Route matcher rejects any consecutive slashes (`//admin`, `/admin//`, interior `//`), eliminating the leading/trailing-vs-interior asymmetry that let non-canonical paths match. | [route.go](runtime/route/route.go) |
| #540 | *(doc)* `CompositeCommandEventSink` documents the non-transactional, partial-commit hazard and the required ordering/idempotency contract. | [events.go](runtime/contracts/events.go) |
| #541 | Patch safety check now scans every start tag for `formmethod="post"` submit controls, not just the `<form method>` attribute. | [regions.go](runtime/ssr/regions.go) |
| #542 | Dev static server and runtime proxy bind synchronously (`net.Listen` before `Serve`), so a bind failure (e.g. address already in use) is returned to the caller instead of being logged from a goroutine while `gowdk dev` reports success. | [dev.go](cmd/gowdk/dev.go) |
| #544 | env-file reload tracks the **last value it applied** per name; a value changed by `os.Setenv` after the initial load is now recognized as an external override and preserved. | [envfile.go](runtime/envfile/envfile.go) |
| #545 | Parenthesized grouping and array-index branches call `parseConditional` instead of `parseOr`, so `(if c { a } else { b })` and `arr[if c { 0 } else { 1 }]` parse, matching call-argument behavior. | [expr_parser.go](internal/clientlang/expr_parser.go) |

## Deferred (need design-level changes, not in this PR)

- **#538 — SSE per-user/audience fanout scoping.** A correct fix means adding an audience field to `EventEnvelope` and deriving per-connection identity in generated handlers — a breaking API change that warrants its own design. Left open.
- **#543 — dev runtime port TOCTOU.** The generated app (a child process) binds the probed port, so fully closing the race needs listener/fd hand-off (socket activation). The limitation is now documented in `freeDevRuntimeAddr`; the feature is left as a follow-up.

## Testing

Each fix has a regression test:

- `TestRunCleanDoesNotFollowSymlinkOutsideRoot`
- `TestLoadPathResolvesNamedStringKeyedMap`
- `TestHubDisconnectsSlowClient` (sse), websocketfanout module tests
- `TestMatchRejectsDuplicateSlashes`
- `TestRenderInvalidatedRegionsSkipsFormmethodPostControls`
- `TestLoadIntoEnvDoesNotOverrideManualValueAfterLoad`
- `TestCheckExprParsesConditionalInParenthesesAndIndex`

All affected packages pass (`go test`), including the nested `runtime/contracts/websocketfanout` module. `gofmt` clean.
