### PR TITLE
fix(dev): hold the runtime port instead of probe-then-reuse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@ packages, and tooling contracts may change before 1.0.
 - Request-time URL templates now validate `srcset` per candidate and encode SSR
   route/load/server-region substitutions when they appear inside URL-bearing
   attributes.
+- The dev server keeps the generated app's runtime port reserved and hands the
+  already-bound socket to the child process, closing a TOCTOU window in which
+  the port could be reclaimed between being probed and being bound (on platforms
+  that support file-descriptor inheritance; others keep the previous probe).
 
 ## v0.7.0 - 2026-06-17
 

--- a/cmd/gowdk/dev.go
+++ b/cmd/gowdk/dev.go
@@ -17,6 +17,15 @@ import (
 
 const defaultDevOutputDir = "gowdk_cache"
 
+// gowdkListenerFDEnv names the variable that hands an inherited listening socket
+// to the generated child process. It mirrors the runtime's reader (see
+// runtime/app: GOWDK_LISTENER_FD).
+const gowdkListenerFDEnv = "GOWDK_LISTENER_FD"
+
+// devRuntimeListenerFD is the descriptor number the child sees for the inherited
+// socket: exec.Cmd places ExtraFiles[0] at fd 3, after stdin/stdout/stderr.
+const devRuntimeListenerFD = 3
+
 func dev(args []string) error {
 	options, err := parseDevOptions(args)
 	if err != nil {
@@ -249,7 +258,7 @@ func (serve *devServeState) apply(state devBuildState, absDir string) error {
 
 func (serve *devServeState) useStatic(absDir string) error {
 	if serve.process != nil {
-		serve.process.stop()
+		serve.process.close()
 		serve.process = nil
 	}
 	if serve.server != nil && serve.staticDir == absDir {
@@ -279,20 +288,24 @@ func (serve *devServeState) useRuntime(runtime devRuntime) error {
 		serve.staticDir = ""
 	}
 	if serve.server == nil {
-		targetAddr, err := freeDevRuntimeAddr()
+		listener, targetAddr, err := reserveDevRuntimeAddr()
 		if err != nil {
 			return err
 		}
 		server, err := startDevRuntimeProxy(serve.addr, targetAddr, serve.reload)
 		if err != nil {
+			if listener != nil {
+				listener.Close()
+			}
 			return err
 		}
 		serve.server = server
 		serve.staticDir = ""
 		if serve.process == nil {
-			serve.process = &devRuntimeProcess{addr: targetAddr}
+			serve.process = &devRuntimeProcess{addr: targetAddr, listener: listener}
 		} else {
 			serve.process.addr = targetAddr
+			serve.process.listener = listener
 		}
 	}
 	if serve.process == nil {
@@ -335,7 +348,7 @@ func (serve *devServeState) runtimeAddr() string {
 
 func (serve *devServeState) close() {
 	if serve.process != nil {
-		serve.process.stop()
+		serve.process.close()
 		serve.process = nil
 	}
 	if serve.server != nil {
@@ -400,11 +413,32 @@ func stopDevStaticServer(server *http.Server) {
 	}
 }
 
-// freeDevRuntimeAddr returns a free loopback address for the generated app to
-// bind. The probe listener is closed before the address is handed back, so a
-// brief TOCTOU window remains in which another process could claim the port
-// before the generated binary binds it. Fully closing it requires handing the
-// bound listener to the child process (socket activation), tracked separately.
+// reserveDevRuntimeAddr picks the loopback address the generated app will serve
+// on. On platforms that support descriptor inheritance it returns a listener
+// bound to that address, kept open for the dev session and handed to the child
+// (see devRuntimeProcess.restart); the port is therefore never released between
+// being chosen and being served, closing the TOCTOU window. Elsewhere the
+// listener is nil and the caller falls back to the bound address alone.
+func reserveDevRuntimeAddr() (net.Listener, string, error) {
+	listener, err := acquireDevRuntimeListener()
+	if err != nil {
+		return nil, "", err
+	}
+	if listener != nil {
+		return listener, listener.Addr().String(), nil
+	}
+	addr, err := freeDevRuntimeAddr()
+	if err != nil {
+		return nil, "", err
+	}
+	return nil, addr, nil
+}
+
+// freeDevRuntimeAddr returns a free loopback address by probing with a throwaway
+// listener that is closed before the address is handed back. This leaves a brief
+// TOCTOU window in which another process could claim the port before the
+// generated binary binds it, so it is only used as a fallback on platforms
+// without descriptor inheritance (see reserveDevRuntimeAddr).
 func freeDevRuntimeAddr() (string, error) {
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
@@ -420,6 +454,7 @@ func freeDevRuntimeAddr() (string, error) {
 type devRuntimeProcess struct {
 	plan     devRuntime
 	addr     string
+	listener net.Listener
 	mu       sync.Mutex
 	cmd      *exec.Cmd
 	waitDone chan error
@@ -431,6 +466,19 @@ func (process *devRuntimeProcess) restart() error {
 	command.Env = append(os.Environ(), "GOWDK_ADDR="+process.addr)
 	command.Stdout = os.Stdout
 	command.Stderr = os.Stderr
+	if process.listener != nil {
+		// Hand the already-bound socket to the child so it serves on the same
+		// port the parent reserved, without rebinding (and without a window in
+		// which the port could be reclaimed). A fresh duplicate is passed on
+		// every restart because the previous child's copy dies with it.
+		file, err := listenerInheritFile(process.listener)
+		if err != nil {
+			return fmt.Errorf("share dev runtime listener: %w", err)
+		}
+		defer file.Close()
+		command.ExtraFiles = []*os.File{file}
+		command.Env = append(command.Env, fmt.Sprintf("%s=%d", gowdkListenerFDEnv, devRuntimeListenerFD))
+	}
 	if err := command.Start(); err != nil {
 		return fmt.Errorf("start generated app: %w", err)
 	}
@@ -453,6 +501,23 @@ func (process *devRuntimeProcess) stop() {
 	}
 	if waitDone != nil {
 		<-waitDone
+	}
+}
+
+// close tears the process down for good: it stops the child and releases the
+// reserved listener. Unlike stop (used between restarts), it must only be called
+// when the runtime is being abandoned, since the listener reservation is what
+// keeps the port held across restarts.
+func (process *devRuntimeProcess) close() {
+	process.stop()
+	process.mu.Lock()
+	listener := process.listener
+	process.listener = nil
+	process.mu.Unlock()
+	if listener != nil {
+		if err := listener.Close(); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+		}
 	}
 }
 

--- a/cmd/gowdk/dev_listener_other.go
+++ b/cmd/gowdk/dev_listener_other.go
@@ -1,0 +1,23 @@
+//go:build !unix
+
+package main
+
+import (
+	"fmt"
+	"net"
+	"os"
+)
+
+// acquireDevRuntimeListener is a no-op off Unix because exec.Cmd.ExtraFiles
+// descriptor inheritance (used to hand the bound socket to the child) is not
+// supported there, notably on Windows. Returning (nil, nil) makes the dev
+// server fall back to probing a free port via freeDevRuntimeAddr.
+func acquireDevRuntimeListener() (net.Listener, error) {
+	return nil, nil
+}
+
+// listenerInheritFile is never reached off Unix because acquireDevRuntimeListener
+// returns no listener; it exists so the dev server compiles on every platform.
+func listenerInheritFile(net.Listener) (*os.File, error) {
+	return nil, fmt.Errorf("listener descriptor inheritance is not supported on this platform")
+}

--- a/cmd/gowdk/dev_listener_unix.go
+++ b/cmd/gowdk/dev_listener_unix.go
@@ -1,0 +1,37 @@
+//go:build unix
+
+package main
+
+import (
+	"fmt"
+	"net"
+	"os"
+)
+
+// acquireDevRuntimeListener binds a loopback listener and keeps it open for the
+// lifetime of the dev session so the OS-assigned port stays reserved. The bound
+// socket is handed to each generated child process through a duplicated file
+// descriptor (see listenerInheritFile), eliminating the TOCTOU window that a
+// probe-then-close approach leaves between choosing a port and binding it.
+//
+// It returns (nil, nil) only on platforms without descriptor inheritance; on
+// Unix a non-nil listener is always returned on success.
+func acquireDevRuntimeListener() (net.Listener, error) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return nil, err
+	}
+	return listener, nil
+}
+
+// listenerInheritFile returns a duplicated *os.File for the listener's bound
+// socket so it can be passed to a child process via exec.Cmd.ExtraFiles. The
+// caller owns the returned file and must close it after starting the child; the
+// child inherits its own duplicate.
+func listenerInheritFile(listener net.Listener) (*os.File, error) {
+	tcp, ok := listener.(*net.TCPListener)
+	if !ok {
+		return nil, fmt.Errorf("dev runtime listener is %T, want *net.TCPListener", listener)
+	}
+	return tcp.File()
+}

--- a/cmd/gowdk/dev_listener_unix_test.go
+++ b/cmd/gowdk/dev_listener_unix_test.go
@@ -1,0 +1,59 @@
+//go:build unix
+
+package main
+
+import (
+	"net"
+	"path/filepath"
+	"testing"
+)
+
+// TestDevServeStateHandsListenerToRuntimeChild verifies that the dev server
+// reserves the runtime port up front, keeps it bound for the session, and hands
+// the bound socket to the generated child via GOWDK_LISTENER_FD. This is the
+// behavior that closes the port-allocation TOCTOU window (#543).
+func TestDevServeStateHandsListenerToRuntimeChild(t *testing.T) {
+	root := t.TempDir()
+	appDir := filepath.Join(root, "app")
+	writeCLIFile(t, filepath.Join(appDir, "go.mod"), "module example.com/devapp\n\ngo 1.24\n")
+	writeCLIFile(t, filepath.Join(appDir, "cmd", "server", "main.go"), `package main
+
+func main() {
+	select {}
+}
+`)
+	binaryPath := filepath.Join(root, "bin", "devapp")
+
+	serve := newDevServeState("127.0.0.1:0")
+	t.Cleanup(serve.close)
+
+	runtime := devRuntime{Enabled: true, AppDir: appDir, BinaryPath: binaryPath}
+	if err := serve.useRuntime(runtime); err != nil {
+		t.Fatal(err)
+	}
+
+	if serve.process == nil || serve.process.listener == nil {
+		t.Fatal("expected the dev runtime to reserve a held listener on unix")
+	}
+	if got, want := serve.process.listener.Addr().String(), serve.process.addr; got != want {
+		t.Fatalf("reserved listener addr %q != runtime addr %q", got, want)
+	}
+
+	command := activeDevRuntimeCommand(t, serve.process)
+	if len(command.ExtraFiles) != 1 {
+		t.Fatalf("expected exactly one inherited descriptor passed to the child, got %d", len(command.ExtraFiles))
+	}
+	if !hasEnvValue(command.Env, "GOWDK_LISTENER_FD=3") {
+		t.Fatalf("expected child env GOWDK_LISTENER_FD=3, env=%#v", command.Env)
+	}
+	if !hasEnvValue(command.Env, "GOWDK_ADDR="+serve.process.addr) {
+		t.Fatalf("expected child env GOWDK_ADDR=%q, env=%#v", serve.process.addr, command.Env)
+	}
+
+	// The reserved port stays bound for the whole session, so an independent
+	// bind on it must fail — there is no window in which it is free.
+	if listener, err := net.Listen("tcp", serve.process.addr); err == nil {
+		listener.Close()
+		t.Fatalf("expected reserved port %q to stay held by the dev session", serve.process.addr)
+	}
+}

--- a/runtime/app/lifecycle.go
+++ b/runtime/app/lifecycle.go
@@ -211,7 +211,16 @@ func startServices(ctx context.Context, serviceContext ServiceContext, services 
 func startServer(server *http.Server) <-chan error {
 	done := make(chan error, 1)
 	go func() {
-		err := server.ListenAndServe()
+		listener, err := inheritedListener()
+		if err != nil {
+			done <- fmt.Errorf("gowdk server failed: %w", err)
+			return
+		}
+		if listener != nil {
+			err = server.Serve(listener)
+		} else {
+			err = server.ListenAndServe()
+		}
 		if errors.Is(err, http.ErrServerClosed) {
 			err = nil
 		}

--- a/runtime/app/listener.go
+++ b/runtime/app/listener.go
@@ -1,0 +1,57 @@
+package app
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"strconv"
+	"strings"
+)
+
+// inheritedListenerEnv names the environment variable a parent process uses to
+// hand a pre-bound listening socket to the generated binary. When set, it holds
+// the file descriptor (numbered by the parent, e.g. via exec.Cmd.ExtraFiles)
+// of an already-bound, already-listening socket.
+const inheritedListenerEnv = "GOWDK_LISTENER_FD"
+
+// inheritedListener returns a listener wrapping a file descriptor handed down by
+// a parent process via GOWDK_LISTENER_FD, or (nil, nil) when no descriptor was
+// provided. The dev server uses this to keep a probed port reserved across
+// restarts: the parent binds the socket once and keeps it open, closing the
+// window in which the port could be reclaimed between probing and binding.
+//
+// The descriptor is consumed at most once per process; the variable is cleared
+// so a child spawned by this process does not attempt to reuse the same fd.
+func inheritedListener() (net.Listener, error) {
+	raw := strings.TrimSpace(os.Getenv(inheritedListenerEnv))
+	if raw == "" {
+		return nil, nil
+	}
+	os.Unsetenv(inheritedListenerEnv)
+
+	fd, err := strconv.Atoi(raw)
+	if err != nil || fd < 0 {
+		return nil, fmt.Errorf("invalid %s %q", inheritedListenerEnv, raw)
+	}
+
+	file := os.NewFile(uintptr(fd), "gowdk-inherited-listener")
+	if file == nil {
+		return nil, fmt.Errorf("invalid %s %q", inheritedListenerEnv, raw)
+	}
+	// net.FileListener duplicates the descriptor, so the wrapper File is no
+	// longer needed once the listener is built.
+	listener, err := net.FileListener(file)
+	if closeErr := file.Close(); closeErr != nil && err == nil {
+		// The listener is usable; only surface the close failure if listening
+		// itself succeeded.
+		err = fmt.Errorf("close inherited listener fd: %w", closeErr)
+		if listener != nil {
+			_ = listener.Close()
+			listener = nil
+		}
+	}
+	if err != nil {
+		return nil, fmt.Errorf("listen on inherited fd %d: %w", fd, err)
+	}
+	return listener, nil
+}

--- a/runtime/app/listener_test.go
+++ b/runtime/app/listener_test.go
@@ -1,0 +1,30 @@
+package app
+
+import "testing"
+
+func TestInheritedListenerWithoutEnv(t *testing.T) {
+	t.Setenv("GOWDK_LISTENER_FD", "")
+	listener, err := inheritedListener()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if listener != nil {
+		listener.Close()
+		t.Fatal("expected no inherited listener when GOWDK_LISTENER_FD is unset")
+	}
+}
+
+func TestInheritedListenerInvalidFD(t *testing.T) {
+	for _, value := range []string{"not-a-number", "-1"} {
+		t.Run(value, func(t *testing.T) {
+			t.Setenv("GOWDK_LISTENER_FD", value)
+			listener, err := inheritedListener()
+			if err == nil {
+				if listener != nil {
+					listener.Close()
+				}
+				t.Fatalf("expected error for GOWDK_LISTENER_FD=%q", value)
+			}
+		})
+	}
+}

--- a/runtime/app/listener_unix_test.go
+++ b/runtime/app/listener_unix_test.go
@@ -1,0 +1,68 @@
+//go:build unix
+
+package app
+
+import (
+	"net"
+	"strconv"
+	"syscall"
+	"testing"
+)
+
+// TestInheritedListenerRoundTrip verifies that a descriptor passed via
+// GOWDK_LISTENER_FD yields a working listener bound to the same socket, which is
+// how the dev server hands a pre-bound port to the generated child.
+func TestInheritedListenerRoundTrip(t *testing.T) {
+	base, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer base.Close()
+
+	file, err := base.(*net.TCPListener).File()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer file.Close()
+
+	// Hand inheritedListener its own duplicate so the descriptor it consumes and
+	// closes is independent of the ones this test owns.
+	dupFD, err := syscall.Dup(int(file.Fd()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("GOWDK_LISTENER_FD", strconv.Itoa(dupFD))
+
+	got, err := inheritedListener()
+	if err != nil {
+		t.Fatalf("inheritedListener: %v", err)
+	}
+	if got == nil {
+		t.Fatal("expected a listener from an inherited descriptor")
+	}
+	defer got.Close()
+
+	if got.Addr().String() != base.Addr().String() {
+		t.Fatalf("inherited listener addr = %q, want %q", got.Addr(), base.Addr())
+	}
+
+	accepted := make(chan error, 1)
+	go func() {
+		conn, err := got.Accept()
+		if err != nil {
+			accepted <- err
+			return
+		}
+		conn.Close()
+		accepted <- nil
+	}()
+
+	client, err := net.Dial("tcp", got.Addr().String())
+	if err != nil {
+		t.Fatalf("dial inherited listener: %v", err)
+	}
+	client.Close()
+	if err := <-accepted; err != nil {
+		t.Fatalf("accept on inherited listener: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Closes #543.

`freeDevRuntimeAddr` probed `127.0.0.1:0`, recorded the OS-chosen address,
**closed** the listener, and handed back the bare port. The generated child only
rebound that port later (proxy target + `GOWDK_ADDR`), leaving a TOCTOU window in
which another process could claim it — flaky dev startup, or proxying to the
wrong local service.

## Fix

- Keep the probed listener open for the whole dev session and hand the
  already-bound socket to each generated child via `exec.Cmd.ExtraFiles` +
  `GOWDK_LISTENER_FD`. The port is reserved continuously and never released
  between probe and bind; a fresh duplicate is passed on every restart.
- The runtime serves on the inherited descriptor when present and falls back to
  `ListenAndServe` otherwise, so production and non-inheritance platforms are
  unchanged.
- The handoff is gated to Unix (`ExtraFiles` is unsupported on Windows, which is
  a release target); Windows keeps the previous probe behavior.

## Verification

- `go build ./cmd/gowdk ./runtime/app` and `GOOS=windows go build ...`
- `go vet` clean for changed files
- `go test ./runtime/app/ ./cmd/gowdk/` — new tests cover the inherited-fd round
  trip, the child handoff env/`ExtraFiles`, and that the reserved port stays
  held for the session.