### PR TITLE
[Runtime] cover hardening bug batch

### DIFF
--- a/addons/auth/auth_test.go
+++ b/addons/auth/auth_test.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"encoding/base64"
 	"encoding/hex"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
@@ -89,6 +90,24 @@ func TestHashPasswordWithIterationsRejectsInvalidIterations(t *testing.T) {
 	}
 	if _, err := (PBKDF2Hasher{Iterations: MaxIterations + 1}).HashPassword("same"); err == nil {
 		t.Fatalf("PBKDF2Hasher accepted iterations=%d", MaxIterations+1)
+	}
+}
+
+func TestDecodeHashEnforcesIterationBoundsBeforeDerivation(t *testing.T) {
+	canonicalSalt := base64.RawStdEncoding.EncodeToString([]byte(strings.Repeat("s", pbkdf2SaltLength)))
+	canonicalKey := base64.RawStdEncoding.EncodeToString([]byte(strings.Repeat("k", pbkdf2KeyLength)))
+	encoded := "pbkdf2-sha256$" + strconv.Itoa(MaxIterations) + "$" + canonicalSalt + "$" + canonicalKey
+	iterations, salt, key, err := decodeHash(encoded)
+	if err != nil {
+		t.Fatalf("decode hash at max iterations: %v", err)
+	}
+	if iterations != MaxIterations || len(salt) != pbkdf2SaltLength || len(key) != pbkdf2KeyLength {
+		t.Fatalf("decoded hash = iterations %d salt %d key %d", iterations, len(salt), len(key))
+	}
+
+	tooHigh := "pbkdf2-sha256$" + strconv.Itoa(MaxIterations+1) + "$" + canonicalSalt + "$" + canonicalKey
+	if _, _, _, err := decodeHash(tooHigh); !errors.Is(err, ErrInvalidHash) {
+		t.Fatalf("decode hash above max error = %v, want %v", err, ErrInvalidHash)
 	}
 }
 

--- a/runtime/app/app_test.go
+++ b/runtime/app/app_test.go
@@ -1614,6 +1614,31 @@ func TestResponseWriterWrappersExposeOptionalCapabilities(t *testing.T) {
 	}
 }
 
+func TestResponseWriterWrappersDoNotInventOptionalCapabilities(t *testing.T) {
+	base := &basicResponseWriter{header: http.Header{}}
+	boundary := wrapBoundaryResponseWriter(&boundaryResponseWriter{ResponseWriter: base})
+	if _, ok := boundary.(http.Flusher); ok {
+		t.Fatal("boundary wrapper exposed http.Flusher without underlying support")
+	}
+	if _, ok := boundary.(http.Hijacker); ok {
+		t.Fatal("boundary wrapper exposed http.Hijacker without underlying support")
+	}
+	if _, ok := boundary.(http.Pusher); ok {
+		t.Fatal("boundary wrapper exposed http.Pusher without underlying support")
+	}
+
+	traceWriter := wrapTraceResponseWriter(&traceResponseWriter{ResponseWriter: base, status: http.StatusOK})
+	if _, ok := traceWriter.(http.Flusher); ok {
+		t.Fatal("trace wrapper exposed http.Flusher without underlying support")
+	}
+	if _, ok := traceWriter.(http.Hijacker); ok {
+		t.Fatal("trace wrapper exposed http.Hijacker without underlying support")
+	}
+	if _, ok := traceWriter.(http.Pusher); ok {
+		t.Fatal("trace wrapper exposed http.Pusher without underlying support")
+	}
+}
+
 func TestBoundaryLogsRecoveredPanicWithRedactedSecret(t *testing.T) {
 	previous := BoundaryLogger
 	t.Cleanup(func() { BoundaryLogger = previous })
@@ -2299,6 +2324,20 @@ func waitForSpans(t *testing.T, ring *gowdktrace.RingSink, want int) []gowdktrac
 }
 
 var errHijackedForTest = errors.New("hijacked for test")
+
+type basicResponseWriter struct {
+	header http.Header
+}
+
+func (writer *basicResponseWriter) Header() http.Header {
+	return writer.header
+}
+
+func (writer *basicResponseWriter) Write(payload []byte) (int, error) {
+	return len(payload), nil
+}
+
+func (writer *basicResponseWriter) WriteHeader(status int) {}
 
 type optionalCapabilityResponseWriter struct {
 	http.ResponseWriter

--- a/runtime/contracts/contracts_test.go
+++ b/runtime/contracts/contracts_test.go
@@ -1230,6 +1230,30 @@ func TestNilRegistryAPIsReturnStructuredErrors(t *testing.T) {
 	}
 }
 
