### PR TITLE
[Client] switch/match expressions and helper locals

### DIFF
--- a/docs/language/syntax.md
+++ b/docs/language/syntax.md
@@ -357,7 +357,22 @@ parentheses. Local variables are visible only to later statements in the same
 client function, lifecycle block, or effect block. Expressions can read nested
 fields and indexed values from Go-typed object and slice state, such as
 `User.Name` and `Items[0].Name`. Expressions also support Go-ish conditional
-values: `if Open { "open" } else { "closed" }`.
+values such as `if Open { "open" } else { "closed" }`, plus bounded
+`switch`/`match` expressions:
+
+```gwdk
+client {
+  computed StatusLabel string {
+    return switch Status { case "draft": "Draft" case "live": "Live" default: "Unknown" }
+  }
+}
+```
+
+The expression form is inline:
+`switch Status { case "draft": "Draft" default: "Unknown" }`. `match` is an
+alias for `switch`. A default branch is required, case values must be comparable
+with the switch value, and all result branches must return compatible scalar
+types.
 
 Async handlers can use the compiler-owned `await fetchJSON[T](urlExpr)` form
 only in assignment statements, such as:
@@ -400,7 +415,8 @@ expression reuse:
 ```gwdk
 client {
   fn Next(value int) int {
-    return value + 1
+    let doubled int = value * 2
+    return switch doubled { case 0: 1 default: doubled + 1 }
   }
 
   fn Add() {
@@ -409,13 +425,16 @@ client {
 }
 ```
 
-Helpers must declare a scalar return type, contain exactly one `return expr`
-statement, and are callable from client expressions such as assignments, local
-initializers, handler arguments, and list mutation arguments. Helpers are not
-event handlers, so `g:on:click={Next(Count)}` is rejected; events must call a
-non-return handler such as `Add()`. Helper call graphs are validated at compile
-time and recursive cycles are rejected. JavaScript-style ternaries, broader
-built-ins such as date/time helpers, and recursion remain compile errors today.
+Helpers must declare a scalar return type and end with `return expr`. Before
+the final return, helpers may declare scalar locals with
+`let name type = expr`; those locals are visible to later helper locals and the
+return expression only. Helpers are callable from client expressions such as
+assignments, local initializers, handler arguments, and list mutation arguments.
+Helpers are not event handlers, so `g:on:click={Next(Count)}` is rejected;
+events must call a non-return handler such as `Add()`. Helper call graphs,
+including calls from helper local initializers, are validated at compile time
+and recursive cycles are rejected. JavaScript-style ternaries, broader built-ins
+such as date/time helpers, and recursion remain compile errors today.
 
 Expressions support the first compiler-owned built-ins:
 
@@ -445,8 +464,8 @@ type.
 
 Generated island JavaScript does not evaluate arbitrary JavaScript source from
 `client {}`. It interprets the compiler-owned expression subset above,
-including conditionals, scalar operators, field/index reads, helper calls, async
-fetch assignments, and the listed built-ins.
+including conditionals, switch/match expressions, scalar operators, field/index
+reads, helper calls, async fetch assignments, and the listed built-ins.
 
 Client blocks can declare computed values:
 

