### PR TITLE
[codex] cover contract error redaction

### DIFF
--- a/runtime/contracts/fileoutbox/fileoutbox_test.go
+++ b/runtime/contracts/fileoutbox/fileoutbox_test.go
@@ -198,32 +198,70 @@ func TestReceiveEventBatchNackKeepsRecords(t *testing.T) {
 }
 
 func TestReceiveEventBatchNackRedactsLastError(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "outbox.jsonl")
-	store := New(path, WithJSONTypeDecoder[patientCreated]())
-	if err := store.StoreEvents(context.Background(), []contracts.EventEnvelope{{
-		Category: contracts.DomainEvent,
-		Type:     patientCreatedType,
-		Value:    patientCreated{ID: "patient-1"},
-	}}); err != nil {
-		t.Fatalf("store events: %v", err)
+	tests := []struct {
+		name string
+		err  string
+		want string
+		leak string
+	}{
+		{
+			name: "bearer token",
+			err:  "subscriber failed Authorization: Bearer abcdefgh1234567890",
+			want: "Authorization: Bearer [REDACTED]",
+			leak: "abcdefgh1234567890",
+		},
+		{
+			name: "dsn password",
+			err:  "subscriber failed opening postgres://app:supersecret@db.local/gowdk",
+			want: "postgres://app:[REDACTED]@db.local/gowdk",
+			leak: "supersecret",
+		},
+		{
+			name: "key value secret",
+			err:  "subscriber failed password=hunter2",
+			want: "password=[REDACTED]",
+			leak: "hunter2",
+		},
+		{
+			name: "non secret",
+			err:  "subscriber failed with temporary outage",
+			want: "subscriber failed with temporary outage",
+		},
 	}
 
-	batch, err := store.ReceiveEventBatch(context.Background())
-	if err != nil {
-		t.Fatalf("receive batch: %v", err)
-	}
-	if err := batch.Nack(context.Background(), errors.New("subscriber failed password=hunter2")); err != nil {
-		t.Fatalf("nack batch: %v", err)
-	}
-	records, err := store.Records(context.Background())
-	if err != nil {
-		t.Fatalf("records: %v", err)
-	}
-	if len(records) != 1 {
-		t.Fatalf("len(records) = %d, want 1", len(records))
-	}
-	if strings.Contains(records[0].LastError, "hunter2") || !strings.Contains(records[0].LastError, "password=[REDACTED]") {
-		t.Fatalf("last error was not redacted: %q", records[0].LastError)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "outbox.jsonl")
+			store := New(path, WithJSONTypeDecoder[patientCreated]())
+			if err := store.StoreEvents(context.Background(), []contracts.EventEnvelope{{
+				Category: contracts.DomainEvent,
+				Type:     patientCreatedType,
+				Value:    patientCreated{ID: "patient-1"},
+			}}); err != nil {
+				t.Fatalf("store events: %v", err)
+			}
+
+			batch, err := store.ReceiveEventBatch(context.Background())
+			if err != nil {
+				t.Fatalf("receive batch: %v", err)
+			}
+			if err := batch.Nack(context.Background(), errors.New(tt.err)); err != nil {
+				t.Fatalf("nack batch: %v", err)
+			}
+			records, err := store.Records(context.Background())
+			if err != nil {
+				t.Fatalf("records: %v", err)
+			}
+			if len(records) != 1 {
+				t.Fatalf("len(records) = %d, want 1", len(records))
+			}
+			if !strings.Contains(records[0].LastError, tt.want) {
+				t.Fatalf("last error = %q, want it to contain %q", records[0].LastError, tt.want)
+			}
+			if tt.leak != "" && strings.Contains(records[0].LastError, tt.leak) {
+				t.Fatalf("last error leaked %q: %q", tt.leak, records[0].LastError)
+			}
+		})
 	}
 }
 

--- a/runtime/contracts/worker_test.go
+++ b/runtime/contracts/worker_test.go
@@ -28,6 +28,62 @@ func (source *scriptedEventSource) ReceiveEventBatch(ctx context.Context) (Event
 	return EventBatch{}, ctx.Err()
 }
 
+func TestWorkerDispatchFailureLogRedactsSecrets(t *testing.T) {
+	tests := []struct {
+		name string
+		err  string
+		want string
+		leak string
+	}{
+		{
+			name: "bearer token",
+			err:  "subscriber failed Authorization: Bearer abcdefgh1234567890",
+			want: "Authorization: Bearer [REDACTED]",
+			leak: "abcdefgh1234567890",
+		},
+		{
+			name: "dsn password",
+			err:  "subscriber failed opening postgres://app:supersecret@db.local/gowdk",
+			want: "postgres://app:[REDACTED]@db.local/gowdk",
+			leak: "supersecret",
+		},
+		{
+			name: "key value secret",
+			err:  "subscriber failed api_key=sk_live_123456789",
+			want: "api_key=[REDACTED]",
+			leak: "sk_live_123456789",
+		},
+		{
+			name: "non secret",
+			err:  "subscriber failed with temporary outage",
+			want: "subscriber failed with temporary outage",
+		},
+	}
+
+	previousLogger := WorkerLogger
+	defer func() { WorkerLogger = previousLogger }()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var logged []string
+			WorkerLogger = func(message string) {
+				logged = append(logged, message)
+			}
+
+			logWorkerDispatchFailure(errors.New(tt.err))
+
+			if len(logged) != 1 {
+				t.Fatalf("logged = %#v, want one message", logged)
+			}
+			if !strings.Contains(logged[0], tt.want) {
+				t.Fatalf("logged message = %q, want it to contain %q", logged[0], tt.want)
+			}
+			if tt.leak != "" && strings.Contains(logged[0], tt.leak) {
+				t.Fatalf("logged message leaked %q: %q", tt.leak, logged[0])
+			}
+		})
+	}
+}
+
 func TestRunEventWorkerDispatchesAndAcks(t *testing.T) {
 	registry := NewRegistry()
 	var webHandled, workerHandled, rolelessHandled int


### PR DESCRIPTION
## Summary

- Adds explicit regression coverage for contract worker failure logs redacting bearer tokens, DSN passwords, and key/value secrets while preserving non-secret messages.
- Expands file outbox `LastError` coverage for the same secret classes before retry/dead-letter persistence.

Closes #570.

## Verification

- `go test ./runtime/contracts ./runtime/contracts/fileoutbox`
- `go test ./runtime/...`
- `go test ./cmd/gowdk -run TestRunAuditTestCommandTimesOut -count=1`
- `go test ./internal/appgen -run TestGeneratedBinaryFailsFastWhenRequiredEnvIsMissing -count=1`

`go test ./...` was also run; it failed in `TestRunAuditTestCommandTimesOut` and `TestGeneratedBinaryFailsFastWhenRequiredEnvIsMissing`, and both passed when rerun individually. The changed runtime packages passed.