### PR TITLE
fix(docs-site): root the Render service at the repo root, not docs-site

### DIFF
--- a/docs-site/README.md
+++ b/docs-site/README.md
@@ -128,11 +128,14 @@ GOWDK_ADDR=127.0.0.1:8091 go run .
 ```
 
 Deployment is a Go web service (see `render.yaml` at the repo root — Render only
-reads a Blueprint from the repository root, not from a subdirectory). With
-`rootDir: docs-site`, Render checks out the monorepo, enters `docs-site/`, runs
-syncdocs and the in-tree GOWDK build, copies `assets/`, then `go build`s
-`main.go` into the `app` binary that embeds and serves `docs-site/dist/site`
-(reading `$PORT`). The Blueprint build filter watches both `docs-site/**` and
+reads a Blueprint from the repository root, not from a subdirectory). The service
+is rooted at the **repo root**, not `docs-site/`: docs-site's `go.mod` replaces
+the framework with `../` and `syncdocs` reads `../docs`, both outside
+`docs-site/`, and Render makes files outside a service's root directory
+unavailable at build time. So the build `cd`s into `docs-site/`, runs syncdocs
+and the in-tree GOWDK build, copies `assets/`, then `go build`s `main.go` into
+the `app` binary that embeds and serves `dist/site` (reading `$PORT`); the start
+command is `cd docs-site && ./app`. The Blueprint build filter watches both `docs-site/**` and
 `docs/**`, so source documentation changes deploy the generated site even though
 `src/pages/docs/**` is gitignored. A static preview of any branch is just the
 build output above served by any static file server, so contributors can review

--- a/render.yaml
+++ b/render.yaml
@@ -2,18 +2,21 @@ services:
   - type: web
     name: gowdk-page
     runtime: go
-    # The docs site lives in the GOWDK monorepo under docs-site/. Render only
-    # reads a Blueprint render.yaml from the repository root, so this file lives
-    # here (not in docs-site/). Render checks out the whole repo and enters
-    # docs-site/ (rootDir) to build; the parent directory (..) is the framework
-    # root whose docs/ tree syncdocs renders.
+    # The docs site lives under docs-site/, but its go.mod has
+    # `replace github.com/cssbruno/gowdk => ../` and cmd/syncdocs reads ../docs —
+    # both OUTSIDE docs-site/. Render makes files outside a service's root
+    # directory unavailable at build time, so we must NOT set rootDir: docs-site
+    # (that would hide the parent module and ../docs). Instead the service is
+    # rooted at the repo root — where the whole repo is available — and every
+    # command cd's into docs-site/. render.yaml itself must live at the repo
+    # root, because Render only reads a Blueprint from there.
     #
     # This deploys as a Go binary (not a static publish): main.go embeds
     # dist/site and serves it, reading $PORT from Render. The build must generate
     # dist/site BEFORE `go build`, because main.go uses //go:embed dist/site.
-    rootDir: docs-site
     buildCommand: |
       set -euo pipefail
+      cd docs-site
       mkdir -p tools
       tailwind_version="v4.3.1"
       tailwind_sha256="2526d063ba03b71f9a3ea7d5cee14f0aec147f117f222d5adc97b1d736d45999"
@@ -28,7 +31,7 @@ services:
       cp -R assets/. dist/site/assets/
       cp assets/favicon.ico dist/site/favicon.ico
       go build -tags netgo -ldflags '-s -w' -o app .
-    startCommand: ./app
+    startCommand: cd docs-site && ./app
     buildFilter:
       paths:
         - docs-site/**


### PR DESCRIPTION
Follow-up to #572, which shipped with `rootDir: docs-site` — a real bug caught in that PR's review (P1).

## Problem
[Render's monorepo docs](https://render.com/docs/monorepo-support): **"Files outside your service's root directory are not available to the service at build time or at runtime."**

`docs-site/go.mod` has `replace github.com/cssbruno/gowdk => ../` and `cmd/syncdocs` reads `../docs` — **both outside `docs-site/`**. So with `rootDir: docs-site`, the Go build can't resolve the in-tree framework module and `syncdocs` can't see `../docs`. The build cannot succeed.

## Fix
- **Remove `rootDir`** — root the service at the repo root, where the whole repo (parent module + `../docs`) is available.
- **`cd docs-site`** inside the build command, and `startCommand: cd docs-site && ./app`. This is the same pattern #546's static config used.
- `buildFilter` still scopes auto-deploys to `docs-site/**` and `docs/**`.

`render.yaml` stays at the repo root (Render only reads a Blueprint from there).

## ⚠️ Operational (the other review finding, P2)
A service's **runtime is immutable** on Render. If a `gowdk-page` service already exists as a different runtime, the Blueprint can't convert it — **delete the existing service and recreate it from the Blueprint** after this merges.