### PR TITLE
docs(release): version-agnostic install snippets + drift guardrail

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,6 +114,9 @@ jobs:
       - name: Check for removed source syntax in docs
         run: sh scripts/check-removed-syntax.sh
 
+      - name: Check docs do not pin a release version
+        run: sh scripts/check-doc-versions.sh
+
   docs-site:
     name: Docs site compile
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -37,10 +37,11 @@ Or use the install script:
 curl -fsSL https://raw.githubusercontent.com/cssbruno/GoWDK/main/scripts/install.sh | sh
 ```
 
-Pin the current CLI release:
+Pin a specific CLI release (replace `<version>` with a tag from the
+[releases page](https://github.com/cssbruno/GoWDK/releases)):
 
 ```sh
-GOWDK_VERSION=v0.7.0 GOWDK_INSTALL_DIR="$HOME/.local/bin" \
+GOWDK_VERSION=<version> GOWDK_INSTALL_DIR="$HOME/.local/bin" \
   sh -c "$(curl -fsSL https://raw.githubusercontent.com/cssbruno/GoWDK/main/scripts/install.sh)"
 ```
 

--- a/docs/engineering/ci.md
+++ b/docs/engineering/ci.md
@@ -125,13 +125,13 @@ the same change or open a narrower issue naming the unstable file/report.
 After publishing a tag, verify the current machine's release artifact locally:
 
 ```sh
-scripts/smoke-release-artifact.sh v0.7.0
+scripts/smoke-release-artifact.sh vX.Y.Z
 ```
 
 Pass an explicit asset name to test a non-native artifact:
 
 ```sh
-scripts/smoke-release-artifact.sh v0.7.0 gowdk-linux-amd64
+scripts/smoke-release-artifact.sh vX.Y.Z gowdk-linux-amd64
 ```
 
 Use `GOWDK_RELEASE_REPO=owner/repo` for forks. The GitHub-only matrix version

--- a/docs/engineering/release.md
+++ b/docs/engineering/release.md
@@ -6,7 +6,8 @@ visible normal GitHub releases with downloadable assets from `v*` tags or a
 manual workflow dispatch. VS Code Marketplace publishing lives in
 `.github/workflows/vscode-extension-publish.yml`.
 
-The current CLI version is `0.7.0`, but this is not a production-readiness
+The current CLI version is set by `const version` in `cmd/gowdk/main.go` (and
+bumped automatically by release-please), but this is not a production-readiness
 claim. It identifies the current development line while the compiler, generated
 runtime, and docs continue through the 0.x line. Public release notes must keep
 the build experimental and not production-ready until the 1.0 release gates are
@@ -84,18 +85,21 @@ go run ./cmd/gowdk build --out /tmp/gowdk-component-assets examples/components/a
 go run ./cmd/gowdk build --out /tmp/gowdk-wasm-island examples/components/wasm/*.gwdk
 ```
 
-After those gates pass on the release commit, run the release workflow manually
-for the current CLI line or push the corresponding tag:
+The normal path is to merge the open **release-please** PR, which bumps the
+version and pushes the `vX.Y.Z` tag that triggers `release.yml`. To release
+manually instead (fallback), after those gates pass on the release commit, run
+the release workflow for the current CLI line or push the corresponding tag
+(substitute the version you are releasing):
 
 ```sh
-gh workflow run release.yml -f version=v0.7.0
+gh workflow run release.yml -f version=vX.Y.Z
 ```
 
 After the release workflow completes, smoke the published artifacts for each
 supported OS artifact:
 
 ```sh
-gh workflow run release-smoke.yml -f version=v0.7.0
+gh workflow run release-smoke.yml -f version=vX.Y.Z
 ```
 
 ## Artifacts
@@ -106,7 +110,7 @@ gh workflow run release-smoke.yml -f version=v0.7.0
 - `gowdk-darwin-arm64`
 - `gowdk-windows-amd64.exe`
 - `checksums.txt`
-- `gowdk-vscode-0.7.0.vsix`
+- `gowdk-vscode-<version>.vsix` (the release version, e.g. `gowdk-vscode-0.8.0.vsix`)
 
 ## Install Script
 
@@ -116,10 +120,10 @@ default. It selects the current operating system and architecture, downloads
 platform before binary download, verifies the binary SHA-256, and writes
 `gowdk` into `GOWDK_INSTALL_DIR` or `/usr/local/bin`.
 
