### PR TITLE
[codex] docs: clarify SSR contract client runtime output

### DIFF
--- a/docs/compiler/generated-output.md
+++ b/docs/compiler/generated-output.md
@@ -104,8 +104,12 @@ Implemented today:
   HTTP 413 for oversized submissions.
 - Generated apps return HTTP 422 for missing or empty direct SPA
   `required` fields when the action declares `valid(input)?`.
-- Generated build output emits `assets/gowdk/gowdk.js` only for pages that use
-  partial form metadata with fragment-producing actions.
+- Generated build output emits `assets/gowdk/gowdk.js` for pages that need
+  compiler-owned browser enhancement: partial form metadata with
+  fragment-producing actions, static-first SPA navigation, realtime
+  subscriptions or invalidated `g:query` regions, and `g:command` write forms.
+  Request-time SSR and hybrid pages use the same runtime when their rendered
+  markup declares those contract or partial-update surfaces.
 - Framework-owned browser runtime sources are authored as `.js` files under
   `internal/clientrt/assets/` and embedded with `go:embed`; generated output
   helpers only perform narrow placeholder substitution for component names,


### PR DESCRIPTION
## Summary

- Update generated-output docs so `assets/gowdk/gowdk.js` is no longer described as partial-forms-only.
- Document that the client runtime is emitted for SPA navigation, realtime subscriptions, invalidated `g:query` regions, and `g:command` write forms.
- Call out that request-time SSR/hybrid pages use the same runtime when their rendered markup declares those contract or partial-update surfaces.

## Context

This is a docs follow-up for the SSR contract client behavior related to #482 and #484. The code and regression tests for emitting the runtime on SSR pages with invalidated `g:query` regions or `g:command` forms are already present on `main`; this PR syncs the generated-output contract text with that behavior.

## Verification

- `go test ./internal/buildgen ./internal/appgen ./internal/clientrt ./internal/compiler`
- `go build ./cmd/gowdk`