### PR TITLE
Harden tracing surfaces and constrain audit --run

### DIFF
--- a/cmd/gowdk/audit.go
+++ b/cmd/gowdk/audit.go
@@ -1,16 +1,17 @@
 package main
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
 	"go/parser"
 	"go/token"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/cssbruno/gowdk"
 	"github.com/cssbruno/gowdk/internal/appgen"
@@ -22,7 +23,7 @@ import (
 	"github.com/cssbruno/gowdk/internal/securitymanifest"
 )
 
-const auditUsage = "usage: gowdk audit [--config <file>] [--env-file <file>] [--module <name>] [--ssr] [--json] [--emit-tests[=<file>]] [--run] [files...]"
+const auditUsage = "usage: gowdk audit [--config <file>] [--env-file <file>] [--module <name>] [--ssr] [--json] [--emit-tests[=<file>]] [--run] [--run-timeout=<duration>] [files...]"
 
 // auditReport is the gowdk audit result: the derived security posture plus the
 // findings from evaluating the built-in baseline and declared policies against
@@ -65,9 +66,10 @@ type auditSummary struct {
 }
 
 type auditCommandOptions struct {
-	EmitTests bool
-	RunTests  bool
-	TestPath  string
+	EmitTests  bool
+	RunTests   bool
+	TestPath   string
+	RunTimeout time.Duration
 }
 
 type auditExitError struct {
@@ -153,6 +155,16 @@ func parseAuditCommandOptions(args []string) (auditCommandOptions, []string, err
 			}
 		case arg == "--run":
 			options.RunTests = true
+		case strings.HasPrefix(arg, "--run-timeout="):
+			value := strings.TrimSpace(strings.TrimPrefix(arg, "--run-timeout="))
+			duration, err := time.ParseDuration(value)
+			if err != nil {
+				return options, nil, fmt.Errorf("invalid --run-timeout %q: %w", value, err)
+			}
+			if duration <= 0 {
+				return options, nil, fmt.Errorf("invalid --run-timeout %q: must be positive", value)
+			}
+			options.RunTimeout = duration
 		default:
 			projectArgs = append(projectArgs, arg)
 		}
@@ -191,21 +203,50 @@ func handleAuditTests(auditOptions auditCommandOptions, options cliOptions, ir g
 		return nil, nil
 	}
 