-Pinned install:
+Pinned install (replace `<version>` with a published release tag):
 
 ```sh
-GOWDK_VERSION=v0.7.0 GOWDK_INSTALL_DIR="$HOME/.local/bin" \
+GOWDK_VERSION=<version> GOWDK_INSTALL_DIR="$HOME/.local/bin" \
   sh -c "$(curl -fsSL https://raw.githubusercontent.com/cssbruno/GoWDK/main/scripts/install.sh)"
 ```
 
@@ -140,7 +144,7 @@ gh attestation verify <artifact> -R <owner>/<repo>
 ## Extension Publishing
 
 The release workflow packages the extension into a `.vsix` named from
-`editors/vscode/package.json`, currently `gowdk-vscode-0.7.0.vsix`.
+`editors/vscode/package.json` (e.g. `gowdk-vscode-0.8.0.vsix`).
 Marketplace publishing is handled by the `Publish VS Code Extension` workflow.
 It is manual-only so CLI/runtime releases do not accidentally republish an
 extension version that already exists on the Marketplace.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -18,10 +18,12 @@ curl -fsSL https://raw.githubusercontent.com/cssbruno/GoWDK/main/scripts/install
 gowdk version
 ```
 
-Pin the current CLI release or install into a user-writable directory:
+Pin a specific CLI release (replace `<version>` with a tag from the
+[releases page](https://github.com/cssbruno/GoWDK/releases)) or install into a
+user-writable directory:
 
 ```sh
-GOWDK_VERSION=v0.7.0 GOWDK_INSTALL_DIR="$HOME/.local/bin" \
+GOWDK_VERSION=<version> GOWDK_INSTALL_DIR="$HOME/.local/bin" \
   sh -c "$(curl -fsSL https://raw.githubusercontent.com/cssbruno/GoWDK/main/scripts/install.sh)"
 ```
 
@@ -96,9 +98,8 @@ Direct artifact names:
 Manual Linux install:
 
 ```sh
-version=v0.7.0
-curl -fsSLO "https://github.com/cssbruno/GoWDK/releases/download/$version/gowdk-linux-amd64"
-curl -fsSLO "https://github.com/cssbruno/GoWDK/releases/download/$version/checksums.txt"
+curl -fsSLO "https://github.com/cssbruno/GoWDK/releases/latest/download/gowdk-linux-amd64"
+curl -fsSLO "https://github.com/cssbruno/GoWDK/releases/latest/download/checksums.txt"
 grep ' gowdk-linux-amd64$' checksums.txt | sha256sum -c -
 chmod 0755 gowdk-linux-amd64
 mkdir -p "$HOME/.local/bin"
@@ -109,9 +110,8 @@ gowdk version
 Manual macOS Intel install:
 
 ```sh
-version=v0.7.0
-curl -fsSLO "https://github.com/cssbruno/GoWDK/releases/download/$version/gowdk-darwin-amd64"
-curl -fsSLO "https://github.com/cssbruno/GoWDK/releases/download/$version/checksums.txt"
+curl -fsSLO "https://github.com/cssbruno/GoWDK/releases/latest/download/gowdk-darwin-amd64"
+curl -fsSLO "https://github.com/cssbruno/GoWDK/releases/latest/download/checksums.txt"
 expected="$(awk '$2 == "gowdk-darwin-amd64" { print $1 }' checksums.txt)"
 actual="$(shasum -a 256 gowdk-darwin-amd64 | awk '{ print $1 }')"
 test "$expected" = "$actual"
@@ -124,9 +124,8 @@ gowdk version
 Manual macOS ARM install:
 
 ```sh
-version=v0.7.0
-curl -fsSLO "https://github.com/cssbruno/GoWDK/releases/download/$version/gowdk-darwin-arm64"
-curl -fsSLO "https://github.com/cssbruno/GoWDK/releases/download/$version/checksums.txt"
+curl -fsSLO "https://github.com/cssbruno/GoWDK/releases/latest/download/gowdk-darwin-arm64"
+curl -fsSLO "https://github.com/cssbruno/GoWDK/releases/latest/download/checksums.txt"
 expected="$(awk '$2 == "gowdk-darwin-arm64" { print $1 }' checksums.txt)"
 actual="$(shasum -a 256 gowdk-darwin-arm64 | awk '{ print $1 }')"
 test "$expected" = "$actual"