+func TestNilAndZeroValueRegistryMetadataAccessorsAreSafe(t *testing.T) {
+	var nilRegistry *Registry
+	if got := nilRegistry.Contracts(); got != nil {
+		t.Fatalf("nil registry contracts = %#v, want nil", got)
+	}
+	if got := nilRegistry.ContractsForRole(RoleWeb); got != nil {
+		t.Fatalf("nil registry role contracts = %#v, want nil", got)
+	}
+	if got := nilRegistry.Invalidations(); got != nil {
+		t.Fatalf("nil registry invalidations = %#v, want nil", got)
+	}
+
+	zeroRegistry := &Registry{}
+	if got := zeroRegistry.Contracts(); len(got) != 0 {
+		t.Fatalf("zero-value registry contracts = %#v, want empty", got)
+	}
+	if got := zeroRegistry.ContractsForRole(RoleWeb); len(got) != 0 {
+		t.Fatalf("zero-value registry role contracts = %#v, want empty", got)
+	}
+	if got := zeroRegistry.Invalidations(); len(got) != 0 {
+		t.Fatalf("zero-value registry invalidations = %#v, want empty", got)
+	}
+}
+
 func TestZeroValueRegistryIsUsable(t *testing.T) {
 	registry := &Registry{}
 	must(t, RegisterCommand[createPatient, createPatientResult](registry, func(ctx context.Context, command createPatient) (createPatientResult, error) {

--- a/runtime/contracts/fileoutbox/fileoutbox_test.go
+++ b/runtime/contracts/fileoutbox/fileoutbox_test.go
@@ -133,6 +133,36 @@ func TestAppendRecordsToPathFailedReplacementPreservesExistingRecords(t *testing
 	}
 }
 
+func TestAppendRecordsToPathDeduplicatesByRecordID(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "deadletter.jsonl")
+	store := New(filepath.Join(t.TempDir(), "outbox.jsonl"))
+	first := Record{
+		ID:       "record-1",
+		EventID:  "event-1",
+		Category: contracts.DomainEvent,
+		Type:     patientCreatedType,
+		Value:    json.RawMessage(`{"id":"patient-1"}`),
+	}
+	duplicate := first
+	duplicate.EventID = "event-duplicate"
+	duplicate.Value = json.RawMessage(`{"id":"patient-duplicate"}`)
+
+	if err := store.appendRecordsToPathLocked(path, []Record{first}); err != nil {
+		t.Fatalf("append initial record: %v", err)
+	}
+	if err := store.appendRecordsToPathLocked(path, []Record{duplicate}); err != nil {
+		t.Fatalf("append duplicate record: %v", err)
+	}
+
+	records, err := store.readRecordsFromPathLocked(path)
+	if err != nil {
+		t.Fatalf("read records: %v", err)
+	}
+	if len(records) != 1 || records[0].EventID != "event-1" {
+		t.Fatalf("duplicate dead-letter record should be ignored, got %#v", records)
+	}
+}
+
 func TestReceiveEventBatchDecodesAndAcksRecords(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "outbox.jsonl")
 	store := New(path, WithJSONTypeDecoder[patientCreated]())
@@ -564,6 +594,39 @@ func TestStoreEventsRejectsRecordLargerThanReaderLimit(t *testing.T) {
 	}
 	if _, statErr := os.Stat(path); !os.IsNotExist(statErr) {
 		t.Fatalf("oversized event should not create outbox file, stat err=%v", statErr)
+	}
+}
+
+func TestStoreEventsRejectsOversizedRecordWithoutPoisoningLaterDelivery(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "outbox.jsonl")
+	store := New(path, WithJSONTypeDecoder[patientCreated]())
+
+	err := store.StoreEvents(context.Background(), []contracts.EventEnvelope{{
+		Category: contracts.DomainEvent,
+		Type:     patientCreatedType,
+		Value:    strings.Repeat("x", maxJSONLineBytes),
+	}})
+	if err == nil || !strings.Contains(err.Error(), "file outbox record exceeds") {
+		t.Fatalf("store oversized event error = %v, want record-size error", err)
+	}
+	if err := store.StoreEvents(context.Background(), []contracts.EventEnvelope{{
+		Category: contracts.DomainEvent,
+		Type:     patientCreatedType,
+		Value:    patientCreated{ID: "patient-1"},
+	}}); err != nil {
+		t.Fatalf("store later event: %v", err)
+	}
+
+	batch, err := store.ReceiveEventBatch(context.Background())
+	if err != nil {
+		t.Fatalf("receive batch after oversized attempt: %v", err)
+	}
+	if len(batch.Events) != 1 {
+		t.Fatalf("len(batch.Events) = %d, want 1", len(batch.Events))
+	}
+	value, ok := batch.Events[0].Value.(patientCreated)
+	if !ok || value.ID != "patient-1" {
+		t.Fatalf("delivered event value = %#v, want patientCreated patient-1", batch.Events[0].Value)
 	}
 }
 

