### PR TITLE
[codex] fix runtime hardening gaps

### DIFF
--- a/addons/auth/auth_test.go
+++ b/addons/auth/auth_test.go
@@ -82,10 +82,13 @@ func TestPBKDF2HasherWithCustomIterations(t *testing.T) {
 }
 
 func TestHashPasswordWithIterationsRejectsInvalidIterations(t *testing.T) {
-	for _, iterations := range []int{0, -1, MinIterations - 1} {
+	for _, iterations := range []int{0, -1, MinIterations - 1, MaxIterations + 1} {
 		if _, err := HashPasswordWithIterations("same", iterations); err == nil {
 			t.Fatalf("HashPasswordWithIterations accepted iterations=%d", iterations)
 		}
+	}
+	if _, err := (PBKDF2Hasher{Iterations: MaxIterations + 1}).HashPassword("same"); err == nil {
+		t.Fatalf("PBKDF2Hasher accepted iterations=%d", MaxIterations+1)
 	}
 }
 
@@ -148,6 +151,7 @@ func TestVerifyPasswordRejectsMalformedHash(t *testing.T) {
 		"bcrypt$10$salt$key",
 		"pbkdf2-sha256$600000$$a2V5",
 		"pbkdf2-sha256$1$" + canonicalSalt + "$" + canonicalKey,
+		"pbkdf2-sha256$" + strconv.Itoa(MaxIterations+1) + "$" + canonicalSalt + "$" + canonicalKey,
 		"pbkdf2-sha256$600000$" + shortSalt + "$" + canonicalKey,
 		"pbkdf2-sha256$600000$" + canonicalSalt + "$" + shortKey,
 	} {

--- a/addons/auth/password.go
+++ b/addons/auth/password.go
@@ -22,6 +22,10 @@ const (
 	// stored hashes. Keep this separate from DefaultIterations so existing
 	// stored hashes remain verifiable if the default later increases.
 	MinIterations = 600000
+	// MaxIterations is the maximum accepted PBKDF2 iteration count for new and
+	// stored hashes. It bounds CPU cost when verifying imported or corrupted
+	// hashes while leaving room for future default increases.
+	MaxIterations = 2000000
 
 	pbkdf2SaltLength = 16
 	pbkdf2KeyLength  = 32
@@ -112,6 +116,9 @@ func (hasher PBKDF2Hasher) iterations() int {
 func validateIterations(iterations int) error {
 	if iterations < MinIterations {
 		return fmt.Errorf("gowdk auth: iterations must be at least %d", MinIterations)
+	}
+	if iterations > MaxIterations {
+		return fmt.Errorf("gowdk auth: iterations must be at most %d", MaxIterations)
 	}
 	return nil
 }

--- a/internal/appgen/adapter_ir.go
+++ b/internal/appgen/adapter_ir.go
@@ -458,6 +458,9 @@ func (ir BackendAdapterIR) GuardNames() []string {
 func (ir BackendAdapterIR) BackendImports() map[string]string {
 	imports := map[string]string{}
 	for _, call := range ir.Calls {
+		if endpointDeniedByOmission(call.Endpoint.Guards) {
+			continue
+		}
 		if call.ImportPath != "" && call.Alias != "" {
 			imports[call.ImportPath] = call.Alias
 		}

--- a/internal/appgen/adapter_ir_test.go
+++ b/internal/appgen/adapter_ir_test.go
@@ -1,6 +1,7 @@
 package appgen
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/cssbruno/gowdk/internal/gwdkir"
@@ -35,6 +36,7 @@ func TestBackendAdapterIRCapturesRouteAndHandlerMetadata(t *testing.T) {
 			APIName: "Health",
 			Method:  "GET",
 			Route:   "/api/health",
+			Guards:  []string{"public"},
 			Binding: source.BackendBinding{
 				Status:       source.BackendBindingBound,
 				ImportPath:   "example.com/app/status",
@@ -50,6 +52,7 @@ func TestBackendAdapterIRCapturesRouteAndHandlerMetadata(t *testing.T) {
 			Route:        "/patients/{id}/list",
 			Target:       "#patients",
 			HTML:         "<section>Patients</section>",
+			Guards:       []string{"public"},
 			Binding: source.BackendBinding{
 				Status:       source.BackendBindingBound,
 				ImportPath:   "example.com/app/patients",
@@ -97,7 +100,7 @@ func TestBackendAdapterIRCapturesRouteAndHandlerMetadata(t *testing.T) {
 		t.Fatalf("expected adapter IR to report dynamic fragment route")
 	}
 	guards := ir.GuardNames()
-	if len(guards) != 1 || guards[0] != "auth.required" {
+	if strings.Join(guards, ",") != "auth.required,public,public" {
 		t.Fatalf("expected adapter guard metadata, got %#v", guards)
 	}
 	imports := ir.BackendImports()

--- a/internal/appgen/appgen_test.go
+++ b/internal/appgen/appgen_test.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"flag"
+	"go/ast"
 	"go/format"
 	"io"
 	"net"
@@ -822,6 +823,7 @@ func TestGenerateWritesBoundContractBackendRoutes(t *testing.T) {
 			Register:  "Register",
 			OwnerKind: gwdkir.SourcePage,
 			OwnerID:   "patients",
+			Guards:    []string{"public"},
 		},
 		{
 			Kind:        gwdkir.ContractQuery,
@@ -840,6 +842,7 @@ func TestGenerateWritesBoundContractBackendRoutes(t *testing.T) {
 			Register:  "Register",
 			OwnerKind: gwdkir.SourcePage,
 			OwnerID:   "patients",
+			Guards:    []string{"public"},
 		},
 	}}
 
@@ -930,6 +933,7 @@ func TestGenerateWritesRealtimeFanoutForSubscriptions(t *testing.T) {
 			Register:    "Register",
 			OwnerKind:   gwdkir.SourcePage,
 			OwnerID:     "patients",
+			Guards:      []string{"public"},
 		}},
 		RealtimeSubscriptions: []gwdkir.RealtimeSubscription{{
 			Query:           "patients.GetPatientPage",
@@ -989,6 +993,7 @@ func TestGenerateWritesRealtimeQueryInvalidationFanout(t *testing.T) {
 			Register:    "Register",
 			OwnerKind:   gwdkir.SourcePage,
 			OwnerID:     "patients",
+			Guards:      []string{"public"},
 		}},
 		QueryInvalidations: []gwdkir.QueryInvalidation{{
 			Query:         "patients.GetPatientPage",
@@ -1059,6 +1064,7 @@ func TestGenerateRegistersSingleFlightRegionRenderers(t *testing.T) {
 			Register:    "Register",
 			OwnerKind:   gwdkir.SourcePage,
 			OwnerID:     "patients",
+			Guards:      []string{"public"},
 		}},
 		QueryInvalidations: []gwdkir.QueryInvalidation{{
 			Query:         "patients.GetPatientPage",
@@ -1200,6 +1206,7 @@ func TestGenerateSkipsSingleFlightRegionRenderersForGuardedRoutes(t *testing.T) 
 			Register:    "Register",
 			OwnerKind:   gwdkir.SourcePage,
 			OwnerID:     "patients",
+			Guards:      []string{"public"},
 		}},
 		QueryInvalidations: []gwdkir.QueryInvalidation{{
 			Query:         "patients.GetPatientPage",
@@ -1893,8 +1900,8 @@ func TestGenerateWiresCSRFForStateChangingAPIs(t *testing.T) {
 		t.Fatalf("expected generated source to contain API case:\n%s", source)
 	}
 	assertSourceOrder(t, source[apiIndex:],
-		`err := csrfValidator.Validate(request)`,
 		`request.Body = http.MaxBytesReader(response, request.Body, maxAPIBodyBytes)`,
+		`err := csrfValidator.Validate(request)`,
 		`result, err := status.Update(ctx, request)`,
 	)
 }
@@ -1955,6 +1962,7 @@ func TestGenerateWiresCSRFForCommandContracts(t *testing.T) {
 		Register:    "Register",
 		OwnerKind:   gwdkir.SourcePage,
 		OwnerID:     "patients",
+		Guards:      []string{"public"},
 	}}}
 
 	result, err := GenerateWithOptions(outputDir, appDir, Options{
@@ -2051,6 +2059,9 @@ func TestGenerateWiresEnvContractValidation(t *testing.T) {
 		`explicit := strings.TrimSpace(os.Getenv("GOWDK_ENV_FILE"))`,
 		`path, _, err := gowdkenvfile.LookupPath("", explicit)`,
 		`_, err = gowdkenvfile.LoadIntoEnv(path, explicit != "")`,
+		`applyEnvDefaults()`,
+		`func applyEnvDefaults()`,
+		`os.Setenv("GOWDK_TEST_ADDR", "127.0.0.1:8080")`,
 		`if err := validateEnvContract(); err != nil {`,
 		`func validateEnvContract() error`,
 		`value := os.Getenv("GOWDK_TEST_BACKEND_ORIGIN")`,
@@ -2065,6 +2076,78 @@ func TestGenerateWiresEnvContractValidation(t *testing.T) {
 	}
 	if strings.Contains(source, `GOWDK_TEST_ADDR is required but is not set`) {
 		t.Fatalf("required env var with a default should not need runtime validation:\n%s", source)
+	}
+	muxIndex := strings.Index(source, `func newServeMux(identity gowdkruntime.Identity) (*http.ServeMux, error)`)
+	if muxIndex < 0 {
+		t.Fatalf("expected generated source to contain newServeMux:\n%s", source)
+	}
+	assertSourceOrder(t, source[muxIndex:],
+		`if err := loadEnvFile(); err != nil {`,
+		`applyEnvDefaults()`,
+		`if err := validateEnvContract(); err != nil {`,
+	)
+}
+
+func TestGenerateLoadsEnvFileForOptionalEnvConfig(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		vars          []gowdk.EnvVar
+		expectDefault bool
+	}{
+		{
+			name: "optional only",
+			vars: []gowdk.EnvVar{{Name: "GOWDK_TEST_OPTIONAL_ORIGIN"}},
+		},
+		{
+			name:          "default only",
+			vars:          []gowdk.EnvVar{{Name: "GOWDK_TEST_ADDR", Default: "127.0.0.1:8080"}},
+			expectDefault: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			outputDir := filepath.Join(root, "dist")
+			appDir := filepath.Join(root, "generated-app")
+			writeTestFile(t, filepath.Join(outputDir, "index.html"), "<main>Home</main>")
+
+			result, err := GenerateWithOptions(outputDir, appDir, Options{
+				Config: gowdk.Config{Env: gowdk.EnvConfig{Vars: tc.vars}},
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			payload, err := os.ReadFile(result.PackagePath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			source := string(payload)
+			for _, expected := range []string{
+				`gowdkenvfile "github.com/cssbruno/gowdk/runtime/envfile"`,
+				`if err := loadEnvFile(); err != nil {`,
+				`func loadEnvFile() error`,
+				`_, err = gowdkenvfile.LoadIntoEnv(path, explicit != "")`,
+			} {
+				if !strings.Contains(source, expected) {
+					t.Fatalf("expected optional env config to load .env via %q:\n%s", expected, source)
+				}
+			}
+			if strings.Contains(source, `func validateEnvContract() error`) {
+				t.Fatalf("optional-only env config should not emit required validation:\n%s", source)
+			}
+			if tc.expectDefault {
+				for _, expected := range []string{
+					`applyEnvDefaults()`,
+					`func applyEnvDefaults()`,
+					`os.Setenv("GOWDK_TEST_ADDR", "127.0.0.1:8080")`,
+				} {
+					if !strings.Contains(source, expected) {
+						t.Fatalf("expected default-only env config to emit %q:\n%s", expected, source)
+					}
+				}
+			} else if strings.Contains(source, `func applyEnvDefaults()`) {
+				t.Fatalf("optional env config without defaults should not emit defaults helper:\n%s", source)
+			}
+		})
 	}
 }
 
@@ -3709,7 +3792,8 @@ func TestGenerateWiresRateLimiterWhenEnabled(t *testing.T) {
 		`func RegisterRateLimiter(limiter *gowdkratelimit.Limiter)`,
 		`result, err := rateLimiter.AllowRequest(request)`,
 		`gowdkratelimit.WriteHeaders(response, result)`,
-		`gowdkratelimit.DefaultLimitHandler(response, request, result)`,
+		`rateLimiter.HandleError(response, request, err)`,
+		`rateLimiter.HandleLimit(response, request, result)`,
 		`if runRateLimit(response, request)`,
 	} {
 		if !strings.Contains(source, expected) {
@@ -5737,6 +5821,7 @@ func TestGeneratedBinaryServesPageAndExecutesContractQuery(t *testing.T) {
 		Register:    "Register",
 		OwnerKind:   gwdkir.SourcePage,
 		OwnerID:     "patients",
+		Guards:      []string{"public"},
 	}}}
 	if _, err := GenerateWithOptions(outputDir, appDir, Options{Config: csrfDisabledConfig(), IR: program}); err != nil {
 		t.Fatal(err)
@@ -5839,6 +5924,7 @@ func TestGeneratedBinaryCommandContractUsesRegisteredEventSink(t *testing.T) {
 		Register:    "Register",
 		OwnerKind:   gwdkir.SourcePage,
 		OwnerID:     "patients",
+		Guards:      []string{"public"},
 	}}}
 	if _, err := GenerateWithOptions(outputDir, appDir, Options{Config: csrfDisabledConfig(), IR: program}); err != nil {
 		t.Fatal(err)
@@ -5966,6 +6052,7 @@ func TestGeneratedBinaryCommandSetsInvalidatedQueriesHeader(t *testing.T) {
 			Register:    "Register",
 			OwnerKind:   gwdkir.SourcePage,
 			OwnerID:     "patients",
+			Guards:      []string{"public"},
 		}},
 		QueryInvalidations: []gwdkir.QueryInvalidation{{
 			Query:         "patients.GetPatientPage",
@@ -6072,6 +6159,7 @@ func TestGeneratedBinaryCommandEmbedsSingleFlightRegionHTML(t *testing.T) {
 			Register:    "Register",
 			OwnerKind:   gwdkir.SourcePage,
 			OwnerID:     "patients",
+			Guards:      []string{"public"},
 		}},
 		QueryInvalidations: []gwdkir.QueryInvalidation{{
 			Query:         "patients.GetPatientPage",
@@ -6259,6 +6347,7 @@ func TestGeneratedBinaryRealtimeFanoutStreamsSubscribedPresentationEvents(t *tes
 			Register:    "Register",
 			OwnerKind:   gwdkir.SourcePage,
 			OwnerID:     "patients",
+			Guards:      []string{"public"},
 		}},
 		RealtimeSubscriptions: []gwdkir.RealtimeSubscription{{
 			Query:           "patients.GetPatientPage",
@@ -6482,7 +6571,7 @@ func GOWDKGuardRegistry() gowdkguard.Registry {
 	if cache := response.Header.Get("Cache-Control"); cache != "no-store" {
 		t.Fatalf("expected guard-denied realtime stream to be no-store, got %q", cache)
 	}
-	if !strings.Contains(string(payload), "guard") {
+	if !strings.Contains(string(payload), "403 forbidden") || strings.Contains(string(payload), "auth.required") {
 		t.Fatalf("expected guard denial response, got %s", payload)
 	}
 }
@@ -6513,6 +6602,7 @@ func TestGeneratedBinaryContractAdaptersReturnJSONErrors(t *testing.T) {
 			Register:  "Register",
 			OwnerKind: gwdkir.SourcePage,
 			OwnerID:   "patients",
+			Guards:    []string{"public"},
 		},
 		{
 			Kind:        gwdkir.ContractQuery,
@@ -6529,6 +6619,7 @@ func TestGeneratedBinaryContractAdaptersReturnJSONErrors(t *testing.T) {
 			Register:    "Register",
 			OwnerKind:   gwdkir.SourcePage,
 			OwnerID:     "patients",
+			Guards:      []string{"public"},
 		},
 	}}
 	if _, err := GenerateWithOptions(outputDir, appDir, Options{Config: csrfDisabledConfig(), IR: program}); err != nil {
@@ -6714,6 +6805,7 @@ func TestGeneratedBinaryContractCommandCSRFReturnsJSONErrorByDefault(t *testing.
 		Register:    "Register",
 		OwnerKind:   gwdkir.SourcePage,
 		OwnerID:     "patients",
+		Guards:      []string{"public"},
 	}}}
 	if _, err := GenerateWithOptions(outputDir, appDir, Options{
 		Config: gowdk.Config{Build: gowdk.BuildConfig{CSRF: gowdk.CSRFConfig{
@@ -8270,6 +8362,7 @@ func TestDeniedPageRoutePatternsSelectsGuardlessDynamicPages(t *testing.T) {
 
 func TestGuardlessActionAndAPIAreDeniedByOmission(t *testing.T) {
 	const deny = `gowdkresponse.WriteNoStoreError(response, http.StatusForbidden, "403 forbidden")`
+	const denyJSON = `gowdkresponse.WriteNoStoreJSONError(response, http.StatusForbidden, "403 forbidden")`
 
 	actionSrc, err := actionHandlerSource([]ActionEndpoint{{PageID: "p", ActionName: "Sub", Route: "/sub"}}, false)
 	if err != nil {
@@ -8285,6 +8378,62 @@ func TestGuardlessActionAndAPIAreDeniedByOmission(t *testing.T) {
 	}
 	if !strings.Contains(apiSrc, deny) {
 		t.Fatalf("guardless api must be denied by omission:\n%s", apiSrc)
+	}
+
+	fragmentAdapter := backendAdapterIR(Options{Fragments: []FragmentEndpoint{{
+		PageID:       "p",
+		FragmentName: "Refresh",
+		Method:       http.MethodPost,
+		Route:        "/fragment",
+		Target:       "#target",
+		HTML:         "<p>Updated</p>",
+	}}})
+	fragmentSrc, err := printActionDecls([]ast.Decl{fragmentFuncDecl(fragmentAdapter.Fragments, false)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(fragmentSrc, deny) {
+		t.Fatalf("guardless fragment must be denied by omission:\n%s", fragmentSrc)
+	}
+
+	contractsAdapter := backendAdapterIR(Options{IR: &gwdkir.Program{ContractRefs: []gwdkir.ContractReference{
+		{
+			Kind:        gwdkir.ContractCommand,
+			Name:        "patients.CreatePatient",
+			ImportAlias: "patients",
+			ImportPath:  "example.com/app/contracts/patients",
+			Type:        "CreatePatient",
+			Result:      "CreatePatientResult",
+			Method:      "POST",
+			Path:        "/patients",
+			Status:      gwdkir.ContractBindingBound,
+			Handler:     "HandleCreatePatient",
+			Register:    "Register",
+			OwnerKind:   gwdkir.SourcePage,
+			OwnerID:     "patients",
+		},
+		{
+			Kind:        gwdkir.ContractQuery,
+			Name:        "patients.GetPatientPage",
+			ImportAlias: "patients",
+			ImportPath:  "example.com/app/contracts/patients",
+			Type:        "GetPatientPage",
+			Result:      "PatientPageData",
+			Method:      "GET",
+			Path:        "/patients",
+			Status:      gwdkir.ContractBindingBound,
+			Handler:     "LoadPatientPage",
+			Register:    "Register",
+			OwnerKind:   gwdkir.SourcePage,
+			OwnerID:     "patients",
+		},
+	}}})
+	contractSrc, err := printActionDecls(contractHandlerDecls(contractsAdapter.ContractExposures, false, false, false, false))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.Count(contractSrc, denyJSON); got != 2 {
+		t.Fatalf("guardless command/query contracts must be denied by omission, got %d JSON denies:\n%s", got, contractSrc)
 	}
 
 	// An endpoint that declares `guard public` is intentionally reachable and

--- a/internal/appgen/appgen_test.go
+++ b/internal/appgen/appgen_test.go
@@ -215,6 +215,7 @@ func TestGenerateLifecycleServiceAliasesReserveBackendImports(t *testing.T) {
 			APIName: "Status",
 			Method:  http.MethodGet,
 			Route:   "/api/status",
+			Guards:  []string{"public"},
 			Binding: source.BackendBinding{
 				Status:       source.BackendBindingBound,
 				ImportPath:   "example.com/site/gowdkservice0",
@@ -290,6 +291,121 @@ func Services() ([]gowdkapp.Service, error) {
 	command.Dir = result.AppDir
 	if output, err := command.CombinedOutput(); err != nil {
 		t.Fatalf("expected lifecycle generated app to compile: %v\n%s", err, output)
+	}
+}
+
+func TestGenerateDeniedContractAndFragmentEndpointsCompileWithoutStaleImports(t *testing.T) {
+	root := t.TempDir()
+	repoRoot, ok := gowdkRuntimeModuleRoot()
+	if !ok {
+		t.Fatal("could not locate GOWDK module root")
+	}
+	writeTestFile(t, filepath.Join(root, "go.mod"), `module example.com/site
+
+go 1.22
+
+require github.com/cssbruno/gowdk v0.0.0
+
+replace github.com/cssbruno/gowdk => `+filepath.ToSlash(repoRoot)+`
+`)
+	writeTestFile(t, filepath.Join(root, "dist", "index.html"), "<main>Home</main>")
+	writeTestFile(t, filepath.Join(root, "contracts", "patients", "patients.go"), `package patients
+
+import "github.com/cssbruno/gowdk/runtime/contracts"
+
+type CreatePatient struct {
+	Name string
+}
+
+type CreatePatientResult struct{}
+
+func Register(registry *contracts.Registry) {}
+`)
+	writeTestFile(t, filepath.Join(root, "fragments", "fragments.go"), `package fragments
+
+import (
+	"context"
+
+	"github.com/cssbruno/gowdk/runtime/response"
+)
+
+func List(ctx context.Context) (response.Response, error) {
+	return response.FragmentFor("#patients", "<section>Patients</section>"), nil
+}
+`)
+	t.Chdir(root)
+
+	program := &gwdkir.Program{ContractRefs: []gwdkir.ContractReference{{
+		Kind:        gwdkir.ContractCommand,
+		Name:        "patients.CreatePatient",
+		ImportAlias: "patients",
+		ImportPath:  "example.com/site/contracts/patients",
+		Type:        "CreatePatient",
+		Result:      "CreatePatientResult",
+		InputFields: []source.BackendInputField{{FieldName: "Name", FormName: "name", Type: "string"}},
+		Method:      http.MethodPost,
+		Path:        "/patients",
+		Status:      gwdkir.ContractBindingBound,
+		Handler:     "HandleCreatePatient",
+		Register:    "Register",
+		OwnerKind:   gwdkir.SourcePage,
+		OwnerID:     "patients",
+	}}}
+	result, err := GenerateWithOptions(filepath.Join(root, "dist"), filepath.Join(root, "generated-app"), Options{
+		Config: csrfDisabledConfig(),
+		IR:     program,
+		Fragments: []FragmentEndpoint{
+			{
+				PageID:       "patients",
+				FragmentName: "StaticList",
+				Method:       http.MethodGet,
+				Route:        "/patients/list",
+				Target:       "#patients",
+				HTML:         "<section>Patients</section>",
+			},
+			{
+				PageID:       "patients",
+				FragmentName: "BoundList",
+				Method:       http.MethodGet,
+				Route:        "/patients/bound-list",
+				Target:       "#patients",
+				HTML:         "<section>Fallback</section>",
+				Binding: source.BackendBinding{
+					Status:       source.BackendBindingBound,
+					ImportPath:   "example.com/site/fragments",
+					PackageName:  "fragments",
+					FunctionName: "List",
+					Signature:    source.BackendSignatureFragment,
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload, err := os.ReadFile(result.PackagePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	source := string(payload)
+	for _, unexpected := range []string{
+		`gowdkform "github.com/cssbruno/gowdk/runtime/form"`,
+		`gowdkpartial "github.com/cssbruno/gowdk/runtime/partial"`,
+		`patients "example.com/site/contracts/patients"`,
+		`fragments "example.com/site/fragments"`,
+		`func decodeContract`,
+		`gowdkform.DecodeExpected`,
+		`fragments.List(ctx)`,
+		`gowdkpartial.Fragment`,
+	} {
+		if strings.Contains(source, unexpected) {
+			t.Fatalf("guardless denied endpoints must not leave stale generated dependency %q:\n%s", unexpected, source)
+		}
+	}
+	command := exec.Command("go", "test", "./...")
+	command.Dir = result.AppDir
+	if output, err := command.CombinedOutput(); err != nil {
+		t.Fatalf("expected generated app with denied endpoints to compile: %v\n%s", err, output)
 	}
 }
 
@@ -1342,6 +1458,7 @@ func TestGenerateWritesDerivedCommandContractBackendRoute(t *testing.T) {
 		Package: "pages",
 		ID:      "patients",
 		Route:   "/patients",
+		Guards:  []string{"public"},
 		Blocks: gwdkir.Blocks{
 			View:     true,
 			ViewBody: `<main><form g:command="patients.CreatePatient"></form></main>`,
@@ -1396,6 +1513,7 @@ func TestGeneratedGoMatchesGoldenFixture(t *testing.T) {
 			Register:  "Register",
 			OwnerKind: gwdkir.SourcePage,
 			OwnerID:   "patients",
+			Guards:    []string{"public"},
 		}, {
 			Kind:        gwdkir.ContractQuery,
 			Name:        "patients.GetPatientPage",
@@ -1413,6 +1531,7 @@ func TestGeneratedGoMatchesGoldenFixture(t *testing.T) {
 			Register:  "Register",
 			OwnerKind: gwdkir.SourcePage,
 			OwnerID:   "patients",
+			Guards:    []string{"public"},
 		},
 		},
 	}
@@ -5757,6 +5876,7 @@ func TestGeneratedBinaryContractFallbacksAreExplicitNoStore(t *testing.T) {
 		Message:   "command patients.CreatePatient is not registered",
 		OwnerKind: gwdkir.SourcePage,
 		OwnerID:   "patients",
+		Guards:    []string{"public"},
 	}}}
 	if _, err := GenerateWithOptions(outputDir, appDir, Options{Config: csrfDisabledConfig(), IR: program}); err != nil {
 		t.Fatal(err)
@@ -8411,6 +8531,7 @@ func TestGuardlessActionAndAPIAreDeniedByOmission(t *testing.T) {
 			Register:    "Register",
 			OwnerKind:   gwdkir.SourcePage,
 			OwnerID:     "patients",
+			InputFields: []source.BackendInputField{{FieldName: "Name", FormName: "name", Type: "string"}},
 		},
 		{
 			Kind:        gwdkir.ContractQuery,
@@ -8434,6 +8555,34 @@ func TestGuardlessActionAndAPIAreDeniedByOmission(t *testing.T) {
 	}
 	if got := strings.Count(contractSrc, denyJSON); got != 2 {
 		t.Fatalf("guardless command/query contracts must be denied by omission, got %d JSON denies:\n%s", got, contractSrc)
+	}
+	if strings.Contains(contractSrc, "contractRegistry") {
+		t.Fatalf("guardless denied contract handlers must not require a registry:\n%s", contractSrc)
+	}
+	if decoders := contractDecoderDecls(contractsAdapter.ContractExposures); len(decoders) != 0 {
+		decoderSrc, err := printActionDecls(decoders)
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Fatalf("guardless denied contracts must not emit unused decoders:\n%s", decoderSrc)
+	}
+
+	fallbackAdapter := backendAdapterIR(Options{IR: &gwdkir.Program{ContractRefs: []gwdkir.ContractReference{{
+		Kind:      gwdkir.ContractCommand,
+		Name:      "patients.CreatePatient",
+		Method:    http.MethodPost,
+		Path:      "/patients",
+		Status:    gwdkir.ContractBindingMissing,
+		Message:   "command patients.CreatePatient is not registered",
+		OwnerKind: gwdkir.SourcePage,
+		OwnerID:   "patients",
+	}}}})
+	fallbackSrc, err := printActionDecls(contractHandlerDecls(fallbackAdapter.ContractExposures, false, false, false, false))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(fallbackSrc, denyJSON) || strings.Contains(fallbackSrc, "StatusNotImplemented") || strings.Contains(fallbackSrc, "not registered") {
+		t.Fatalf("guardless fallback contract handler must deny by omission instead of exposing fallback JSON:\n%s", fallbackSrc)
 	}
 
 	// An endpoint that declares `guard public` is intentionally reachable and

--- a/internal/appgen/source.go
+++ b/internal/appgen/source.go
@@ -272,6 +272,7 @@ func appShellDecls(options Options) []ast.Decl {
 		decls = append(decls, configuredServicesDecl(nil))
 	}
 	decls = append(decls, loadEnvFileDecl(options)...)
+	decls = append(decls, applyEnvDefaultsDecl(options.Config.Env)...)
 	decls = append(decls, validateEnvContractDecl(options.Config.Env)...)
 	return decls
 }
@@ -293,6 +294,7 @@ func backendShellDecls(options Options) []ast.Decl {
 		decls = append(decls, configuredServicesDecl(nil))
 	}
 	decls = append(decls, loadEnvFileDecl(options)...)
+	decls = append(decls, applyEnvDefaultsDecl(options.Config.Env)...)
 	decls = append(decls, validateEnvContractDecl(options.Config.Env)...)
 	return decls
 }
@@ -432,6 +434,7 @@ func serveMuxDecl(options Options, embedded bool) ast.Decl {
 func newServeMuxDecl(options Options, embedded bool) ast.Decl {
 	stmts := []ast.Stmt{}
 	stmts = append(stmts, loadEnvFileStmt(options)...)
+	stmts = append(stmts, applyEnvDefaultsStmt(options.Config.Env)...)
 	stmts = append(stmts, authSetupStmts(options)...)
 	stmts = append(stmts, validateEnvContractStmt(options.Config.Env)...)
 	if embedded {

--- a/internal/appgen/source_api.go
+++ b/internal/appgen/source_api.go
@@ -73,9 +73,11 @@ func apiCaseStmts(api BackendAPIAdapter, csrf bool, rateLimit bool) []ast.Stmt {
 		stmts = append(stmts, returnBool(true))
 		return stmts
 	}
-	stmts = append(stmts, apiCSRFStmts(csrf)...)
 	stmts = append(stmts,
 		assign([]ast.Expr{selExpr(id("request"), "Body")}, call(sel("http", "MaxBytesReader"), id("response"), selExpr(id("request"), "Body"), id("maxAPIBodyBytes"))),
+	)
+	stmts = append(stmts, apiCSRFStmts(csrf)...)
+	stmts = append(stmts,
 		define([]ast.Expr{id("result"), id("err")}, call(sel(api.BackendAlias, api.Binding.FunctionName), id("ctx"), id("request"))),
 		&ast.IfStmt{
 			Cond: notNil("err"),

--- a/internal/appgen/source_contracts.go
+++ b/internal/appgen/source_contracts.go
@@ -284,6 +284,9 @@ func contractFormSchemaExpr(fields []source.BackendInputField) ast.Expr {
 }
 
 func fallbackContractHandlerDecl(exposure BackendContractExposure) *ast.FuncDecl {
+	if endpointDeniedByOmission(exposure.Guards) {
+		return funcDecl(contractHandlerName(exposure), actionParams(), boolResults(), denyByOmissionJSONStmts())
+	}
 	return funcDecl(contractHandlerName(exposure), actionParams(), boolResults(), []ast.Stmt{
 		writeNoStoreJSONErrorStmt(sel("http", "StatusNotImplemented"), contractFallbackMessage(exposure)),
 		returnBool(true),
@@ -341,7 +344,8 @@ func executableCommandContractExposures(exposures []BackendContractExposure) []B
 }
 
 func contractExposureExecutable(exposure BackendContractExposure) bool {
-	return exposure.Status == gwdkir.ContractBindingBound &&
+	return !endpointDeniedByOmission(exposure.Guards) &&
+		exposure.Status == gwdkir.ContractBindingBound &&
 		strings.TrimSpace(exposure.ImportAlias) != "" &&
 		strings.TrimSpace(exposure.ImportPath) != "" &&
 		strings.TrimSpace(exposure.Type) != "" &&

--- a/internal/appgen/source_contracts.go
+++ b/internal/appgen/source_contracts.go
@@ -38,6 +38,9 @@ func executableContractHandlerDecl(exposure BackendContractExposure, csrf bool, 
 }
 
 func executableContractHandlerStmts(exposure BackendContractExposure, csrf bool, rateLimit bool, queryInvalidations bool, commandPatches bool) []ast.Stmt {
+	if endpointDeniedByOmission(exposure.Guards) {
+		return denyByOmissionJSONStmts()
+	}
 	stmts := endpointContextStmts(
 		string(exposure.Endpoint.Kind),
 		exposure.Endpoint.PageID,
@@ -348,6 +351,9 @@ func contractExposureExecutable(exposure BackendContractExposure) bool {
 
 func contractExposuresUseForm(exposures []BackendContractExposure) bool {
 	for _, exposure := range exposures {
+		if endpointDeniedByOmission(exposure.Guards) {
+			continue
+		}
 		if len(exposure.InputFields) > 0 {
 			return true
 		}
@@ -357,6 +363,9 @@ func contractExposuresUseForm(exposures []BackendContractExposure) bool {
 
 func contractExposuresParseForm(exposures []BackendContractExposure) bool {
 	for _, exposure := range exposures {
+		if endpointDeniedByOmission(exposure.Guards) {
+			continue
+		}
 		if exposure.Endpoint.Kind == BackendEndpointCommand {
 			return true
 		}

--- a/internal/appgen/source_env.go
+++ b/internal/appgen/source_env.go
@@ -23,7 +23,20 @@ func envRuntimeValidationRequired(config gowdk.EnvConfig) bool {
 }
 
 func generatedEnvFileLoadRequired(options Options) bool {
-	return envRuntimeValidationRequired(options.Config.Env) || csrfEnabled(options) || generatedUsesAuthAddon(options)
+	return envConfigDeclared(options.Config.Env) || csrfEnabled(options) || generatedUsesAuthAddon(options)
+}
+
+func envConfigDeclared(config gowdk.EnvConfig) bool {
+	return len(config.Vars) > 0 || len(config.Secrets) > 0
+}
+
+func envDefaultsRequired(config gowdk.EnvConfig) bool {
+	for _, variable := range config.Vars {
+		if variable.Default != "" {
+			return true
+		}
+	}
+	return false
 }
 
 func loadEnvFileDecl(options Options) []ast.Decl {
@@ -52,6 +65,35 @@ func loadEnvFileStmt(options Options) []ast.Stmt {
 		Cond: notNil("err"),
 		Body: block(&ast.ReturnStmt{Results: []ast.Expr{id("nil"), id("err")}}),
 	}}
+}
+
+func applyEnvDefaultsDecl(config gowdk.EnvConfig) []ast.Decl {
+	if !envDefaultsRequired(config) {
+		return nil
+	}
+	var stmts []ast.Stmt
+	for _, variable := range config.Vars {
+		if variable.Default == "" {
+			continue
+		}
+		stmts = append(stmts, &ast.IfStmt{
+			Init: define([]ast.Expr{id("value")}, call(sel("os", "Getenv"), stringLit(variable.Name))),
+			Cond: &ast.BinaryExpr{
+				X:  call(sel("strings", "TrimSpace"), id("value")),
+				Op: token.EQL,
+				Y:  stringLit(""),
+			},
+			Body: block(exprStmt(call(sel("os", "Setenv"), stringLit(variable.Name), stringLit(variable.Default)))),
+		})
+	}
+	return []ast.Decl{funcDecl("applyEnvDefaults", nil, nil, stmts)}
+}
+
+func applyEnvDefaultsStmt(config gowdk.EnvConfig) []ast.Stmt {
+	if !envDefaultsRequired(config) {
+		return nil
+	}
+	return []ast.Stmt{exprStmt(call(id("applyEnvDefaults")))}
 }
 
 func validateEnvContractDecl(config gowdk.EnvConfig) []ast.Decl {

--- a/internal/appgen/source_fragments.go
+++ b/internal/appgen/source_fragments.go
@@ -168,6 +168,9 @@ func fragmentTypedRouteParams(fragment BackendFragmentAdapter) []source.RoutePar
 
 func fragmentsUseStaticFallback(fragments []BackendFragmentAdapter) bool {
 	for _, fragment := range fragments {
+		if endpointDeniedByOmission(fragment.Guards) {
+			continue
+		}
 		if fragment.Binding.Status != source.BackendBindingBound && fragment.Binding.Status != source.BackendBindingUnsupportedSignature {
 			return true
 		}

--- a/internal/appgen/source_fragments.go
+++ b/internal/appgen/source_fragments.go
@@ -62,6 +62,9 @@ func fragmentCaseExpr(fragment BackendFragmentAdapter) ast.Expr {
 }
 
 func fragmentCaseStmts(fragment BackendFragmentAdapter, rateLimit bool) []ast.Stmt {
+	if endpointDeniedByOmission(fragment.Guards) {
+		return denyByOmissionStmts()
+	}
 	stmts := fragmentContextStmts(fragment, false)
 	stmts = append(stmts, rateLimitStmts(rateLimit)...)
 	stmts = append(stmts, guardStmts(fragment.Guards)...)
@@ -110,6 +113,9 @@ func fragmentDynamicIfStmt(fragment BackendFragmentAdapter, rateLimit bool) ast.
 }
 
 func fragmentDynamicCaseStmts(fragment BackendFragmentAdapter, rateLimit bool) []ast.Stmt {
+	if endpointDeniedByOmission(fragment.Guards) {
+		return denyByOmissionStmts()
+	}
 	stmts := fragmentContextStmts(fragment, true)
 	stmts = append(stmts, rateLimitStmts(rateLimit)...)
 	stmts = append(stmts, guardStmts(fragment.Guards)...)

--- a/internal/appgen/source_guards.go
+++ b/internal/appgen/source_guards.go
@@ -154,6 +154,13 @@ func denyByOmissionStmts() []ast.Stmt {
 	}
 }
 
+func denyByOmissionJSONStmts() []ast.Stmt {
+	return []ast.Stmt{
+		writeNoStoreJSONErrorStmt(sel("http", "StatusForbidden"), "403 forbidden"),
+		returnBool(true),
+	}
+}
+
 func generatedUsesCustomGuards(options Options) bool {
 	return generatedRequiresAppGuardRegistry(options)
 }

--- a/internal/appgen/source_rate_limit.go
+++ b/internal/appgen/source_rate_limit.go
@@ -50,7 +50,7 @@ func runRateLimitDecl() ast.Decl {
 		&ast.IfStmt{
 			Cond: notNil("err"),
 			Body: block(
-				exprStmt(call(sel("gowdkratelimit", "DefaultErrorHandler"), id("response"), id("request"), id("err"))),
+				exprStmt(call(selExpr(id("rateLimiter"), "HandleError"), id("response"), id("request"), id("err"))),
 				returnBool(true),
 			),
 		},
@@ -58,7 +58,7 @@ func runRateLimitDecl() ast.Decl {
 		&ast.IfStmt{
 			Cond: &ast.UnaryExpr{Op: token.NOT, X: selExpr(id("result"), "Allowed")},
 			Body: block(
-				exprStmt(call(sel("gowdkratelimit", "DefaultLimitHandler"), id("response"), id("request"), id("result"))),
+				exprStmt(call(selExpr(id("rateLimiter"), "HandleLimit"), id("response"), id("request"), id("result"))),
 				returnBool(true),
 			),
 		},

--- a/internal/appgen/testdata/generated_go_golden/app.go.golden
+++ b/internal/appgen/testdata/generated_go_golden/app.go.golden
@@ -181,13 +181,68 @@ func fragment(response http.ResponseWriter, request *http.Request) bool {
 }
 func commandPatientsCreatePatientPOSTPatients(contractRegistry *gowdkcontracts.Registry) gowdkruntime.BackendHandler {
 	return func(response http.ResponseWriter, request *http.Request) bool {
-		gowdkresponse.WriteNoStoreJSONError(response, http.StatusForbidden, "403 forbidden")
+		ctx := gowdkruntime.WithEndpoint(gowdkruntime.WithRequest(request.Context(), request), gowdkruntime.EndpointMetadata{Kind: "command", PageID: "patients", Name: "patients.CreatePatient", Method: "POST", Path: "/patients"})
+		request = request.WithContext(ctx)
+		request.Body = http.MaxBytesReader(response, request.Body, maxActionBodyBytes)
+		if err := request.ParseForm(); err != nil {
+			if strings.Contains(err.Error(), "request body too large") {
+				gowdkresponse.WriteNoStoreJSONError(response, http.StatusRequestEntityTooLarge, "request body too large")
+				return true
+			}
+			gowdkresponse.WriteNoStoreJSONError(response, http.StatusBadRequest, "invalid form")
+			return true
+		}
+		if csrfValidator != nil {
+			if err := csrfValidator.Validate(request); err != nil {
+				gowdkresponse.WriteNoStoreJSONError(response, http.StatusForbidden, "invalid csrf token")
+				return true
+			}
+		}
+		values := gowdkform.FromURLValues(request.PostForm)
+		input, err := decodeContractPatientsCreatePatientInput(values)
+		if err != nil {
+			gowdkresponse.WriteNoStoreJSONError(response, http.StatusBadRequest, "invalid form")
+			return true
+		}
+		result, events, err := gowdkcontracts.CaptureCommandEventsForRole[patients.CreatePatient, patients.CreatePatientResult](ctx, contractRegistry, gowdkcontracts.RoleWeb, input)
+		if err != nil {
+			gowdkresponse.WriteNoStoreHandlerJSONError(response, err, http.StatusInternalServerError)
+			return true
+		}
+		if dispatchErr := gowdkcontracts.DispatchCommandEvents(ctx, currentContractEventSink(), contractRegistry, gowdkcontracts.RoleWeb, events); dispatchErr != nil {
+			gowdkresponse.WriteNoStoreHandlerJSONError(response, dispatchErr, http.StatusInternalServerError)
+			return true
+		}
+		httpResult, err := gowdkresponse.JSONValue(http.StatusOK, result)
+		if err != nil {
+			gowdkresponse.WriteNoStoreHandlerJSONError(response, err, http.StatusInternalServerError)
+			return true
+		}
+		_ = gowdkresponse.WriteNoStoreHTTP(response, httpResult)
 		return true
 	}
 }
 func queryPatientsGetPatientPageGETPatients(contractRegistry *gowdkcontracts.Registry) gowdkruntime.BackendHandler {
 	return func(response http.ResponseWriter, request *http.Request) bool {
-		gowdkresponse.WriteNoStoreJSONError(response, http.StatusForbidden, "403 forbidden")
+		ctx := gowdkruntime.WithEndpoint(gowdkruntime.WithRequest(request.Context(), request), gowdkruntime.EndpointMetadata{Kind: "query", PageID: "patients", Name: "patients.GetPatientPage", Method: "GET", Path: "/patients"})
+		request = request.WithContext(ctx)
+		values := gowdkform.FromURLValues(request.URL.Query())
+		input, err := decodeContractPatientsGetPatientPageInput(values)
+		if err != nil {
+			gowdkresponse.WriteNoStoreJSONError(response, http.StatusBadRequest, "invalid form")
+			return true
+		}
+		result, err := gowdkcontracts.ExecuteQueryForRole[patients.GetPatientPage, patients.PatientPageData](ctx, contractRegistry, gowdkcontracts.RoleWeb, input)
+		if err != nil {
+			gowdkresponse.WriteNoStoreHandlerJSONError(response, err, http.StatusInternalServerError)
+			return true
+		}
+		httpResult, err := gowdkresponse.JSONValue(http.StatusOK, result)
+		if err != nil {
+			gowdkresponse.WriteNoStoreHandlerJSONError(response, err, http.StatusInternalServerError)
+			return true
+		}
+		_ = gowdkresponse.WriteNoStoreHTTP(response, httpResult)
 		return true
 	}
 }

--- a/internal/appgen/testdata/generated_go_golden/app.go.golden
+++ b/internal/appgen/testdata/generated_go_golden/app.go.golden
@@ -181,68 +181,13 @@ func fragment(response http.ResponseWriter, request *http.Request) bool {
 }
 func commandPatientsCreatePatientPOSTPatients(contractRegistry *gowdkcontracts.Registry) gowdkruntime.BackendHandler {
 	return func(response http.ResponseWriter, request *http.Request) bool {
-		ctx := gowdkruntime.WithEndpoint(gowdkruntime.WithRequest(request.Context(), request), gowdkruntime.EndpointMetadata{Kind: "command", PageID: "patients", Name: "patients.CreatePatient", Method: "POST", Path: "/patients"})
-		request = request.WithContext(ctx)
-		request.Body = http.MaxBytesReader(response, request.Body, maxActionBodyBytes)
-		if err := request.ParseForm(); err != nil {
-			if strings.Contains(err.Error(), "request body too large") {
-				gowdkresponse.WriteNoStoreJSONError(response, http.StatusRequestEntityTooLarge, "request body too large")
-				return true
-			}
-			gowdkresponse.WriteNoStoreJSONError(response, http.StatusBadRequest, "invalid form")
-			return true
-		}
-		if csrfValidator != nil {
-			if err := csrfValidator.Validate(request); err != nil {
-				gowdkresponse.WriteNoStoreJSONError(response, http.StatusForbidden, "invalid csrf token")
-				return true
-			}
-		}
-		values := gowdkform.FromURLValues(request.PostForm)
-		input, err := decodeContractPatientsCreatePatientInput(values)
-		if err != nil {
-			gowdkresponse.WriteNoStoreJSONError(response, http.StatusBadRequest, "invalid form")
-			return true
-		}
-		result, events, err := gowdkcontracts.CaptureCommandEventsForRole[patients.CreatePatient, patients.CreatePatientResult](ctx, contractRegistry, gowdkcontracts.RoleWeb, input)
-		if err != nil {
-			gowdkresponse.WriteNoStoreHandlerJSONError(response, err, http.StatusInternalServerError)
-			return true
-		}
-		if dispatchErr := gowdkcontracts.DispatchCommandEvents(ctx, currentContractEventSink(), contractRegistry, gowdkcontracts.RoleWeb, events); dispatchErr != nil {
-			gowdkresponse.WriteNoStoreHandlerJSONError(response, dispatchErr, http.StatusInternalServerError)
-			return true
-		}
-		httpResult, err := gowdkresponse.JSONValue(http.StatusOK, result)
-		if err != nil {
-			gowdkresponse.WriteNoStoreHandlerJSONError(response, err, http.StatusInternalServerError)
-			return true
-		}
-		_ = gowdkresponse.WriteNoStoreHTTP(response, httpResult)
+		gowdkresponse.WriteNoStoreJSONError(response, http.StatusForbidden, "403 forbidden")
 		return true
 	}
 }
 func queryPatientsGetPatientPageGETPatients(contractRegistry *gowdkcontracts.Registry) gowdkruntime.BackendHandler {
 	return func(response http.ResponseWriter, request *http.Request) bool {
-		ctx := gowdkruntime.WithEndpoint(gowdkruntime.WithRequest(request.Context(), request), gowdkruntime.EndpointMetadata{Kind: "query", PageID: "patients", Name: "patients.GetPatientPage", Method: "GET", Path: "/patients"})
-		request = request.WithContext(ctx)
-		values := gowdkform.FromURLValues(request.URL.Query())
-		input, err := decodeContractPatientsGetPatientPageInput(values)
-		if err != nil {
-			gowdkresponse.WriteNoStoreJSONError(response, http.StatusBadRequest, "invalid form")
-			return true
-		}
-		result, err := gowdkcontracts.ExecuteQueryForRole[patients.GetPatientPage, patients.PatientPageData](ctx, contractRegistry, gowdkcontracts.RoleWeb, input)
-		if err != nil {
-			gowdkresponse.WriteNoStoreHandlerJSONError(response, err, http.StatusInternalServerError)
-			return true
-		}
-		httpResult, err := gowdkresponse.JSONValue(http.StatusOK, result)
-		if err != nil {
-			gowdkresponse.WriteNoStoreHandlerJSONError(response, err, http.StatusInternalServerError)
-			return true
-		}
-		_ = gowdkresponse.WriteNoStoreHTTP(response, httpResult)
+		gowdkresponse.WriteNoStoreJSONError(response, http.StatusForbidden, "403 forbidden")
 		return true
 	}
 }

--- a/runtime/app/app_test.go
+++ b/runtime/app/app_test.go
@@ -1,9 +1,11 @@
 package app
 
 import (
+	"bufio"
 	"context"
 	"errors"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -1263,6 +1265,102 @@ func TestBackendRouterRecoversAPIPanic(t *testing.T) {
 	}
 }
 
+func TestBackendRouterRecoversContractPanicsAsJSON(t *testing.T) {
+	for _, tc := range []struct {
+		kind   string
+		method string
+		path   string
+		header func(*http.Request)
+	}{
+		{kind: "command", method: http.MethodPost, path: "/patients"},
+		{kind: "query", method: http.MethodGet, path: "/patients", header: func(request *http.Request) {
+			request.Header.Set("Accept", "application/json")
+		}},
+	} {
+		t.Run(tc.kind, func(t *testing.T) {
+			router, err := NewBackendRouter(BackendRoute{
+				Method: tc.method,
+				Path:   tc.path,
+				Kind:   tc.kind,
+				Handler: func(http.ResponseWriter, *http.Request) bool {
+					panic("secret token")
+				},
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			recorder := httptest.NewRecorder()
+			request := httptest.NewRequest(tc.method, tc.path, nil)
+			if tc.header != nil {
+				tc.header(request)
+			}
+
+			if !router.Dispatch(recorder, request) {
+				t.Fatal("expected route to dispatch")
+			}
+			if recorder.Code != http.StatusInternalServerError {
+				t.Fatalf("unexpected status: %d", recorder.Code)
+			}
+			if contentType := recorder.Header().Get("Content-Type"); !strings.Contains(contentType, "application/json") {
+				t.Fatalf("expected JSON boundary response, got %q", contentType)
+			}
+			body := recorder.Body.String()
+			if !strings.Contains(body, `GOWDK `+tc.kind+` handler failed`) || strings.Contains(body, "secret token") {
+				t.Fatalf("unexpected boundary body: %q", body)
+			}
+			if cache := recorder.Header().Get("Cache-Control"); cache != "no-store" {
+				t.Fatalf("expected no-store boundary response, got %q", cache)
+			}
+		})
+	}
+}
+
+func TestResponseWriterWrappersExposeOptionalCapabilities(t *testing.T) {
+	base := &optionalCapabilityResponseWriter{ResponseWriter: httptest.NewRecorder()}
+	boundary := wrapBoundaryResponseWriter(&boundaryResponseWriter{ResponseWriter: base})
+	if _, ok := boundary.(http.Flusher); !ok {
+		t.Fatal("boundary wrapper did not expose http.Flusher")
+	}
+	if _, ok := boundary.(http.Hijacker); !ok {
+		t.Fatal("boundary wrapper did not expose http.Hijacker")
+	}
+	if _, ok := boundary.(http.Pusher); !ok {
+		t.Fatal("boundary wrapper did not expose http.Pusher")
+	}
+	boundary.(http.Flusher).Flush()
+	if err := boundary.(http.Pusher).Push("/app.css", nil); err != nil {
+		t.Fatalf("boundary push: %v", err)
+	}
+	if _, _, err := boundary.(http.Hijacker).Hijack(); !errors.Is(err, errHijackedForTest) {
+		t.Fatalf("boundary hijack error = %v, want %v", err, errHijackedForTest)
+	}
+	if !base.flushed || base.pushed != "/app.css" {
+		t.Fatalf("boundary optional methods were not delegated: %#v", base)
+	}
+
+	base = &optionalCapabilityResponseWriter{ResponseWriter: httptest.NewRecorder()}
+	traceWriter := wrapTraceResponseWriter(&traceResponseWriter{ResponseWriter: base, status: http.StatusOK})
+	if _, ok := traceWriter.(http.Flusher); !ok {
+		t.Fatal("trace wrapper did not expose http.Flusher")
+	}
+	if _, ok := traceWriter.(http.Hijacker); !ok {
+		t.Fatal("trace wrapper did not expose http.Hijacker")
+	}
+	if _, ok := traceWriter.(http.Pusher); !ok {
+		t.Fatal("trace wrapper did not expose http.Pusher")
+	}
+	traceWriter.(http.Flusher).Flush()
+	if err := traceWriter.(http.Pusher).Push("/app.js", nil); err != nil {
+		t.Fatalf("trace push: %v", err)
+	}
+	if _, _, err := traceWriter.(http.Hijacker).Hijack(); !errors.Is(err, errHijackedForTest) {
+		t.Fatalf("trace hijack error = %v, want %v", err, errHijackedForTest)
+	}
+	if !base.flushed || base.pushed != "/app.js" {
+		t.Fatalf("trace optional methods were not delegated: %#v", base)
+	}
+}
+
 func TestBoundaryLogsRecoveredPanicWithRedactedSecret(t *testing.T) {
 	previous := BoundaryLogger
 	t.Cleanup(func() { BoundaryLogger = previous })
@@ -1770,7 +1868,7 @@ func TestTracedBackendRouteMarksServerStatusError(t *testing.T) {
 	if !handler(recorder, request) {
 		t.Fatal("expected backend handler to handle request")
 	}
-	spans := ring.Spans()
+	spans := waitForSpans(t, ring, 1)
 	if len(spans) != 1 {
 		t.Fatalf("spans = %d, want 1", len(spans))
 	}
@@ -1805,7 +1903,7 @@ func TestTracedBackendRouteRecordsEndpointLanes(t *testing.T) {
 				t.Fatal("expected backend handler to handle request")
 			}
 
-			spans := ring.Spans()
+			spans := waitForSpans(t, ring, 1)
 			if len(spans) != 1 {
 				t.Fatalf("spans = %d, want 1", len(spans))
 			}
@@ -1845,7 +1943,7 @@ func TestTracedBackendRouteRecordsPanicAsRedactedError(t *testing.T) {
 		_ = handler(recorder, request)
 	}()
 
-	spans := ring.Spans()
+	spans := waitForSpans(t, ring, 1)
 	if len(spans) != 1 {
 		t.Fatalf("spans = %d, want 1", len(spans))
 	}
@@ -1866,6 +1964,42 @@ func spanAttr(span gowdktrace.Snapshot, key string) any {
 	return nil
 }
 
+func waitForSpans(t *testing.T, ring *gowdktrace.RingSink, want int) []gowdktrace.Snapshot {
+	t.Helper()
+	deadline := time.Now().Add(time.Second)
+	for {
+		spans := ring.Spans()
+		if len(spans) >= want {
+			return spans
+		}
+		if time.Now().After(deadline) {
+			return spans
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+}
+
+var errHijackedForTest = errors.New("hijacked for test")
+
+type optionalCapabilityResponseWriter struct {
+	http.ResponseWriter
+	flushed bool
+	pushed  string
+}
+
+func (writer *optionalCapabilityResponseWriter) Flush() {
+	writer.flushed = true
+}
+
+func (writer *optionalCapabilityResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	return nil, nil, errHijackedForTest
+}
+
+func (writer *optionalCapabilityResponseWriter) Push(target string, options *http.PushOptions) error {
+	writer.pushed = target
+	return nil
+}
+
 func TestFinishHTTPTraceMarksServerStatusError(t *testing.T) {
 	ring := gowdktrace.NewRingSink(4)
 	tracer := gowdktrace.NewTracer(gowdktrace.WithSink(ring))
@@ -1875,7 +2009,7 @@ func TestFinishHTTPTraceMarksServerStatusError(t *testing.T) {
 
 	FinishHTTPTrace(recorder, span)
 
-	spans := ring.Spans()
+	spans := waitForSpans(t, ring, 1)
 	if len(spans) != 1 {
 		t.Fatalf("spans = %d, want 1", len(spans))
 	}

--- a/runtime/app/backend.go
+++ b/runtime/app/backend.go
@@ -173,10 +173,13 @@ func traceBackendRoute(kind, routePath string, source gowdktrace.SourceRef, hand
 		if _, ok := gowdktrace.TracerFromContext(request.Context()); !ok {
 			return handler(writer, request)
 		}
-		recorder, ok := writer.(*traceResponseWriter)
-		if !ok {
-			recorder = &traceResponseWriter{ResponseWriter: writer, status: http.StatusOK}
-			writer = recorder
+		recorder, ok := writer.(interface{ traceRecorder() *traceResponseWriter })
+		var traceRecorder *traceResponseWriter
+		if ok {
+			traceRecorder = recorder.traceRecorder()
+		} else {
+			traceRecorder = &traceResponseWriter{ResponseWriter: writer, status: http.StatusOK}
+			writer = wrapTraceResponseWriter(traceRecorder)
 		}
 		ctx, span := gowdktrace.Start(request.Context(), name,
 			gowdktrace.WithSurface(gowdktrace.SurfaceBackend),
@@ -193,9 +196,9 @@ func traceBackendRoute(kind, routePath string, source gowdktrace.SourceRef, hand
 				span.End()
 				panic(recovered)
 			}
-			span.Set(gowdktrace.AttrHTTPResponseStatusCode, recorder.status)
-			if recorder.status >= 500 {
-				span.SetStatus(gowdktrace.StatusError, http.StatusText(recorder.status))
+			span.Set(gowdktrace.AttrHTTPResponseStatusCode, traceRecorder.status)
+			if traceRecorder.status >= 500 {
+				span.SetStatus(gowdktrace.StatusError, http.StatusText(traceRecorder.status))
 			} else {
 				span.SetStatus(gowdktrace.StatusOK, "")
 			}

--- a/runtime/app/boundary.go
+++ b/runtime/app/boundary.go
@@ -36,6 +36,7 @@ func Boundary(kind string, handler HandlerFunc) HandlerFunc {
 	kind = normalizeBoundaryKind(kind)
 	return func(writer http.ResponseWriter, request *http.Request) (handled bool) {
 		boundaryWriter := &boundaryResponseWriter{ResponseWriter: writer}
+		wrappedWriter := wrapBoundaryResponseWriter(boundaryWriter)
 		defer func() {
 			if value := recover(); value != nil {
 				if value == http.ErrAbortHandler {
@@ -54,7 +55,7 @@ func Boundary(kind string, handler HandlerFunc) HandlerFunc {
 				writeBoundaryError(boundaryWriter, request, kind, value)
 			}
 		}()
-		return handler(boundaryWriter, request)
+		return handler(wrappedWriter, request)
 	}
 }
 
@@ -96,6 +97,10 @@ func normalizeBoundaryKind(kind string) string {
 		return "action"
 	case "api":
 		return "api"
+	case "command":
+		return "command"
+	case "query":
+		return "query"
 	case "ssr":
 		return "ssr"
 	default:
@@ -108,6 +113,10 @@ func writeBoundaryError(writer http.ResponseWriter, request *http.Request, kind 
 	message := fmt.Sprintf("GOWDK %s handler failed", boundaryKindLabel(kind))
 	if kind == "ssr" && request != nil {
 		WriteErrorPage(writer, request, http.StatusInternalServerError, message)
+		return
+	}
+	if kind == "command" || kind == "query" {
+		response.WriteNoStoreJSONError(writer, http.StatusInternalServerError, message)
 		return
 	}
 	response.WriteNoStoreError(writer, http.StatusInternalServerError, message)

--- a/runtime/app/response_writer_optional.go
+++ b/runtime/app/response_writer_optional.go
@@ -1,0 +1,199 @@
+package app
+
+import (
+	"bufio"
+	"net"
+	"net/http"
+)
+
+const (
+	responseWriterFlusher = 1 << iota
+	responseWriterHijacker
+	responseWriterPusher
+)
+
+func optionalResponseWriterMask(writer http.ResponseWriter) int {
+	mask := 0
+	if _, ok := writer.(http.Flusher); ok {
+		mask |= responseWriterFlusher
+	}
+	if _, ok := writer.(http.Hijacker); ok {
+		mask |= responseWriterHijacker
+	}
+	if _, ok := writer.(http.Pusher); ok {
+		mask |= responseWriterPusher
+	}
+	return mask
+}
+
+func wrapBoundaryResponseWriter(writer *boundaryResponseWriter) http.ResponseWriter {
+	switch optionalResponseWriterMask(writer.ResponseWriter) {
+	case responseWriterFlusher:
+		return boundaryFlusher{writer}
+	case responseWriterHijacker:
+		return boundaryHijacker{writer}
+	case responseWriterPusher:
+		return boundaryPusher{writer}
+	case responseWriterFlusher | responseWriterHijacker:
+		return boundaryFlusherHijacker{writer}
+	case responseWriterFlusher | responseWriterPusher:
+		return boundaryFlusherPusher{writer}
+	case responseWriterHijacker | responseWriterPusher:
+		return boundaryHijackerPusher{writer}
+	case responseWriterFlusher | responseWriterHijacker | responseWriterPusher:
+		return boundaryFlusherHijackerPusher{writer}
+	default:
+		return writer
+	}
+}
+
+func (writer *boundaryResponseWriter) flush() {
+	writer.wrote = true
+	writer.ResponseWriter.(http.Flusher).Flush()
+}
+
+func (writer *boundaryResponseWriter) hijack() (net.Conn, *bufio.ReadWriter, error) {
+	conn, rw, err := writer.ResponseWriter.(http.Hijacker).Hijack()
+	if err == nil {
+		writer.wrote = true
+	}
+	return conn, rw, err
+}
+
+func (writer *boundaryResponseWriter) push(target string, options *http.PushOptions) error {
+	return writer.ResponseWriter.(http.Pusher).Push(target, options)
+}
+
+type boundaryFlusher struct{ *boundaryResponseWriter }
+
+func (writer boundaryFlusher) Flush() { writer.flush() }
+
+type boundaryHijacker struct{ *boundaryResponseWriter }
+
+func (writer boundaryHijacker) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	return writer.hijack()
+}
+
+type boundaryPusher struct{ *boundaryResponseWriter }
+
+func (writer boundaryPusher) Push(target string, options *http.PushOptions) error {
+	return writer.push(target, options)
+}
+
+type boundaryFlusherHijacker struct{ *boundaryResponseWriter }
+
+func (writer boundaryFlusherHijacker) Flush() { writer.flush() }
+func (writer boundaryFlusherHijacker) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	return writer.hijack()
+}
+
+type boundaryFlusherPusher struct{ *boundaryResponseWriter }
+
+func (writer boundaryFlusherPusher) Flush() { writer.flush() }
+func (writer boundaryFlusherPusher) Push(target string, options *http.PushOptions) error {
+	return writer.push(target, options)
+}
+
+type boundaryHijackerPusher struct{ *boundaryResponseWriter }
+
+func (writer boundaryHijackerPusher) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	return writer.hijack()
+}
+func (writer boundaryHijackerPusher) Push(target string, options *http.PushOptions) error {
+	return writer.push(target, options)
+}
+
+type boundaryFlusherHijackerPusher struct{ *boundaryResponseWriter }
+
+func (writer boundaryFlusherHijackerPusher) Flush() { writer.flush() }
+func (writer boundaryFlusherHijackerPusher) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	return writer.hijack()
+}
+func (writer boundaryFlusherHijackerPusher) Push(target string, options *http.PushOptions) error {
+	return writer.push(target, options)
+}
+
+func wrapTraceResponseWriter(writer *traceResponseWriter) http.ResponseWriter {
+	switch optionalResponseWriterMask(writer.ResponseWriter) {
+	case responseWriterFlusher:
+		return traceFlusher{writer}
+	case responseWriterHijacker:
+		return traceHijacker{writer}
+	case responseWriterPusher:
+		return tracePusher{writer}
+	case responseWriterFlusher | responseWriterHijacker:
+		return traceFlusherHijacker{writer}
+	case responseWriterFlusher | responseWriterPusher:
+		return traceFlusherPusher{writer}
+	case responseWriterHijacker | responseWriterPusher:
+		return traceHijackerPusher{writer}
+	case responseWriterFlusher | responseWriterHijacker | responseWriterPusher:
+		return traceFlusherHijackerPusher{writer}
+	default:
+		return writer
+	}
+}
+
+func (writer *traceResponseWriter) flush() {
+	if writer.status == 0 {
+		writer.status = http.StatusOK
+	}
+	writer.ResponseWriter.(http.Flusher).Flush()
+}
+
+func (writer *traceResponseWriter) hijack() (net.Conn, *bufio.ReadWriter, error) {
+	return writer.ResponseWriter.(http.Hijacker).Hijack()
+}
+
+func (writer *traceResponseWriter) push(target string, options *http.PushOptions) error {
+	return writer.ResponseWriter.(http.Pusher).Push(target, options)
+}
+
+type traceFlusher struct{ *traceResponseWriter }
+
+func (writer traceFlusher) Flush() { writer.flush() }
+
+type traceHijacker struct{ *traceResponseWriter }
+
+func (writer traceHijacker) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	return writer.hijack()
+}
+
+type tracePusher struct{ *traceResponseWriter }
+
+func (writer tracePusher) Push(target string, options *http.PushOptions) error {
+	return writer.push(target, options)
+}
+
+type traceFlusherHijacker struct{ *traceResponseWriter }
+
+func (writer traceFlusherHijacker) Flush() { writer.flush() }
+func (writer traceFlusherHijacker) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	return writer.hijack()
+}
+
+type traceFlusherPusher struct{ *traceResponseWriter }
+
+func (writer traceFlusherPusher) Flush() { writer.flush() }
+func (writer traceFlusherPusher) Push(target string, options *http.PushOptions) error {
+	return writer.push(target, options)
+}
+
+type traceHijackerPusher struct{ *traceResponseWriter }
+
+func (writer traceHijackerPusher) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	return writer.hijack()
+}
+func (writer traceHijackerPusher) Push(target string, options *http.PushOptions) error {
+	return writer.push(target, options)
+}
+
+type traceFlusherHijackerPusher struct{ *traceResponseWriter }
+
+func (writer traceFlusherHijackerPusher) Flush() { writer.flush() }
+func (writer traceFlusherHijackerPusher) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	return writer.hijack()
+}
+func (writer traceFlusherHijackerPusher) Push(target string, options *http.PushOptions) error {
+	return writer.push(target, options)
+}

--- a/runtime/app/tracing.go
+++ b/runtime/app/tracing.go
@@ -81,7 +81,8 @@ func (handler Handler) startRequestTrace(response http.ResponseWriter, request *
 	if span == nil {
 		return response, request, nil
 	}
-	return &traceResponseWriter{ResponseWriter: response, status: http.StatusOK}, request, span
+	recorder := &traceResponseWriter{ResponseWriter: response, status: http.StatusOK}
+	return wrapTraceResponseWriter(recorder), request, span
 }
 
 func finishRequestTrace(response http.ResponseWriter, span *gowdktrace.Span) {
@@ -94,8 +95,8 @@ func FinishHTTPTrace(response http.ResponseWriter, span *gowdktrace.Span) {
 		return
 	}
 	status := http.StatusOK
-	if recorder, ok := response.(*traceResponseWriter); ok {
-		status = recorder.status
+	if recorder, ok := response.(interface{ traceRecorder() *traceResponseWriter }); ok {
+		status = recorder.traceRecorder().status
 	}
 	span.Set(gowdktrace.AttrHTTPResponseStatusCode, status)
 	if status >= 500 {
@@ -138,6 +139,10 @@ func (writer *traceResponseWriter) Write(payload []byte) (int, error) {
 
 func (writer *traceResponseWriter) Unwrap() http.ResponseWriter {
 	return writer.ResponseWriter
+}
+
+func (writer *traceResponseWriter) traceRecorder() *traceResponseWriter {
+	return writer
 }
 
 // Trace records a redacted user event on the active span. It is intentionally

--- a/runtime/contracts/command.go
+++ b/runtime/contracts/command.go
@@ -12,6 +12,9 @@ func RegisterCommand[C, R any](registry *Registry, handler CommandHandler[C, R],
 	if handler == nil {
 		return nilHandlerError(Command, typeName[C]())
 	}
+	if registry == nil {
+		return nilRegistryError(Command, typeName[C]())
+	}
 	return registry.registerCommand(typeName[C](), typeName[R](), handler, roles)
 }
 
@@ -154,6 +157,10 @@ func runCommand[C, R any](ctx context.Context, registry *Registry, command C, ro
 	)
 	var spanErr error
 	defer func() { finishContractSpan(span, spanErr) }()
+	if registry == nil {
+		spanErr = nilRegistryError(Command, contract)
+		return zero, nil, ctx, spanErr
+	}
 	entry, ok := registry.command(typeName[C]())
 	if !ok {
 		spanErr = missingHandlerError(Command, contract)
@@ -180,6 +187,7 @@ func runCommand[C, R any](ctx context.Context, registry *Registry, command C, ro
 func (registry *Registry) registerCommand(command, result string, handler any, roles []Role) error {
 	registry.mu.Lock()
 	defer registry.mu.Unlock()
+	registry.ensureMapsLocked()
 	if _, exists := registry.commands[command]; exists {
 		return duplicateHandlerError(Command, command)
 	}

--- a/runtime/contracts/contracts_test.go
+++ b/runtime/contracts/contracts_test.go
@@ -910,7 +910,7 @@ func TestContractTracingRecordsCommandQueryEventAndJobSpans(t *testing.T) {
 		t.Fatalf("execute job: %v", err)
 	}
 
-	spans := ring.Spans()
+	spans := waitForSpans(t, ring, 4)
 	assertContractSpan(t, spans, string(ObservationExecuteCommand), gowdktrace.LaneContract, string(Command))
 	assertContractSpan(t, spans, string(ObservationPublishEvent), gowdktrace.LaneContract, string(Event))
 	assertContractSpan(t, spans, string(ObservationExecuteQuery), gowdktrace.LaneContract, string(Query))
@@ -1185,6 +1185,67 @@ func TestMetadataIsDeterministic(t *testing.T) {
 	}
 }
 
+func TestNilRegistryAPIsReturnStructuredErrors(t *testing.T) {
+	if err := RegisterQuery[patientPageQuery, patientPage](nil, func(ctx context.Context, query patientPageQuery) (patientPage, error) {
+		return patientPage{}, nil
+	}); !Is(err, ErrNilHandler) {
+		t.Fatalf("RegisterQuery nil registry error = %v, want %s", err, ErrNilHandler)
+	}
+	if _, err := ExecuteQuery[patientPageQuery, patientPage](context.Background(), nil, patientPageQuery{}); !Is(err, ErrNilHandler) {
+		t.Fatalf("ExecuteQuery nil registry error = %v, want %s", err, ErrNilHandler)
+	}
+	if err := RegisterCommand[createPatient, createPatientResult](nil, func(ctx context.Context, command createPatient) (createPatientResult, error) {
+		return createPatientResult{}, nil
+	}); !Is(err, ErrNilHandler) {
+		t.Fatalf("RegisterCommand nil registry error = %v, want %s", err, ErrNilHandler)
+	}
+	if _, err := ExecuteCommand[createPatient, createPatientResult](context.Background(), nil, createPatient{}); !Is(err, ErrNilHandler) {
+		t.Fatalf("ExecuteCommand nil registry error = %v, want %s", err, ErrNilHandler)
+	}
+	if err := RegisterDomainEvent[patientCreated](nil, func(ctx context.Context, event patientCreated) error {
+		return nil
+	}); !Is(err, ErrNilHandler) {
+		t.Fatalf("RegisterDomainEvent nil registry error = %v, want %s", err, ErrNilHandler)
+	}
+	if err := PublishDomain(context.Background(), nil, patientCreated{}); !Is(err, ErrNilHandler) {
+		t.Fatalf("PublishDomain nil registry error = %v, want %s", err, ErrNilHandler)
+	}
+}
+
+func TestZeroValueRegistryIsUsable(t *testing.T) {
+	registry := &Registry{}
+	must(t, RegisterCommand[createPatient, createPatientResult](registry, func(ctx context.Context, command createPatient) (createPatientResult, error) {
+		return createPatientResult{ID: command.Name}, nil
+	}, RoleWeb))
+	must(t, RegisterQuery[patientPageQuery, patientPage](registry, func(ctx context.Context, query patientPageQuery) (patientPage, error) {
+		return patientPage{Name: query.ID}, nil
+	}, RoleWeb))
+	var handled string
+	must(t, RegisterDomainEvent[patientCreated](registry, func(ctx context.Context, event patientCreated) error {
+		handled = event.ID
+		return nil
+	}, RoleWorker))
+	must(t, RegisterInvalidation[patientCreated, patientPageQuery](registry))
+
+	commandResult, err := ExecuteCommandForRole[createPatient, createPatientResult](context.Background(), registry, RoleWeb, createPatient{Name: "patient-1"})
+	if err != nil || commandResult.ID != "patient-1" {
+		t.Fatalf("zero-value command result = %#v err=%v", commandResult, err)
+	}
+	queryResult, err := ExecuteQueryForRole[patientPageQuery, patientPage](context.Background(), registry, RoleWeb, patientPageQuery{ID: "Ada"})
+	if err != nil || queryResult.Name != "Ada" {
+		t.Fatalf("zero-value query result = %#v err=%v", queryResult, err)
+	}
+	if err := PublishDomainForRole(context.Background(), registry, RoleWorker, patientCreated{ID: "event-1"}); err != nil {
+		t.Fatalf("zero-value publish domain: %v", err)
+	}
+	if handled != "event-1" {
+		t.Fatalf("handled = %q, want event-1", handled)
+	}
+	if got := registry.Invalidations(); len(got) != 1 {
+		t.Fatalf("zero-value invalidations = %#v, want one", got)
+	}
+}
+
 func TestExecuteRolelessContractFailsClosedForConcreteRole(t *testing.T) {
 	registry := NewRegistry()
 	must(t, RegisterCommand[createPatient, createPatientResult](registry, func(ctx context.Context, command createPatient) (createPatientResult, error) {
@@ -1255,6 +1316,21 @@ func contractSpanAttr(span gowdktrace.Snapshot, key string) any {
 		}
 	}
 	return nil
+}
+
+func waitForSpans(t *testing.T, ring *gowdktrace.RingSink, want int) []gowdktrace.Snapshot {
+	t.Helper()
+	deadline := time.Now().Add(time.Second)
+	for {
+		spans := ring.Spans()
+		if len(spans) >= want {
+			return spans
+		}
+		if time.Now().After(deadline) {
+			return spans
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
 }
 
 func must(t *testing.T, err error) {

--- a/runtime/contracts/errors.go
+++ b/runtime/contracts/errors.go
@@ -64,3 +64,7 @@ func roleNotAllowedError(kind Kind, contract string, role Role) error {
 func nilHandlerError(kind Kind, contract string) error {
 	return Error{Kind: ErrNilHandler, Contract: contract, Message: fmt.Sprintf("%s %s cannot register a nil handler", kind, contract)}
 }
+
+func nilRegistryError(kind Kind, contract string) error {
+	return Error{Kind: ErrNilHandler, Contract: contract, Message: fmt.Sprintf("%s %s registry cannot be nil", kind, contract)}
+}

--- a/runtime/contracts/events.go
+++ b/runtime/contracts/events.go
@@ -228,6 +228,10 @@ func publishEnvelopeForRole(ctx context.Context, registry *Registry, event Event
 	)
 	var spanErr error
 	defer func() { finishContractSpan(span, spanErr) }()
+	if registry == nil {
+		spanErr = nilRegistryError(Event, event.Type)
+		return spanErr
+	}
 	key := eventKey{category: event.Category, event: event.Type}
 	entries := registry.eventEntries(key)
 	for index, entry := range entries {
@@ -259,8 +263,12 @@ func registerEvent[E any](registry *Registry, category EventCategory, handler Ev
 	if handler == nil {
 		return nilHandlerError(Event, typeName[E]())
 	}
+	if registry == nil {
+		return nilRegistryError(Event, typeName[E]())
+	}
 	registry.mu.Lock()
 	defer registry.mu.Unlock()
+	registry.ensureMapsLocked()
 	key := eventKey{category: category, event: typeName[E]()}
 	registry.events[key] = append(registry.events[key], eventEntry{
 		event:    key.event,
@@ -313,6 +321,9 @@ func eventsWithTraceparent(ctx context.Context, events []EventEnvelope) []EventE
 }
 
 func (registry *Registry) eventEntries(key eventKey) []eventEntry {
+	if registry == nil {
+		return nil
+	}
 	registry.mu.RLock()
 	defer registry.mu.RUnlock()
 	entries := registry.events[key]

--- a/runtime/contracts/fileoutbox/fileoutbox.go
+++ b/runtime/contracts/fileoutbox/fileoutbox.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/cssbruno/gowdk/runtime/contracts"
+	"github.com/cssbruno/gowdk/runtime/security"
 )
 
 const defaultBatchSize = 100
@@ -285,7 +286,7 @@ func (store *Store) readRecordsFromPathLocked(path string) ([]Record, error) {
 
 	var records []Record
 	scanner := bufio.NewScanner(file)
-	scanner.Buffer(make([]byte, 0, 64*1024), 10*1024*1024)
+	scanner.Buffer(make([]byte, 0, 64*1024), maxJSONLineBytes)
 	line := 0
 	for scanner.Scan() {
 		line++
@@ -328,7 +329,7 @@ func (store *Store) markRecordsFailedLocked(mark map[string]bool, cause error) e
 	now := store.now().UTC()
 	message := ""
 	if cause != nil {
-		message = cause.Error()
+		message = security.RedactSecrets(cause.Error())
 	}
 	var kept []Record
 	var dead []Record
@@ -366,5 +367,21 @@ func (store *Store) appendRecordsToPathLocked(path string, records []Record) err
 	if err != nil {
 		return err
 	}
-	return writeJSONLinesAtomic(path, ".gowdk-outbox-*", append(existing, records...), store.rename)
+	seen := make(map[string]bool, len(existing))
+	merged := append([]Record(nil), existing...)
+	for _, record := range existing {
+		if record.ID != "" {
+			seen[record.ID] = true
+		}
+	}
+	for _, record := range records {
+		if record.ID != "" && seen[record.ID] {
+			continue
+		}
+		merged = append(merged, record)
+		if record.ID != "" {
+			seen[record.ID] = true
+		}
+	}
+	return writeJSONLinesAtomic(path, ".gowdk-outbox-*", merged, store.rename)
 }

--- a/runtime/contracts/fileoutbox/fileoutbox_test.go
+++ b/runtime/contracts/fileoutbox/fileoutbox_test.go
@@ -197,6 +197,36 @@ func TestReceiveEventBatchNackKeepsRecords(t *testing.T) {
 	}
 }
 
+func TestReceiveEventBatchNackRedactsLastError(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "outbox.jsonl")
+	store := New(path, WithJSONTypeDecoder[patientCreated]())
+	if err := store.StoreEvents(context.Background(), []contracts.EventEnvelope{{
+		Category: contracts.DomainEvent,
+		Type:     patientCreatedType,
+		Value:    patientCreated{ID: "patient-1"},
+	}}); err != nil {
+		t.Fatalf("store events: %v", err)
+	}
+
+	batch, err := store.ReceiveEventBatch(context.Background())
+	if err != nil {
+		t.Fatalf("receive batch: %v", err)
+	}
+	if err := batch.Nack(context.Background(), errors.New("subscriber failed password=hunter2")); err != nil {
+		t.Fatalf("nack batch: %v", err)
+	}
+	records, err := store.Records(context.Background())
+	if err != nil {
+		t.Fatalf("records: %v", err)
+	}
+	if len(records) != 1 {
+		t.Fatalf("len(records) = %d, want 1", len(records))
+	}
+	if strings.Contains(records[0].LastError, "hunter2") || !strings.Contains(records[0].LastError, "password=[REDACTED]") {
+		t.Fatalf("last error was not redacted: %q", records[0].LastError)
+	}
+}
+
 func TestReceiveEventBatchAckKeepsDuplicateEventIDRowsDistinct(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "outbox.jsonl")
 	store := New(path, WithBatchSize(1), WithJSONTypeDecoder[patientCreated]())
@@ -341,6 +371,84 @@ func TestReceiveEventBatchMovesRecordToDeadLetterAfterMaxAttempts(t *testing.T) 
 	}
 }
 
+func TestReceiveEventBatchDoesNotDuplicateDeadLetterAfterPendingRewriteFailure(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "outbox.jsonl")
+	deadLetterPath := filepath.Join(root, "dead-letter.jsonl")
+	store := New(path, WithBatchSize(1), WithJSONTypeDecoder[patientCreated](), WithDeadLetter(deadLetterPath, 1))
+	if err := store.StoreEvents(context.Background(), []contracts.EventEnvelope{
+		{
+			Category: contracts.DomainEvent,
+			Type:     patientCreatedType,
+			Value:    patientCreated{ID: "patient-1"},
+		},
+		{
+			Category: contracts.DomainEvent,
+			Type:     patientCreatedType,
+			Value:    patientCreated{ID: "patient-2"},
+		},
+	}); err != nil {
+		t.Fatalf("store events: %v", err)
+	}
+
+	renameErr := errors.New("pending rewrite failed")
+	var renames int
+	store.rename = func(old, new string) error {
+		renames++
+		if renames == 2 {
+			return renameErr
+		}
+		return os.Rename(old, new)
+	}
+
+	first, err := store.ReceiveEventBatch(context.Background())
+	if err != nil {
+		t.Fatalf("receive first batch: %v", err)
+	}
+	if err := first.Nack(context.Background(), errors.New("subscriber failed password=hunter2")); !errors.Is(err, renameErr) {
+		t.Fatalf("first nack error = %v, want %v", err, renameErr)
+	}
+	records, err := store.Records(context.Background())
+	if err != nil {
+		t.Fatalf("records after failed pending rewrite: %v", err)
+	}
+	if len(records) != 2 {
+		t.Fatalf("pending records after failed rewrite = %#v, want two", records)
+	}
+	dead, err := store.DeadLetterRecords(context.Background())
+	if err != nil {
+		t.Fatalf("dead letter after failed pending rewrite: %v", err)
+	}
+	if len(dead) != 1 {
+		t.Fatalf("dead letter records after failed pending rewrite = %#v, want one", dead)
+	}
+	if strings.Contains(dead[0].LastError, "hunter2") || !strings.Contains(dead[0].LastError, "password=[REDACTED]") {
+		t.Fatalf("dead letter error was not redacted: %q", dead[0].LastError)
+	}
+
+	second, err := store.ReceiveEventBatch(context.Background())
+	if err != nil {
+		t.Fatalf("receive retry batch: %v", err)
+	}
+	if err := second.Nack(context.Background(), errors.New("subscriber failed password=hunter2")); err != nil {
+		t.Fatalf("retry nack: %v", err)
+	}
+	dead, err = store.DeadLetterRecords(context.Background())
+	if err != nil {
+		t.Fatalf("dead letter after retry: %v", err)
+	}
+	if len(dead) != 1 {
+		t.Fatalf("dead letter records after retry = %#v, want one deduplicated record", dead)
+	}
+	records, err = store.Records(context.Background())
+	if err != nil {
+		t.Fatalf("records after retry: %v", err)
+	}
+	if len(records) != 1 || records[0].EventID == dead[0].EventID {
+		t.Fatalf("pending records after retry = %#v, want only the untouched second record", records)
+	}
+}
+
 func TestReceiveEventBatchHonorsBatchSize(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "outbox.jsonl")
 	store := New(path, WithBatchSize(1), WithJSONTypeDecoder[patientCreated]())
@@ -401,6 +509,23 @@ func TestRunEventWorkerConsumesFileOutbox(t *testing.T) {
 	}
 	if len(records) != 0 {
 		t.Fatalf("len(records) = %d, want 0", len(records))
+	}
+}
+
+func TestStoreEventsRejectsRecordLargerThanReaderLimit(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "outbox.jsonl")
+	store := New(path)
+
+	err := store.StoreEvents(context.Background(), []contracts.EventEnvelope{{
+		Category: contracts.DomainEvent,
+		Type:     patientCreatedType,
+		Value:    strings.Repeat("x", maxJSONLineBytes),
+	}})
+	if err == nil || !strings.Contains(err.Error(), "file outbox record exceeds") {
+		t.Fatalf("store oversized event error = %v, want record-size error", err)
+	}
+	if _, statErr := os.Stat(path); !os.IsNotExist(statErr) {
+		t.Fatalf("oversized event should not create outbox file, stat err=%v", statErr)
 	}
 }
 

--- a/runtime/contracts/fileoutbox/jsonlines.go
+++ b/runtime/contracts/fileoutbox/jsonlines.go
@@ -1,10 +1,14 @@
 package fileoutbox
 
 import (
+	"bytes"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 )
+
+const maxJSONLineBytes = 10 * 1024 * 1024
 
 func writeJSONLinesAtomic[T any](path, pattern string, records []T, rename func(string, string) error) error {
 	if len(records) == 0 {
@@ -28,9 +32,18 @@ func writeJSONLinesAtomic[T any](path, pattern string, records []T, rename func(
 		}
 	}()
 
-	encoder := json.NewEncoder(temp)
 	for _, record := range records {
+		var line bytes.Buffer
+		encoder := json.NewEncoder(&line)
 		if err := encoder.Encode(record); err != nil {
+			_ = temp.Close()
+			return err
+		}
+		if line.Len() > maxJSONLineBytes {
+			_ = temp.Close()
+			return fmt.Errorf("file outbox record exceeds %d bytes", maxJSONLineBytes)
+		}
+		if _, err := temp.Write(line.Bytes()); err != nil {
 			_ = temp.Close()
 			return err
 		}

--- a/runtime/contracts/invalidation.go
+++ b/runtime/contracts/invalidation.go
@@ -14,6 +14,7 @@ func RegisterInvalidation[E, Q any](registry *Registry) error {
 	}
 	registry.mu.Lock()
 	defer registry.mu.Unlock()
+	registry.ensureMapsLocked()
 	invalidation := QueryInvalidation{
 		EventCategory: DomainEvent,
 		EventType:     typeName[E](),

--- a/runtime/contracts/jobs.go
+++ b/runtime/contracts/jobs.go
@@ -11,6 +11,9 @@ func RegisterJob[J any](registry *Registry, handler JobHandler[J], roles ...Role
 	if handler == nil {
 		return nilHandlerError(Job, typeName[J]())
 	}
+	if registry == nil {
+		return nilRegistryError(Job, typeName[J]())
+	}
 	return registry.registerJob(typeName[J](), handler, roles)
 }
 
@@ -32,6 +35,10 @@ func executeJob[J any](ctx context.Context, registry *Registry, job J, role Role
 	)
 	var spanErr error
 	defer func() { finishContractSpan(span, spanErr) }()
+	if registry == nil {
+		spanErr = nilRegistryError(Job, contract)
+		return spanErr
+	}
 	entry, ok := registry.job(contract)
 	if !ok {
 		spanErr = missingHandlerError(Job, contract)
@@ -53,6 +60,7 @@ func executeJob[J any](ctx context.Context, registry *Registry, job J, role Role
 func (registry *Registry) registerJob(job string, handler any, roles []Role) error {
 	registry.mu.Lock()
 	defer registry.mu.Unlock()
+	registry.ensureMapsLocked()
 	if _, exists := registry.jobs[job]; exists {
 		return duplicateHandlerError(Job, job)
 	}

--- a/runtime/contracts/query.go
+++ b/runtime/contracts/query.go
@@ -11,6 +11,9 @@ func RegisterQuery[Q, R any](registry *Registry, handler QueryHandler[Q, R], rol
 	if handler == nil {
 		return nilHandlerError(Query, typeName[Q]())
 	}
+	if registry == nil {
+		return nilRegistryError(Query, typeName[Q]())
+	}
 	return registry.registerQuery(typeName[Q](), typeName[R](), handler, roles)
 }
 
@@ -33,6 +36,10 @@ func executeQuery[Q, R any](ctx context.Context, registry *Registry, query Q, ro
 	)
 	var spanErr error
 	defer func() { finishContractSpan(span, spanErr) }()
+	if registry == nil {
+		spanErr = nilRegistryError(Query, contract)
+		return zero, spanErr
+	}
 	entry, ok := registry.query(contract)
 	if !ok {
 		spanErr = missingHandlerError(Query, contract)
@@ -55,6 +62,7 @@ func executeQuery[Q, R any](ctx context.Context, registry *Registry, query Q, ro
 func (registry *Registry) registerQuery(query, result string, handler any, roles []Role) error {
 	registry.mu.Lock()
 	defer registry.mu.Unlock()
+	registry.ensureMapsLocked()
 	if _, exists := registry.queries[query]; exists {
 		return duplicateHandlerError(Query, query)
 	}

--- a/runtime/contracts/registry.go
+++ b/runtime/contracts/registry.go
@@ -28,16 +28,25 @@ func NewRegistry() *Registry {
 
 // Contracts returns deterministic metadata for registered contracts.
 func (registry *Registry) Contracts() []Metadata {
+	if registry == nil {
+		return nil
+	}
 	return registry.contractsForRole("")
 }
 
 // ContractsForRole returns deterministic metadata for contracts available to role.
 func (registry *Registry) ContractsForRole(role Role) []Metadata {
+	if registry == nil {
+		return nil
+	}
 	return registry.contractsForRole(role)
 }
 
 // Invalidations returns deterministic event-to-query invalidation metadata.
 func (registry *Registry) Invalidations() []QueryInvalidation {
+	if registry == nil {
+		return nil
+	}
 	registry.mu.RLock()
 	defer registry.mu.RUnlock()
 	out := append([]QueryInvalidation(nil), registry.invalidations...)
@@ -51,6 +60,21 @@ func (registry *Registry) Invalidations() []QueryInvalidation {
 		return out[i].QueryType < out[j].QueryType
 	})
 	return out
+}
+
+func (registry *Registry) ensureMapsLocked() {
+	if registry.queries == nil {
+		registry.queries = map[string]queryEntry{}
+	}
+	if registry.commands == nil {
+		registry.commands = map[string]commandEntry{}
+	}
+	if registry.events == nil {
+		registry.events = map[eventKey][]eventEntry{}
+	}
+	if registry.jobs == nil {
+		registry.jobs = map[string]jobEntry{}
+	}
 }
 
 func (registry *Registry) contractsForRole(role Role) []Metadata {

--- a/runtime/contracts/worker.go
+++ b/runtime/contracts/worker.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"time"
 
+	"github.com/cssbruno/gowdk/runtime/security"
 	gowdktrace "github.com/cssbruno/gowdk/runtime/trace"
 )
 
@@ -24,7 +25,7 @@ func logWorkerDispatchFailure(err error) {
 	if logger == nil {
 		return
 	}
-	logger("gowdk: event worker nacked batch after dispatch failure: " + err.Error())
+	logger("gowdk: event worker nacked batch after dispatch failure: " + security.RedactSecrets(err.Error()))
 }
 
 // EventBatch is one ordered delivery batch from an outbox, queue, or broker

--- a/runtime/contracts/worker_test.go
+++ b/runtime/contracts/worker_test.go
@@ -251,7 +251,7 @@ func TestRunEventWorkerWithSeenStoreDoesNotMarkAckFailure(t *testing.T) {
 
 func TestRunEventWorkerNacksSubscriberFailureAndContinues(t *testing.T) {
 	registry := NewRegistry()
-	subscriberErr := errors.New("subscriber unavailable")
+	subscriberErr := errors.New("subscriber unavailable password=hunter2")
 	must(t, RegisterDomainEvent[patientCreated](registry, func(ctx context.Context, event patientCreated) error {
 		return subscriberErr
 	}, RoleWorker))
@@ -294,8 +294,11 @@ func TestRunEventWorkerNacksSubscriberFailureAndContinues(t *testing.T) {
 	if !Is(nackCause, ErrSubscriberFailed) {
 		t.Fatalf("nack cause = %v, want subscriber failure", nackCause)
 	}
-	if len(logged) != 1 || !strings.Contains(logged[0], subscriberErr.Error()) {
-		t.Fatalf("logged = %#v, want one recovered dispatch failure", logged)
+	if len(logged) != 1 || !strings.Contains(logged[0], "subscriber unavailable") || !strings.Contains(logged[0], "password=[REDACTED]") {
+		t.Fatalf("logged = %#v, want one redacted dispatch failure", logged)
+	}
+	if strings.Contains(logged[0], "hunter2") {
+		t.Fatalf("worker log leaked secret: %q", logged[0])
 	}
 }
 

--- a/runtime/guard/guard.go
+++ b/runtime/guard/guard.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/cssbruno/gowdk/runtime/auth"
+	"github.com/cssbruno/gowdk/runtime/security"
 	gowdktrace "github.com/cssbruno/gowdk/runtime/trace"
 )
 
@@ -34,7 +35,7 @@ func RunGuardsWithAuth(ctx Context, names []string, registry Registry, provider 
 		guardCtx, span := startGuardTrace(ctx, name)
 		ctx.Context = guardCtx
 		if err := guard(ctx); err != nil {
-			span.SetStatus(gowdktrace.StatusError, err.Error())
+			span.SetStatus(gowdktrace.StatusError, security.RedactSecrets(err.Error()))
 			span.End()
 			return fmt.Errorf("guard %q failed: %w", name, err)
 		}

--- a/runtime/guard/guard_test.go
+++ b/runtime/guard/guard_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	gowdkauth "github.com/cssbruno/gowdk/runtime/auth"
 	gowdkresponse "github.com/cssbruno/gowdk/runtime/response"
@@ -74,7 +75,7 @@ func TestRunGuardsRecordsFailedGuardSpan(t *testing.T) {
 	if !errors.Is(err, expected) {
 		t.Fatalf("expected failed guard error, got %v", err)
 	}
-	spans := ring.Spans()
+	spans := waitForSpans(t, ring, 1)
 	if len(spans) != 1 {
 		t.Fatalf("spans = %d, want 1", len(spans))
 	}
@@ -174,7 +175,22 @@ func TestWriteNoStoreFailure(t *testing.T) {
 
 	ordinary := httptest.NewRecorder()
 	WriteNoStoreFailure(ordinary, errors.New("guard failed"))
-	if ordinary.Code != http.StatusForbidden || ordinary.Header().Get("Cache-Control") != "no-store" || !strings.Contains(ordinary.Body.String(), "guard failed") {
+	if ordinary.Code != http.StatusForbidden || ordinary.Header().Get("Cache-Control") != "no-store" || !strings.Contains(ordinary.Body.String(), "403 forbidden") || strings.Contains(ordinary.Body.String(), "guard failed") {
 		t.Fatalf("unexpected ordinary failure response: status=%d headers=%v body=%q", ordinary.Code, ordinary.Header(), ordinary.Body.String())
+	}
+}
+
+func waitForSpans(t *testing.T, ring *gowdktrace.RingSink, want int) []gowdktrace.Snapshot {
+	t.Helper()
+	deadline := time.Now().Add(time.Second)
+	for {
+		spans := ring.Spans()
+		if len(spans) >= want {
+			return spans
+		}
+		if time.Now().After(deadline) {
+			return spans
+		}
+		time.Sleep(5 * time.Millisecond)
 	}
 }

--- a/runtime/guard/response.go
+++ b/runtime/guard/response.go
@@ -98,7 +98,7 @@ func WriteNoStoreFailure(writer http.ResponseWriter, err error) {
 		_ = response.WriteNoStoreHTTP(writer, result)
 		return
 	}
-	response.WriteNoStoreError(writer, http.StatusForbidden, err.Error())
+	response.WriteNoStoreError(writer, http.StatusForbidden, "403 forbidden")
 }
 
 func validateRedirectURL(url string) error {

--- a/runtime/ratelimit/ratelimit.go
+++ b/runtime/ratelimit/ratelimit.go
@@ -125,6 +125,24 @@ func (limiter *Limiter) AllowRequest(request *http.Request) (Result, error) {
 	return limiter.store.Take(request.Context(), key, limiter.limit, limiter.window, limiter.now())
 }
 
+// HandleError writes the configured rate-limit store-error response.
+func (limiter *Limiter) HandleError(writer http.ResponseWriter, request *http.Request, err error) {
+	if limiter == nil || limiter.errorHandler == nil {
+		DefaultErrorHandler(writer, request, err)
+		return
+	}
+	limiter.errorHandler(writer, request, err)
+}
+
+// HandleLimit writes the configured blocked-request response.
+func (limiter *Limiter) HandleLimit(writer http.ResponseWriter, request *http.Request, result Result) {
+	if limiter == nil || limiter.limitHandler == nil {
+		DefaultLimitHandler(writer, request, result)
+		return
+	}
+	limiter.limitHandler(writer, request, result)
+}
+
 // Middleware wraps an HTTP handler with rate limiting.
 func (limiter *Limiter) Middleware(next http.Handler) http.Handler {
 	if next == nil {

--- a/runtime/ratelimit/ratelimit_test.go
+++ b/runtime/ratelimit/ratelimit_test.go
@@ -156,6 +156,39 @@ func TestMiddlewareHidesStoreErrorDetails(t *testing.T) {
 	}
 }
 
+func TestHandleMethodsUseConfiguredHandlers(t *testing.T) {
+	limiter, err := New(Options{
+		Limit:  1,
+		Window: time.Minute,
+		Store:  NewInMemoryStore(InMemoryOptions{}),
+		LimitHandler: func(writer http.ResponseWriter, request *http.Request, result Result) {
+			writer.Header().Set("X-Custom-Limit", result.Key)
+			http.Error(writer, "blocked by app", http.StatusTeapot)
+		},
+		ErrorHandler: func(writer http.ResponseWriter, request *http.Request, err error) {
+			writer.Header().Set("X-Custom-Error", err.Error())
+			http.Error(writer, "store unavailable", http.StatusBadGateway)
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	limitRecorder := httptest.NewRecorder()
+	limitRequest := httptest.NewRequest(http.MethodGet, "/", nil)
+	limiter.HandleLimit(limitRecorder, limitRequest, Result{Key: "patient-api"})
+	if limitRecorder.Code != http.StatusTeapot || limitRecorder.Header().Get("X-Custom-Limit") != "patient-api" {
+		t.Fatalf("custom limit handler did not run: status=%d headers=%#v body=%q", limitRecorder.Code, limitRecorder.Header(), limitRecorder.Body.String())
+	}
+
+	errorRecorder := httptest.NewRecorder()
+	errorRequest := httptest.NewRequest(http.MethodGet, "/", nil)
+	limiter.HandleError(errorRecorder, errorRequest, errors.New("redis down"))
+	if errorRecorder.Code != http.StatusBadGateway || errorRecorder.Header().Get("X-Custom-Error") != "redis down" {
+		t.Fatalf("custom error handler did not run: status=%d headers=%#v body=%q", errorRecorder.Code, errorRecorder.Header(), errorRecorder.Body.String())
+	}
+}
+
 func TestKeyByRemoteAddrIgnoresForwardedHeaders(t *testing.T) {
 	request := httptest.NewRequest(http.MethodGet, "/", nil)
 	request.RemoteAddr = "198.51.100.10:44000"

--- a/runtime/response/response.go
+++ b/runtime/response/response.go
@@ -77,6 +77,10 @@ func HandlerStatus(err error, fallback int) int {
 	if errors.As(err, &handlerErr) && handlerErr.Status != 0 {
 		return handlerErr.Status
 	}
+	var maxBytesErr *http.MaxBytesError
+	if errors.As(err, &maxBytesErr) {
+		return http.StatusRequestEntityTooLarge
+	}
 	return fallback
 }
 

--- a/runtime/response/response_test.go
+++ b/runtime/response/response_test.go
@@ -427,6 +427,9 @@ func TestHandlerError(t *testing.T) {
 	if got := HandlerStatus(errors.New("ordinary"), 500); got != 500 {
 		t.Fatalf("unexpected fallback status: %d", got)
 	}
+	if got := HandlerStatus(&http.MaxBytesError{Limit: 1024}, 500); got != http.StatusRequestEntityTooLarge {
+		t.Fatalf("unexpected max bytes status: %d", got)
+	}
 }
 
 func TestHandlerErrorMessageHidesOrdinary5xxDetails(t *testing.T) {

--- a/runtime/trace/sink.go
+++ b/runtime/trace/sink.go
@@ -3,6 +3,7 @@ package trace
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"sync"
@@ -24,15 +25,16 @@ func (fn sinkFunc) RecordSpan(ctx context.Context, span Snapshot) error {
 func MultiSink(sinks ...Sink) Sink {
 	copied := append([]Sink(nil), sinks...)
 	return sinkFunc(func(ctx context.Context, span Snapshot) error {
+		var joined error
 		for _, sink := range copied {
 			if sink == nil {
 				continue
 			}
 			if err := sink.RecordSpan(ctx, span); err != nil {
-				return err
+				joined = errors.Join(joined, err)
 			}
 		}
-		return nil
+		return joined
 	})
 }
 

--- a/runtime/trace/span.go
+++ b/runtime/trace/span.go
@@ -2,9 +2,12 @@ package trace
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"sync"
 	"time"
+
+	"github.com/cssbruno/gowdk/runtime/security"
 )
 
 type spanContextKey struct{}
@@ -89,6 +92,11 @@ func (span *Span) EndTime(t time.Time) {
 
 func recordSpanAsync(sink Sink, snapshot Snapshot) {
 	go func() {
+		defer func() {
+			if recovered := recover(); recovered != nil {
+				logSinkFailure(fmt.Errorf("panic: %v", recovered))
+			}
+		}()
 		ctx, cancel := context.WithTimeout(context.Background(), defaultSinkTimeout)
 		defer cancel()
 		if err := sink.RecordSpan(ctx, snapshot); err != nil {
@@ -101,7 +109,7 @@ func logSinkFailure(err error) {
 	if err == nil || SinkLogger == nil {
 		return
 	}
-	SinkLogger("gowdk trace: sink failed: " + err.Error())
+	SinkLogger("gowdk trace: sink failed: " + security.RedactSecrets(err.Error()))
 }
 
 // Event records a timestamped event on the span.

--- a/runtime/trace/span.go
+++ b/runtime/trace/span.go
@@ -2,11 +2,20 @@ package trace
 
 import (
 	"context"
+	"log"
 	"sync"
 	"time"
 )
 
 type spanContextKey struct{}
+
+const defaultSinkTimeout = 5 * time.Second
+
+// SinkLogger receives completed-span export failures. Set it to nil to silence
+// sink failure logging. It defaults to the standard log package.
+var SinkLogger func(message string) = func(message string) {
+	log.Print(message)
+}
 
 // Span records one sampled unit of work. Methods are nil-safe so callers can
 // defer span.End() even when sampling is disabled.
@@ -74,8 +83,25 @@ func (span *Span) EndTime(t time.Time) {
 	}
 	span.mu.Unlock()
 	if sink != nil {
-		_ = sink.RecordSpan(context.Background(), snapshot)
+		recordSpanAsync(sink, snapshot)
 	}
+}
+
+func recordSpanAsync(sink Sink, snapshot Snapshot) {
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), defaultSinkTimeout)
+		defer cancel()
+		if err := sink.RecordSpan(ctx, snapshot); err != nil {
+			logSinkFailure(err)
+		}
+	}()
+}
+
+func logSinkFailure(err error) {
+	if err == nil || SinkLogger == nil {
+		return
+	}
+	SinkLogger("gowdk trace: sink failed: " + err.Error())
 }
 
 // Event records a timestamped event on the span.

--- a/runtime/trace/trace_test.go
+++ b/runtime/trace/trace_test.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -37,7 +38,7 @@ func TestStartRecordsSpanToSink(t *testing.T) {
 	if !ok || !traceContext.TraceID.Valid() || !traceContext.SpanID.Valid() {
 		t.Fatalf("expected trace context in returned context, got %#v", traceContext)
 	}
-	spans := ring.Spans()
+	spans := waitForSpans(t, ring, 1)
 	if len(spans) != 1 {
 		t.Fatalf("expected one span, got %d", len(spans))
 	}
@@ -109,6 +110,47 @@ func TestJSONLAndConsoleSinks(t *testing.T) {
 	}
 	if !strings.Contains(console.String(), "unit trace=") {
 		t.Fatalf("unexpected console output: %q", console.String())
+	}
+}
+
+func TestSpanEndDoesNotBlockOnSink(t *testing.T) {
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	tracer := trace.NewTracer(trace.WithSink(blockingSink{entered: entered, release: release}))
+	_, span := tracer.Start(context.Background(), "blocked-export")
+	done := make(chan struct{})
+
+	go func() {
+		span.EndTime(time.Unix(1, 0).UTC())
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(100 * time.Millisecond):
+		close(release)
+		t.Fatal("span end blocked on sink export")
+	}
+	select {
+	case <-entered:
+	case <-time.After(time.Second):
+		close(release)
+		t.Fatal("sink was not invoked")
+	}
+	close(release)
+}
+
+func TestMultiSinkAttemptsLaterSinksAfterFailure(t *testing.T) {
+	expected := errors.New("first sink failed")
+	recording := &recordingSink{}
+	sink := trace.MultiSink(failingSink{err: expected}, recording)
+
+	err := sink.RecordSpan(context.Background(), trace.Snapshot{Name: "fanout"})
+	if !errors.Is(err, expected) {
+		t.Fatalf("MultiSink error = %v, want %v", err, expected)
+	}
+	if len(recording.spans) != 1 || recording.spans[0].Name != "fanout" {
+		t.Fatalf("later sink did not receive span: %#v", recording.spans)
 	}
 }
 
@@ -226,6 +268,56 @@ func (denySampler) Sample(trace.SamplingContext) bool {
 
 type recordingExporter struct {
 	spans []trace.OTLPSpan
+}
+
+type blockingSink struct {
+	entered chan<- struct{}
+	release <-chan struct{}
+}
+
+func (sink blockingSink) RecordSpan(ctx context.Context, span trace.Snapshot) error {
+	close(sink.entered)
+	select {
+	case <-sink.release:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+type failingSink struct {
+	err error
+}
+
+func (sink failingSink) RecordSpan(context.Context, trace.Snapshot) error {
+	return sink.err
+}
+
+type recordingSink struct {
+	spans []trace.Snapshot
+}
+
+func (sink *recordingSink) RecordSpan(ctx context.Context, span trace.Snapshot) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	sink.spans = append(sink.spans, span)
+	return nil
+}
+
+func waitForSpans(t *testing.T, ring *trace.RingSink, want int) []trace.Snapshot {
+	t.Helper()
+	deadline := time.Now().Add(time.Second)
+	for {
+		spans := ring.Spans()
+		if len(spans) >= want {
+			return spans
+		}
+		if time.Now().After(deadline) {
+			return spans
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
 }
 
 func (exporter *recordingExporter) ExportSpans(ctx context.Context, spans []trace.OTLPSpan) error {

--- a/runtime/trace/trace_test.go
+++ b/runtime/trace/trace_test.go
@@ -140,6 +140,35 @@ func TestSpanEndDoesNotBlockOnSink(t *testing.T) {
 	close(release)
 }
 
+func TestSpanEndRecoversPanickingSinkAndRedactsLog(t *testing.T) {
+	logged := captureSinkLogs(t)
+	tracer := trace.NewTracer(trace.WithSink(panickingSink{value: "token=super-secret-token-value"}))
+	_, span := tracer.Start(context.Background(), "panic-export")
+
+	span.EndTime(time.Unix(1, 0).UTC())
+
+	message := waitForSinkLog(t, logged)
+	if !strings.Contains(message, "gowdk trace: sink failed: panic:") {
+		t.Fatalf("unexpected sink panic log: %q", message)
+	}
+	if strings.Contains(message, "super-secret-token-value") || !strings.Contains(message, "[REDACTED]") {
+		t.Fatalf("sink panic log was not redacted: %q", message)
+	}
+}
+
+func TestSpanEndRedactsSinkFailureLog(t *testing.T) {
+	logged := captureSinkLogs(t)
+	tracer := trace.NewTracer(trace.WithSink(failingSink{err: errors.New("export failed: Authorization: Bearer abcdefghijklmnop")}))
+	_, span := tracer.Start(context.Background(), "failed-export")
+
+	span.EndTime(time.Unix(1, 0).UTC())
+
+	message := waitForSinkLog(t, logged)
+	if strings.Contains(message, "abcdefghijklmnop") || !strings.Contains(message, "Bearer [REDACTED]") {
+		t.Fatalf("sink failure log was not redacted: %q", message)
+	}
+}
+
 func TestMultiSinkAttemptsLaterSinksAfterFailure(t *testing.T) {
 	expected := errors.New("first sink failed")
 	recording := &recordingSink{}
@@ -293,6 +322,14 @@ func (sink failingSink) RecordSpan(context.Context, trace.Snapshot) error {
 	return sink.err
 }
 
+type panickingSink struct {
+	value any
+}
+
+func (sink panickingSink) RecordSpan(context.Context, trace.Snapshot) error {
+	panic(sink.value)
+}
+
 type recordingSink struct {
 	spans []trace.Snapshot
 }
@@ -317,6 +354,30 @@ func waitForSpans(t *testing.T, ring *trace.RingSink, want int) []trace.Snapshot
 			return spans
 		}
 		time.Sleep(5 * time.Millisecond)
+	}
+}
+
+func captureSinkLogs(t *testing.T) <-chan string {
+	t.Helper()
+	logged := make(chan string, 1)
+	previous := trace.SinkLogger
+	trace.SinkLogger = func(message string) {
+		logged <- message
+	}
+	t.Cleanup(func() {
+		trace.SinkLogger = previous
+	})
+	return logged
+}
+
+func waitForSinkLog(t *testing.T, logged <-chan string) string {
+	t.Helper()
+	select {
+	case message := <-logged:
+		return message
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for sink log")
+		return ""
 	}
 }
 


### PR DESCRIPTION
## Summary

- Enforce default-deny for guardless fragments and command/query contract adapters while preserving JSON errors for contract endpoints.
- Harden request parsing, env defaults/loading, rate-limit handler delegation, guard error responses, panic boundaries, and response-writer optional HTTP capabilities.
- Add runtime safeguards for file outbox record limits/dead-letter dedupe/redaction, contract registry nil/zero-value use, tracing sink isolation, worker error redaction, and PBKDF2 iteration bounds.

## Why

The runtime/generated-output audit found several gaps where stale or malformed generated state could bypass intended defaults, leak internal details, or wedge runtime workers/exporters. This change makes those paths fail closed and adds focused regression coverage.

## Validation

- `go test ./internal/appgen ./runtime/app ./runtime/guard ./runtime/response ./runtime/ratelimit ./runtime/trace ./runtime/contracts ./runtime/contracts/fileoutbox ./addons/auth`
- `go test ./...`
- `scripts/test-go-modules.sh`
- `go build ./cmd/gowdk`