--- a/editors/vscode/syntaxes/gwdk.tmLanguage.json
+++ b/editors/vscode/syntaxes/gwdk.tmLanguage.json
@@ -61,7 +61,7 @@
       "patterns": [
         {
           "name": "keyword.control.client.gwdk",
-          "match": "\\b(?:async|fn|computed|on|mount|destroy|effect|when|ref|let|return|await|if|else|in|emit)\\b"
+          "match": "\\b(?:async|fn|computed|on|mount|destroy|effect|when|ref|let|return|await|if|else|switch|match|case|default|in|emit)\\b"
         },
         {
           "name": "support.function.builtin.gwdk",

--- a/examples/store-persist/add-button.cmp.gwdk
+++ b/examples/store-persist/add-button.cmp.gwdk
@@ -11,8 +11,13 @@ state ui.CartState = ui.NewCartState()
 client {
   use cart
 
+  func Next(value int) int {
+    let next int = value + 1
+    return switch next { case 1: 1 default: next }
+  }
+
   func Add() {
-    Count++
+    Count = Next(Count)
   }
 
   // `clear cart` resets the used store to its build-time init and drops the

--- a/internal/buildgen/islands_test.go
+++ b/internal/buildgen/islands_test.go
@@ -1067,7 +1067,8 @@ func TestBuildEmitsClientHelperFunctionsForJSIsland(t *testing.T) {
 	component := counterComponent()
 	component.Blocks.Client = true
 	component.Blocks.ClientBody = `fn Next(value int) int {
-  return value + 1
+  let doubled int = value * 2
+  return switch doubled { case 0: 1 default: doubled + 1 }
 }
 
 fn Add() {
@@ -1097,7 +1098,7 @@ fn Add() {
 	html := readFile(t, filepath.Join(outputDir, "counter", "index.html"))
 	for _, expected := range []string{
 		`&#34;handlers&#34;:{&#34;Add&#34;:{&#34;statements&#34;:[&#34;Count = Next(Count)&#34;]}}`,
-		`&#34;helpers&#34;:{&#34;Next&#34;:{&#34;params&#34;:[&#34;value&#34;],&#34;return&#34;:&#34;value + 1&#34;}}`,
+		`&#34;helpers&#34;:{&#34;Next&#34;:{&#34;params&#34;:[&#34;value&#34;],&#34;locals&#34;:[{&#34;name&#34;:&#34;doubled&#34;,&#34;expr&#34;:&#34;value * 2&#34;}],&#34;return&#34;:&#34;switch doubled { case 0: 1 default: doubled + 1 }&#34;}}`,
 		`data-gowdk-on-click="Add()"`,
 	} {
 		if !strings.Contains(html, expected) {
@@ -1107,6 +1108,7 @@ fn Add() {
 	js := readSharedIslandRuntime(t, outputDir)
 	for _, expected := range []string{
 		`function callHelper(name, args, state, helpers, stack)`,
+		`nextScope[local.name] = valueOf(local.expr || "", state, nextScope, helpers, stack.concat([name]));`,
 		`return callHelper(expr.name, args, state, helpers, stack);`,
 		`const helpers = client.helpers || {};`,
 	} {

--- a/internal/clientlang/clientlang.go
+++ b/internal/clientlang/clientlang.go
@@ -374,10 +374,18 @@ type Handler struct {
 // Helper is a return-valued component-local function callable from
 // expressions. Helpers cannot be called directly as event handlers.
 type Helper struct {
-	Params     []string    `json:"params,omitempty"`
-	ParamTypes []ValueType `json:"-"`
-	ReturnType ValueType   `json:"-"`
-	Return     string      `json:"return"`
+	Params     []string      `json:"params,omitempty"`
+	ParamTypes []ValueType   `json:"-"`
+	ReturnType ValueType     `json:"-"`
+	Locals     []HelperLocal `json:"locals,omitempty"`
+	Return     string        `json:"return"`
+}
+
+// HelperLocal is a scalar local evaluated before a helper's final return.
+type HelperLocal struct {
+	Name string    `json:"name"`
+	Expr string    `json:"expr"`
+	Type ValueType `json:"-"`
 }
 
 // Bootstrap is the runtime payload emitted into data-gowdk-client when a
@@ -747,10 +755,38 @@ func (program Program) HelperMap() map[string]Helper {
 			Params:     params,
 			ParamTypes: paramTypes,
 			ReturnType: NormalizeType(function.ReturnType),
-			Return:     strings.TrimSpace(strings.TrimPrefix(function.Statements[0], "return ")),
+			Locals:     helperLocals(function),
+			Return:     helperReturnExpr(function),
 		}
 	}
 	return helpers
+}
+
+func helperLocals(function Function) []HelperLocal {
+	if len(function.Statements) <= 1 {
+		return nil
+	}
+	locals := make([]HelperLocal, 0, len(function.Statements)-1)
+	for _, statement := range function.Statements[:len(function.Statements)-1] {
+		local, ok := parseLetStatement(statement)
+		if !ok {
+			continue
+		}
+		locals = append(locals, HelperLocal{
+			Name: local.Name,
+			Expr: local.Expr,
+			Type: NormalizeType(local.Type),
+		})
+	}
+	return locals
+}
+
+func helperReturnExpr(function Function) string {
+	if len(function.Statements) == 0 {
+		return ""
+	}
+	statement := strings.TrimSpace(function.Statements[len(function.Statements)-1])
+	return strings.TrimSpace(strings.TrimPrefix(statement, "return "))
 }
 
 // RefMap returns declared DOM refs keyed by name.
@@ -1124,16 +1160,29 @@ func validateFunctionReturnShape(function Function) error {
 		}
 		return nil
 	}
-	if len(function.Statements) != 1 {
-		return parseErrorf(function.Span.StartLine, "client helper function %s must contain exactly one return statement", function.Name)
+	if len(function.Statements) == 0 {
+		return parseErrorf(function.Span.StartLine, "client helper function %s must contain a final return statement", function.Name)
 	}
-	statement := strings.TrimSpace(function.Statements[0])
+	for index, statement := range function.Statements[:len(function.Statements)-1] {
+		statement = strings.TrimSpace(statement)
+		if strings.Contains(statement, "await ") {
+			return parseErrorf(functionStatementLine(function, index), "client helper function %s cannot use await", function.Name)
+		}
+		local, ok := parseLetStatement(statement)
+		if !ok {
+			return parseErrorf(functionStatementLine(function, index), "client helper function %s can only declare `let name type = expr` before its final return", function.Name)
+		}
+		if !isSupportedLocalType(NormalizeType(local.Type)) {
+			return parseErrorf(functionStatementLine(function, index), "client helper function %s local %q uses unsupported type %q", function.Name, local.Name, local.Type)
+		}
+	}
+	statement := strings.TrimSpace(function.Statements[len(function.Statements)-1])
 	if !strings.HasPrefix(statement, "return ") {
-		return parseErrorf(functionStatementLine(function, 0), "client helper function %s must use `return expr`", function.Name)
+		return parseErrorf(functionStatementLine(function, len(function.Statements)-1), "client helper function %s must end with `return expr`", function.Name)
 	}
 	expr := strings.TrimSpace(strings.TrimPrefix(statement, "return "))
 	if expr == "" {
-		return parseErrorf(functionStatementLine(function, 0), "client helper function %s must return an expression", function.Name)
+		return parseErrorf(functionStatementLine(function, len(function.Statements)-1), "client helper function %s must return an expression", function.Name)
 	}
 	return nil
 }
@@ -1163,7 +1212,7 @@ func isSupportedReturnType(value string) bool {
 
 func isReservedFunctionName(name string) bool {
 	switch name {
-	case "append", "remove", "move", "clear", "len", "lower", "upper", "contains", "string", "int", "float":
+	case "append", "remove", "move", "clear", "len", "lower", "upper", "contains", "string", "int", "float", "switch", "match":
 		return true
 	default:
 		return false
@@ -1247,7 +1296,7 @@ func allowsInlineBraceExpression(statement string) bool {
 	}
 	if right, ok := strings.CutPrefix(strings.TrimSpace(statement), "return "); ok {
 		right = strings.TrimSpace(right)
-		if !strings.HasPrefix(right, "if ") {
+		if !isInlineBraceExpressionStart(right) {
 			return false
 		}
 		_, err := ParseExpr(right)
@@ -1258,11 +1307,17 @@ func allowsInlineBraceExpression(statement string) bool {
 		return false
 	}
 	right := strings.TrimSpace(statement[assign+1:])
-	if !strings.HasPrefix(right, "if ") {
+	if !isInlineBraceExpressionStart(right) {
 		return false
 	}
 	_, err := ParseExpr(right)
 	return err == nil
+}
+
+func isInlineBraceExpressionStart(expr string) bool {
+	return strings.HasPrefix(expr, "if ") ||
+		strings.HasPrefix(expr, "switch ") ||
+		strings.HasPrefix(expr, "match ")
 }
 
 func balancedInlineBraces(source string) bool {

--- a/internal/clientlang/clientlang_test.go
+++ b/internal/clientlang/clientlang_test.go
@@ -198,6 +198,44 @@ fn Add() {
 	}
 }
 
+func TestParseHelperFunctionAllowsLocalStatementsBeforeReturn(t *testing.T) {
+	program, err := Parse(`
+fn Next(value int) int {
+  let doubled int = value * 2
+  let adjusted int = switch doubled { case 0: 1 default: doubled + 1 }
+  return adjusted
+}
+`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	helpers := program.HelperMap()
+	helper := helpers["Next"]
+	if helper.Return != "adjusted" || helper.ReturnType != TypeInt {
+		t.Fatalf("unexpected helper return: %#v", helper)
+	}
+	if len(helper.Locals) != 2 ||
+		helper.Locals[0].Name != "doubled" || helper.Locals[0].Expr != "value * 2" || helper.Locals[0].Type != TypeInt ||
+		helper.Locals[1].Name != "adjusted" || helper.Locals[1].Expr != `switch doubled { case 0: 1 default: doubled + 1 }` || helper.Locals[1].Type != TypeInt {
+		t.Fatalf("unexpected helper locals: %#v", helper.Locals)
+	}
+}
+
+func TestParseRejectsHelperNonLetBeforeReturn(t *testing.T) {
+	_, err := Parse(`
+fn Next(value int) int {
+  value = value + 1
+  return value
+}
+`)
+	if err == nil {
+		t.Fatal("expected helper local syntax error")
+	}
+	if !strings.Contains(err.Error(), "can only declare `let name type = expr`") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestParseRejectsReturnInEventHandler(t *testing.T) {
 	_, err := Parse(`
 fn Add() {

--- a/internal/clientlang/expr.go
+++ b/internal/clientlang/expr.go
@@ -127,6 +127,23 @@ type ConditionalExpr struct {
 
 func (ConditionalExpr) exprNode() {}
 
+// SwitchCase is one case branch in a switch or match expression.
+type SwitchCase struct {
+	Match Expr
+	Value Expr
+}
+
+// SwitchExpr chooses the first case whose match expression equals Value.
+type SwitchExpr struct {
+	Keyword string
+	Value   Expr
+	Cases   []SwitchCase
+	Default Expr
+	Span    ExprSourceSpan
+}
+
+func (SwitchExpr) exprNode() {}
+
 // ParseExpr parses the supported client expression subset.
 func ParseExpr(source string) (Expr, error) {
 	return ParseExprWithSpans(source)
@@ -170,6 +187,8 @@ func ExprSpan(expr Expr) ExprSourceSpan {
 	case BinaryExpr:
 		return typed.Span
 	case ConditionalExpr:
+		return typed.Span
+	case SwitchExpr:
 		return typed.Span
 	default:
 		return ExprSourceSpan{}

--- a/internal/clientlang/expr_canonical.go
+++ b/internal/clientlang/expr_canonical.go
@@ -44,6 +44,15 @@ func canonicalExpr(expr Expr) string {
 		return "(" + canonicalExpr(typed.Left) + " " + typed.Op + " " + canonicalExpr(typed.Right) + ")"
 	case ConditionalExpr:
 		return "if " + canonicalExpr(typed.Cond) + " { " + canonicalExpr(typed.Then) + " } else { " + canonicalExpr(typed.Else) + " }"
+	case SwitchExpr:
+		parts := make([]string, 0, len(typed.Cases)+2)
+		parts = append(parts, "switch "+canonicalExpr(typed.Value)+" {")
+		for _, item := range typed.Cases {
+			parts = append(parts, "case "+canonicalExpr(item.Match)+": "+canonicalExpr(item.Value))
+		}
+		parts = append(parts, "default: "+canonicalExpr(typed.Default))
+		parts = append(parts, "}")
+		return strings.Join(parts, " ")
 	default:
 		return ""
 	}

--- a/internal/clientlang/expr_check.go
+++ b/internal/clientlang/expr_check.go
@@ -158,28 +158,87 @@ func checkExpr(expr Expr, symbols map[string]ValueType, functions map[string]Exp
 		}
 		typ, err := checkConditionalBranches(thenType, elseType)
 		return typ, wrapExprError(typed, err)
+	case SwitchExpr:
+		valueType, err := checkExpr(typed.Value, symbols, functions, fields)
+		if err != nil {
+			return TypeUnknown, err
+		}
+		var branchType ValueType
+		branchSeen := false
+		for _, item := range typed.Cases {
+			matchType, err := checkExpr(item.Match, symbols, functions, fields)
+			if err != nil {
+				return TypeUnknown, err
+			}
+			if err := checkSwitchCaseType(valueType, matchType); err != nil {
+				return TypeUnknown, wrapExprError(item.Match, err)
+			}
+			caseType, err := checkExpr(item.Value, symbols, functions, fields)
+			if err != nil {
+				return TypeUnknown, err
+			}
+			if !branchSeen {
+				branchType = caseType
+				branchSeen = true
+			} else {
+				branchType, err = mergeBranchTypes(branchType, caseType, typed.Keyword)
+				if err != nil {
+					return TypeUnknown, wrapExprError(item.Value, err)
+				}
+			}
+		}
+		defaultType, err := checkExpr(typed.Default, symbols, functions, fields)
+		if err != nil {
+			return TypeUnknown, err
+		}
+		typ, err := mergeBranchTypes(branchType, defaultType, typed.Keyword)
+		return typ, wrapExprError(typed, err)
 	default:
 		return TypeUnknown, fmt.Errorf("unknown expression node")
 	}
 }
 
 func checkConditionalBranches(thenType, elseType ValueType) (ValueType, error) {
-	if thenType == TypeUnknown || elseType == TypeUnknown {
+	return mergeBranchTypes(thenType, elseType, "if")
+}
+
+func mergeBranchTypes(left, right ValueType, label string) (ValueType, error) {
+	if left == TypeUnknown || right == TypeUnknown {
 		return TypeUnknown, nil
 	}
-	if thenType == elseType {
-		return thenType, nil
+	if left == right {
+		return left, nil
 	}
-	if compatibleNumericType(thenType, elseType) {
-		if thenType == TypeFloat || elseType == TypeFloat {
+	if compatibleNumericType(left, right) {
+		if left == TypeFloat || right == TypeFloat {
 			return TypeFloat, nil
 		}
 		return TypeInt, nil
 	}
-	if thenType == TypeNil || elseType == TypeNil {
+	if left == TypeNil || right == TypeNil {
 		return TypeUnknown, fmt.Errorf("nil is only supported in == or != scalar comparisons")
 	}
-	return TypeUnknown, fmt.Errorf("if expression branches must have matching types, got %s and %s", thenType, elseType)
+	return TypeUnknown, fmt.Errorf("%s expression branches must have matching types, got %s and %s", label, left, right)
+}
+
+func checkSwitchCaseType(valueType, matchType ValueType) error {
+	if valueType == TypeUnknown || matchType == TypeUnknown {
+		return nil
+	}
+	if valueType == TypeNil || matchType == TypeNil {
+		other := valueType
+		if valueType == TypeNil {
+			other = matchType
+		}
+		if other == TypeNil || other == TypeArray || other == TypeObject {
+			return fmt.Errorf("switch case supports nil only with scalar values")
+		}
+		return nil
+	}
+	if valueType == matchType || compatibleNumericType(valueType, matchType) {
+		return nil
+	}
+	return fmt.Errorf("switch case requires comparable matching types, got %s and %s", valueType, matchType)
 }
 
 func checkBinaryExpr(op string, left, right ValueType) (ValueType, error) {

--- a/internal/clientlang/expr_collect.go
+++ b/internal/clientlang/expr_collect.go
@@ -46,6 +46,13 @@ func collectExprFields(expr Expr, fields map[string]bool) {
 		collectExprFields(typed.Cond, fields)
 		collectExprFields(typed.Then, fields)
 		collectExprFields(typed.Else, fields)
+	case SwitchExpr:
+		collectExprFields(typed.Value, fields)
+		for _, item := range typed.Cases {
+			collectExprFields(item.Match, fields)
+			collectExprFields(item.Value, fields)
+		}
+		collectExprFields(typed.Default, fields)
 	}
 }
 
@@ -70,6 +77,13 @@ func collectExprCalls(expr Expr, calls map[string]bool) {
 		collectExprCalls(typed.Cond, calls)
 		collectExprCalls(typed.Then, calls)
 		collectExprCalls(typed.Else, calls)
+	case SwitchExpr:
+		collectExprCalls(typed.Value, calls)
+		for _, item := range typed.Cases {
+			collectExprCalls(item.Match, calls)
+			collectExprCalls(item.Value, calls)
+		}
+		collectExprCalls(typed.Default, calls)
 	}
 }
 

--- a/internal/clientlang/expr_eval.go
+++ b/internal/clientlang/expr_eval.go
@@ -157,6 +157,21 @@ func evalExpr(expr Expr, values map[string]string) (any, error) {
 			return evalExpr(typed.Then, values)
 		}
 		return evalExpr(typed.Else, values)
+	case SwitchExpr:
+		value, err := evalExpr(typed.Value, values)
+		if err != nil {
+			return nil, err
+		}
+		for _, item := range typed.Cases {
+			match, err := evalExpr(item.Match, values)
+			if err != nil {
+				return nil, err
+			}
+			if valuesEqual(value, match) {
+				return evalExpr(item.Value, values)
+			}
+		}
+		return evalExpr(typed.Default, values)
 	default:
 		return nil, fmt.Errorf("unknown expression node")
 	}

--- a/internal/clientlang/expr_lexer.go
+++ b/internal/clientlang/expr_lexer.go
@@ -26,6 +26,7 @@ const (
 	tokenLBrace
 	tokenRBrace
 	tokenComma
+	tokenColon
 )
 
 type exprToken struct {
@@ -89,6 +90,10 @@ func (lexer *exprLexer) next() (exprToken, error) {
 		start := lexer.index
 		lexer.index++
 		return exprToken{kind: tokenComma, value: ",", start: start, end: lexer.index}, nil
+	case char == ':':
+		start := lexer.index
+		lexer.index++
+		return exprToken{kind: tokenColon, value: ":", start: start, end: lexer.index}, nil
 	default:
 		return lexer.operator()
 	}

--- a/internal/clientlang/expr_parser.go
+++ b/internal/clientlang/expr_parser.go
@@ -38,7 +38,13 @@ func (parser *exprParser) parseOr() (Expr, error) {
 
 func (parser *exprParser) parseConditional() (Expr, error) {
 	token := parser.peek()
-	if token.kind != tokenIdent || token.value != "if" {
+	if token.kind != tokenIdent {
+		return parser.parseOr()
+	}
+	if token.value == "switch" || token.value == "match" {
+		return parser.parseSwitch()
+	}
+	if token.value != "if" {
 		return parser.parseOr()
 	}
 	start := parser.consume()
@@ -73,6 +79,66 @@ func (parser *exprParser) parseConditional() (Expr, error) {
 		return nil, parser.expected("closing } after else branch", token)
 	}
 	return ConditionalExpr{Cond: cond, Then: thenExpr, Else: elseExpr, Span: mergeExprSpans(tokenSpan(start), tokenSpan(end))}, nil
+}
+
+func (parser *exprParser) parseSwitch() (Expr, error) {
+	start := parser.consume()
+	value, err := parser.parseOr()
+	if err != nil {
+		return nil, err
+	}
+	if token := parser.consume(); token.kind != tokenLBrace {
+		return nil, parser.expected("opening { after "+start.value+" value", token)
+	}
+	var cases []SwitchCase
+	var defaultExpr Expr
+	for {
+		token := parser.peek()
+		if token.kind == tokenRBrace {
+			if len(cases) == 0 {
+				return nil, fmt.Errorf("%s expression must contain at least one case", start.value)
+			}
+			if defaultExpr == nil {
+				return nil, fmt.Errorf("%s expression must contain a default branch", start.value)
+			}
+			end := parser.consume()
+			return SwitchExpr{Keyword: start.value, Value: value, Cases: cases, Default: defaultExpr, Span: mergeExprSpans(tokenSpan(start), tokenSpan(end))}, nil
+		}
+		if token.kind != tokenIdent {
+			return nil, parser.expected("case or default in "+start.value+" expression", token)
+		}
+		switch token.value {
+		case "case":
+			parser.consume()
+			match, err := parser.parseConditional()
+			if err != nil {
+				return nil, err
+			}
+			if token := parser.consume(); token.kind != tokenColon {
+				return nil, parser.expected(": after case expression", token)
+			}
+			expr, err := parser.parseConditional()
+			if err != nil {
+				return nil, err
+			}
+			cases = append(cases, SwitchCase{Match: match, Value: expr})
+		case "default":
+			parser.consume()
+			if defaultExpr != nil {
+				return nil, fmt.Errorf("%s expression must contain only one default branch", start.value)
+			}
+			if token := parser.consume(); token.kind != tokenColon {
+				return nil, parser.expected(": after default", token)
+			}
+			expr, err := parser.parseConditional()
+			if err != nil {
+				return nil, err
+			}
+			defaultExpr = expr
+		default:
+			return nil, parser.expected("case or default in "+start.value+" expression", token)
+		}
+	}
 }
 
 func (parser *exprParser) parseAnd() (Expr, error) {

--- a/internal/clientlang/expr_runtime_spec.go
+++ b/internal/clientlang/expr_runtime_spec.go
@@ -14,6 +14,7 @@ type ExpressionRuntimeSpec struct {
 	TermOperators     []string                `json:"termOperators"`
 	FactorOperators   []string                `json:"factorOperators"`
 	TokenOperators    []string                `json:"tokenOperators"`
+	SwitchKeywords    []string                `json:"switchKeywords"`
 }
 
 // ExpressionBuiltinSpec describes one compiler-owned client expression builtin.
@@ -42,6 +43,7 @@ func RuntimeExpressionSpec() ExpressionRuntimeSpec {
 		TermOperators:     []string{"+", "-"},
 		FactorOperators:   []string{"*", "/", "%"},
 		TokenOperators:    []string{"==", "!=", "<=", ">=", "&&", "||"},
+		SwitchKeywords:    []string{"switch", "match"},
 	}
 }
 

--- a/internal/clientlang/expr_test.go
+++ b/internal/clientlang/expr_test.go
@@ -69,6 +69,17 @@ func TestCanonicalExprNormalizesWhitespaceAndLiterals(t *testing.T) {
 	}
 }
 
+func TestCanonicalExprNormalizesMatchToSwitch(t *testing.T) {
+	got, err := CanonicalExpr(`match Status{case "draft":Label default:"Unknown"}`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := `switch Status { case "draft": Label default: "Unknown" }`
+	if got != want {
+		t.Fatalf("unexpected canonical expression:\nwant %s\ngot  %s", want, got)
+	}
+}
+
 func TestCheckExprRejectsTypeMismatch(t *testing.T) {
 	_, _, err := CheckExpr(`Count && Open`, map[string]ValueType{
 		"Count": TypeInt,
@@ -177,6 +188,22 @@ func TestCheckExprParsesConditionalInParenthesesAndIndex(t *testing.T) {
 	}
 	if typ != TypeString {
 		t.Fatalf("expected string type for conditional index, got %s", typ)
+	}
+}
+
+func TestCheckExprParsesSwitchExpression(t *testing.T) {
+	typ, fields, err := CheckExpr(`switch Status { case "draft": "Draft" case "live": Label default: "Unknown" }`, map[string]ValueType{
+		"Status": TypeString,
+		"Label":  TypeString,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if typ != TypeString {
+		t.Fatalf("expected string type, got %s", typ)
+	}
+	if strings.Join(fields, ",") != "Label,Status" {
+		t.Fatalf("unexpected fields: %#v", fields)
 	}
 }
 
@@ -299,11 +326,11 @@ func TestCheckExprRejectsNilObjectComparison(t *testing.T) {
 }
 
 func TestExprCallsCollectsHelperCalls(t *testing.T) {
-	calls, err := ExprCalls(`A(B(Count), if Open { C() } else { 0 })`)
+	calls, err := ExprCalls(`A(B(Count), if Open { C() } else { switch Kind { case "d": D() default: E() } })`)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if strings.Join(calls, ",") != "A,B,C" {
+	if strings.Join(calls, ",") != "A,B,C,D,E" {
 		t.Fatalf("unexpected calls: %#v", calls)
 	}
 }
@@ -329,6 +356,30 @@ func TestCheckExprRejectsGoishConditionalNonBoolCondition(t *testing.T) {
 		t.Fatal("expected non-bool condition diagnostic")
 	}
 	if !strings.Contains(err.Error(), "if expression condition requires bool") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestCheckExprRejectsSwitchCaseTypeMismatch(t *testing.T) {
+	_, _, err := CheckExpr(`switch Count { case "1": 1 default: 0 }`, map[string]ValueType{
+		"Count": TypeInt,
+	})
+	if err == nil {
+		t.Fatal("expected case type mismatch")
+	}
+	if !strings.Contains(err.Error(), "switch case requires comparable matching types") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestCheckExprRejectsSwitchBranchTypeMismatch(t *testing.T) {
+	_, _, err := CheckExpr(`switch Count { case 1: 1 default: "many" }`, map[string]ValueType{
+		"Count": TypeInt,
+	})
+	if err == nil {
+		t.Fatal("expected branch type mismatch")
+	}
+	if !strings.Contains(err.Error(), "switch expression branches must have matching types") {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
@@ -392,6 +443,19 @@ func TestEvalScalarEvaluatesGoishConditionalExpression(t *testing.T) {
 	}
 	if got != "Ada" {
 		t.Fatalf("expected Ada, got %q", got)
+	}
+}
+
+func TestEvalScalarEvaluatesSwitchExpression(t *testing.T) {
+	got, err := EvalScalar(`match Status { case "open": Count case "closed": 0 default: 1 }`, map[string]string{
+		"Count":  "3",
+		"Status": "open",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "3" {
+		t.Fatalf("expected 3, got %q", got)
 	}
 }
 

--- a/internal/clientrt/assets/island.js
+++ b/internal/clientrt/assets/island.js
@@ -23,6 +23,7 @@
     token: new Set(expressionSpec.tokenOperators || [])
   });
   const builtinSpecByName = Object.freeze(Object.fromEntries((expressionSpec.builtins || []).map((builtin) => [builtin.name, builtin])));
+  const expressionSwitchKeywords = new Set(expressionSpec.switchKeywords || []);
   const registry = window.__gowdkIslandRegistry || (window.__gowdkIslandRegistry = { components: Object.create(null), roots: new WeakMap() });
   window.__gowdkMountIslands = () => {
     Object.keys(registry.components).forEach((name) => mountComponentIsland(name, document));
@@ -59,6 +60,9 @@
     const nextScope = Object.create(null);
     (helper.params || []).forEach((param, index) => {
       nextScope[param] = args[index];
+    });
+    (helper.locals || []).forEach((local) => {
+      nextScope[local.name] = valueOf(local.expr || "", state, nextScope, helpers, stack.concat([name]));
     });
     return valueOf(helper.return || "", state, nextScope, helpers, stack.concat([name]));
   }
@@ -300,7 +304,37 @@
           this.expect("}");
           return { kind: "if", cond, thenExpr, elseExpr };
         }
+        if (this.peek().kind === "ident" && expressionSwitchKeywords.has(this.peek().value)) {
+          return this.parseSwitch();
+        }
         return this.parseOr();
+      },
+      parseSwitch() {
+        const keyword = this.expect("ident").value;
+        const value = this.parseOr();
+        this.expect("{");
+        const cases = [];
+        let defaultExpr = null;
+        for (;;) {
+          if (this.match("}")) {
+            if (!cases.length) throw new Error(keyword + " expression must contain at least one case");
+            if (!defaultExpr) throw new Error(keyword + " expression must contain a default branch");
+            return { kind: "switch", keyword, value, cases, defaultExpr };
+          }
+          if (this.match("ident", "case")) {
+            const match = this.parseConditional();
+            this.expect(":");
+            cases.push({ match, value: this.parseConditional() });
+            continue;
+          }
+          if (this.match("ident", "default")) {
+            if (defaultExpr) throw new Error(keyword + " expression must contain only one default branch");
+            this.expect(":");
+            defaultExpr = this.parseConditional();
+            continue;
+          }
+          throw new Error("expected case or default in " + keyword + " expression");
+        }
       },
       parseOr() {
         let expr = this.parseAnd();
@@ -490,6 +524,15 @@
         return requireBool("if", evalExpression(expr.cond, state, scope, helpers, stack))
           ? evalExpression(expr.thenExpr, state, scope, helpers, stack)
           : evalExpression(expr.elseExpr, state, scope, helpers, stack);
+      case "switch": {
+        const value = evalExpression(expr.value, state, scope, helpers, stack);
+        for (const item of expr.cases) {
+          if (deepEqual(value, evalExpression(item.match, state, scope, helpers, stack))) {
+            return evalExpression(item.value, state, scope, helpers, stack);
+          }
+        }
+        return evalExpression(expr.defaultExpr, state, scope, helpers, stack);
+      }
       default:
         throw new Error("unknown expression node");
     }

--- a/internal/clientrt/expression_conformance_test.go
+++ b/internal/clientrt/expression_conformance_test.go
@@ -51,6 +51,18 @@ func TestIslandExpressionRuntimeMatchesGoEvaluator(t *testing.T) {
 			State:  map[string]any{"Open": true, "Label": "Ada"},
 		},
 		{
+			Name:   "switch expression",
+			Expr:   `switch Status { case "draft": "Draft" case "live": Label default: "Unknown" }`,
+			Values: map[string]string{"Status": "live", "Label": "Published"},
+			State:  map[string]any{"Status": "live", "Label": "Published"},
+		},
+		{
+			Name:   "match expression",
+			Expr:   `match Count { case 0: "empty" case 1: "single" default: string(Count) }`,
+			Values: map[string]string{"Count": "3"},
+			State:  map[string]any{"Count": 3},
+		},
+		{
 			Name:   "nested member and index",
 			Expr:   `User.Open && Items[0].Name == "first"`,
 			Values: map[string]string{"User": `{"Name":"Ada","Open":true}`, "Items": `[{"Name":"first"},{"Name":"second"}]`},

--- a/internal/compiler/validate_component_client.go
+++ b/internal/compiler/validate_component_client.go
@@ -114,6 +114,58 @@ func validateComponentClient(component gwdkir.Component, stateTypes map[string]c
 		for _, param := range function.Params {
 			readFields[param.Name] = clientlang.NormalizeType(param.Type)
 		}
+		helperValid := true
+		for index, local := range helper.Locals {
+			if _, exists := readFields[local.Name]; exists {
+				diagnostics = append(diagnostics, ValidationError{
+					Code:          "component_client_error",
+					ComponentName: component.Name,
+					Source:        component.Source,
+					Span:          clientSpan(component, helperLocalSpan(function, index)),
+					Message:       fmt.Sprintf("component %s helper function %s local %q conflicts with an existing client value", component.Name, function.Name, local.Name),
+				})
+				helperValid = false
+				continue
+			}
+			actual, _, err := clientlang.CheckExprWithFunctions(local.Expr, readFields, helperFuncs)
+			if err != nil {
+				diagnostics = append(diagnostics, ValidationError{
+					Code:          "component_client_error",
+					ComponentName: component.Name,
+					Source:        component.Source,
+					Span:          clientExpressionErrorSpan(component, helperLocalStatement(function, index), helperLocalSpan(function, index), err),
+					Message:       fmt.Sprintf("component %s helper function %s local %s expression %q is invalid: %v", component.Name, function.Name, local.Name, local.Expr, err),
+				})
+				helperValid = false
+				continue
+			}
+			if actual == clientlang.TypeArray || actual == clientlang.TypeObject {
+				diagnostics = append(diagnostics, ValidationError{
+					Code:          "component_client_error",
+					ComponentName: component.Name,
+					Source:        component.Source,
+					Span:          clientSpan(component, helperLocalSpan(function, index)),
+					Message:       fmt.Sprintf("component %s helper function %s local %s cannot use %s expression", component.Name, function.Name, local.Name, actual),
+				})
+				helperValid = false
+				continue
+			}
+			if local.Type != clientlang.TypeUnknown && actual != clientlang.TypeUnknown && local.Type != actual && !compatibleNumericType(actual, local.Type) {
+				diagnostics = append(diagnostics, ValidationError{
+					Code:          "component_client_error",
+					ComponentName: component.Name,
+					Source:        component.Source,
+					Span:          clientSpan(component, helperLocalSpan(function, index)),
+					Message:       fmt.Sprintf("component %s helper function %s local %s expects %s, got %s", component.Name, function.Name, local.Name, local.Type, actual),
+				})
+				helperValid = false
+				continue
+			}
+			readFields[local.Name] = local.Type
+		}
+		if !helperValid {
+			continue
+		}
 		actual, _, err := clientlang.CheckExprWithFunctions(helper.Return, readFields, helperFuncs)
 		if err != nil {
 			diagnostics = append(diagnostics, ValidationError{
@@ -311,6 +363,20 @@ func functionReturnSpan(function clientlang.Function) clientlang.Span {
 	return function.StatementSpans[len(function.StatementSpans)-1]
 }
 
+func helperLocalSpan(function clientlang.Function, index int) clientlang.Span {
+	if index >= 0 && index < len(function.StatementSpans) {
+		return function.StatementSpans[index]
+	}
+	return function.Span
+}
+
+func helperLocalStatement(function clientlang.Function, index int) string {
+	if index >= 0 && index < len(function.Statements) {
+		return function.Statements[index]
+	}
+	return ""
+}
+
 func clientSpan(component gwdkir.Component, span clientlang.Span) source.SourceSpan {
 	return clientSpanColumns(component, span, 1, 2)
 }
@@ -371,6 +437,17 @@ func validateHelperCallGraph(helpers map[string]clientlang.Helper) error {
 	}
 	graph := map[string][]string{}
 	for name, helper := range helpers {
+		for _, local := range helper.Locals {
+			calls, err := clientlang.ExprCalls(local.Expr)
+			if err != nil {
+				return fmt.Errorf("%s local %s expression: %w", name, local.Name, err)
+			}
+			for _, call := range calls {
+				if _, ok := helpers[call]; ok {
+					graph[name] = append(graph[name], call)
+				}
+			}
+		}
 		calls, err := clientlang.ExprCalls(helper.Return)
 		if err != nil {
 			return fmt.Errorf("%s return expression: %w", name, err)

--- a/internal/compiler/validate_test.go
+++ b/internal/compiler/validate_test.go
@@ -2005,6 +2005,69 @@ fn Add() {
 	}
 }
 
+func TestValidateManifestAllowsClientHelperLocalsAndSwitch(t *testing.T) {
+	app := appFixture{Components: []gwdkir.Component{{
+		Name:    "Counter",
+		Source:  "components/counter.cmp.gwdk",
+		Imports: []gwdkir.Import{{Alias: "ui", Path: "github.com/cssbruno/gowdk/testfixture/islands"}},
+		State: gwdkir.StateContract{
+			Type: gwdkir.GoRef{Alias: "ui", Name: "CounterState"},
+			Init: gwdkir.GoRef{Alias: "ui", Name: "NewCounterState"},
+		},
+		Blocks: gwdkir.Blocks{
+			Client: true,
+			ClientBody: `fn Next(value int) int {
+  let next int = value + 1
+  return switch next { case 1: 1 default: next }
+}
+
+fn Add() {
+  Count = Next(Count)
+}`,
+			View:     true,
+			ViewBody: `<button g:on:click={Add()}>{Count}</button>`,
+		},
+	}}}
+
+	if err := validateManifest(gowdk.Config{}, app); err != nil {
+		t.Fatalf("expected client helper locals and switch to validate, got %v", err)
+	}
+}
+
+func TestValidateManifestRejectsClientHelperLocalMismatch(t *testing.T) {
+	app := appFixture{Components: []gwdkir.Component{{
+		Name:    "Counter",
+		Source:  "components/counter.cmp.gwdk",
+		Imports: []gwdkir.Import{{Alias: "ui", Path: "github.com/cssbruno/gowdk/testfixture/islands"}},
+		State: gwdkir.StateContract{
+			Type: gwdkir.GoRef{Alias: "ui", Name: "CounterState"},
+			Init: gwdkir.GoRef{Alias: "ui", Name: "NewCounterState"},
+		},
+		Blocks: gwdkir.Blocks{
+			Client: true,
+			ClientBody: `fn Bad(value int) int {
+  let next int = Open
+  return next
+}
+
+fn Add() {
+  Count = Bad(Count)
+}`,
+			View:     true,
+			ViewBody: `<button g:on:click={Add()}>{Count}</button>`,
+		},
+	}}}
+
+	err := validateManifest(gowdk.Config{}, app)
+	if err == nil {
+		t.Fatal("expected helper local mismatch diagnostic")
+	}
+	diagnostics := err.(ValidationErrors)
+	if !hasDiagnosticCode(diagnostics, "component_client_error") || !strings.Contains(err.Error(), "local next expects int, got bool") {
+		t.Fatalf("Missing helper local mismatch diagnostic: %#v", diagnostics)
+	}
+}
+
 func TestValidateManifestAllowsClientBuiltins(t *testing.T) {
 	app := appFixture{Components: []gwdkir.Component{{
 		Name:    "Nested",
@@ -2239,6 +2302,44 @@ fn Add() {
 	}
 	diagnostics := err.(ValidationErrors)
 	if !hasDiagnosticCode(diagnostics, "component_client_error") {
+		t.Fatalf("Missing component_client_error diagnostic: %#v", diagnostics)
+	}
+}
+
+func TestValidateManifestRejectsHelperCallCycleThroughLocal(t *testing.T) {
+	app := appFixture{Components: []gwdkir.Component{{
+		Name:    "Counter",
+		Source:  "components/counter.cmp.gwdk",
+		Imports: []gwdkir.Import{{Alias: "ui", Path: "github.com/cssbruno/gowdk/testfixture/islands"}},
+		State: gwdkir.StateContract{
+			Type: gwdkir.GoRef{Alias: "ui", Name: "CounterState"},
+			Init: gwdkir.GoRef{Alias: "ui", Name: "NewCounterState"},
+		},
+		Blocks: gwdkir.Blocks{
+			Client: true,
+			ClientBody: `fn A() int {
+  let next int = B()
+  return next
+}
+
+fn B() int {
+  return A()
+}
+
+fn Add() {
+  Count = A()
+}`,
+			View:     true,
+			ViewBody: `<button g:on:click={Add()}>{Count}</button>`,
+		},
+	}}}
+
+	err := validateManifest(gowdk.Config{}, app)
+	if err == nil {
+		t.Fatal("expected helper local call cycle diagnostic")
+	}
+	diagnostics := err.(ValidationErrors)
+	if !hasDiagnosticCode(diagnostics, "component_client_error") || !strings.Contains(err.Error(), "helper call graph is invalid") {
 		t.Fatalf("Missing component_client_error diagnostic: %#v", diagnostics)
 	}
 }

--- a/internal/lang/completion.go
+++ b/internal/lang/completion.go
@@ -35,6 +35,8 @@ func Completions() []Completion {
 		{Label: "fn", Detail: "Declare a client handler or helper function."},
 		{Label: "let", Detail: "Declare a local client variable."},
 		{Label: "return", Detail: "Return a value from a client helper or cleanup block."},
+		{Label: "switch", Detail: "Select a client expression branch by comparable value."},
+		{Label: "case", Detail: "Declare a branch in a client switch or match expression."},
 		{Label: "effect", Detail: "Declare a client effect block."},
 		{Label: "on mount", Detail: "Declare a component mount lifecycle block."},
 		{Label: "on destroy", Detail: "Declare a component destroy lifecycle block."},


### PR DESCRIPTION
## Summary
- add bounded inline `switch`/`match` expressions to the client expression parser, Go evaluator, typechecker, canonicalizer, dependency/call collectors, and browser island runtime
- allow return-valued client helpers to declare ordered scalar `let` locals before the final `return expr`, with compiler validation and helper call-cycle checks covering local initializers
- update docs, editor keyword support, generated island tests, runtime conformance tests, and the store-persist example

Closes #504.

Follow-up issues still open: #501, #505, #506, #509, #510.

## Verification
- `go test ./internal/clientlang`
- `go test ./internal/clientrt`
- `go test ./internal/compiler`
- `go test ./internal/buildgen`
- `go test ./internal/lang`
- `go test ./...`
- `go build ./cmd/gowdk`
- `go run ./cmd/gowdk build --out /tmp/gowdk-store-persist-pr examples/store-persist/*.gwdk`
- `scripts/test-go-modules.sh`