@@ -139,9 +138,8 @@ gowdk version
 Manual Windows install from PowerShell:
 
 ```powershell
-$version = "v0.7.0"
-Invoke-WebRequest "https://github.com/cssbruno/GoWDK/releases/download/$version/gowdk-windows-amd64.exe" -OutFile "gowdk.exe"
-Invoke-WebRequest "https://github.com/cssbruno/GoWDK/releases/download/$version/checksums.txt" -OutFile "checksums.txt"
+Invoke-WebRequest "https://github.com/cssbruno/GoWDK/releases/latest/download/gowdk-windows-amd64.exe" -OutFile "gowdk.exe"
+Invoke-WebRequest "https://github.com/cssbruno/GoWDK/releases/latest/download/checksums.txt" -OutFile "checksums.txt"
 $expected = (Select-String -Path checksums.txt -Pattern "gowdk-windows-amd64.exe").Line.Split(" ")[0]
 $actual = (Get-FileHash .\gowdk.exe -Algorithm SHA256).Hash.ToLower()
 if ($expected -ne $actual) { throw "checksum mismatch" }
@@ -155,10 +153,11 @@ gh attestation verify ./gowdk-linux-amd64 -R cssbruno/GOWDK
 ```
 
 Install the VS Code extension package from a release when a `.vsix` is
-published:
+published (the filename carries the release version, e.g.
+`gowdk-vscode-0.8.0.vsix`):
 
 ```sh
-code --install-extension gowdk-vscode-0.7.0.vsix
+code --install-extension ./gowdk-vscode-*.vsix
 ```
 
 ## Build From Source

--- a/scripts/check-doc-versions.sh
+++ b/scripts/check-doc-versions.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env sh
+set -eu
+
+# Guard against install/download docs pinning a release version. release-please
+# bumps only the canonical version (cmd/gowdk/main.go + editors/vscode/package.json);
+# any version hardcoded in install snippets drifts on every release and sends
+# users to the previous release. Install snippets must use
+# `releases/latest/download/<asset>` or a `<version>` / `vX.Y.Z` placeholder.
+# See docs/engineering/release.md.
+
+repo_root=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+cd "${repo_root}"
+
+status=0
+
+check() {
+  matches=$(grep -rEn --include='*.md' "$2" README.md docs 2>/dev/null || true)
+  if [ -n "${matches}" ]; then
+    echo "error: $1" >&2
+    printf '%s\n\n' "${matches}" >&2
+    status=1
+  fi
+}
+
+check "hardcoded release download URL (use releases/latest/download/<asset>)" \
+  'releases/download/v[0-9]'
+check "hardcoded GOWDK_VERSION (use a <version> placeholder)" \
+  'GOWDK_VERSION=v[0-9]'
+
+if [ "${status}" -ne 0 ]; then
+  echo "Install/download docs must not pin a release version; see docs/engineering/release.md." >&2
+fi
+
+exit "${status}"


### PR DESCRIPTION
## Why
Follow-up to #626 (release-please). release-please bumps **only** the canonical version (`cmd/gowdk/main.go` + `editors/vscode/package.json`). User-facing install/download docs that hardcoded `v0.7.0` would **drift on every release** — after 0.8.0 cuts, copy-paste install/smoke instructions would still fetch the previous release. (Caught by review on #626.)

## What
Makes the version-bearing docs **version-agnostic** so there's nothing to bump, plus a guardrail so it can't regress:

- **Manual per-OS download blocks** (`docs/getting-started.md`) → use GitHub's `releases/latest/download/<asset>` (dropped the `version=v0.7.0` var). Always fetches the newest release.
- **Pinned-install + VSIX snippets** (`README.md`, `getting-started.md`, `release.md`) → `<version>` placeholder with a link to the releases page.
- **Runbook/CI examples** (`release.md`, `ci.md`) → `vX.Y.Z` placeholders; "current CLI version" now points at `cmd/gowdk/main.go` instead of a hardcoded number, and notes release-please as the normal release path.
- **Guardrail**: `scripts/check-doc-versions.sh` + a step in the CI `docs` job fails if install docs ever pin a release version again.

## Verification
- `scripts/check-doc-versions.sh` → passes (and correctly fails on a pinned form)
- `scripts/check-docs-links.sh` → `docs links ok`
- `scripts/check-removed-syntax.sh` → ok
- No `v0.7.0` left in `README.md`/`docs/**`

Note: the default one-liner installer was already version-agnostic; this fixes the pinned/manual paths it didn't cover.