-	runPath, output, err := runGeneratedAppAuditTests(options, ir)
-	if err == nil {
-		if runPath != "" {
-			fmt.Fprintf(os.Stderr, "audit generated app tests passed: %s\n", runPath)
-		}
+	runOptions := defaultAuditRunOptions()
+	if auditOptions.RunTimeout > 0 {
+		runOptions.Timeout = auditOptions.RunTimeout
+	}
+
+	testPath, result, err := runGeneratedAppAuditTests(options, ir, runOptions)
+	if err != nil {
+		return nil, err
+	}
+	if testPath == "" {
+		// No generated audit tests exist for this program; nothing to run.
 		return nil, nil
 	}
-	return []auditspec.Finding{{
-		Code:        "audit_test_failed",
-		Severity:    auditDiagnosticSeverity("audit_test_failed"),
-		Target:      "runtime",
-		Source:      runPath,
-		Message:     "generated audit integration tests failed",
-		Remediation: "Run gowdk audit --run locally, then update generated runtime behavior or policy expectations.",
-	}}, writeAuditRunOutput(output)
+
+	switch {
+	case result.TimedOut:
+		writeAuditRunOutput(result)
+		fmt.Fprintf(os.Stderr, "audit generated app tests timed out after %s: %s\n", runOptions.Timeout, testPath)
+		return []auditspec.Finding{{
+			Code:        "audit_test_timeout",
+			Severity:    auditDiagnosticSeverity("audit_test_timeout"),
+			Target:      "runtime",
+			Source:      testPath,
+			Message:     fmt.Sprintf("generated audit integration tests timed out after %s", runOptions.Timeout),
+			Remediation: "Investigate the hanging test, or raise the deadline with gowdk audit --run --run-timeout=<duration>.",
+		}}, nil
+	case result.ExitErr != nil:
+		writeAuditRunOutput(result)
+		message := "generated audit integration tests failed"
+		if result.Truncated {
+			message += " (output truncated)"
+		}
+		return []auditspec.Finding{{
+			Code:        "audit_test_failed",
+			Severity:    auditDiagnosticSeverity("audit_test_failed"),
+			Target:      "runtime",
+			Source:      testPath,
+			Message:     message,
+			Remediation: "Run gowdk audit --run locally, then update generated runtime behavior or policy expectations.",
+		}}, nil
+	default:
+		fmt.Fprintf(os.Stderr, "audit generated app tests passed: %s\n", testPath)
+		return nil, nil
+	}
 }
 
 func standaloneAuditPackageName(dir string) string {
@@ -224,34 +265,40 @@ func standaloneAuditPackageName(dir string) string {
 	return names[0] + "_test"
 }
 
-func runGeneratedAppAuditTests(options cliOptions, ir gwdkir.Program) (string, string, error) {
+// runGeneratedAppAuditTests builds and generates a throwaway app from the
+// validated IR, then runs its audit test package under the bounded execution
+// boundary in runAuditTestCommand. The returned testPath is empty when the
+// program has no generated audit tests. A non-nil error reports an
+// infrastructure failure (build or generation); test execution outcomes,
+// including non-zero exit and timeout, are reported through auditRunResult.
+func runGeneratedAppAuditTests(options cliOptions, ir gwdkir.Program, runOptions auditRunOptions) (string, auditRunResult, error) {
 	source, err := appgen.GeneratedAuditTestSource(appgen.OptionsFromIR(options.Config, &ir))
 	if err != nil || len(source) == 0 {
-		return "", "", err
+		return "", auditRunResult{}, err
 	}
 
 	tempRoot, err := os.MkdirTemp("", "gowdk-audit-run-*")
 	if err != nil {
-		return "", "", err
+		return "", auditRunResult{}, err
 	}
 	defer os.RemoveAll(tempRoot)
 
 	outputDir := filepath.Join(tempRoot, "output")
 	appDir := filepath.Join(tempRoot, "app")
 	if _, err := buildgen.BuildFromValidatedIR(options.Config, ir, outputDir); err != nil {
-		return "", "", err
+		return "", auditRunResult{}, err
 	}
 	app, err := appgen.GenerateWithOptions(outputDir, appDir, appgen.OptionsFromIR(options.Config, &ir))
 	if err != nil {
-		return "", "", err
+		return "", auditRunResult{}, err
 	}
 	if err := writeGeneratedAppAuditRunHooks(app.AppDir, ir); err != nil {
-		return "", "", err
+		return "", auditRunResult{}, err
 	}
 
 	testPath := filepath.Join(app.AppDir, "gowdkapp", "gowdk_audit_test.go")
-	output, err := runGeneratedAppTestPackage(app.AppDir)
-	return testPath, output, err
+	result := runAuditTestCommand(context.Background(), app.AppDir, runOptions)
+	return testPath, result, nil
 }
 
 func writeGeneratedAppAuditRunHooks(appDir string, ir gwdkir.Program) error {
@@ -376,19 +423,15 @@ func auditGuardsUseNativeRBAC(guards []string) bool {
 	return false
 }
 
-func runGeneratedAppTestPackage(appDir string) (string, error) {
-	command := exec.Command("go", "test", "./gowdkapp")
-	command.Dir = appDir
-	output, err := command.CombinedOutput()
-	return string(output), err
-}
-
-func writeAuditRunOutput(output string) error {
-	output = strings.TrimSpace(output)
-	if output != "" {
+// writeAuditRunOutput prints the bounded test output to stderr, followed by an
+// explicit truncation marker when the output exceeded the capture limit.
+func writeAuditRunOutput(result auditRunResult) {
+	if output := strings.TrimSpace(result.Output); output != "" {
 		fmt.Fprintln(os.Stderr, output)
 	}
-	return nil
+	if result.Truncated {
+		fmt.Fprintln(os.Stderr, auditRunTruncationMarker)
+	}
 }
 
 func auditDiagnosticSeverity(code string) diagnostics.Severity {

--- a/cmd/gowdk/audit_run.go
+++ b/cmd/gowdk/audit_run.go
@@ -1,0 +1,160 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"os/exec"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	// defaultAuditRunTimeout bounds how long `gowdk audit --run` lets the
+	// generated app test process run before it is killed. Override it with
+	// --run-timeout=<duration>.
+	defaultAuditRunTimeout = 2 * time.Minute
+	// defaultAuditRunOutputLimit bounds the combined stdout/stderr captured from
+	// the test process so a runaway test cannot overwhelm CI logs or memory.
+	defaultAuditRunOutputLimit = 1 << 20 // 1 MiB
+	// auditRunTruncationMarker is printed after bounded output when the test
+	// process produced more than the limit, so truncation is explicit.
+	auditRunTruncationMarker = "... [gowdk audit] test output truncated at the configured limit ..."
+)
+
+// auditRunOptions configures the execution boundary for `gowdk audit --run`.
+type auditRunOptions struct {
+	Timeout        time.Duration
+	MaxOutputBytes int
+	// Seeds are environment variables explicitly seeded into the otherwise
+	// minimized test environment (for example a deterministic audit-run marker).
+	Seeds map[string]string
+}
+
+func defaultAuditRunOptions() auditRunOptions {
+	return auditRunOptions{
+		Timeout:        defaultAuditRunTimeout,
+		MaxOutputBytes: defaultAuditRunOutputLimit,
+		Seeds:          map[string]string{"GOWDK_AUDIT_RUN": "1"},
+	}
+}
+
+// auditRunResult reports the outcome of a single audit test execution. Timeout,
+// process failure, and output truncation are distinct so callers can report
+// them distinctly.
+type auditRunResult struct {
+	Output    string
+	Truncated bool
+	TimedOut  bool
+	ExitErr   error
+}
+
+// runAuditTestCommand runs `go test` for the generated audit app under a strict
+// execution boundary: a deadline (exec.CommandContext), a sanitized environment
+// with dependency downloads disabled, and a bounded combined output buffer.
+func runAuditTestCommand(ctx context.Context, dir string, options auditRunOptions) auditRunResult {
+	if options.Timeout <= 0 {
+		options.Timeout = defaultAuditRunTimeout
+	}
+	if options.MaxOutputBytes <= 0 {
+		options.MaxOutputBytes = defaultAuditRunOutputLimit
+	}
+	runCtx, cancel := context.WithTimeout(ctx, options.Timeout)
+	defer cancel()
+
+	output := &boundedBuffer{limit: options.MaxOutputBytes}
+	command := exec.CommandContext(runCtx, "go", "test", "-count=1", "./gowdkapp")
+	command.Dir = dir
+	command.Env = auditTestEnv(os.Environ(), options.Seeds)
+	command.Stdout = output
+	command.Stderr = output
+
+	err := command.Run()
+	result := auditRunResult{Output: output.String(), Truncated: output.Truncated()}
+	if runCtx.Err() == context.DeadlineExceeded {
+		result.TimedOut = true
+		return result
+	}
+	result.ExitErr = err
+	return result
+}
+
+// auditTestEnv builds a minimized environment for the audit test process. It
+// keeps only the Go toolchain and GOWDK variables required to compile and run
+// the generated app, drops everything else so local secrets are not leaked into
+// the test process, and forces dependency downloads and toolchain fetches off so
+// an audit run cannot reach the network.
+func auditTestEnv(base []string, seeds map[string]string) []string {
+	allowed := map[string]bool{
+		"PATH": true, "HOME": true,
+		"GOROOT": true, "GOPATH": true, "GOCACHE": true,
+		"GOMODCACHE": true, "GOTMPDIR": true,
+		"CGO_ENABLED": true, "GOOS": true, "GOARCH": true,
+		// Windows toolchain and cache discovery.
+		"SYSTEMROOT": true, "SYSTEMDRIVE": true, "TEMP": true, "TMP": true,
+		"USERPROFILE": true, "LOCALAPPDATA": true, "APPDATA": true,
+	}
+	env := make([]string, 0, len(allowed)+len(seeds)+6)
+	for _, entry := range base {
+		key, _, ok := strings.Cut(entry, "=")
+		if !ok {
+			continue
+		}
+		upper := strings.ToUpper(key)
+		if allowed[upper] || strings.HasPrefix(upper, "GOWDK_") {
+			env = append(env, entry)
+		}
+	}
+	// Deterministic overrides: resolve modules from the local cache only and
+	// never fetch from the network, so an audit run is hermetic.
+	env = append(env,
+		"GOPROXY=off",
+		"GOSUMDB=off",
+		"GOTOOLCHAIN=local",
+		"GOWORK=off",
+		"GOFLAGS=-mod=mod",
+	)
+	for key, value := range seeds {
+		env = append(env, key+"="+value)
+	}
+	return env
+}
+
+// boundedBuffer captures up to limit bytes of combined output and records
+// whether more was produced. Writes past the limit are discarded but reported
+// as fully written so the child process is not killed by a short write.
+type boundedBuffer struct {
+	mu        sync.Mutex
+	buffer    bytes.Buffer
+	limit     int
+	truncated bool
+}
+
+func (b *boundedBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if remaining := b.limit - b.buffer.Len(); remaining > 0 {
+		if len(p) > remaining {
+			b.buffer.Write(p[:remaining])
+			b.truncated = true
+		} else {
+			b.buffer.Write(p)
+		}
+	} else if len(p) > 0 {
+		b.truncated = true
+	}
+	return len(p), nil
+}
+
+func (b *boundedBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buffer.String()
+}
+
+func (b *boundedBuffer) Truncated() bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.truncated
+}

--- a/cmd/gowdk/audit_run.go
+++ b/cmd/gowdk/audit_run.go
@@ -21,6 +21,9 @@ const (
 	// auditRunTruncationMarker is printed after bounded output when the test
 	// process produced more than the limit, so truncation is explicit.
 	auditRunTruncationMarker = "... [gowdk audit] test output truncated at the configured limit ..."
+	// auditRunCommandGrace lets the generated test binary handle Go's own
+	// -timeout panic before the parent go command is killed by context.
+	auditRunCommandGrace = 5 * time.Second
 )
 
 // auditRunOptions configures the execution boundary for `gowdk audit --run`.
@@ -60,11 +63,11 @@ func runAuditTestCommand(ctx context.Context, dir string, options auditRunOption
 	if options.MaxOutputBytes <= 0 {
 		options.MaxOutputBytes = defaultAuditRunOutputLimit
 	}
-	runCtx, cancel := context.WithTimeout(ctx, options.Timeout)
+	runCtx, cancel := context.WithTimeout(ctx, options.Timeout+auditRunCommandGrace)
 	defer cancel()
 
 	output := &boundedBuffer{limit: options.MaxOutputBytes}
-	command := exec.CommandContext(runCtx, "go", "test", "-count=1", "./gowdkapp")
+	command := exec.CommandContext(runCtx, "go", "test", "-count=1", "-timeout="+options.Timeout.String(), "./gowdkapp")
 	command.Dir = dir
 	command.Env = auditTestEnv(os.Environ(), options.Seeds)
 	command.Stdout = output
@@ -72,12 +75,16 @@ func runAuditTestCommand(ctx context.Context, dir string, options auditRunOption
 
 	err := command.Run()
 	result := auditRunResult{Output: output.String(), Truncated: output.Truncated()}
-	if runCtx.Err() == context.DeadlineExceeded {
+	if runCtx.Err() == context.DeadlineExceeded || auditRunOutputTimedOut(result.Output) {
 		result.TimedOut = true
 		return result
 	}
 	result.ExitErr = err
 	return result
+}
+
+func auditRunOutputTimedOut(output string) bool {
+	return strings.Contains(output, "panic: test timed out")
 }
 
 // auditTestEnv builds a minimized environment for the audit test process. It
@@ -113,12 +120,43 @@ func auditTestEnv(base []string, seeds map[string]string) []string {
 		"GOSUMDB=off",
 		"GOTOOLCHAIN=local",
 		"GOWORK=off",
-		"GOFLAGS=-mod=mod",
+		"GOFLAGS="+auditRunGOFlags(base),
 	)
 	for key, value := range seeds {
 		env = append(env, key+"="+value)
 	}
 	return env
+}
+
+func auditRunGOFlags(base []string) string {
+	flags := auditSafeGOFlags(base)
+	flags = append(flags, "-mod=mod")
+	return strings.Join(flags, " ")
+}
+
+func auditSafeGOFlags(base []string) []string {
+	for _, entry := range base {
+		key, value, ok := strings.Cut(entry, "=")
+		if !ok || !strings.EqualFold(key, "GOFLAGS") {
+			continue
+		}
+		fields := strings.Fields(value)
+		flags := make([]string, 0, len(fields))
+		for index := 0; index < len(fields); index++ {
+			field := fields[index]
+			switch {
+			case field == "-tags" || field == "--tags":
+				if index+1 < len(fields) {
+					flags = append(flags, field, fields[index+1])
+					index++
+				}
+			case strings.HasPrefix(field, "-tags="), strings.HasPrefix(field, "--tags="):
+				flags = append(flags, field)
+			}
+		}
+		return flags
+	}
+	return nil
 }
 
 // boundedBuffer captures up to limit bytes of combined output and records

--- a/cmd/gowdk/audit_run_test.go
+++ b/cmd/gowdk/audit_run_test.go
@@ -1,0 +1,192 @@
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// writeAuditRunModule creates a throwaway module whose ./gowdkapp package holds
+// the given test file body, mirroring the layout runAuditTestCommand expects.
+func writeAuditRunModule(t *testing.T, testBody string) string {
+	t.Helper()
+	dir := t.TempDir()
+	writeAuditRunFile(t, filepath.Join(dir, "go.mod"), "module gowdkaudittest\n\ngo 1.26\n")
+	pkgDir := filepath.Join(dir, "gowdkapp")
+	if err := os.MkdirAll(pkgDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeAuditRunFile(t, filepath.Join(pkgDir, "app.go"), "package gowdkapp\n")
+	writeAuditRunFile(t, filepath.Join(pkgDir, "app_test.go"), testBody)
+	return dir
+}
+
+func writeAuditRunFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRunAuditTestCommandTimesOut(t *testing.T) {
+	dir := writeAuditRunModule(t, `package gowdkapp
+
+import (
+	"testing"
+	"time"
+)
+
+func TestSleeps(t *testing.T) { time.Sleep(60 * time.Second) }
+`)
+	options := defaultAuditRunOptions()
+	options.Timeout = time.Second
+
+	result := runAuditTestCommand(context.Background(), dir, options)
+	if !result.TimedOut {
+		t.Fatalf("expected timeout, got %#v", result)
+	}
+}
+
+func TestRunAuditTestCommandReportsFailure(t *testing.T) {
+	dir := writeAuditRunModule(t, `package gowdkapp
+
+import "testing"
+
+func TestFails(t *testing.T) { t.Fatal("intentional failure") }
+`)
+	result := runAuditTestCommand(context.Background(), dir, defaultAuditRunOptions())
+	if result.TimedOut {
+		t.Fatalf("did not expect timeout: %#v", result)
+	}
+	if result.ExitErr == nil {
+		t.Fatalf("expected non-zero test exit, got %#v", result)
+	}
+	if !strings.Contains(result.Output, "intentional failure") {
+		t.Fatalf("expected failure output captured, got %q", result.Output)
+	}
+}
+
+func TestRunAuditTestCommandBoundsOutput(t *testing.T) {
+	// The test fails so go test relays its (large) output back to the runner;
+	// a passing test's output would be buffered and hidden.
+	dir := writeAuditRunModule(t, `package gowdkapp
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestLoud(t *testing.T) {
+	t.Log(strings.Repeat("x", 200000))
+	t.Fatal("loud test fails so its output is relayed")
+}
+`)
+	options := defaultAuditRunOptions()
+	options.MaxOutputBytes = 4096
+
+	result := runAuditTestCommand(context.Background(), dir, options)
+	if !result.Truncated {
+		t.Fatalf("expected truncation, got %#v", result.Truncated)
+	}
+	if len(result.Output) > options.MaxOutputBytes {
+		t.Fatalf("output not bounded: len=%d limit=%d", len(result.Output), options.MaxOutputBytes)
+	}
+}
+
+func TestRunAuditTestCommandSeedsAndMinimizesEnv(t *testing.T) {
+	t.Setenv("MY_CLOUD_SECRET", "leak")
+	dir := writeAuditRunModule(t, `package gowdkapp
+
+import (
+	"os"
+	"testing"
+)
+
+func TestEnv(t *testing.T) {
+	if os.Getenv("GOWDK_AUDIT_RUN") != "1" {
+		t.Fatalf("missing seed GOWDK_AUDIT_RUN=%q", os.Getenv("GOWDK_AUDIT_RUN"))
+	}
+	if leaked := os.Getenv("MY_CLOUD_SECRET"); leaked != "" {
+		t.Fatalf("secret leaked into test env: %q", leaked)
+	}
+}
+`)
+	result := runAuditTestCommand(context.Background(), dir, defaultAuditRunOptions())
+	if result.TimedOut || result.ExitErr != nil {
+		t.Fatalf("expected env test to pass, got %#v\noutput:\n%s", result, result.Output)
+	}
+}
+
+func TestAuditTestEnvMinimizesAndSeeds(t *testing.T) {
+	base := []string{
+		"PATH=/usr/bin",
+		"HOME=/home/u",
+		"AWS_SECRET=shh",
+		"GOWDK_CUSTOM=keep",
+		"GOPROXY=https://proxy.example",
+	}
+	env := envMap(auditTestEnv(base, map[string]string{"GOWDK_AUDIT_RUN": "1"}))
+
+	if env["PATH"] != "/usr/bin" || env["HOME"] != "/home/u" {
+		t.Fatalf("required Go variables were dropped: %#v", env)
+	}
+	if env["GOWDK_CUSTOM"] != "keep" {
+		t.Fatal("GOWDK_-prefixed variable should pass through")
+	}
+	if _, leaked := env["AWS_SECRET"]; leaked {
+		t.Fatal("non-allowlisted secret should be dropped")
+	}
+	if env["GOPROXY"] != "off" || env["GOTOOLCHAIN"] != "local" {
+		t.Fatalf("download-disabling overrides missing: GOPROXY=%q GOTOOLCHAIN=%q", env["GOPROXY"], env["GOTOOLCHAIN"])
+	}
+	if env["GOWDK_AUDIT_RUN"] != "1" {
+		t.Fatal("explicit seed missing")
+	}
+}
+
+func TestBoundedBufferTruncates(t *testing.T) {
+	buffer := &boundedBuffer{limit: 10}
+	if n, _ := buffer.Write([]byte("hello")); n != 5 {
+		t.Fatalf("short write reported n=%d", n)
+	}
+	if n, _ := buffer.Write([]byte("world!!!")); n != 8 {
+		t.Fatalf("over-limit write must report full length, got n=%d", n)
+	}
+	if !buffer.Truncated() {
+		t.Fatal("expected buffer to report truncation")
+	}
+	if got := buffer.String(); got != "helloworld" {
+		t.Fatalf("bounded content = %q, want %q", got, "helloworld")
+	}
+}
+
+func TestParseAuditCommandOptionsRunTimeout(t *testing.T) {
+	options, _, err := parseAuditCommandOptions([]string{"--run", "--run-timeout=90s"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !options.RunTests || options.RunTimeout != 90*time.Second {
+		t.Fatalf("unexpected options: %#v", options)
+	}
+	if _, _, err := parseAuditCommandOptions([]string{"--run-timeout=nonsense"}); err == nil {
+		t.Fatal("expected error for invalid duration")
+	}
+	if _, _, err := parseAuditCommandOptions([]string{"--run-timeout=-5s"}); err == nil {
+		t.Fatal("expected error for non-positive duration")
+	}
+}
+
+func envMap(env []string) map[string]string {
+	out := make(map[string]string, len(env))
+	for _, entry := range env {
+		key, value, ok := strings.Cut(entry, "=")
+		if !ok {
+			continue
+		}
+		out[key] = value
+	}
+	return out
+}

--- a/cmd/gowdk/audit_run_test.go
+++ b/cmd/gowdk/audit_run_test.go
@@ -48,6 +48,9 @@ func TestSleeps(t *testing.T) { time.Sleep(60 * time.Second) }
 	if !result.TimedOut {
 		t.Fatalf("expected timeout, got %#v", result)
 	}
+	if !strings.Contains(result.Output, "panic: test timed out") {
+		t.Fatalf("expected Go test timeout output, got %q", result.Output)
+	}
 }
 
 func TestRunAuditTestCommandReportsFailure(t *testing.T) {
@@ -127,6 +130,7 @@ func TestAuditTestEnvMinimizesAndSeeds(t *testing.T) {
 		"AWS_SECRET=shh",
 		"GOWDK_CUSTOM=keep",
 		"GOPROXY=https://proxy.example",
+		"GOFLAGS=-tags=enterprise -mod=vendor -ldflags=-X=secret",
 	}
 	env := envMap(auditTestEnv(base, map[string]string{"GOWDK_AUDIT_RUN": "1"}))
 
@@ -139,11 +143,18 @@ func TestAuditTestEnvMinimizesAndSeeds(t *testing.T) {
 	if _, leaked := env["AWS_SECRET"]; leaked {
 		t.Fatal("non-allowlisted secret should be dropped")
 	}
-	if env["GOPROXY"] != "off" || env["GOTOOLCHAIN"] != "local" {
-		t.Fatalf("download-disabling overrides missing: GOPROXY=%q GOTOOLCHAIN=%q", env["GOPROXY"], env["GOTOOLCHAIN"])
+	if env["GOPROXY"] != "off" || env["GOTOOLCHAIN"] != "local" || env["GOFLAGS"] != "-tags=enterprise -mod=mod" {
+		t.Fatalf("download-disabling overrides missing: GOPROXY=%q GOTOOLCHAIN=%q GOFLAGS=%q", env["GOPROXY"], env["GOTOOLCHAIN"], env["GOFLAGS"])
 	}
 	if env["GOWDK_AUDIT_RUN"] != "1" {
 		t.Fatal("explicit seed missing")
+	}
+}
+
+func TestAuditSafeGOFlagsPreservesSeparateTagsValue(t *testing.T) {
+	flags := auditSafeGOFlags([]string{"GOFLAGS=-tags enterprise,sqlite -trimpath"})
+	if got := strings.Join(flags, " "); got != "-tags enterprise,sqlite" {
+		t.Fatalf("safe GOFLAGS = %q, want -tags enterprise,sqlite", got)
 	}
 }
 

--- a/docs/language/audit.md
+++ b/docs/language/audit.md
@@ -77,7 +77,10 @@ Raw HTML allowlist values match either the exact source reference reported by
 `test {}` blocks become generated Go tests. `gowdk audit --emit-tests` writes a
 readable standalone `gowdk_audit_test.go`; `gowdk audit --run` builds a
 temporary generated app and runs its generated `gowdkapp/gowdk_audit_test.go`
-with `go test ./gowdkapp`.
+with `go test ./gowdkapp`. The run is bounded: a default 2m deadline
+(`--run-timeout=<duration>` overrides it), truncated combined output, and a
+minimized, download-free environment. A timeout is reported as
+`audit_test_timeout`, distinct from an expectation failure (`audit_test_failed`).
 
 Supported expectations:
 

--- a/docs/product/observability-tracing-spec.md
+++ b/docs/product/observability-tracing-spec.md
@@ -52,6 +52,37 @@ Sentry, or a hosted observability backend.
 - The exporter adapter produces an OTLP-like span shape without importing
   OpenTelemetry packages.
 
+### Hardening
+
+- Console output is for development and local diagnostics. `ConsoleSink` escapes
+  control characters in every field (span names, status messages, source paths,
+  and event messages), so untrusted values cannot forge log lines or emit
+  terminal control sequences. Use `JSONLSink` for production logging where
+  downstream tooling parses structured records.
+- Trace and span IDs come from an injectable `IDGenerator`. The default
+  `CryptoIDGenerator` uses `crypto/rand` and never falls back to a predictable
+  value: on entropy failure it records the loss through `EntropyFailureCount` and
+  the handler set by `SetEntropyFailureHandler`, and the tracer drops the span
+  rather than emit a guessable ID. Tests inject deterministic IDs through
+  `WithIDGenerator`.
+- `SourceRef.File` is normalized before a snapshot leaves the process. The
+  default `SourcePolicy` (relative mode) reduces absolute filesystem paths to
+  project-relative logical paths consistently across the viewer, JSON/SSE,
+  console, and OTLP surfaces; `SourcePathAbsolute` is an opt-in debug mode for
+  local development only. In production, only project-relative source paths
+  leave the process.
+- The `runtime/trace/otel` bridge distinguishes GOWDK-owned providers (`NewSink`,
+  and `NewSinkWithProvider(nil)`) from app-owned providers
+  (`NewSinkWithProvider(provider)`): `Shutdown` only shuts down a provider the
+  sink owns, unless `WithProviderShutdown` transfers ownership.
+  `WithNativeIdentity` asserts the provider uses `SnapshotIDGenerator`, so GOWDK
+  IDs are not duplicated as attributes; otherwise they are preserved as
+  `gowdk.trace_id`/`gowdk.span_id`. The bridge sets span kind by lane, preserves
+  event level as `gowdk.event.level`, applies a stable instrumentation
+  name/version and default `service.name` resource, converts only the closed
+  scalar/array value model, and drops unsupported values (counted, and listed in
+  `gowdk.dropped_attributes`) instead of stringifying them.
+
 ### Non-Functional
 
 - Runtime package imports must stay standard-library only.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -23,7 +23,7 @@ gowdk inspect ir|tree|endpoint-graph|asset-graph|go-bindings [--config <file>] [
 gowdk generate stubs [--config <file>] [--env-file <file>] [--module <name>] [--ssr] [files...]
 gowdk explain [--json] <diagnostic-code>
 gowdk doctor [--config <file>] [--env-file <file>] [--module <name>] [--ssr] [--json] [files...]
-gowdk audit [--config <file>] [--env-file <file>] [--module <name>] [--ssr] [--json] [--emit-tests[=<file>]] [--run] [files...]
+gowdk audit [--config <file>] [--env-file <file>] [--module <name>] [--ssr] [--json] [--emit-tests[=<file>]] [--run] [--run-timeout=<duration>] [files...]
 gowdk contracts [--json] [dir]
 gowdk graph [--json] [dir]
 gowdk trace <contract> [--json] [dir]
@@ -70,8 +70,13 @@ gowdk lsp [--ssr]
   path from `--emit-tests=<file>`) that drives a `runtime/app` posture harness
   through `runtime/testkit`. `--run` builds a temporary generated app from the
   same validated IR and runs the generated app's audit test with
-  `go test ./gowdkapp`; a failed expectation is reported as
-  `audit_test_failed`.
+  `go test ./gowdkapp` under a strict execution boundary: a default 2m deadline
+  (override with `--run-timeout=<duration>`), bounded combined output truncated
+  with an explicit marker, and a minimized environment that keeps only the Go and
+  `GOWDK_*` variables required to run and disables dependency downloads
+  (`GOPROXY=off`, `GOTOOLCHAIN=local`). A failed expectation is reported as
+  `audit_test_failed`; exceeding the deadline is reported distinctly as
+  `audit_test_timeout`.
   `gowdk build` runs the same baseline gate, blocks production builds on
   error-severity findings unless `--allow-insecure` is set, and writes the
   posture alone to a non-served `.gowdk/reports/<output-name>/gowdk-security.json`

--- a/docs/reference/diagnostic-codes.md
+++ b/docs/reference/diagnostic-codes.md
@@ -184,7 +184,8 @@ Parser diagnostics emit stable codes for common unsupported syntax and keep
   `audit_observability_production_exposed`,
   `audit_raw_html_sink`, `audit_max_body_exceeds_policy`,
   `audit_public_not_allowed`, `audit_required_guard_missing`,
-  `audit_runtime_mismatch`, `audit_test_failed`, `policy_duplicate_name`,
+  `audit_runtime_mismatch`, `audit_test_failed`, `audit_test_timeout`,
+  `policy_duplicate_name`,
   `policy_extends_cycle`, `policy_unknown_extends`,
   `policy_unknown_selector`, `policy_selector_matched_nothing`. These are
   experimental and emitted by `gowdk audit`, declared audit policies, or the

--- a/internal/appgen/appgen_test.go
+++ b/internal/appgen/appgen_test.go
@@ -1301,6 +1301,59 @@ func TestGenerateObservabilityTracesSSRRouteAndLoad(t *testing.T) {
 	}
 }
 
+func TestGenerateObservabilityNormalizesAbsoluteSourcePaths(t *testing.T) {
+	root := t.TempDir()
+	outputDir := filepath.Join(root, "dist")
+	appDir := filepath.Join(root, "generated-app")
+	writeTestFile(t, filepath.Join(outputDir, "dashboard", "index.html"), "<main>Dashboard</main>")
+
+	config := csrfDisabledConfig()
+	config.Addons = []gowdk.Addon{gowdk.NewAddon("observability", gowdk.FeatureObservability)}
+	pageSource := filepath.Join(root, "pages", "dashboard.page.gwdk")
+	ssrRoute := SSRRoute{
+		PageID:     "dashboard",
+		Route:      "/dashboard",
+		Render:     gowdk.SSR,
+		Guards:     []string{"public"},
+		HasLoad:    true,
+		Source:     pageSource,
+		SourceSpan: source.SourceSpan{Start: source.SourcePosition{Line: 3, Column: 1}},
+		LoadBinding: source.BackendBinding{
+			Kind:         "load",
+			PageID:       "dashboard",
+			Source:       pageSource,
+			Span:         source.SourceSpan{Start: source.SourcePosition{Line: 6, Column: 1}},
+			Status:       source.BackendBindingBound,
+			ImportPath:   "example.com/app/dashboard",
+			PackageName:  "dashboard",
+			FunctionName: "LoadDashboard",
+			Signature:    source.BackendSignatureLoadError,
+		},
+		HTML: "<main>Dashboard</main>",
+	}
+
+	result, err := GenerateWithOptions(outputDir, appDir, Options{Config: config, SSR: []SSRRoute{ssrRoute}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload, err := os.ReadFile(result.PackagePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	generated := string(payload)
+	if strings.Contains(generated, filepath.ToSlash(root)) {
+		t.Fatalf("generated trace source leaked project root %q:\n%s", root, generated)
+	}
+	for _, expected := range []string{
+		`gowdktrace.WithSource(gowdktrace.SourceRef{File: "pages/dashboard.page.gwdk", Line: 3, Column: 1, OwnerKind: "page", OwnerID: "dashboard"})`,
+		`gowdktrace.WithSource(gowdktrace.SourceRef{File: "pages/dashboard.page.gwdk", Line: 6, Column: 1, OwnerKind: "load", OwnerID: "dashboard"})`,
+	} {
+		if !strings.Contains(generated, expected) {
+			t.Fatalf("expected generated source to contain %q:\n%s", expected, generated)
+		}
+	}
+}
+
 func TestGenerateSkipsSingleFlightRegionRenderersForGuardedRoutes(t *testing.T) {
 	root := t.TempDir()
 	outputDir := filepath.Join(root, "dist")

--- a/internal/appgen/auto_routes.go
+++ b/internal/appgen/auto_routes.go
@@ -2,7 +2,9 @@ package appgen
 
 import (
 	"fmt"
+	"os"
 	"path"
+	"path/filepath"
 	"sort"
 	"strings"
 	"unicode"
@@ -10,11 +12,13 @@ import (
 	"github.com/cssbruno/gowdk/internal/buildgen"
 	"github.com/cssbruno/gowdk/internal/gwdkir"
 	"github.com/cssbruno/gowdk/internal/source"
+	gowdktrace "github.com/cssbruno/gowdk/runtime/trace"
 )
 
 func resolveOptions(outputDir string, options Options) (Options, error) {
 	resolved := options
 	if !options.AutoRoutes {
+		normalizeTraceSources(&resolved, filepath.Dir(outputDir), nil)
 		assignBackendAliases(&resolved)
 		return resolved, nil
 	}
@@ -44,6 +48,7 @@ func resolveOptions(outputDir string, options Options) (Options, error) {
 	resolved.APIs = append(append([]APIEndpoint(nil), options.APIs...), apis...)
 	resolved.Fragments = append(append([]FragmentEndpoint(nil), options.Fragments...), fragments...)
 	resolved.SSR = append(append([]SSRRoute(nil), options.SSR...), ssrRoutes(ssrArtifacts)...)
+	normalizeTraceSources(&resolved, filepath.Dir(outputDir), &ir)
 	assignBackendAliases(&resolved)
 	return resolved, nil
 }
@@ -51,6 +56,7 @@ func resolveOptions(outputDir string, options Options) (Options, error) {
 func resolveBackendOptions(options Options) (Options, error) {
 	resolved := options
 	if !options.AutoRoutes {
+		normalizeTraceSources(&resolved, "", nil)
 		assignBackendAliases(&resolved)
 		return resolved, nil
 	}
@@ -74,6 +80,7 @@ func resolveBackendOptions(options Options) (Options, error) {
 	resolved.APIs = append(append([]APIEndpoint(nil), options.APIs...), apis...)
 	resolved.Fragments = append(append([]FragmentEndpoint(nil), options.Fragments...), fragments...)
 	resolved.SSR = nil
+	normalizeTraceSources(&resolved, "", &ir)
 	assignBackendAliases(&resolved)
 	return resolved, nil
 }
@@ -86,6 +93,113 @@ func optionsIR(options Options) (gwdkir.Program, error) {
 		return *options.IR, nil
 	}
 	return gwdkir.Program{}, fmt.Errorf("auto route detection requires compiler IR")
+}
+
+func normalizeTraceSources(options *Options, outputRoot string, ir *gwdkir.Program) {
+	normalizer := newTraceSourceNormalizer(outputRoot, ir)
+	for index := range options.Actions {
+		options.Actions[index].Source = normalizer.normalize(options.Actions[index].Source)
+		options.Actions[index].Binding = normalizeTraceBindingSource(options.Actions[index].Binding, normalizer)
+	}
+	for index := range options.APIs {
+		options.APIs[index].Source = normalizer.normalize(options.APIs[index].Source)
+		options.APIs[index].Binding = normalizeTraceBindingSource(options.APIs[index].Binding, normalizer)
+	}
+	for index := range options.Fragments {
+		options.Fragments[index].Source = normalizer.normalize(options.Fragments[index].Source)
+		options.Fragments[index].Binding = normalizeTraceBindingSource(options.Fragments[index].Binding, normalizer)
+	}
+	for index := range options.SSR {
+		options.SSR[index].Source = normalizer.normalize(options.SSR[index].Source)
+		options.SSR[index].LoadBinding = normalizeTraceBindingSource(options.SSR[index].LoadBinding, normalizer)
+	}
+}
+
+func normalizeTraceBindingSource(binding source.BackendBinding, normalizer traceSourceNormalizer) source.BackendBinding {
+	binding.Source = normalizer.normalize(binding.Source)
+	return binding
+}
+
+type traceSourceNormalizer struct {
+	roots []string
+}
+
+func newTraceSourceNormalizer(outputRoot string, ir *gwdkir.Program) traceSourceNormalizer {
+	var roots []string
+	addRoot := func(root string) {
+		root = strings.TrimSpace(root)
+		if root == "" {
+			return
+		}
+		abs, err := filepath.Abs(root)
+		if err != nil {
+			return
+		}
+		abs = filepath.Clean(abs)
+		for _, existing := range roots {
+			if existing == abs {
+				return
+			}
+		}
+		roots = append(roots, abs)
+	}
+
+	addRoot(outputRoot)
+	if workingDir, err := os.Getwd(); err == nil {
+		addRoot(workingDir)
+	}
+	if ir != nil {
+		for _, pkg := range ir.Packages {
+			for _, dir := range pkg.SourceDirs {
+				addRoot(filepath.Dir(dir))
+				addRoot(dir)
+			}
+		}
+	}
+	return traceSourceNormalizer{roots: roots}
+}
+
+func (normalizer traceSourceNormalizer) normalize(file string) string {
+	file = strings.TrimSpace(file)
+	if file == "" {
+		return ""
+	}
+	if !isAbsoluteTraceSource(file) {
+		return gowdktrace.NormalizeSourceFile(file, gowdktrace.SourcePolicy{})
+	}
+	for _, root := range normalizer.roots {
+		if rel, ok := relativeTraceSource(root, file); ok {
+			return gowdktrace.NormalizeSourceFile(rel, gowdktrace.SourcePolicy{})
+		}
+	}
+	return gowdktrace.NormalizeSourceFile(file, gowdktrace.SourcePolicy{})
+}
+
+func isAbsoluteTraceSource(file string) bool {
+	slashed := strings.ReplaceAll(file, `\`, "/")
+	return filepath.IsAbs(file) ||
+		strings.HasPrefix(slashed, "//") ||
+		(len(slashed) >= 3 && slashed[1] == ':' && slashed[2] == '/' && isASCIILetter(slashed[0]))
+}
+
+func relativeTraceSource(root string, file string) (string, bool) {
+	absFile := file
+	if !filepath.IsAbs(absFile) {
+		var err error
+		absFile, err = filepath.Abs(absFile)
+		if err != nil {
+			return "", false
+		}
+	}
+	rel, err := filepath.Rel(root, filepath.Clean(absFile))
+	if err != nil || rel == "." || rel == ".." || strings.HasPrefix(rel, "../") || strings.HasPrefix(rel, `..\`) {
+		return "", false
+	}
+	return filepath.ToSlash(rel), true
+}
+
+func isASCIILetter(char byte) bool {
+	return (char >= 'a' && char <= 'z') || (char >= 'A' && char <= 'Z')
 }
 
 func assignBackendAliases(options *Options) {

--- a/internal/diagnostics/explain.go
+++ b/internal/diagnostics/explain.go
@@ -415,6 +415,13 @@ guard public
 			"Fix the handler, the guard configuration, or the test expectation as appropriate.",
 		},
 	},
+	"audit_test_timeout": {
+		Details: "gowdk audit --run executes the generated app's audit tests under a strict deadline (default 2m). The run exceeded that deadline and was terminated, so the audit could not confirm the runtime posture.",
+		NextSteps: []string{
+			"Inspect the generated app for a hanging handler, guard, or test before trusting the posture.",
+			"Raise the deadline for a legitimately slow suite with gowdk audit --run --run-timeout=<duration>.",
+		},
+	},
 	"policy_duplicate_name": {
 		Details: "Two audit policies declare the same name. Policy names must be unique so extends and override resolution is unambiguous.",
 		NextSteps: []string{

--- a/internal/diagnostics/registry.go
+++ b/internal/diagnostics/registry.go
@@ -83,6 +83,7 @@ var Registry = []Code{
 	{Code: "audit_required_guard_missing", Area: "audit", Stability: StabilityExperimental, Severity: SeverityError, Summary: "target does not declare a role or permission guard required by policy"},
 	{Code: "audit_runtime_mismatch", Area: "audit", Stability: StabilityExperimental, Severity: SeverityError, Summary: "runtime behavior does not match the declared security posture"},
 	{Code: "audit_test_failed", Area: "audit", Stability: StabilityExperimental, Severity: SeverityError, Summary: "an audit integration test expectation did not hold"},
+	{Code: "audit_test_timeout", Area: "audit", Stability: StabilityExperimental, Severity: SeverityError, Summary: "the audit integration test run exceeded its deadline"},
 	{Code: "backend_binding_required", Area: "backend", Stability: StabilityStable, Severity: SeverityError, Summary: "strict builds require a supported backend handler binding"},
 	{Code: "client_go_block_wasm_build_error", Area: "wasm", Stability: StabilityExperimental, Severity: SeverityError, Summary: "page go client WASM build failed"},
 	{Code: "client_go_block_wasm_entrypoint_error", Area: "wasm", Stability: StabilityExperimental, Severity: SeverityError, Summary: "page go client WASM entrypoint is missing or invalid"},

--- a/runtime/app/app_test.go
+++ b/runtime/app/app_test.go
@@ -24,6 +24,12 @@ import (
 	gowdktrace "github.com/cssbruno/gowdk/runtime/trace"
 )
 
+type invalidTraceIDGenerator struct{}
+
+func (invalidTraceIDGenerator) NewTraceID() gowdktrace.TraceID { return "" }
+
+func (invalidTraceIDGenerator) NewSpanID() gowdktrace.SpanID { return "" }
+
 func TestHandlerServesAppIndexAndIdentityHeaders(t *testing.T) {
 	handler := Handler{
 		Root: fstest.MapFS{
@@ -2135,6 +2141,28 @@ func TestTracedBackendRouteRecordsEndpointLanes(t *testing.T) {
 				t.Fatalf("route attr = %#v, want /patients", got)
 			}
 		})
+	}
+}
+
+func TestTracedBackendRouteContinuesWhenSpanDropped(t *testing.T) {
+	ring := gowdktrace.NewRingSink(1)
+	tracer := gowdktrace.NewTracer(gowdktrace.WithSink(ring), gowdktrace.WithIDGenerator(invalidTraceIDGenerator{}))
+	handler := traceBackendRoute("action", "/patients", gowdktrace.SourceRef{}, func(writer http.ResponseWriter, request *http.Request) bool {
+		writer.WriteHeader(http.StatusNoContent)
+		return true
+	})
+	request := httptest.NewRequest(http.MethodPost, "/patients", nil)
+	request = request.WithContext(gowdktrace.ContextWithTracer(request.Context(), tracer))
+	recorder := httptest.NewRecorder()
+
+	if !handler(recorder, request) {
+		t.Fatal("expected backend handler to run after dropped span")
+	}
+	if recorder.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusNoContent)
+	}
+	if spans := ring.Spans(); len(spans) != 0 {
+		t.Fatalf("spans = %d, want 0 after ID generation failure", len(spans))
 	}
 }
 

--- a/runtime/app/backend.go
+++ b/runtime/app/backend.go
@@ -261,9 +261,14 @@ func traceBackendRoute(kind, routePath string, source gowdktrace.SourceRef, hand
 		)
 		defer func() {
 			if recovered := recover(); recovered != nil {
-				span.SetStatus(gowdktrace.StatusError, redactSecrets(strings.TrimSpace(fmt.Sprint(recovered))))
-				span.End()
+				if span != nil {
+					span.SetStatus(gowdktrace.StatusError, redactSecrets(strings.TrimSpace(fmt.Sprint(recovered))))
+					span.End()
+				}
 				panic(recovered)
+			}
+			if span == nil {
+				return
 			}
 			span.Set(gowdktrace.AttrHTTPResponseStatusCode, traceRecorder.status)
 			if traceRecorder.status >= 500 {

--- a/runtime/guard/guard.go
+++ b/runtime/guard/guard.go
@@ -35,12 +35,16 @@ func RunGuardsWithAuth(ctx Context, names []string, registry Registry, provider 
 		guardCtx, span := startGuardTrace(ctx, name)
 		ctx.Context = guardCtx
 		if err := guard(ctx); err != nil {
-			span.SetStatus(gowdktrace.StatusError, security.RedactSecrets(err.Error()))
-			span.End()
+			if span != nil {
+				span.SetStatus(gowdktrace.StatusError, security.RedactSecrets(err.Error()))
+				span.End()
+			}
 			return fmt.Errorf("guard %q failed: %w", name, err)
 		}
-		span.SetStatus(gowdktrace.StatusOK, "")
-		span.End()
+		if span != nil {
+			span.SetStatus(gowdktrace.StatusOK, "")
+			span.End()
+		}
 	}
 	return nil
 }

--- a/runtime/guard/guard_test.go
+++ b/runtime/guard/guard_test.go
@@ -14,6 +14,12 @@ import (
 	gowdktrace "github.com/cssbruno/gowdk/runtime/trace"
 )
 
+type invalidTraceIDGenerator struct{}
+
+func (invalidTraceIDGenerator) NewTraceID() gowdktrace.TraceID { return "" }
+
+func (invalidTraceIDGenerator) NewSpanID() gowdktrace.SpanID { return "" }
+
 func TestNewContextCarriesRequestContext(t *testing.T) {
 	request, err := http.NewRequestWithContext(context.WithValue(context.Background(), "trace", "abc"), http.MethodGet, "/dashboard", nil)
 	if err != nil {
@@ -81,6 +87,30 @@ func TestRunGuardsRecordsFailedGuardSpan(t *testing.T) {
 	}
 	if spans[0].Name != "guard auth.required" || spans[0].Lane != gowdktrace.LaneGuard || spans[0].Status.Code != gowdktrace.StatusError {
 		t.Fatalf("unexpected guard span: %#v", spans[0])
+	}
+}
+
+func TestRunGuardsContinuesWhenSpanDropped(t *testing.T) {
+	ring := gowdktrace.NewRingSink(1)
+	tracer := gowdktrace.NewTracer(gowdktrace.WithSink(ring), gowdktrace.WithIDGenerator(invalidTraceIDGenerator{}))
+	request := httptest.NewRequest(http.MethodGet, "/dashboard", nil)
+	request = request.WithContext(gowdktrace.ContextWithTracer(request.Context(), tracer))
+	called := false
+
+	err := RunGuards(NewContext(request, nil), []string{"auth.required"}, Registry{
+		"auth.required": func(Context) error {
+			called = true
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("expected guard to pass after dropped span, got %v", err)
+	}
+	if !called {
+		t.Fatal("guard was not called")
+	}
+	if spans := ring.Spans(); len(spans) != 0 {
+		t.Fatalf("spans = %d, want 0 after ID generation failure", len(spans))
 	}
 }
 

--- a/runtime/trace/collector.go
+++ b/runtime/trace/collector.go
@@ -103,6 +103,11 @@ func (collector *Collector) RecordSpan(ctx context.Context, span Snapshot) error
 	if collector == nil {
 		return nil
 	}
+	// Normalize here so externally ingested spans (browser POST) are subject to
+	// the same source-path policy as locally produced spans before they reach
+	// the JSON, SSE, or viewer surfaces. Locally produced spans are already
+	// normalized; re-applying the policy is idempotent.
+	span = normalizeSnapshotSource(span)
 	if err := collector.ring.RecordSpan(ctx, span); err != nil {
 		return err
 	}

--- a/runtime/trace/console_test.go
+++ b/runtime/trace/console_test.go
@@ -1,0 +1,66 @@
+package trace_test
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/cssbruno/gowdk/runtime/trace"
+)
+
+func TestConsoleSinkEscapesControlCharacters(t *testing.T) {
+	span := trace.Snapshot{
+		Name:    "GET /p\n[forged] injected=line",
+		TraceID: trace.NewTraceID(),
+		SpanID:  trace.NewSpanID(),
+		Surface: trace.SurfaceBackend,
+		Lane:    trace.LaneRoute,
+		Status:  trace.Status{Code: trace.StatusError, Message: "boom\r\nlevel=fatal"},
+		Source:  trace.SourceRef{File: "pages/\x1b[31mhome.gwdk", Line: 2},
+		Events: []trace.Event{
+			{Message: "loaded\tpatients\nfake=event", Level: "info"},
+		},
+	}
+
+	var buffer bytes.Buffer
+	if err := trace.NewConsoleSink(&buffer).RecordSpan(context.Background(), span); err != nil {
+		t.Fatal(err)
+	}
+	out := buffer.String()
+
+	if count := strings.Count(out, "\n"); count != 1 {
+		t.Fatalf("console output forged extra log lines (%d newlines): %q", count, out)
+	}
+	if !strings.HasSuffix(out, "\n") {
+		t.Fatalf("console output is not newline-terminated: %q", out)
+	}
+	for _, forbidden := range []string{"\r", "\x1b", "\t"} {
+		if strings.ContainsRune(out, []rune(forbidden)[0]) {
+			t.Fatalf("console output contains a raw control character %q: %q", forbidden, out)
+		}
+	}
+	// Span name, status message, source field, and event message must all be
+	// present but escaped.
+	for _, want := range []string{`GET /p\n[forged]`, `boom\r\nlevel=fatal`, `\x1b[31mhome.gwdk`, `loaded\tpatients\nfake=event`} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("console output missing escaped field %q in %q", want, out)
+		}
+	}
+}
+
+func TestConsoleSinkKeepsNormalSpansReadable(t *testing.T) {
+	span := trace.Snapshot{
+		Name:    "GET /patients",
+		TraceID: trace.NewTraceID(),
+		SpanID:  trace.NewSpanID(),
+		Status:  trace.Status{Code: trace.StatusOK},
+	}
+	var buffer bytes.Buffer
+	if err := trace.NewConsoleSink(&buffer).RecordSpan(context.Background(), span); err != nil {
+		t.Fatal(err)
+	}
+	if got := buffer.String(); !strings.HasPrefix(got, "GET /patients trace=") {
+		t.Fatalf("normal span lost its readable form: %q", got)
+	}
+}

--- a/runtime/trace/idgen.go
+++ b/runtime/trace/idgen.go
@@ -1,0 +1,124 @@
+package trace
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"sync/atomic"
+)
+
+// IDGenerator produces trace and span identifiers for new spans.
+//
+// The default generator (CryptoIDGenerator) draws identifiers from
+// crypto/rand. Provide a custom generator with WithIDGenerator to make IDs
+// deterministic in tests, or to source identity from another subsystem. A
+// generator may report transient failure by returning an empty (invalid) ID;
+// the tracer treats that as "cannot start a span" rather than substituting a
+// predictable identifier.
+type IDGenerator interface {
+	// NewTraceID returns a valid W3C trace ID, or "" if one cannot be produced.
+	NewTraceID() TraceID
+	// NewSpanID returns a valid W3C span ID, or "" if one cannot be produced.
+	NewSpanID() SpanID
+}
+
+// maxEntropyAttempts bounds how many times the crypto generator retries a
+// failed read before giving up and returning an invalid ID. crypto/rand
+// failures are extraordinary; the bound prevents an unbounded spin while still
+// tolerating a transient hiccup.
+const maxEntropyAttempts = 16
+
+// entropyRead reads cryptographic randomness for the default ID generator. It
+// is a package variable so tests can simulate a CSPRNG failure without making
+// crypto/rand actually fail.
+var entropyRead = rand.Read
+
+// entropyFailures counts crypto/rand failures observed by the default ID
+// generator since process start.
+var entropyFailures atomic.Uint64
+
+// onEntropyFailure, when non-nil, is invoked for each crypto/rand failure
+// observed by the default ID generator.
+var onEntropyFailure atomic.Pointer[func(error)]
+
+// EntropyFailureCount reports how many crypto/rand failures the default ID
+// generator has observed since process start. It is zero on healthy systems.
+// A non-zero value means trace/span identity could not be generated from the
+// system CSPRNG and the affected spans were dropped rather than assigned a
+// predictable identifier.
+func EntropyFailureCount() uint64 {
+	return entropyFailures.Load()
+}
+
+// SetEntropyFailureHandler installs a callback invoked for each crypto/rand
+// failure observed by the default ID generator. Pass nil to clear it.
+//
+// The handler must not start spans or otherwise re-enter the tracer: doing so
+// during an entropy failure can recurse. Use it to increment an external
+// metric or emit a single rate-limited alert.
+func SetEntropyFailureHandler(handler func(error)) {
+	if handler == nil {
+		onEntropyFailure.Store(nil)
+		return
+	}
+	onEntropyFailure.Store(&handler)
+}
+
+func reportEntropyFailure(err error) {
+	entropyFailures.Add(1)
+	if handler := onEntropyFailure.Load(); handler != nil {
+		(*handler)(err)
+	}
+}
+
+// CryptoIDGenerator is the default IDGenerator. It reads identifiers from
+// crypto/rand and never falls back to predictable values such as timestamps or
+// sequence counters. On the (extraordinary) event of a crypto/rand failure it
+// records the failure via EntropyFailureCount and the entropy failure handler,
+// then returns an invalid ID so the caller can observe the loss instead of
+// emitting a guessable identifier.
+type CryptoIDGenerator struct{}
+
+// NewTraceID implements IDGenerator.
+func (CryptoIDGenerator) NewTraceID() TraceID {
+	var buf [16]byte
+	if !readEntropy(buf[:]) {
+		return ""
+	}
+	id := TraceID(hex.EncodeToString(buf[:]))
+	if !id.Valid() {
+		return ""
+	}
+	return id
+}
+
+// NewSpanID implements IDGenerator.
+func (CryptoIDGenerator) NewSpanID() SpanID {
+	var buf [8]byte
+	if !readEntropy(buf[:]) {
+		return ""
+	}
+	id := SpanID(hex.EncodeToString(buf[:]))
+	if !id.Valid() {
+		return ""
+	}
+	return id
+}
+
+// readEntropy fills buf from crypto/rand, retrying a bounded number of times on
+// failure. Each failure is reported. It returns false only when entropy could
+// not be read at all, which is the signal to drop identity rather than degrade
+// to a predictable value.
+func readEntropy(buf []byte) bool {
+	for attempt := 0; attempt < maxEntropyAttempts; attempt++ {
+		if _, err := entropyRead(buf); err == nil {
+			return true
+		} else {
+			reportEntropyFailure(err)
+		}
+	}
+	return false
+}
+
+// defaultIDGenerator backs the package-level NewTraceID/NewSpanID helpers and
+// any tracer constructed without WithIDGenerator.
+var defaultIDGenerator IDGenerator = CryptoIDGenerator{}

--- a/runtime/trace/idgen_internal_test.go
+++ b/runtime/trace/idgen_internal_test.go
@@ -1,0 +1,62 @@
+package trace
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestCryptoIDGeneratorReportsEntropyFailure(t *testing.T) {
+	previousRead := entropyRead
+	previousHandler := onEntropyFailure.Load()
+	t.Cleanup(func() {
+		entropyRead = previousRead
+		onEntropyFailure.Store(previousHandler)
+	})
+
+	wantErr := errors.New("no entropy")
+	entropyRead = func([]byte) (int, error) { return 0, wantErr }
+
+	handled := 0
+	SetEntropyFailureHandler(func(err error) {
+		if !errors.Is(err, wantErr) {
+			t.Errorf("handler error = %v, want %v", err, wantErr)
+		}
+		handled++
+	})
+
+	before := EntropyFailureCount()
+	if id := (CryptoIDGenerator{}).NewTraceID(); id != "" {
+		t.Fatalf("NewTraceID under entropy failure = %q, want empty (no predictable fallback)", id)
+	}
+	if id := (CryptoIDGenerator{}).NewSpanID(); id != "" {
+		t.Fatalf("NewSpanID under entropy failure = %q, want empty (no predictable fallback)", id)
+	}
+	if EntropyFailureCount() <= before {
+		t.Fatalf("EntropyFailureCount did not increase: before=%d after=%d", before, EntropyFailureCount())
+	}
+	if handled == 0 {
+		t.Fatal("entropy failure handler was not invoked")
+	}
+}
+
+func TestCryptoIDGeneratorRecoversAfterTransientFailure(t *testing.T) {
+	previousRead := entropyRead
+	t.Cleanup(func() { entropyRead = previousRead })
+
+	calls := 0
+	entropyRead = func(buf []byte) (int, error) {
+		calls++
+		if calls == 1 {
+			return 0, errors.New("transient")
+		}
+		for i := range buf {
+			buf[i] = 0x42
+		}
+		return len(buf), nil
+	}
+
+	id := (CryptoIDGenerator{}).NewTraceID()
+	if !id.Valid() {
+		t.Fatalf("expected a valid trace id after a transient failure, got %q", id)
+	}
+}

--- a/runtime/trace/idgen_test.go
+++ b/runtime/trace/idgen_test.go
@@ -1,0 +1,81 @@
+package trace_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cssbruno/gowdk/runtime/trace"
+)
+
+// staticIDGenerator returns fixed IDs so tests can assert deterministic
+// identity without relying on entropy failure.
+type staticIDGenerator struct {
+	traceID trace.TraceID
+	spanID  trace.SpanID
+}
+
+func (generator staticIDGenerator) NewTraceID() trace.TraceID { return generator.traceID }
+func (generator staticIDGenerator) NewSpanID() trace.SpanID   { return generator.spanID }
+
+func TestWithIDGeneratorInjectsDeterministicIDs(t *testing.T) {
+	wantTrace := trace.TraceID("0123456789abcdef0123456789abcdef")
+	wantSpan := trace.SpanID("0123456789abcdef")
+	tracer := trace.NewTracer(trace.WithIDGenerator(staticIDGenerator{traceID: wantTrace, spanID: wantSpan}))
+
+	_, span := tracer.Start(context.Background(), "unit")
+	if span == nil {
+		t.Fatal("expected sampled span")
+	}
+	got := span.TraceContext()
+	if got.TraceID != wantTrace || got.SpanID != wantSpan {
+		t.Fatalf("injected IDs not used: %#v", got)
+	}
+}
+
+func TestInvalidGeneratedIDDropsSpanWithoutPredictableFallback(t *testing.T) {
+	// A generator that cannot produce identity returns empty IDs. The tracer
+	// must drop the span rather than emit a predictable identifier.
+	tracer := trace.NewTracer(trace.WithIDGenerator(staticIDGenerator{}))
+	ctx := context.Background()
+	next, span := tracer.Start(ctx, "unit")
+	if span != nil {
+		t.Fatal("expected no span when identity cannot be generated")
+	}
+	if next != ctx {
+		t.Fatal("expected unchanged context when identity cannot be generated")
+	}
+}
+
+func TestDefaultGeneratorProducesUniqueValidIDs(t *testing.T) {
+	seen := make(map[trace.TraceID]bool, 1000)
+	for i := 0; i < 1000; i++ {
+		id := trace.NewTraceID()
+		if !id.Valid() {
+			t.Fatalf("default generator produced invalid trace id %q", id)
+		}
+		if seen[id] {
+			t.Fatalf("default generator produced duplicate trace id %q", id)
+		}
+		seen[id] = true
+	}
+}
+
+func TestRatioSamplerWithDefaultGeneratorApproximatesRatio(t *testing.T) {
+	// The default crypto generator yields uniformly distributed sampling keys,
+	// so deterministic ratio sampling keeps its statistical assumptions. The
+	// tolerance is many standard deviations wide, so this is not flaky.
+	const ratio = 0.5
+	const samples = 4000
+	sampler := trace.RatioSampler(ratio)
+
+	sampled := 0
+	for i := 0; i < samples; i++ {
+		if sampler.Sample(trace.SamplingContext{TraceID: trace.NewTraceID()}) {
+			sampled++
+		}
+	}
+	fraction := float64(sampled) / float64(samples)
+	if fraction < ratio-0.1 || fraction > ratio+0.1 {
+		t.Fatalf("ratio sampling fraction %.3f deviates from %.2f beyond tolerance", fraction, ratio)
+	}
+}

--- a/runtime/trace/otel/bridge.go
+++ b/runtime/trace/otel/bridge.go
@@ -285,7 +285,7 @@ func (sink *Sink) RecordSpan(ctx context.Context, span gowdktrace.Snapshot) erro
 func spanKind(span gowdktrace.Snapshot) oteltrace.SpanKind {
 	switch span.Lane {
 	case gowdktrace.LaneRoute, gowdktrace.LaneHandler, gowdktrace.LaneSSR,
-		gowdktrace.LaneAction, gowdktrace.LaneAPI:
+		gowdktrace.LaneAction, gowdktrace.LaneAPI, gowdktrace.LaneFragment:
 		return oteltrace.SpanKindServer
 	case gowdktrace.LaneContract:
 		return oteltrace.SpanKindClient

--- a/runtime/trace/otel/bridge.go
+++ b/runtime/trace/otel/bridge.go
@@ -5,14 +5,44 @@ package otel
 import (
 	"context"
 	"crypto/rand"
-	"fmt"
+	"sync/atomic"
 
 	gowdktrace "github.com/cssbruno/gowdk/runtime/trace"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
+	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	semconv "go.opentelemetry.io/otel/semconv/v1.41.0"
 	oteltrace "go.opentelemetry.io/otel/trace"
+)
+
+const (
+	// instrumentationName and instrumentationVersion identify this bridge as
+	// the OpenTelemetry instrumentation scope. The version is the bridge's
+	// stable GOWDK-to-OpenTelemetry semantic-convention version, not the GOWDK
+	// release version, so downstream consumers can pin to a known mapping.
+	instrumentationName    = "github.com/cssbruno/gowdk/runtime/trace"
+	instrumentationVersion = "0.1.0"
+
+	// defaultServiceName is the service.name applied to the default resource of
+	// a GOWDK-owned provider when the application does not supply its own.
+	defaultServiceName = "gowdk"
+
+	// AttrGOWDKEventLevel carries a GOWDK span event's level (for example
+	// "info", "warn", "error") on the emitted OTel event, which has no native
+	// level field.
+	AttrGOWDKEventLevel = "gowdk.event.level"
+	// AttrGOWDKDroppedAttributes lists the keys of attributes that could not be
+	// represented in OpenTelemetry's closed value model and were dropped. It is
+	// the documented loss marker for unsupported attribute values.
+	AttrGOWDKDroppedAttributes = "gowdk.dropped_attributes"
+
+	attrGOWDKTraceID         = "gowdk.trace_id"
+	attrGOWDKSpanID          = "gowdk.span_id"
+	attrGOWDKParentSpanID    = "gowdk.parent_span_id"
+	attrGOWDKSourceOwnerKind = "gowdk.source.owner_kind"
+	attrGOWDKSourceOwnerID   = "gowdk.source.owner_id"
 )
 
 // Option configures the OTLP HTTP bridge.
@@ -51,10 +81,30 @@ func WithHeaders(headers map[string]string) Option {
 	}
 }
 
+// unsupportedAttributes counts attribute values that could not be represented
+// in OpenTelemetry's closed value model and were dropped.
+var unsupportedAttributes atomic.Uint64
+
+// UnsupportedAttributeCount reports how many attribute values have been dropped
+// because their Go type is outside the supported scalar/array model. Dropped
+// keys are also recorded on the span or event via AttrGOWDKDroppedAttributes.
+func UnsupportedAttributeCount() uint64 {
+	return unsupportedAttributes.Load()
+}
+
 // Sink records GOWDK spans through an OpenTelemetry TracerProvider.
 type Sink struct {
 	provider *sdktrace.TracerProvider
 	tracer   oteltrace.Tracer
+	// ownsProvider is true when this sink created the provider (NewSink) or was
+	// explicitly granted ownership (WithProviderShutdown). Only an owned
+	// provider is shut down by Sink.Shutdown.
+	ownsProvider bool
+	// preservesIdentity is true when the provider is guaranteed to emit native
+	// OTel trace/span IDs equal to the GOWDK snapshot IDs (it uses
+	// SnapshotIDGenerator). When true the GOWDK IDs are not duplicated as
+	// ordinary attributes.
+	preservesIdentity bool
 }
 
 type snapshotIDContextKey struct{}
@@ -64,7 +114,31 @@ type snapshotIDs struct {
 	spanID  oteltrace.SpanID
 }
 
-// NewSink creates an OTLP HTTP-backed sink.
+// ProviderOption configures how a Sink relates to an app-supplied provider.
+type ProviderOption func(*Sink)
+
+// WithProviderShutdown transfers provider lifecycle ownership to the sink, so
+// Sink.Shutdown flushes and shuts the provider down. Without it a provider
+// passed to NewSinkWithProvider is treated as app-owned and left running by
+// Sink.Shutdown.
+func WithProviderShutdown() ProviderOption {
+	return func(sink *Sink) { sink.ownsProvider = true }
+}
+
+// WithNativeIdentity asserts that the supplied provider was configured with
+// SnapshotIDGenerator, so emitted OTel trace/span IDs equal the GOWDK snapshot
+// IDs. When set, the bridge relies on native identity and does not duplicate
+// the GOWDK IDs as ordinary attributes. Set it only when the provider really
+// uses SnapshotIDGenerator; otherwise leave it unset and the GOWDK IDs are
+// preserved as gowdk.trace_id / gowdk.span_id attributes.
+func WithNativeIdentity() ProviderOption {
+	return func(sink *Sink) { sink.preservesIdentity = true }
+}
+
+// NewSink creates an OTLP HTTP-backed sink. GOWDK owns the resulting provider:
+// it is configured with SnapshotIDGenerator (so native OTel identity equals the
+// GOWDK snapshot identity) and a default service resource, and Sink.Shutdown
+// shuts it down.
 func NewSink(ctx context.Context, options ...Option) (*Sink, error) {
 	var cfg config
 	for _, option := range options {
@@ -89,24 +163,68 @@ func NewSink(ctx context.Context, options ...Option) (*Sink, error) {
 	provider := sdktrace.NewTracerProvider(
 		sdktrace.WithBatcher(exporter),
 		sdktrace.WithIDGenerator(SnapshotIDGenerator{}),
+		sdktrace.WithResource(defaultResource()),
 	)
-	return NewSinkWithProvider(provider), nil
+	sink := newSink(provider)
+	sink.ownsProvider = true
+	sink.preservesIdentity = true
+	return sink, nil
 }
 
-// NewSinkWithProvider creates a sink backed by an existing provider. It is
-// useful when applications already own OpenTelemetry lifecycle and resources.
-// Providers should be configured with SnapshotIDGenerator when exact GOWDK
-// trace/span identity preservation is required.
-func NewSinkWithProvider(provider *sdktrace.TracerProvider) *Sink {
+// NewSinkWithProvider creates a sink backed by an existing, app-owned provider.
+// It is useful when applications already own the OpenTelemetry lifecycle and
+// resources.
+//
+// By default the provider is treated as borrowed: Sink.Shutdown does not shut
+// it down, and GOWDK trace/span IDs are preserved as gowdk.trace_id /
+// gowdk.span_id attributes because native OTel identity is not guaranteed. Pass
+// WithProviderShutdown to transfer lifecycle ownership, and WithNativeIdentity
+// when the provider is configured with SnapshotIDGenerator. A nil provider is a
+// shorthand for a GOWDK-owned, identity-preserving provider.
+func NewSinkWithProvider(provider *sdktrace.TracerProvider, options ...ProviderOption) *Sink {
 	if provider == nil {
-		provider = sdktrace.NewTracerProvider(sdktrace.WithIDGenerator(SnapshotIDGenerator{}))
+		provider = sdktrace.NewTracerProvider(
+			sdktrace.WithIDGenerator(SnapshotIDGenerator{}),
+			sdktrace.WithResource(defaultResource()),
+		)
+		sink := newSink(provider)
+		sink.ownsProvider = true
+		sink.preservesIdentity = true
+		return sink
 	}
-	return &Sink{provider: provider, tracer: provider.Tracer("github.com/cssbruno/gowdk/runtime/trace")}
+	sink := newSink(provider)
+	for _, option := range options {
+		if option != nil {
+			option(sink)
+		}
+	}
+	return sink
 }
 
-// Shutdown flushes and closes the underlying TracerProvider.
+func newSink(provider *sdktrace.TracerProvider) *Sink {
+	return &Sink{
+		provider: provider,
+		tracer:   provider.Tracer(instrumentationName, oteltrace.WithInstrumentationVersion(instrumentationVersion)),
+	}
+}
+
+// defaultResource returns the default GOWDK service resource. It merges the
+// SDK's default resource (process and SDK metadata) with a stable GOWDK
+// service.name so app-owned providers that omit a resource still emit
+// identifiable spans.
+func defaultResource() *resource.Resource {
+	merged, err := resource.Merge(resource.Default(), resource.NewSchemaless(semconv.ServiceName(defaultServiceName)))
+	if err != nil {
+		return resource.Default()
+	}
+	return merged
+}
+
+// Shutdown flushes and closes the underlying TracerProvider, but only when the
+// sink owns it. A borrowed (app-owned) provider is left running so the
+// application controls its lifecycle.
 func (sink *Sink) Shutdown(ctx context.Context) error {
-	if sink == nil || sink.provider == nil {
+	if sink == nil || sink.provider == nil || !sink.ownsProvider {
 		return nil
 	}
 	return sink.provider.Shutdown(ctx)
@@ -126,15 +244,29 @@ func (sink *Sink) RecordSpan(ctx context.Context, span gowdktrace.Snapshot) erro
 		return err
 	}
 	parent = context.WithValue(parent, snapshotIDContextKey{}, ids)
-	attrs := spanAttributes(span)
+
+	spanAttrs, dropped := convertAttributes(span.Attributes)
+	spanAttrs = append(spanAttrs, semanticAttributes(span, sink.preservesIdentity)...)
+	if len(dropped) > 0 {
+		spanAttrs = append(spanAttrs, attribute.StringSlice(AttrGOWDKDroppedAttributes, dropped))
+	}
+
 	_, otelSpan := sink.tracer.Start(parent, span.Name,
 		oteltrace.WithTimestamp(span.StartTime),
-		oteltrace.WithAttributes(attrs...),
+		oteltrace.WithSpanKind(spanKind(span)),
+		oteltrace.WithAttributes(spanAttrs...),
 	)
 	for _, event := range span.Events {
+		eventAttrs, droppedEvent := convertAttributes(event.Attributes)
+		if event.Level != "" {
+			eventAttrs = append(eventAttrs, attribute.String(AttrGOWDKEventLevel, event.Level))
+		}
+		if len(droppedEvent) > 0 {
+			eventAttrs = append(eventAttrs, attribute.StringSlice(AttrGOWDKDroppedAttributes, droppedEvent))
+		}
 		otelSpan.AddEvent(event.Message,
 			oteltrace.WithTimestamp(event.Time),
-			oteltrace.WithAttributes(attributes(event.Attributes)...),
+			oteltrace.WithAttributes(eventAttrs...),
 		)
 	}
 	switch span.Status.Code {
@@ -145,6 +277,57 @@ func (sink *Sink) RecordSpan(ctx context.Context, span gowdktrace.Snapshot) erro
 	}
 	otelSpan.End(oteltrace.WithTimestamp(span.EndTime))
 	return nil
+}
+
+// spanKind maps a GOWDK lane to an OpenTelemetry span kind. Request-handling
+// lanes are servers, outbound contract calls are clients, and everything else
+// is internal.
+func spanKind(span gowdktrace.Snapshot) oteltrace.SpanKind {
+	switch span.Lane {
+	case gowdktrace.LaneRoute, gowdktrace.LaneHandler, gowdktrace.LaneSSR,
+		gowdktrace.LaneAction, gowdktrace.LaneAPI:
+		return oteltrace.SpanKindServer
+	case gowdktrace.LaneContract:
+		return oteltrace.SpanKindClient
+	default:
+		return oteltrace.SpanKindInternal
+	}
+}
+
+// semanticAttributes builds the gowdk.* attributes describing surface, lane,
+// and source. The GOWDK trace/span IDs are added only when native OTel identity
+// is not guaranteed (preservesIdentity is false); otherwise they would
+// duplicate the span's own IDs. The source file is normalized through the
+// active trace source policy so absolute filesystem paths are not exported.
+func semanticAttributes(span gowdktrace.Snapshot, preservesIdentity bool) []attribute.KeyValue {
+	attrs := make([]attribute.KeyValue, 0, 8)
+	if !preservesIdentity {
+		attrs = append(attrs,
+			attribute.String(attrGOWDKTraceID, string(span.TraceID)),
+			attribute.String(attrGOWDKSpanID, string(span.SpanID)),
+			attribute.String(attrGOWDKParentSpanID, string(span.ParentSpanID)),
+		)
+	}
+	attrs = append(attrs,
+		attribute.String(gowdktrace.AttrGOWDKSurface, string(span.Surface)),
+		attribute.String(gowdktrace.AttrGOWDKLane, string(span.Lane)),
+	)
+	if file := gowdktrace.NormalizeSourceFile(span.Source.File, gowdktrace.CurrentSourcePolicy()); file != "" {
+		attrs = append(attrs, attribute.String(gowdktrace.AttrGOWDKSourceFile, file))
+	}
+	if span.Source.Line > 0 {
+		attrs = append(attrs, attribute.Int(gowdktrace.AttrGOWDKSourceLine, span.Source.Line))
+	}
+	if span.Source.Column > 0 {
+		attrs = append(attrs, attribute.Int(gowdktrace.AttrGOWDKSourceCol, span.Source.Column))
+	}
+	if span.Source.OwnerKind != "" {
+		attrs = append(attrs, attribute.String(attrGOWDKSourceOwnerKind, span.Source.OwnerKind))
+	}
+	if span.Source.OwnerID != "" {
+		attrs = append(attrs, attribute.String(attrGOWDKSourceOwnerID, span.Source.OwnerID))
+	}
+	return attrs
 }
 
 func snapshotIDsFromSpan(span gowdktrace.Snapshot) (snapshotIDs, error) {
@@ -219,41 +402,48 @@ func randomSpanID() oteltrace.SpanID {
 	}
 }
 
-func spanAttributes(span gowdktrace.Snapshot) []attribute.KeyValue {
-	attrs := attributes(span.Attributes)
-	attrs = append(attrs,
-		attribute.String("gowdk.trace_id", string(span.TraceID)),
-		attribute.String("gowdk.span_id", string(span.SpanID)),
-		attribute.String("gowdk.parent_span_id", string(span.ParentSpanID)),
-		attribute.String("gowdk.surface", string(span.Surface)),
-		attribute.String("gowdk.lane", string(span.Lane)),
-		attribute.String("gowdk.source.file", span.Source.File),
-		attribute.Int("gowdk.source.line", span.Source.Line),
-		attribute.Int("gowdk.source.column", span.Source.Column),
-		attribute.String("gowdk.source.owner_kind", span.Source.OwnerKind),
-		attribute.String("gowdk.source.owner_id", span.Source.OwnerID),
-	)
-	return attrs
+// convertAttributes maps GOWDK attributes to OTel key/values using the closed
+// scalar/array value model. Values outside the model are dropped (not
+// stringified): they increment the unsupported-attribute counter and their keys
+// are returned so the caller can record them via AttrGOWDKDroppedAttributes.
+func convertAttributes(attrs []gowdktrace.Attribute) (out []attribute.KeyValue, dropped []string) {
+	out = make([]attribute.KeyValue, 0, len(attrs))
+	for _, attr := range attrs {
+		keyValue, ok := convertAttribute(attr)
+		if !ok {
+			unsupportedAttributes.Add(1)
+			dropped = append(dropped, attr.Key)
+			continue
+		}
+		out = append(out, keyValue)
+	}
+	return out, dropped
 }
 
-func attributes(attrs []gowdktrace.Attribute) []attribute.KeyValue {
-	out := make([]attribute.KeyValue, 0, len(attrs))
-	for _, attr := range attrs {
-		key := attribute.Key(attr.Key)
-		switch value := attr.Value.(type) {
-		case string:
-			out = append(out, key.String(value))
-		case bool:
-			out = append(out, key.Bool(value))
-		case int:
-			out = append(out, key.Int(value))
-		case int64:
-			out = append(out, key.Int64(value))
-		case float64:
-			out = append(out, key.Float64(value))
-		default:
-			out = append(out, key.String(fmt.Sprint(value)))
-		}
+func convertAttribute(attr gowdktrace.Attribute) (attribute.KeyValue, bool) {
+	key := attribute.Key(attr.Key)
+	switch value := attr.Value.(type) {
+	case string:
+		return key.String(value), true
+	case bool:
+		return key.Bool(value), true
+	case int:
+		return key.Int(value), true
+	case int64:
+		return key.Int64(value), true
+	case float64:
+		return key.Float64(value), true
+	case []string:
+		return key.StringSlice(value), true
+	case []bool:
+		return key.BoolSlice(value), true
+	case []int:
+		return key.IntSlice(value), true
+	case []int64:
+		return key.Int64Slice(value), true
+	case []float64:
+		return key.Float64Slice(value), true
+	default:
+		return attribute.KeyValue{}, false
 	}
-	return out
 }

--- a/runtime/trace/otel/bridge_semantics_test.go
+++ b/runtime/trace/otel/bridge_semantics_test.go
@@ -1,0 +1,203 @@
+package otel
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	gowdktrace "github.com/cssbruno/gowdk/runtime/trace"
+	"go.opentelemetry.io/otel/attribute"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	oteltrace "go.opentelemetry.io/otel/trace"
+)
+
+// shutdownRecorder wraps a span processor and records whether Shutdown was
+// called so ownership behavior can be asserted.
+type shutdownRecorder struct {
+	sdktrace.SpanProcessor
+	shutdownCalled bool
+}
+
+func (recorder *shutdownRecorder) Shutdown(ctx context.Context) error {
+	recorder.shutdownCalled = true
+	return recorder.SpanProcessor.Shutdown(ctx)
+}
+
+func newRecorderProvider() (*sdktrace.TracerProvider, *tracetest.SpanRecorder, *shutdownRecorder) {
+	recorder := tracetest.NewSpanRecorder()
+	wrapper := &shutdownRecorder{SpanProcessor: recorder}
+	provider := sdktrace.NewTracerProvider(
+		sdktrace.WithSpanProcessor(wrapper),
+		sdktrace.WithIDGenerator(SnapshotIDGenerator{}),
+	)
+	return provider, recorder, wrapper
+}
+
+func attributeMap(keyValues []attribute.KeyValue) map[string]attribute.Value {
+	out := make(map[string]attribute.Value, len(keyValues))
+	for _, keyValue := range keyValues {
+		out[string(keyValue.Key)] = keyValue.Value
+	}
+	return out
+}
+
+func semanticsSnapshot() gowdktrace.Snapshot {
+	now := time.Unix(1, 0).UTC()
+	return gowdktrace.Snapshot{
+		TraceID: gowdktrace.NewTraceID(),
+		SpanID:  gowdktrace.NewSpanID(),
+		Name:    "GET /patients",
+		Surface: gowdktrace.SurfaceBackend,
+		Lane:    gowdktrace.LaneRoute,
+		Source:  gowdktrace.SourceRef{File: "/abs/app/home.page.gwdk", Line: 3, Column: 1, OwnerKind: "page", OwnerID: "home"},
+		Attributes: []gowdktrace.Attribute{
+			{Key: "tags", Value: []string{"a", "b"}},
+			{Key: "weird", Value: struct{}{}},
+		},
+		Events: []gowdktrace.Event{
+			{Message: "loaded", Level: "warn", Time: now},
+		},
+		Status:    gowdktrace.Status{Code: gowdktrace.StatusOK},
+		StartTime: now,
+		EndTime:   now.Add(time.Millisecond),
+	}
+}
+
+func TestRecordSpanPreservesSemantics(t *testing.T) {
+	provider, recorder, _ := newRecorderProvider()
+	sink := NewSinkWithProvider(provider, WithNativeIdentity())
+
+	snapshot := semanticsSnapshot()
+	beforeUnsupported := UnsupportedAttributeCount()
+	if err := sink.RecordSpan(context.Background(), snapshot); err != nil {
+		t.Fatalf("RecordSpan: %v", err)
+	}
+
+	ended := recorder.Ended()
+	if len(ended) != 1 {
+		t.Fatalf("ended spans = %d, want 1", len(ended))
+	}
+	span := ended[0]
+
+	if span.SpanKind() != oteltrace.SpanKindServer {
+		t.Fatalf("span kind = %v, want server", span.SpanKind())
+	}
+	if scope := span.InstrumentationScope(); scope.Name != instrumentationName || scope.Version != instrumentationVersion {
+		t.Fatalf("instrumentation scope = %+v, want %s/%s", scope, instrumentationName, instrumentationVersion)
+	}
+
+	attrs := attributeMap(span.Attributes())
+	if _, ok := attrs[attrGOWDKTraceID]; ok {
+		t.Fatal("gowdk.trace_id must not be duplicated as an attribute when native identity is preserved")
+	}
+	if got := attrs[gowdktrace.AttrGOWDKSourceFile].AsString(); got != "abs/app/home.page.gwdk" {
+		t.Fatalf("source file attribute not normalized: %q", got)
+	}
+	if got := attrs["tags"].AsStringSlice(); len(got) != 2 || got[0] != "a" || got[1] != "b" {
+		t.Fatalf("string slice attribute not preserved: %#v", got)
+	}
+	if _, ok := attrs["weird"]; ok {
+		t.Fatal("unsupported attribute value should be dropped, not stringified")
+	}
+	if UnsupportedAttributeCount() <= beforeUnsupported {
+		t.Fatal("unsupported attribute counter did not increase")
+	}
+	if dropped := attrs[AttrGOWDKDroppedAttributes].AsStringSlice(); len(dropped) != 1 || dropped[0] != "weird" {
+		t.Fatalf("dropped-attribute marker = %#v, want [weird]", dropped)
+	}
+
+	events := span.Events()
+	if len(events) != 1 {
+		t.Fatalf("events = %d, want 1", len(events))
+	}
+	if level := attributeMap(events[0].Attributes)[AttrGOWDKEventLevel].AsString(); level != "warn" {
+		t.Fatalf("event level attribute = %q, want warn", level)
+	}
+}
+
+func TestRecordSpanKindByLane(t *testing.T) {
+	cases := []struct {
+		lane gowdktrace.Lane
+		want oteltrace.SpanKind
+	}{
+		{gowdktrace.LaneRoute, oteltrace.SpanKindServer},
+		{gowdktrace.LaneAPI, oteltrace.SpanKindServer},
+		{gowdktrace.LaneContract, oteltrace.SpanKindClient},
+		{gowdktrace.LaneJob, oteltrace.SpanKindInternal},
+		{gowdktrace.LaneNav, oteltrace.SpanKindInternal},
+	}
+	for _, testCase := range cases {
+		provider, recorder, _ := newRecorderProvider()
+		sink := NewSinkWithProvider(provider, WithNativeIdentity())
+		snapshot := semanticsSnapshot()
+		snapshot.Lane = testCase.lane
+		if err := sink.RecordSpan(context.Background(), snapshot); err != nil {
+			t.Fatalf("RecordSpan(%s): %v", testCase.lane, err)
+		}
+		if got := recorder.Ended()[0].SpanKind(); got != testCase.want {
+			t.Fatalf("lane %s span kind = %v, want %v", testCase.lane, got, testCase.want)
+		}
+	}
+}
+
+func TestBorrowedProviderPreservesIDsAsAttributes(t *testing.T) {
+	provider, recorder, _ := newRecorderProvider()
+	sink := NewSinkWithProvider(provider) // borrowed default: native identity not asserted
+
+	snapshot := semanticsSnapshot()
+	snapshot.Attributes = nil
+	if err := sink.RecordSpan(context.Background(), snapshot); err != nil {
+		t.Fatalf("RecordSpan: %v", err)
+	}
+	span := recorder.Ended()[0]
+	// Native identity still matches because the provider uses SnapshotIDGenerator...
+	if got := span.SpanContext().TraceID().String(); got != string(snapshot.TraceID) {
+		t.Fatalf("native trace id = %s, want %s", got, snapshot.TraceID)
+	}
+	// ...and the GOWDK IDs are also retained as attributes for borrowed providers.
+	if got := attributeMap(span.Attributes())[attrGOWDKTraceID].AsString(); got != string(snapshot.TraceID) {
+		t.Fatalf("gowdk.trace_id attribute = %q, want %q", got, snapshot.TraceID)
+	}
+}
+
+func TestProviderOwnershipControlsShutdown(t *testing.T) {
+	borrowedProvider, _, borrowedShutdown := newRecorderProvider()
+	borrowed := NewSinkWithProvider(borrowedProvider)
+	if err := borrowed.Shutdown(context.Background()); err != nil {
+		t.Fatalf("borrowed Shutdown: %v", err)
+	}
+	if borrowedShutdown.shutdownCalled {
+		t.Fatal("borrowed (app-owned) provider must not be shut down by the sink")
+	}
+	_ = borrowedProvider.Shutdown(context.Background())
+
+	ownedProvider, _, ownedShutdown := newRecorderProvider()
+	owned := NewSinkWithProvider(ownedProvider, WithProviderShutdown())
+	if err := owned.Shutdown(context.Background()); err != nil {
+		t.Fatalf("owned Shutdown: %v", err)
+	}
+	if !ownedShutdown.shutdownCalled {
+		t.Fatal("owned provider must be shut down by the sink")
+	}
+}
+
+func TestNilProviderIsOwnedAndIdentityPreserving(t *testing.T) {
+	sink := NewSinkWithProvider(nil)
+	if !sink.ownsProvider || !sink.preservesIdentity {
+		t.Fatalf("nil provider should yield an owned, identity-preserving sink: %+v", sink)
+	}
+	if err := sink.Shutdown(context.Background()); err != nil {
+		t.Fatalf("Shutdown: %v", err)
+	}
+}
+
+func TestDefaultResourceHasServiceName(t *testing.T) {
+	resource := defaultResource()
+	for _, keyValue := range resource.Attributes() {
+		if string(keyValue.Key) == "service.name" && keyValue.Value.AsString() == defaultServiceName {
+			return
+		}
+	}
+	t.Fatalf("default resource missing service.name=%q: %#v", defaultServiceName, resource.Attributes())
+}

--- a/runtime/trace/otel/bridge_semantics_test.go
+++ b/runtime/trace/otel/bridge_semantics_test.go
@@ -123,6 +123,7 @@ func TestRecordSpanKindByLane(t *testing.T) {
 	}{
 		{gowdktrace.LaneRoute, oteltrace.SpanKindServer},
 		{gowdktrace.LaneAPI, oteltrace.SpanKindServer},
+		{gowdktrace.LaneFragment, oteltrace.SpanKindServer},
 		{gowdktrace.LaneContract, oteltrace.SpanKindClient},
 		{gowdktrace.LaneJob, oteltrace.SpanKindInternal},
 		{gowdktrace.LaneNav, oteltrace.SpanKindInternal},

--- a/runtime/trace/sink.go
+++ b/runtime/trace/sink.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"strings"
 	"sync"
 	"time"
 )
@@ -39,6 +40,13 @@ func MultiSink(sinks ...Sink) Sink {
 }
 
 // ConsoleSink writes one readable line per completed span.
+//
+// ConsoleSink is intended for development and local diagnostics. Span names,
+// status messages, source paths, and event messages can derive from request,
+// route, or browser-supplied values, so every field is escaped (see
+// escapeControl) before it is written: control characters cannot forge an
+// additional log line or emit raw terminal control sequences. Use JSONLSink for
+// production logging where downstream tooling parses structured records.
 type ConsoleSink struct {
 	mu     sync.Mutex
 	writer io.Writer
@@ -57,11 +65,93 @@ func (sink *ConsoleSink) RecordSpan(ctx context.Context, span Snapshot) error {
 	if err := ctx.Err(); err != nil {
 		return err
 	}
-	duration := time.Duration(span.DurationNS)
+	line := formatConsoleSpan(span)
 	sink.mu.Lock()
 	defer sink.mu.Unlock()
-	_, err := fmt.Fprintf(sink.writer, "%s trace=%s span=%s parent=%s surface=%s lane=%s duration=%s status=%s\n", span.Name, span.TraceID, span.SpanID, span.ParentSpanID, span.Surface, span.Lane, duration, span.Status.Code)
+	_, err := io.WriteString(sink.writer, line)
 	return err
+}
+
+// formatConsoleSpan renders one escaped, single-line representation of span.
+// Every string field is passed through escapeControl so user- or
+// browser-controlled values cannot break out of the line.
+func formatConsoleSpan(span Snapshot) string {
+	duration := time.Duration(span.DurationNS)
+	var builder strings.Builder
+	fmt.Fprintf(&builder, "%s trace=%s span=%s parent=%s surface=%s lane=%s duration=%s status=%s",
+		escapeControl(span.Name),
+		escapeControl(string(span.TraceID)),
+		escapeControl(string(span.SpanID)),
+		escapeControl(string(span.ParentSpanID)),
+		escapeControl(string(span.Surface)),
+		escapeControl(string(span.Lane)),
+		duration,
+		escapeControl(string(span.Status.Code)),
+	)
+	if message := span.Status.Message; message != "" {
+		builder.WriteString(" message=")
+		builder.WriteString(escapeControl(message))
+	}
+	if file := span.Source.File; file != "" {
+		fmt.Fprintf(&builder, " source=%s:%d", escapeControl(file), span.Source.Line)
+	}
+	if len(span.Events) > 0 {
+		builder.WriteString(" events=")
+		for index, event := range span.Events {
+			if index > 0 {
+				builder.WriteByte('|')
+			}
+			builder.WriteString(escapeControl(event.Message))
+		}
+	}
+	builder.WriteByte('\n')
+	return builder.String()
+}
+
+// escapeControl renders value with control characters replaced by printable
+// escape sequences so a span field cannot forge a new console log line or emit
+// raw terminal control sequences. Newline, carriage return, and tab become \n,
+// \r, \t; the backslash is doubled so escapes stay unambiguous; every other C0
+// or C1 control byte and DEL becomes \xNN. Printable text, including spaces and
+// non-control Unicode, is preserved so normal span names remain readable.
+func escapeControl(value string) string {
+	if value == "" {
+		return value
+	}
+	if strings.IndexFunc(value, needsControlEscape) < 0 {
+		return value
+	}
+	var builder strings.Builder
+	builder.Grow(len(value) + 8)
+	for _, r := range value {
+		switch r {
+		case '\\':
+			builder.WriteString(`\\`)
+		case '\n':
+			builder.WriteString(`\n`)
+		case '\r':
+			builder.WriteString(`\r`)
+		case '\t':
+			builder.WriteString(`\t`)
+		default:
+			if isControlRune(r) {
+				fmt.Fprintf(&builder, `\x%02x`, r)
+			} else {
+				builder.WriteRune(r)
+			}
+		}
+	}
+	return builder.String()
+}
+
+func needsControlEscape(r rune) bool {
+	return r == '\\' || isControlRune(r)
+}
+
+// isControlRune reports whether r is a C0 control (including DEL) or a C1
+// control character, all of which can alter terminal state or log structure.
+func isControlRune(r rune) bool {
+	return r < 0x20 || (r >= 0x7f && r <= 0x9f)
 }
 
 // JSONLSink writes one JSON object per completed span.

--- a/runtime/trace/source.go
+++ b/runtime/trace/source.go
@@ -1,0 +1,116 @@
+package trace
+
+import (
+	"path"
+	"strings"
+	"sync/atomic"
+)
+
+// SourcePathMode controls how SourceRef.File paths are exposed outside the
+// process (trace viewer, JSON/SSE, console, and OTLP export).
+type SourcePathMode int
+
+const (
+	// SourcePathRelative reduces absolute filesystem paths to project-relative
+	// logical paths so local filesystem structure is not revealed to trace
+	// consumers. It is the default and the only production-safe mode.
+	SourcePathRelative SourcePathMode = iota
+	// SourcePathAbsolute exposes source paths verbatim, including absolute local
+	// filesystem paths. It is a debugging aid for local development and must not
+	// be enabled when traces leave the machine.
+	SourcePathAbsolute
+)
+
+// SourcePolicy controls source-path normalization applied to a span snapshot's
+// SourceRef.File before the snapshot is exposed outside the process.
+type SourcePolicy struct {
+	// Mode selects relative (default) or absolute path exposure.
+	Mode SourcePathMode
+	// ProjectRoot, when set, is the directory that absolute source paths under
+	// it are made relative to in SourcePathRelative mode.
+	ProjectRoot string
+}
+
+var sourcePolicy atomic.Pointer[SourcePolicy]
+
+// SetSourcePolicy installs the process-wide source-path normalization policy.
+// It is applied to every span snapshot before it is exposed through the trace
+// viewer, JSON/SSE, console, or OTLP surfaces. The zero SourcePolicy (relative
+// mode, no project root) is the default and never exposes absolute paths.
+func SetSourcePolicy(policy SourcePolicy) {
+	sourcePolicy.Store(&policy)
+}
+
+// CurrentSourcePolicy returns the active source-path normalization policy.
+func CurrentSourcePolicy() SourcePolicy {
+	if policy := sourcePolicy.Load(); policy != nil {
+		return *policy
+	}
+	return SourcePolicy{}
+}
+
+// NormalizeSourceFile applies policy to a single SourceRef.File value.
+//
+// In the default relative mode it never returns an absolute path: Windows drive
+// letters and UNC prefixes are stripped, the path is made relative to
+// policy.ProjectRoot when it lies beneath it, leading separators are removed,
+// and leading parent-directory ("..") segments are collapsed so the logical
+// path cannot escape the project root. In absolute mode the path is returned
+// cleaned but otherwise unchanged.
+func NormalizeSourceFile(file string, policy SourcePolicy) string {
+	if file == "" {
+		return ""
+	}
+	// Normalize separators ourselves rather than with filepath.ToSlash so a
+	// Windows-style path is reduced the same way on every host OS.
+	slashed := strings.ReplaceAll(file, `\`, "/")
+	if policy.Mode == SourcePathAbsolute {
+		return path.Clean(slashed)
+	}
+	return reduceToProjectRelative(slashed, policy.ProjectRoot)
+}
+
+func reduceToProjectRelative(slashed, root string) string {
+	// Make the path relative to the project root when it lies beneath it.
+	if root != "" {
+		cleanRoot := path.Clean(strings.ReplaceAll(root, `\`, "/"))
+		clean := path.Clean(slashed)
+		if clean == cleanRoot {
+			return "."
+		}
+		if rel := strings.TrimPrefix(clean, cleanRoot+"/"); rel != clean {
+			return rel
+		}
+	}
+	trimmed := slashed
+	// Drop a Windows drive prefix such as "C:" so "C:/Users/..." → "/Users/...".
+	if len(trimmed) >= 2 && trimmed[1] == ':' && isASCIILetter(trimmed[0]) {
+		trimmed = trimmed[2:]
+	}
+	// Force a relative path: strip leading separators (covers absolute POSIX
+	// paths and UNC "//host/share" forms).
+	trimmed = strings.TrimLeft(trimmed, "/")
+	trimmed = path.Clean(trimmed)
+	// Collapse any leading traversal so the logical path stays inside the root.
+	for strings.HasPrefix(trimmed, "../") {
+		trimmed = trimmed[len("../"):]
+	}
+	switch trimmed {
+	case "", ".", "..":
+		return ""
+	}
+	return trimmed
+}
+
+func isASCIILetter(b byte) bool {
+	return (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z')
+}
+
+// normalizeSnapshotSource returns snapshot with its SourceRef.File normalized
+// per the active policy. It is applied at the points where a snapshot is born
+// (span completion and external ingest) so the viewer, JSON/SSE, console, and
+// OTLP surfaces all observe the same normalized value.
+func normalizeSnapshotSource(snapshot Snapshot) Snapshot {
+	snapshot.Source.File = NormalizeSourceFile(snapshot.Source.File, CurrentSourcePolicy())
+	return snapshot
+}

--- a/runtime/trace/source_test.go
+++ b/runtime/trace/source_test.go
@@ -1,0 +1,80 @@
+package trace_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/cssbruno/gowdk/runtime/trace"
+)
+
+func TestNormalizeSourceFileRelativeMode(t *testing.T) {
+	cases := []struct {
+		name   string
+		file   string
+		policy trace.SourcePolicy
+		want   string
+	}{
+		{name: "empty", file: "", want: ""},
+		{name: "relative unchanged", file: "pages/home.page.gwdk", want: "pages/home.page.gwdk"},
+		{name: "absolute posix stripped", file: "/Users/me/app/home.page.gwdk", want: "Users/me/app/home.page.gwdk"},
+		{name: "under project root", file: "/Users/me/app/home.page.gwdk", policy: trace.SourcePolicy{ProjectRoot: "/Users/me/app"}, want: "home.page.gwdk"},
+		{name: "windows drive absolute", file: `C:\Users\me\app\home.page.gwdk`, want: "Users/me/app/home.page.gwdk"},
+		{name: "windows relative", file: `pages\home.page.gwdk`, want: "pages/home.page.gwdk"},
+		{name: "unc path", file: `\\host\share\app\home.page.gwdk`, want: "host/share/app/home.page.gwdk"},
+		{name: "traversal collapsed", file: "../../etc/passwd", want: "etc/passwd"},
+		{name: "leading dot slash", file: "./pages/home.page.gwdk", want: "pages/home.page.gwdk"},
+		{name: "generated absolute source", file: "/tmp/gowdk-build/output/home.page.go", want: "tmp/gowdk-build/output/home.page.go"},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			got := trace.NormalizeSourceFile(testCase.file, testCase.policy)
+			if got != testCase.want {
+				t.Fatalf("NormalizeSourceFile(%q) = %q, want %q", testCase.file, got, testCase.want)
+			}
+		})
+	}
+}
+
+func TestNormalizeSourceFileAbsoluteModeKeepsPath(t *testing.T) {
+	policy := trace.SourcePolicy{Mode: trace.SourcePathAbsolute}
+	const absolute = "/Users/me/app/home.page.gwdk"
+	if got := trace.NormalizeSourceFile(absolute, policy); got != absolute {
+		t.Fatalf("absolute mode = %q, want %q preserved", got, absolute)
+	}
+}
+
+func TestSnapshotNormalizesAbsoluteSourcePath(t *testing.T) {
+	ring := trace.NewRingSink(1)
+	tracer := trace.NewTracer(trace.WithSink(ring))
+	_, span := tracer.Start(context.Background(), "unit",
+		trace.WithSource(trace.SourceRef{File: "/Users/me/secret/app/home.page.gwdk", Line: 3}))
+	if span == nil {
+		t.Fatal("expected sampled span")
+	}
+	span.EndTime(time.Unix(1, 0).UTC())
+
+	spans := waitForSpans(t, ring, 1)
+	if len(spans) != 1 {
+		t.Fatalf("expected one span, got %d", len(spans))
+	}
+	if got := spans[0].Source.File; got != "Users/me/secret/app/home.page.gwdk" {
+		t.Fatalf("completed-span source not normalized: %q", got)
+	}
+}
+
+func TestCollectorNormalizesIngestedSource(t *testing.T) {
+	collector := trace.NewCollector(1)
+	if err := collector.RecordSpan(context.Background(), trace.Snapshot{
+		TraceID: trace.NewTraceID(),
+		SpanID:  trace.NewSpanID(),
+		Name:    "ingested",
+		Source:  trace.SourceRef{File: "/abs/host/path/file.gwdk"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	spans := collector.Spans()
+	if len(spans) != 1 || spans[0].Source.File != "abs/host/path/file.gwdk" {
+		t.Fatalf("collector did not normalize ingested source: %#v", spans)
+	}
+}

--- a/runtime/trace/span.go
+++ b/runtime/trace/span.go
@@ -200,7 +200,10 @@ func (span *Span) snapshotLocked() Snapshot {
 	if duration < 0 {
 		duration = 0
 	}
-	return Snapshot{
+	// Normalize the source path here, the single point every completed-span
+	// snapshot is created, so the viewer, JSON/SSE, console, and OTLP surfaces
+	// never observe an absolute local filesystem path by default.
+	return normalizeSnapshotSource(Snapshot{
 		TraceID:      span.traceID,
 		SpanID:       span.spanID,
 		ParentSpanID: span.parentSpanID,
@@ -214,7 +217,7 @@ func (span *Span) snapshotLocked() Snapshot {
 		StartTime:    span.start,
 		EndTime:      end,
 		DurationNS:   duration.Nanoseconds(),
-	}
+	})
 }
 
 func attributesFromMap(attrs map[string]any) []Attribute {

--- a/runtime/trace/tracer.go
+++ b/runtime/trace/tracer.go
@@ -8,10 +8,11 @@ import (
 
 var defaultTracer = NewTracer()
 
-// Tracer owns sampling and completed-span delivery.
+// Tracer owns sampling, identity generation, and completed-span delivery.
 type Tracer struct {
 	sink    Sink
 	sampler Sampler
+	idGen   IDGenerator
 }
 
 // TracerOption configures a Tracer.
@@ -31,14 +32,28 @@ func WithSampler(sampler Sampler) TracerOption {
 	}
 }
 
+// WithIDGenerator sets the trace/span ID generator. Nil keeps the default
+// CryptoIDGenerator. Tests use this to inject deterministic identifiers without
+// relying on entropy failure.
+func WithIDGenerator(generator IDGenerator) TracerOption {
+	return func(tracer *Tracer) {
+		if generator != nil {
+			tracer.idGen = generator
+		}
+	}
+}
+
 // NewTracer creates a Tracer.
 func NewTracer(options ...TracerOption) *Tracer {
-	tracer := &Tracer{sampler: AlwaysOn()}
+	tracer := &Tracer{sampler: AlwaysOn(), idGen: defaultIDGenerator}
 	for _, option := range options {
 		option(tracer)
 	}
 	if tracer.sampler == nil {
 		tracer.sampler = AlwaysOn()
+	}
+	if tracer.idGen == nil {
+		tracer.idGen = defaultIDGenerator
 	}
 	return tracer
 }
@@ -68,11 +83,21 @@ func (tracer *Tracer) Start(ctx context.Context, name string, options ...StartOp
 		return ctx, nil
 	}
 	parent, hasParent := TraceContextFromContext(ctx)
+	generator := cfg.tracer.idGen
+	if generator == nil {
+		generator = defaultIDGenerator
+	}
 	traceID := parent.TraceID
 	if !traceID.Valid() {
-		traceID = NewTraceID()
+		traceID = generator.NewTraceID()
 	}
-	spanID := NewSpanID()
+	spanID := generator.NewSpanID()
+	if !traceID.Valid() || !spanID.Valid() {
+		// Identity could not be generated (an entropy failure on the default
+		// generator). Drop the span rather than emit a predictable identifier.
+		// The loss is observable through EntropyFailureCount / the handler.
+		return ctx, nil
+	}
 	samplingContext := SamplingContext{
 		TraceID:      traceID,
 		ParentSpanID: parent.SpanID,

--- a/runtime/trace/types.go
+++ b/runtime/trace/types.go
@@ -4,13 +4,10 @@ package trace
 
 import (
 	"context"
-	"crypto/rand"
-	"encoding/hex"
 	"errors"
 	"fmt"
 	"strconv"
 	"strings"
-	"sync/atomic"
 	"time"
 )
 
@@ -117,42 +114,20 @@ type TraceContext struct {
 type contextKey struct{}
 type tracerContextKey struct{}
 
-var idSequence uint64
-
-// NewTraceID creates a non-zero W3C trace ID.
+// NewTraceID returns a valid W3C trace ID from the default ID generator
+// (CryptoIDGenerator). It returns "" only when the system CSPRNG cannot
+// provide entropy; see EntropyFailureCount. It never falls back to a
+// predictable value.
 func NewTraceID() TraceID {
-	for {
-		var buf [16]byte
-		if _, err := rand.Read(buf[:]); err == nil {
-			id := TraceID(hex.EncodeToString(buf[:]))
-			if id.Valid() {
-				return id
-			}
-		}
-		seq := atomic.AddUint64(&idSequence, 1)
-		id := TraceID(fmt.Sprintf("%016x%016x", uint64(time.Now().UTC().UnixNano()), seq))
-		if id.Valid() {
-			return id
-		}
-	}
+	return defaultIDGenerator.NewTraceID()
 }
 
-// NewSpanID creates a non-zero W3C span ID.
+// NewSpanID returns a valid W3C span ID from the default ID generator
+// (CryptoIDGenerator). It returns "" only when the system CSPRNG cannot
+// provide entropy; see EntropyFailureCount. It never falls back to a
+// predictable value.
 func NewSpanID() SpanID {
-	for {
-		var buf [8]byte
-		if _, err := rand.Read(buf[:]); err == nil {
-			id := SpanID(hex.EncodeToString(buf[:]))
-			if id.Valid() {
-				return id
-			}
-		}
-		seq := atomic.AddUint64(&idSequence, 1)
-		id := SpanID(fmt.Sprintf("%016x", seq))
-		if id.Valid() {
-			return id
-		}
-	}
+	return defaultIDGenerator.NewSpanID()
 }
 
 // Valid reports whether id is a valid non-zero W3C trace ID.


### PR DESCRIPTION
Hardens the built-in tracing pipeline and the `gowdk audit --run` runner. Six security/observability issues, one PR.

## What changed

### `runtime/trace`
- **#579 — Console log-line injection.** `ConsoleSink` now escapes control characters in every field it writes (span name, status message, source path, event messages). Newlines, CR, tab, ANSI/ESC, and C0/C1 controls become `\n`/`\r`/`\t`/`\xNN`, so untrusted values can't forge log lines or emit terminal sequences. Documented as dev/diagnostic-only; `JSONLSink` is the structured production path.
- **#580 — No predictable ID fallback.** Trace/span ID generation is now an injectable `IDGenerator` (`WithIDGenerator`). The default `CryptoIDGenerator` never degrades to time+sequence: on a `crypto/rand` failure it bumps `EntropyFailureCount` and the `SetEntropyFailureHandler` callback, and the tracer drops the span instead of emitting a guessable ID. Ratio sampling keeps its uniform-key assumption.
- **#583 — Source-path normalization.** A `SourcePolicy` normalizes `SourceRef.File` to a project-relative logical path before a snapshot leaves the process, applied at the single snapshot chokepoint + collector ingest so the viewer, JSON/SSE, console, and OTLP surfaces are all consistent. Absolute paths require opt-in `SourcePathAbsolute` (debug only). Handles POSIX, Windows drive/UNC, and traversal segments.

### `runtime/trace/otel` bridge
- **#581 — Provider ownership.** Owned (`NewSink`, `NewSinkWithProvider(nil)`) vs borrowed (`NewSinkWithProvider(provider)`) are now distinct; `Shutdown` only shuts down a provider the sink owns unless `WithProviderShutdown` transfers ownership. `WithNativeIdentity` marks providers configured with `SnapshotIDGenerator`.
- **#582 — Semantic preservation.** Span kind by lane, event level as `gowdk.event.level`, stable instrumentation name/version + default `service.name` resource, a closed scalar/array attribute model (unsupported values dropped + counted + listed in `gowdk.dropped_attributes` instead of `fmt.Sprint`), and GOWDK IDs no longer duplicated as attributes when native identity is guaranteed.

### `gowdk audit --run`
- **#584 — Execution boundary.** The generated-app test run now uses `exec.CommandContext` with a default 2m deadline (`--run-timeout=<duration>`), bounded combined output with an explicit truncation marker, and a minimized environment (Go + `GOWDK_*` only) with downloads disabled (`GOPROXY=off`, `GOTOOLCHAIN=local`). Timeout is reported distinctly via the new `audit_test_timeout` diagnostic; failure stays `audit_test_failed`.

## Tests
New tests cover each acceptance area: console control-character escaping; deterministic ID injection, dropped-span-on-failure, entropy counter/handler, and ratio-sampling distribution; source normalization (absolute/relative/Windows/UNC/traversal/generated, plus end-to-end snapshot + collector ingest); owned vs borrowed shutdown, identity preservation/attributes, span kind, event level, resource, supported arrays, unsupported drops; and audit-run timeout, failure, output bounding, and environment seeding/minimization. Full `runtime/...`, `runtime/trace/otel`, `internal/diagnostics`, and `cmd/gowdk` suites pass; both modules `go vet` clean.

Fixes #579
Fixes #580
Fixes #581
Fixes #582
Fixes #583
Fixes #584