--- a/runtime/guard/guard_test.go
+++ b/runtime/guard/guard_test.go
@@ -210,6 +210,68 @@ func TestWriteNoStoreFailure(t *testing.T) {
 	}
 }
 
+func TestWriteNoStoreFailureRedactsGuardRuntimeErrors(t *testing.T) {
+	request := httptest.NewRequest(http.MethodGet, "/dashboard", nil)
+	cases := []struct {
+		name    string
+		err     error
+		blocked []string
+	}{
+		{
+			name: "custom guard failure",
+			err: RunGuards(NewContext(request, nil), []string{"auth.required"}, Registry{
+				"auth.required": func(Context) error {
+					return errors.New("database denied tenant=acme password=hunter2")
+				},
+			}),
+			blocked: []string{"auth.required", "database", "tenant=acme", "hunter2"},
+		},
+		{
+			name:    "missing guard",
+			err:     RunGuards(NewContext(request, nil), []string{"billing.active"}, Registry{}),
+			blocked: []string{"billing.active", "not registered"},
+		},
+		{
+			name:    "native missing auth provider",
+			err:     RunGuardsWithAuth(NewContext(request, nil), []string{"role:admin"}, nil, nil),
+			blocked: []string{"role:admin", "requires an auth provider"},
+		},
+		{
+			name: "native unauthenticated",
+			err: RunGuardsWithAuth(NewContext(request, nil), []string{"role:admin"}, nil, gowdkauth.ProviderFunc(func(*http.Request) (*gowdkauth.Principal, error) {
+				return nil, nil
+			})),
+			blocked: []string{"role:admin", gowdkauth.ErrUnauthenticated.Error()},
+		},
+		{
+			name: "native forbidden",
+			err: RunGuardsWithAuth(NewContext(request, nil), []string{"permission:posts.write"}, nil, gowdkauth.ProviderFunc(func(*http.Request) (*gowdkauth.Principal, error) {
+				return &gowdkauth.Principal{}, nil
+			})),
+			blocked: []string{"permission:posts.write", gowdkauth.ErrForbidden.Error()},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.err == nil {
+				t.Fatal("expected guard failure")
+			}
+			recorder := httptest.NewRecorder()
+			WriteNoStoreFailure(recorder, tc.err)
+			body := recorder.Body.String()
+			if recorder.Code != http.StatusForbidden || recorder.Header().Get("Cache-Control") != "no-store" || !strings.Contains(body, "403 forbidden") {
+				t.Fatalf("unexpected generic response: status=%d headers=%v body=%q", recorder.Code, recorder.Header(), body)
+			}
+			for _, text := range tc.blocked {
+				if strings.Contains(body, text) {
+					t.Fatalf("guard failure body leaked %q: %q", text, body)
+				}
+			}
+		})
+	}
+}
+
 func waitForSpans(t *testing.T, ring *gowdktrace.RingSink, want int) []gowdktrace.Snapshot {
 	t.Helper()
 	deadline := time.Now().Add(time.Second)


### PR DESCRIPTION
## Summary

- Add guard regression coverage that routes real custom, missing, and native RBAC guard failures through `WriteNoStoreFailure` and verifies clients only receive the generic `403 forbidden` body.
- Add ResponseWriter wrapper coverage that boundary/tracing wrappers preserve optional capabilities only when the underlying writer supports them.
- Add file outbox coverage for oversized-record rejection without poisoning later delivery and dead-letter duplicate-ID dedupe.
- Add PBKDF2 stored-hash iteration-bound decode coverage, plus nil/zero-value contract registry metadata accessor coverage.

## Issues

Closes #563
Closes #564
Closes #565
Closes #566
Closes #567
Closes #568

## Verification

- `go test ./runtime/guard`
- `go test ./runtime/contracts ./runtime/contracts/fileoutbox ./addons/auth ./runtime/app ./runtime/guard`