### PR TITLE
[codex] complete refactor issue cleanup

### DIFF
--- a/cmd/gowdk/add.go
+++ b/cmd/gowdk/add.go
@@ -137,6 +137,22 @@ func addAddon(args []string) error {
 	jsonOutput := false
 	for index := 0; index < len(args); index++ {
 		arg := args[index]
+		if value, next, ok, missing := consumeValueFlag(args, index, "--config", true); ok {
+			if missing {
+				return fmt.Errorf("%s\n--config requires a value", addUsage)
+			}
+			configPath = value
+			index = next
+			continue
+		}
+		if value, next, ok, missing := consumeValueFlag(args, index, "--base-url", true); ok {
+			if missing || value == "" {
+				return fmt.Errorf("%s\n--base-url requires a value", addUsage)
+			}
+			options.SEOBaseURL = value
+			index = next
+			continue
+		}
 		switch {
 		case arg == "--list":
 			list = true
@@ -144,25 +160,6 @@ func addAddon(args []string) error {
 			registryList = true
 		case arg == "--json":
 			jsonOutput = true
-		case arg == "--config":
-			if index+1 >= len(args) {
-				return fmt.Errorf("%s\n--config requires a value", addUsage)
-			}
-			index++
-			configPath = args[index]
-		case strings.HasPrefix(arg, "--config="):
-			configPath = strings.TrimPrefix(arg, "--config=")
-		case arg == "--base-url":
-			if index+1 >= len(args) {
-				return fmt.Errorf("%s\n--base-url requires a value", addUsage)
-			}
-			index++
-			options.SEOBaseURL = args[index]
-		case strings.HasPrefix(arg, "--base-url="):
-			options.SEOBaseURL = strings.TrimPrefix(arg, "--base-url=")
-			if options.SEOBaseURL == "" {
-				return fmt.Errorf("%s\n--base-url requires a value", addUsage)
-			}
 		case strings.HasPrefix(arg, "-"):
 			return fmt.Errorf("unknown add flag %q", arg)
 		default:

--- a/cmd/gowdk/build.go
+++ b/cmd/gowdk/build.go
@@ -68,7 +68,6 @@ type buildOptions struct {
 	DockerBase        string
 	DeployRecipes     []string
 	ConfigPath        string
-	EnvFilePath       string
 	TargetNames       []string
 	ModuleNames       []string
 	Paths             []string
@@ -108,11 +107,31 @@ func (plan buildOptions) request() buildRequest {
 }
 
 func (plan buildOptions) hasAdHocArgs() bool {
-	return hasAdHocBuildArgs(plan.OutputDir, plan.AppDir, plan.BinaryPath, plan.WASMPath, plan.BackendAppDir, plan.BackendBinaryPath, plan.Docker, plan.DockerBase, plan.DeployRecipes, plan.ModuleNames, plan.Paths)
+	return plan.request().hasAdHocArgs()
 }
 
 func (plan buildOptions) shouldBuildConfiguredTargets() bool {
-	return shouldBuildConfiguredTargets(plan.Options.Config, plan.TargetNames, plan.OutputDir, plan.AppDir, plan.BinaryPath, plan.WASMPath, plan.BackendAppDir, plan.BackendBinaryPath, plan.Docker, plan.DockerBase, plan.DeployRecipes, plan.ModuleNames, plan.Paths)
+	if len(plan.TargetNames) > 0 {
+		return true
+	}
+	if len(plan.Options.Config.Build.Targets) == 0 {
+		return false
+	}
+	return !plan.request().hasAdHocArgs()
+}
+
+func (request buildRequest) hasAdHocArgs() bool {
+	return strings.TrimSpace(request.OutputDir) != "" ||
+		strings.TrimSpace(request.AppDir) != "" ||
+		strings.TrimSpace(request.BinaryPath) != "" ||
+		strings.TrimSpace(request.WASMPath) != "" ||
+		strings.TrimSpace(request.BackendAppDir) != "" ||
+		strings.TrimSpace(request.BackendBinaryPath) != "" ||
+		request.Docker ||
+		strings.TrimSpace(request.DockerBase) != "" ||
+		len(request.DeployRecipes) > 0 ||
+		len(request.Modules) > 0 ||
+		len(request.Paths) > 0
 }
 
 func buildOnce(options cliOptions, request buildRequest, timings *buildTimingRecorder) error {
@@ -439,40 +458,6 @@ func buildOnce(options cliOptions, request buildRequest, timings *buildTimingRec
 	return nil
 }
 
-func shouldBuildConfiguredTargets(config gowdk.Config, targetNames []string, outputDir, appDir, binaryPath, wasmPath, backendAppDir, backendBinaryPath string, docker bool, dockerBase string, deployRecipes []string, moduleNames, paths []string) bool {
-	if len(targetNames) > 0 {
-		return true
-	}
-	if len(config.Build.Targets) == 0 {
-		return false
-	}
-	return strings.TrimSpace(outputDir) == "" &&
-		strings.TrimSpace(appDir) == "" &&
-		strings.TrimSpace(binaryPath) == "" &&
-		strings.TrimSpace(wasmPath) == "" &&
-		strings.TrimSpace(backendAppDir) == "" &&
-		strings.TrimSpace(backendBinaryPath) == "" &&
-		!docker &&
-		strings.TrimSpace(dockerBase) == "" &&
-		len(deployRecipes) == 0 &&
-		len(moduleNames) == 0 &&
-		len(paths) == 0
-}
-
-func hasAdHocBuildArgs(outputDir, appDir, binaryPath, wasmPath, backendAppDir, backendBinaryPath string, docker bool, dockerBase string, deployRecipes, moduleNames, paths []string) bool {
-	return strings.TrimSpace(outputDir) != "" ||
-		strings.TrimSpace(appDir) != "" ||
-		strings.TrimSpace(binaryPath) != "" ||
-		strings.TrimSpace(wasmPath) != "" ||
-		strings.TrimSpace(backendAppDir) != "" ||
-		strings.TrimSpace(backendBinaryPath) != "" ||
-		docker ||
-		strings.TrimSpace(dockerBase) != "" ||
-		len(deployRecipes) > 0 ||
-		len(moduleNames) > 0 ||
-		len(paths) > 0
-}
-
 func buildConfiguredTargets(plan buildOptions, timings *buildTimingRecorder) error {
 	targets, err := selectBuildTargets(plan.Options.Config.Build.Targets, plan.TargetNames)
 	if err != nil {
@@ -502,6 +487,42 @@ func buildConfiguredTargets(plan buildOptions, timings *buildTimingRecorder) err
 }
 
 func selectBuildTargets(targets []gowdk.BuildTargetConfig, targetNames []string) ([]gowdk.BuildTargetConfig, error) {
+	selected, err := resolveConfiguredBuildTargets(targets, targetNames)
+	if err != nil {
+		return nil, err
+	}
+	normalized := make([]gowdk.BuildTargetConfig, 0, len(selected))
+	for _, target := range selected {
+		target.Modules = cleanNames(target.Modules)
+		recipes, err := normalizeDeploymentRecipes(target.DeployRecipes)
+		if err != nil {
+			return nil, fmt.Errorf("build target %q: %w", target.Name, err)
+		}
+		target.DeployRecipes = recipes
+		if strings.TrimSpace(target.Output) == "" {
+			target.Output = defaultBuildTargetOutput(target.Name)
+		}
+		if strings.TrimSpace(target.Binary) != "" && strings.TrimSpace(target.App) == "" {
+			return nil, fmt.Errorf("build target %q binary requires app", target.Name)
+		}
+		if strings.TrimSpace(target.WASM) != "" && strings.TrimSpace(target.App) == "" {
+			return nil, fmt.Errorf("build target %q wasm requires app", target.Name)
+		}
+		if strings.TrimSpace(target.BackendBinary) != "" && strings.TrimSpace(target.BackendApp) == "" {
+			return nil, fmt.Errorf("build target %q backend binary requires backend app", target.Name)
+		}
+		target.Output = strings.TrimSpace(target.Output)
+		target.App = strings.TrimSpace(target.App)
+		target.Binary = strings.TrimSpace(target.Binary)
+		target.WASM = strings.TrimSpace(target.WASM)
+		target.BackendApp = strings.TrimSpace(target.BackendApp)
+		target.BackendBinary = strings.TrimSpace(target.BackendBinary)
+		normalized = append(normalized, target)
+	}
+	return normalized, nil
+}
+
+func resolveConfiguredBuildTargets(targets []gowdk.BuildTargetConfig, targetNames []string) ([]gowdk.BuildTargetConfig, error) {
 	byName := map[string]gowdk.BuildTargetConfig{}
 	var normalized []gowdk.BuildTargetConfig
 	for _, target := range targets {
@@ -513,34 +534,9 @@ func selectBuildTargets(targets []gowdk.BuildTargetConfig, targetNames []string)
 			return nil, fmt.Errorf("build target %q is configured more than once", name)
 		}
 		target.Name = name
-		target.Modules = cleanNames(target.Modules)
-		recipes, err := normalizeDeploymentRecipes(target.DeployRecipes)
-		if err != nil {
-			return nil, fmt.Errorf("build target %q: %w", name, err)
-		}
-		target.DeployRecipes = recipes
-		if strings.TrimSpace(target.Output) == "" {
-			target.Output = defaultBuildTargetOutput(name)
-		}
-		if strings.TrimSpace(target.Binary) != "" && strings.TrimSpace(target.App) == "" {
-			return nil, fmt.Errorf("build target %q binary requires app", name)
-		}
-		if strings.TrimSpace(target.WASM) != "" && strings.TrimSpace(target.App) == "" {
-			return nil, fmt.Errorf("build target %q wasm requires app", name)
-		}
-		if strings.TrimSpace(target.BackendBinary) != "" && strings.TrimSpace(target.BackendApp) == "" {
-			return nil, fmt.Errorf("build target %q backend binary requires backend app", name)
-		}
-		target.Output = strings.TrimSpace(target.Output)
-		target.App = strings.TrimSpace(target.App)
-		target.Binary = strings.TrimSpace(target.Binary)
-		target.WASM = strings.TrimSpace(target.WASM)
-		target.BackendApp = strings.TrimSpace(target.BackendApp)
-		target.BackendBinary = strings.TrimSpace(target.BackendBinary)
 		byName[name] = target
 		normalized = append(normalized, target)
 	}
-
 	if len(targetNames) == 0 {
 		return normalized, nil
 	}
@@ -619,6 +615,120 @@ func parseBuildOptions(args []string) (buildOptions, error) {
 	var plan buildOptions
 	for i := 0; i < len(args); i++ {
 		arg := args[i]
+		if value, next, ok, missing := consumeValueFlag(args, i, "--out", false); ok {
+			if missing {
+				return buildOptions{}, fmt.Errorf(buildUsage)
+			}
+			plan.OutputDir = value
+			i = next
+			continue
+		}
+		if value, next, ok, missing := consumeValueFlag(args, i, "--app", false); ok {
+			if missing {
+				return buildOptions{}, fmt.Errorf(buildUsage)
+			}
+			plan.AppDir = value
+			if strings.TrimSpace(plan.AppDir) == "" {
+				return buildOptions{}, fmt.Errorf("generated app directory is required")
+			}
+			i = next
+			continue
+		}
+		if value, next, ok, missing := consumeValueFlag(args, i, "--bin", false); ok {
+			if missing {
+				return buildOptions{}, fmt.Errorf(buildUsage)
+			}
+			plan.BinaryPath = value
+			if strings.TrimSpace(plan.BinaryPath) == "" {
+				return buildOptions{}, fmt.Errorf("binary output path is required")
+			}
+			i = next
+			continue
+		}
+		if value, next, ok, missing := consumeValueFlag(args, i, "--docker-base", true); ok {
+			if missing {
+				return buildOptions{}, fmt.Errorf(buildUsage)
+			}
+			plan.DockerBase = value
+			if strings.TrimSpace(plan.DockerBase) == "" {
+				return buildOptions{}, fmt.Errorf("Docker base is required")
+			}
+			i = next
+			continue
+		}
+		if value, next, ok, missing := consumeValueFlag(args, i, "--deploy-recipe", true); ok {
+			if missing {
+				return buildOptions{}, fmt.Errorf(buildUsage)
+			}
+			plan.DeployRecipes = appendNames(plan.DeployRecipes, value)
+			i = next
+			continue
+		}
+		if value, next, ok, missing := consumeValueFlag(args, i, "--wasm", false); ok {
+			if missing {
+				return buildOptions{}, fmt.Errorf(buildUsage)
+			}
+			plan.WASMPath = value
+			if strings.TrimSpace(plan.WASMPath) == "" {
+				return buildOptions{}, fmt.Errorf("wasm output path is required")
+			}
+			i = next
+			continue
+		}
+		if value, next, ok, missing := consumeValueFlag(args, i, "--backend-app", false); ok {
+			if missing {
+				return buildOptions{}, fmt.Errorf(buildUsage)
+			}
+			plan.BackendAppDir = value
+			if strings.TrimSpace(plan.BackendAppDir) == "" {
+				return buildOptions{}, fmt.Errorf("generated backend app directory is required")
+			}
+			i = next
+			continue
+		}
+		if value, next, ok, missing := consumeValueFlag(args, i, "--backend-bin", false); ok {
+			if missing {
+				return buildOptions{}, fmt.Errorf(buildUsage)
+			}
+			plan.BackendBinaryPath = value
+			if strings.TrimSpace(plan.BackendBinaryPath) == "" {
+				return buildOptions{}, fmt.Errorf("backend binary output path is required")
+			}
+			i = next
+			continue
+		}
+		if value, next, ok, missing := consumeValueFlag(args, i, "--config", false); ok {
+			if missing {
+				return buildOptions{}, fmt.Errorf(buildUsage)
+			}
+			plan.ConfigPath = value
+			i = next
+			continue
+		}
+		if value, next, ok, missing := consumeValueFlag(args, i, "--env-file", false); ok {
+			if missing {
+				return buildOptions{}, fmt.Errorf(buildUsage)
+			}
+			plan.Options.EnvFilePath = value
+			i = next
+			continue
+		}
+		if value, next, ok, missing := consumeValueFlag(args, i, "--target", false); ok {
+			if missing {
+				return buildOptions{}, fmt.Errorf(buildUsage)
+			}
+			plan.TargetNames = appendNames(plan.TargetNames, value)
+			i = next
+			continue
+		}
+		if value, next, ok, missing := consumeValueFlag(args, i, "--module", false); ok {
+			if missing {
+				return buildOptions{}, fmt.Errorf(buildUsage)
+			}
+			plan.ModuleNames = appendNames(plan.ModuleNames, value)
+			i = next
+			continue
+		}
 		switch {
 		case arg == "--ssr":
 			plan.Options.Config.Addons = append(plan.Options.Config.Addons, ssr.Addon())
@@ -648,142 +758,8 @@ func parseBuildOptions(args []string) (buildOptions, error) {
 			plan.Options.ObfuscateAssets = true
 			plan.Options.Config.Build.ObfuscateAssets = true
 			plan.Options.Config.Build.Mode = gowdk.Production
-		case arg == "--out":
-			i++
-			if i >= len(args) {
-				return buildOptions{}, fmt.Errorf(buildUsage)
-			}
-			plan.OutputDir = args[i]
-		case len(arg) > len("--out=") && arg[:len("--out=")] == "--out=":
-			plan.OutputDir = arg[len("--out="):]
-		case arg == "--app":
-			i++
-			if i >= len(args) {
-				return buildOptions{}, fmt.Errorf(buildUsage)
-			}
-			plan.AppDir = args[i]
-			if strings.TrimSpace(plan.AppDir) == "" {
-				return buildOptions{}, fmt.Errorf("generated app directory is required")
-			}
-		case len(arg) > len("--app=") && arg[:len("--app=")] == "--app=":
-			plan.AppDir = arg[len("--app="):]
-			if strings.TrimSpace(plan.AppDir) == "" {
-				return buildOptions{}, fmt.Errorf("generated app directory is required")
-			}
-		case arg == "--bin":
-			i++
-			if i >= len(args) {
-				return buildOptions{}, fmt.Errorf(buildUsage)
-			}
-			plan.BinaryPath = args[i]
-			if strings.TrimSpace(plan.BinaryPath) == "" {
-				return buildOptions{}, fmt.Errorf("binary output path is required")
-			}
-		case len(arg) > len("--bin=") && arg[:len("--bin=")] == "--bin=":
-			plan.BinaryPath = arg[len("--bin="):]
-			if strings.TrimSpace(plan.BinaryPath) == "" {
-				return buildOptions{}, fmt.Errorf("binary output path is required")
-			}
 		case arg == "--docker":
 			plan.Docker = true
-		case arg == "--docker-base":
-			i++
-			if i >= len(args) {
-				return buildOptions{}, fmt.Errorf(buildUsage)
-			}
-			plan.DockerBase = args[i]
-			if strings.TrimSpace(plan.DockerBase) == "" {
-				return buildOptions{}, fmt.Errorf("Docker base is required")
-			}
-		case strings.HasPrefix(arg, "--docker-base="):
-			plan.DockerBase = strings.TrimPrefix(arg, "--docker-base=")
-			if strings.TrimSpace(plan.DockerBase) == "" {
-				return buildOptions{}, fmt.Errorf("Docker base is required")
-			}
-		case arg == "--deploy-recipe":
-			i++
-			if i >= len(args) {
-				return buildOptions{}, fmt.Errorf(buildUsage)
-			}
-			plan.DeployRecipes = appendNames(plan.DeployRecipes, args[i])
-		case strings.HasPrefix(arg, "--deploy-recipe="):
-			plan.DeployRecipes = appendNames(plan.DeployRecipes, strings.TrimPrefix(arg, "--deploy-recipe="))
-		case arg == "--wasm":
-			i++
-			if i >= len(args) {
-				return buildOptions{}, fmt.Errorf(buildUsage)
-			}
-			plan.WASMPath = args[i]
-			if strings.TrimSpace(plan.WASMPath) == "" {
-				return buildOptions{}, fmt.Errorf("wasm output path is required")
-			}
-		case len(arg) > len("--wasm=") && arg[:len("--wasm=")] == "--wasm=":
-			plan.WASMPath = arg[len("--wasm="):]
-			if strings.TrimSpace(plan.WASMPath) == "" {
-				return buildOptions{}, fmt.Errorf("wasm output path is required")
-			}
-		case arg == "--backend-app":
-			i++
-			if i >= len(args) {
-				return buildOptions{}, fmt.Errorf(buildUsage)
-			}
-			plan.BackendAppDir = args[i]
-			if strings.TrimSpace(plan.BackendAppDir) == "" {
-				return buildOptions{}, fmt.Errorf("generated backend app directory is required")
-			}
-		case len(arg) > len("--backend-app=") && arg[:len("--backend-app=")] == "--backend-app=":
-			plan.BackendAppDir = arg[len("--backend-app="):]
-			if strings.TrimSpace(plan.BackendAppDir) == "" {
-				return buildOptions{}, fmt.Errorf("generated backend app directory is required")
-			}
-		case arg == "--backend-bin":
-			i++
-			if i >= len(args) {
-				return buildOptions{}, fmt.Errorf(buildUsage)
-			}
-			plan.BackendBinaryPath = args[i]
-			if strings.TrimSpace(plan.BackendBinaryPath) == "" {
-				return buildOptions{}, fmt.Errorf("backend binary output path is required")
-			}
-		case len(arg) > len("--backend-bin=") && arg[:len("--backend-bin=")] == "--backend-bin=":
-			plan.BackendBinaryPath = arg[len("--backend-bin="):]
-			if strings.TrimSpace(plan.BackendBinaryPath) == "" {
-				return buildOptions{}, fmt.Errorf("backend binary output path is required")
-			}
-		case arg == "--config":
-			i++
-			if i >= len(args) {
-				return buildOptions{}, fmt.Errorf(buildUsage)
-			}
-			plan.ConfigPath = args[i]
-		case len(arg) > len("--config=") && arg[:len("--config=")] == "--config=":
-			plan.ConfigPath = arg[len("--config="):]
-		case arg == "--env-file":
-			i++
-			if i >= len(args) {
-				return buildOptions{}, fmt.Errorf(buildUsage)
-			}
-			plan.EnvFilePath = args[i]
-			plan.Options.EnvFilePath = args[i]
-		case len(arg) > len("--env-file=") && arg[:len("--env-file=")] == "--env-file=":
-			plan.EnvFilePath = arg[len("--env-file="):]
-			plan.Options.EnvFilePath = plan.EnvFilePath
-		case arg == "--target":
-			i++
-			if i >= len(args) {
-				return buildOptions{}, fmt.Errorf(buildUsage)
-			}
-			plan.TargetNames = appendNames(plan.TargetNames, args[i])
-		case len(arg) > len("--target=") && arg[:len("--target=")] == "--target=":
-			plan.TargetNames = appendNames(plan.TargetNames, arg[len("--target="):])
-		case arg == "--module":
-			i++
-			if i >= len(args) {
-				return buildOptions{}, fmt.Errorf(buildUsage)
-			}
-			plan.ModuleNames = appendNames(plan.ModuleNames, args[i])
-		case len(arg) > len("--module=") && arg[:len("--module=")] == "--module=":
-			plan.ModuleNames = appendNames(plan.ModuleNames, arg[len("--module="):])
 		case len(arg) > 0 && arg[0] == '-':
 			return buildOptions{}, fmt.Errorf("unknown build flag %q", arg)
 		default:

--- a/cmd/gowdk/build_options_test.go
+++ b/cmd/gowdk/build_options_test.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/cssbruno/gowdk"
+)
+
+func TestBuildRequestHasAdHocArgs(t *testing.T) {
+	tests := []struct {
+		name    string
+		request buildRequest
+		want    bool
+	}{
+		{name: "empty"},
+		{name: "output", request: buildRequest{OutputDir: "dist"}, want: true},
+		{name: "app", request: buildRequest{AppDir: "app"}, want: true},
+		{name: "binary", request: buildRequest{BinaryPath: "bin/site"}, want: true},
+		{name: "wasm", request: buildRequest{WASMPath: "bin/site.wasm"}, want: true},
+		{name: "backend app", request: buildRequest{BackendAppDir: "backend"}, want: true},
+		{name: "backend binary", request: buildRequest{BackendBinaryPath: "bin/backend"}, want: true},
+		{name: "docker", request: buildRequest{Docker: true}, want: true},
+		{name: "docker base", request: buildRequest{DockerBase: "scratch"}, want: true},
+		{name: "deploy recipe", request: buildRequest{DeployRecipes: []string{"caddy"}}, want: true},
+		{name: "modules", request: buildRequest{Modules: []string{"site"}}, want: true},
+		{name: "paths", request: buildRequest{Paths: []string{"home.page.gwdk"}}, want: true},
+		{name: "timings path is not build input", request: buildRequest{TimingsPath: "timings.json"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.request.hasAdHocArgs(); got != tt.want {
+				t.Fatalf("hasAdHocArgs() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBuildOptionsShouldBuildConfiguredTargets(t *testing.T) {
+	targetConfig := gowdk.Config{Build: gowdk.BuildConfig{Targets: []gowdk.BuildTargetConfig{{Name: "site"}}}}
+	tests := []struct {
+		name string
+		plan buildOptions
+		want bool
+	}{
+		{name: "configured targets without ad hoc args", plan: buildOptions{Options: cliOptions{Config: targetConfig}}, want: true},
+		{name: "explicit target", plan: buildOptions{TargetNames: []string{"site"}}, want: true},
+		{name: "no configured targets", plan: buildOptions{}, want: false},
+		{name: "ad hoc output", plan: buildOptions{Options: cliOptions{Config: targetConfig}, OutputDir: "dist"}, want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.plan.shouldBuildConfiguredTargets(); got != tt.want {
+				t.Fatalf("shouldBuildConfiguredTargets() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolveConfiguredBuildTargets(t *testing.T) {
+	targets := []gowdk.BuildTargetConfig{
+		{Name: " site ", Output: "out/site"},
+		{Name: "admin", Output: "out/admin"},
+	}
+	selected, err := resolveConfiguredBuildTargets(targets, []string{" admin ", "site"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := targetNames(selected); !reflect.DeepEqual(got, []string{"admin", "site"}) {
+		t.Fatalf("selected names = %#v", got)
+	}
+	if selected[0].Output != "out/admin" || selected[1].Output != "out/site" {
+		t.Fatalf("selected targets = %#v, want requested order with original target fields", selected)
+	}
+
+	all, err := resolveConfiguredBuildTargets(targets, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := targetNames(all); !reflect.DeepEqual(got, []string{"site", "admin"}) {
+		t.Fatalf("all names = %#v, want configured order", got)
+	}
+}
+
+func TestResolveConfiguredBuildTargetsRejectsDuplicateAndUnknownNames(t *testing.T) {
+	if _, err := resolveConfiguredBuildTargets([]gowdk.BuildTargetConfig{{Name: "site"}, {Name: " site "}}, nil); err == nil || !strings.Contains(err.Error(), `build target "site" is configured more than once`) {
+		t.Fatalf("duplicate target error = %v", err)
+	}
+	if _, err := resolveConfiguredBuildTargets([]gowdk.BuildTargetConfig{{Name: "site"}}, []string{"missing"}); err == nil || !strings.Contains(err.Error(), `build target "missing" is not configured`) {
+		t.Fatalf("unknown target error = %v", err)
+	}
+}
+
+func TestSelectBuildTargetsAppliesBuildOnlyDefaultsAndValidation(t *testing.T) {
+	targets, err := selectBuildTargets([]gowdk.BuildTargetConfig{{
+		Name:    " site ",
+		Modules: []string{" app ", ""},
+	}}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(targets) != 1 {
+		t.Fatalf("targets = %#v, want one", targets)
+	}
+	target := targets[0]
+	if target.Name != "site" || target.Output != ".gowdk/output/site" || !reflect.DeepEqual(target.Modules, []string{"app"}) {
+		t.Fatalf("normalized build target = %#v", target)
+	}
+	if _, err := selectBuildTargets([]gowdk.BuildTargetConfig{{Name: "site", Binary: "bin/site"}}, nil); err == nil || !strings.Contains(err.Error(), "binary requires app") {
+		t.Fatalf("binary without app error = %v", err)
+	}
+}
+
+func targetNames(targets []gowdk.BuildTargetConfig) []string {
+	names := make([]string, 0, len(targets))
+	for _, target := range targets {
+		names = append(names, target.Name)
+	}
+	return names
+}

--- a/cmd/gowdk/clean.go
+++ b/cmd/gowdk/clean.go
@@ -36,35 +36,35 @@ func clean(args []string) error {
 	)
 	for i := 0; i < len(args); i++ {
 		arg := args[i]
+		if value, next, ok, missing := consumeValueFlag(args, i, "--config", true); ok {
+			if missing {
+				return errors.New(cleanUsage)
+			}
+			configPath = value
+			i = next
+			continue
+		}
+		if value, next, ok, missing := consumeValueFlag(args, i, "--target", true); ok {
+			if missing {
+				return errors.New(cleanUsage)
+			}
+			targetNames = appendNames(targetNames, value)
+			i = next
+			continue
+		}
+		if value, next, ok, missing := consumeValueFlag(args, i, "--out", true); ok {
+			if missing {
+				return errors.New(cleanUsage)
+			}
+			outDir = value
+			i = next
+			continue
+		}
 		switch {
 		case arg == "--dry-run":
 			dryRun = true
 		case arg == "--json":
 			jsonOutput = true
-		case arg == "--config":
-			i++
-			if i >= len(args) {
-				return errors.New(cleanUsage)
-			}
-			configPath = args[i]
-		case strings.HasPrefix(arg, "--config="):
-			configPath = strings.TrimPrefix(arg, "--config=")
-		case arg == "--target":
-			i++
-			if i >= len(args) {
-				return errors.New(cleanUsage)
-			}
-			targetNames = appendNames(targetNames, args[i])
-		case strings.HasPrefix(arg, "--target="):
-			targetNames = appendNames(targetNames, strings.TrimPrefix(arg, "--target="))
-		case arg == "--out":
-			i++
-			if i >= len(args) {
-				return errors.New(cleanUsage)
-			}
-			outDir = args[i]
-		case strings.HasPrefix(arg, "--out="):
-			outDir = strings.TrimPrefix(arg, "--out=")
 		default:
 			return fmt.Errorf("unknown clean flag %q\n%s", arg, cleanUsage)
 		}
@@ -136,32 +136,21 @@ func cleanTargets(config gowdk.Config, targetNames []string, outDir string) ([]s
 		}
 	}
 
-	selected := cleanNames(targetNames)
-	if len(selected) == 0 {
+	selectedNames := cleanNames(targetNames)
+	if len(selectedNames) == 0 {
 		add(config.Build.Output)
 	}
-
-	wanted := map[string]bool{}
-	for _, name := range selected {
-		wanted[name] = true
+	selectedTargets, err := resolveConfiguredBuildTargets(config.Build.Targets, selectedNames)
+	if err != nil {
+		return nil, err
 	}
-	seen := map[string]bool{}
-	for _, target := range config.Build.Targets {
-		if len(wanted) > 0 && !wanted[target.Name] {
-			continue
-		}
-		seen[target.Name] = true
+	for _, target := range selectedTargets {
 		add(target.Output)
 		add(target.App)
 		add(target.Binary)
 		add(target.WASM)
 		add(target.BackendApp)
 		add(target.BackendBinary)
-	}
-	for _, name := range selected {
-		if !seen[name] {
-			return nil, fmt.Errorf("target %q is not configured", name)
-		}
 	}
 
 	add(outDir)

--- a/cmd/gowdk/clean_test.go
+++ b/cmd/gowdk/clean_test.go
@@ -13,7 +13,7 @@ func TestCleanTargetsCollectsConfiguredOutputs(t *testing.T) {
 		Build: gowdk.BuildConfig{
 			Output: "gowdk_cache",
 			Targets: []gowdk.BuildTargetConfig{
-				{Name: "site", Output: ".gowdk/output/site", App: ".gowdk/app/site", Binary: "bin/site", WASM: "bin/site.wasm"},
+				{Name: "site", Output: ".gowdk/output/site", App: ".gowdk/app/site", Binary: "bin/site", WASM: "bin/site.wasm", BackendApp: ".gowdk/backend/site", BackendBinary: "bin/site-backend"},
 			},
 		},
 	}
@@ -21,7 +21,7 @@ func TestCleanTargetsCollectsConfiguredOutputs(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	for _, want := range []string{"gowdk_cache", ".gowdk/output/site", ".gowdk/app/site", "bin/site", "bin/site.wasm"} {
+	for _, want := range []string{"gowdk_cache", ".gowdk/output/site", ".gowdk/app/site", "bin/site", "bin/site.wasm", ".gowdk/backend/site", "bin/site-backend"} {
 		if !contains(targets, want) {
 			t.Fatalf("expected %q in targets %v", want, targets)
 		}
@@ -47,6 +47,24 @@ func TestCleanTargetsFiltersByTargetName(t *testing.T) {
 	}
 	if !contains(targets, "out/admin") {
 		t.Fatalf("expected the admin output, got %v", targets)
+	}
+}
+
+func TestCleanTargetsUsesNormalizedTargetNames(t *testing.T) {
+	config := gowdk.Config{Build: gowdk.BuildConfig{Targets: []gowdk.BuildTargetConfig{{Name: " admin ", Output: "out/admin"}}}}
+	targets, err := cleanTargets(config, []string{"admin"}, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(targets) != 1 || targets[0] != "out/admin" {
+		t.Fatalf("targets = %#v, want admin output", targets)
+	}
+}
+
+func TestCleanTargetsRejectsDuplicateTargetNames(t *testing.T) {
+	config := gowdk.Config{Build: gowdk.BuildConfig{Targets: []gowdk.BuildTargetConfig{{Name: "site"}, {Name: " site "}}}}
+	if _, err := cleanTargets(config, nil, ""); err == nil {
+		t.Fatal("expected an error for duplicate target names")
 	}
 }
 

--- a/cmd/gowdk/dev.go
+++ b/cmd/gowdk/dev.go
@@ -576,31 +576,27 @@ func parseDevOptions(args []string) (devOptions, error) {
 	}
 	for i := 0; i < len(args); i++ {
 		arg := args[i]
+		if value, next, ok, missing := consumeValueFlag(args, i, "--addr", true); ok {
+			if missing {
+				return devOptions{}, errors.New(devUsage())
+			}
+			options.Addr = value
+			i = next
+			continue
+		}
+		if value, next, ok, missing := consumeValueFlag(args, i, "--interval", true); ok {
+			if missing {
+				return devOptions{}, errors.New(devUsage())
+			}
+			interval, err := parseDevInterval(value)
+			if err != nil {
+				return devOptions{}, err
+			}
+			options.Interval = interval
+			i = next
+			continue
+		}
 		switch {
-		case arg == "--addr":
-			i++
-			if i >= len(args) {
-				return devOptions{}, errors.New(devUsage())
-			}
-			options.Addr = args[i]
-		case strings.HasPrefix(arg, "--addr="):
-			options.Addr = strings.TrimPrefix(arg, "--addr=")
-		case arg == "--interval":
-			i++
-			if i >= len(args) {
-				return devOptions{}, errors.New(devUsage())
-			}
-			interval, err := parseDevInterval(args[i])
-			if err != nil {
-				return devOptions{}, err
-			}
-			options.Interval = interval
-		case strings.HasPrefix(arg, "--interval="):
-			interval, err := parseDevInterval(strings.TrimPrefix(arg, "--interval="))
-			if err != nil {
-				return devOptions{}, err
-			}
-			options.Interval = interval
 		default:
 			options.BuildArgs = append(options.BuildArgs, arg)
 		}

--- a/cmd/gowdk/flags.go
+++ b/cmd/gowdk/flags.go
@@ -1,0 +1,21 @@
+package main
+
+import "strings"
+
+func consumeValueFlag(args []string, index int, name string, allowEmptyEquals bool) (value string, next int, ok bool, missing bool) {
+	arg := args[index]
+	if arg == name {
+		if index+1 >= len(args) {
+			return "", index, true, true
+		}
+		return args[index+1], index + 1, true, false
+	}
+	prefix := name + "="
+	if strings.HasPrefix(arg, prefix) {
+		if !allowEmptyEquals && len(arg) == len(prefix) {
+			return "", index, false, false
+		}
+		return strings.TrimPrefix(arg, prefix), index, true, false
+	}
+	return "", index, false, false
+}

--- a/cmd/gowdk/flags_test.go
+++ b/cmd/gowdk/flags_test.go
@@ -1,0 +1,64 @@
+package main
+
+import "testing"
+
+func TestConsumeValueFlag(t *testing.T) {
+	tests := []struct {
+		name             string
+		args             []string
+		index            int
+		allowEmptyEquals bool
+		wantValue        string
+		wantNext         int
+		wantOK           bool
+		wantMissing      bool
+	}{
+		{
+			name:        "space value",
+			args:        []string{"--config", "gowdk.config.go"},
+			wantValue:   "gowdk.config.go",
+			wantNext:    1,
+			wantOK:      true,
+			wantMissing: false,
+		},
+		{
+			name:        "equals value",
+			args:        []string{"--config=gowdk.config.go"},
+			wantValue:   "gowdk.config.go",
+			wantNext:    0,
+			wantOK:      true,
+			wantMissing: false,
+		},
+		{
+			name:        "missing space value",
+			args:        []string{"--config"},
+			wantNext:    0,
+			wantOK:      true,
+			wantMissing: true,
+		},
+		{
+			name:             "empty equals accepted",
+			args:             []string{"--config="},
+			allowEmptyEquals: true,
+			wantNext:         0,
+			wantOK:           true,
+		},
+		{
+			name:             "empty equals ignored when disallowed",
+			args:             []string{"--app="},
+			allowEmptyEquals: false,
+			wantNext:         0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			value, next, ok, missing := consumeValueFlag(tt.args, tt.index, "--config", tt.allowEmptyEquals)
+			if tt.name == "empty equals ignored when disallowed" {
+				value, next, ok, missing = consumeValueFlag(tt.args, tt.index, "--app", tt.allowEmptyEquals)
+			}
+			if value != tt.wantValue || next != tt.wantNext || ok != tt.wantOK || missing != tt.wantMissing {
+				t.Fatalf("consumeValueFlag = (%q, %d, %v, %v), want (%q, %d, %v, %v)", value, next, ok, missing, tt.wantValue, tt.wantNext, tt.wantOK, tt.wantMissing)
+			}
+		})
+	}
+}

--- a/cmd/gowdk/lang.go
+++ b/cmd/gowdk/lang.go
@@ -203,20 +203,8 @@ func endpointsJSONCommand(args []string) error {
 }
 
 func routeMetadataForCommand(args []string, command string) (compiler.RouteMetadata, error) {
-	options, paths, err := loadCommandInputs(args, command, false)
+	options, ir, err := commandProgram(args, command, false)
 	if err != nil {
-		return compiler.RouteMetadata{}, err
-	}
-	checked, diagnostics := lang.CheckFilesWithOptions(options.Config, paths, lang.CheckOptions{ProjectRoot: options.ProjectRoot})
-	for _, diagnostic := range diagnostics {
-		fmt.Fprintln(os.Stderr, diagnostic.String())
-	}
-	if diagnostics.HasErrors() {
-		return compiler.RouteMetadata{}, fmt.Errorf("%s failed", command)
-	}
-
-	ir := checked.IR
-	if err := linkIRContractReferences(&ir, options.ProjectRoot); err != nil {
 		return compiler.RouteMetadata{}, err
 	}
 	metadata := compiler.BuildRouteMetadataFromIR(options.Config, ir)

--- a/cmd/gowdk/lsp.go
+++ b/cmd/gowdk/lsp.go
@@ -30,17 +30,17 @@ func languageServerConfig(args []string) (gowdk.Config, error) {
 	var configPath string
 	for i := 0; i < len(args); i++ {
 		arg := args[i]
+		if value, next, ok, missing := consumeValueFlag(args, i, "--config", true); ok {
+			if missing {
+				return gowdk.Config{}, errors.New(lspUsage)
+			}
+			configPath = value
+			i = next
+			continue
+		}
 		switch {
 		case arg == "--ssr":
 			options.Config.Addons = append(options.Config.Addons, ssr.Addon())
-		case arg == "--config":
-			i++
-			if i >= len(args) {
-				return gowdk.Config{}, errors.New(lspUsage)
-			}
-			configPath = args[i]
-		case strings.HasPrefix(arg, "--config="):
-			configPath = strings.TrimPrefix(arg, "--config=")
 		default:
 			return gowdk.Config{}, errors.New(lspUsage)
 		}

--- a/cmd/gowdk/main.go
+++ b/cmd/gowdk/main.go
@@ -58,67 +58,11 @@ func run(args []string) error {
 		}
 	}
 
-	switch args[0] {
-	case "version":
-		return printVersion(args[1:])
-	case "init":
-		return initProject(args[1:])
-	case "add":
-		return addAddon(args[1:])
-	case "tokens":
-		return tokens(args[1:])
-	case "fmt":
-		return format(args[1:])
-	case "check":
-		return check(args[1:])
-	case "fix":
-		return fixCommand(args[1:])
-	case "manifest":
-		return manifestJSON(args[1:])
-	case "sitemap":
-		return siteMapJSON(args[1:])
-	case "routes":
-		return routesJSON(args[1:])
-	case "endpoints":
-		return endpointsJSONCommand(args[1:])
-	case "inspect":
-		return inspect(args[1:])
-	case "generate":
-		return generate(args[1:])
-	case "explain":
-		return explainDiagnostic(args[1:])
-	case "doctor":
-		return doctor(args[1:])
-	case "test":
-		return gowdkTest(args[1:])
-	case "audit":
-		return audit(args[1:])
-	case "contracts":
-		return contractsReport(args[1:])
-	case "graph":
-		return contractGraph(args[1:])
-	case "trace":
-		return contractTrace(args[1:])
-	case "list":
-		return listContracts(args[1:])
-	case "build":
-		return build(args[1:])
-	case "clean":
-		return clean(args[1:])
-	case "dev":
-		return dev(args[1:])
-	case "preview":
-		return preview(args[1:])
-	case "playground":
-		return playgroundCommand(args[1:])
-	case "serve":
-		return serve(args[1:])
-	case "lsp":
-		return languageServer(args[1:])
-	default:
-		usage()
-		return fmt.Errorf("unknown command %q", args[0])
+	if command, ok := topLevelCommand(args[0]); ok {
+		return command.Handler(args[1:])
 	}
+	usage()
+	return fmt.Errorf("unknown command %q", args[0])
 }
 
 func commandHelpRequested(args []string) bool {
@@ -154,66 +98,61 @@ func nestedCommandUsage(args []string) (string, bool) {
 }
 
 func commandUsage(command string) (string, bool) {
-	switch command {
-	case "version":
-		return "usage: gowdk version [--json]", true
-	case "init":
-		return initUsage, true
-	case "add":
-		return addUsage, true
-	case "tokens":
-		return "usage: gowdk tokens <file.gwdk>", true
-	case "fmt":
-		return "usage: gowdk fmt [--write] [--check] <files>", true
-	case "check":
-		return projectCommandUsage("check", true), true
-	case "fix":
-		return fixUsage, true
-	case "manifest":
-		return projectCommandUsage("manifest", false), true
-	case "sitemap":
-		return projectCommandUsage("sitemap", false), true
-	case "routes":
-		return projectCommandUsage("routes", false), true
-	case "endpoints":
-		return projectCommandUsage("endpoints", false), true
-	case "inspect":
-		return inspectUsage, true
-	case "generate":
-		return generateUsage, true
-	case "explain":
-		return "usage: gowdk explain [--json] <diagnostic-code>", true
-	case "doctor":
-		return doctorUsage, true
-	case "test":
-		return testUsage, true
-	case "audit":
-		return auditUsage, true
-	case "contracts":
-		return "usage: gowdk contracts [--json] [dir]", true
-	case "graph":
-		return "usage: gowdk graph [--json] [dir]", true
-	case "trace":
-		return "usage: gowdk trace <contract> [--json] [dir]", true
-	case "list":
-		return "usage: gowdk list commands|queries|events|jobs [--json] [dir]", true
-	case "build":
-		return buildUsage, true
-	case "clean":
-		return cleanUsage, true
-	case "dev":
-		return devUsage(), true
-	case "preview":
-		return previewUsage(), true
-	case "playground":
-		return playgroundUsage, true
-	case "serve":
-		return "usage: gowdk serve --dir <dir> [--addr <addr>]", true
-	case "lsp":
-		return lspUsage, true
-	default:
-		return "", false
+	if descriptor, ok := topLevelCommand(command); ok {
+		return descriptor.Usage(), true
 	}
+	return "", false
+}
+
+type topLevelCommandDescriptor struct {
+	Name       string
+	Handler    func([]string) error
+	Usage      func() string
+	ListSuffix string
+}
+
+func staticCommandUsage(value string) func() string {
+	return func() string { return value }
+}
+
+var topLevelCommands = []topLevelCommandDescriptor{
+	{Name: "version", Handler: printVersion, Usage: staticCommandUsage("usage: gowdk version [--json]"), ListSuffix: " [--json]         print CLI version"},
+	{Name: "init", Handler: initProject, Usage: staticCommandUsage(initUsage), ListSuffix: " [--force] [--tests] [--template <site|minimal>] [dir] scaffold a starter GOWDK project"},
+	{Name: "add", Handler: addAddon, Usage: staticCommandUsage(addUsage), ListSuffix: " <addon> [--config <file>] [--base-url <url>] | add --list [--registry] [--json]  wire or list addons"},
+	{Name: "tokens", Handler: tokens, Usage: staticCommandUsage("usage: gowdk tokens <file.gwdk>"), ListSuffix: " <file.gwdk>       print language tokens"},
+	{Name: "fmt", Handler: format, Usage: staticCommandUsage("usage: gowdk fmt [--write] [--check] <files>"), ListSuffix: " [--write] [--check] <files>  format .gwdk files (--check reports files that need formatting)"},
+	{Name: "check", Handler: check, Usage: func() string { return projectCommandUsage("check", true) }, ListSuffix: " [--config <file>] [--env-file <file>] [--module <name>] [--json] [--warnings-as-errors] [--ssr] [files...] parse and validate .gwdk files"},
+	{Name: "fix", Handler: fixCommand, Usage: staticCommandUsage(fixUsage), ListSuffix: " [--dry-run] [--code <diagnostic-code>] [--config <file>] [--env-file <file>] [--module <name>] [--ssr] [files...] apply registered safe diagnostic fixes"},
+	{Name: "manifest", Handler: manifestJSON, Usage: func() string { return projectCommandUsage("manifest", false) }, ListSuffix: " [--config <file>] [--env-file <file>] [--module <name>] [--ssr] [files...] print validated manifest JSON"},
+	{Name: "sitemap", Handler: siteMapJSON, Usage: func() string { return projectCommandUsage("sitemap", false) }, ListSuffix: " [--config <file>] [--env-file <file>] [--module <name>] [--ssr] [files...] print editor site-map JSON"},
+	{Name: "routes", Handler: routesJSON, Usage: func() string { return projectCommandUsage("routes", false) }, ListSuffix: " [--config <file>] [--env-file <file>] [--module <name>] [--ssr] [files...] print route and endpoint metadata JSON"},
+	{Name: "endpoints", Handler: endpointsJSONCommand, Usage: func() string { return projectCommandUsage("endpoints", false) }, ListSuffix: " [--config <file>] [--env-file <file>] [--module <name>] [--ssr] [files...] print endpoint metadata JSON"},
+	{Name: "inspect", Handler: inspect, Usage: staticCommandUsage(inspectUsage), ListSuffix: " ir|tree|endpoint-graph|asset-graph|go-bindings [--config <file>] [--env-file <file>] [--module <name>] [--json] [--ssr] [files...] print validated compiler inspection JSON"},
+	{Name: "generate", Handler: generate, Usage: staticCommandUsage(generateUsage), ListSuffix: " stubs [--config <file>] [--env-file <file>] [--module <name>] [--ssr] [files...] write missing action/API Go handler stubs"},
+	{Name: "explain", Handler: explainDiagnostic, Usage: staticCommandUsage("usage: gowdk explain [--json] <diagnostic-code>"), ListSuffix: " [--json] <diagnostic-code> explain a diagnostic code and next steps"},
+	{Name: "doctor", Handler: doctor, Usage: staticCommandUsage(doctorUsage), ListSuffix: " [--config <file>] [--env-file <file>] [--module <name>] [--ssr] [--json] [files...] check local GOWDK environment and project health"},
+	{Name: "test", Handler: gowdkTest, Usage: staticCommandUsage(testUsage), ListSuffix: " [--config <file>] [--env-file <file>] [--module <name>] [--target <name>] [--stage <unit|app|binary|browser>] [--run <pattern>] [--timeout <duration>] [--count <n>] [--cover] [--json] [--keep-workdir] [--browser-command <command>] [--ssr] [files...] run Go tests against generated app artifacts"},
+	{Name: "audit", Handler: audit, Usage: staticCommandUsage(auditUsage), ListSuffix: " [--config <file>] [--env-file <file>] [--module <name>] [--ssr] [--json] [--sarif[=<file>]] [--diff <previous-report>] [--schema[=report|security]] [--emit-tests[=<file>]] [--force] [--run] [files...] check security posture, emit SARIF/JSON-Schema, diff against a previous report, and run optional runtime tests"},
+	{Name: "contracts", Handler: contractsReport, Usage: staticCommandUsage("usage: gowdk contracts [--json] [dir]"), ListSuffix: " [--json] [dir]  print Go contract registration metadata"},
+	{Name: "graph", Handler: contractGraph, Usage: staticCommandUsage("usage: gowdk graph [--json] [dir]"), ListSuffix: " [--json] [dir]      print command/event contract graph"},
+	{Name: "trace", Handler: contractTrace, Usage: staticCommandUsage("usage: gowdk trace <contract> [--json] [dir]"), ListSuffix: " <contract> [--json] [dir] print one command/query/event/job contract trace"},
+	{Name: "list", Handler: listContracts, Usage: staticCommandUsage("usage: gowdk list commands|queries|events|jobs [--json] [dir]"), ListSuffix: " commands|queries|events|jobs [--json] [dir] print filtered contract metadata"},
+	{Name: "build", Handler: build, Usage: staticCommandUsage(buildUsage), ListSuffix: " [--config <file>] [--env-file <file>] [--debug] [--timings[=<file>]] [--ssr] [--allow-missing-backend] [--allow-insecure] [--obfuscate-assets] [--target <name>] [--module <name>] [--out <dir>] [--app <dir>] [--bin <file>] [--docker] [--docker-base <distroless|scratch>] [--deploy-recipe <caddy|nginx|split|static|systemd>] [--wasm <file>] [--backend-app <dir>] [--backend-bin <file>] [files...] compile .gwdk files into build output"},
+	{Name: "clean", Handler: clean, Usage: staticCommandUsage(cleanUsage), ListSuffix: " [--config <file>] [--target <name>] [--out <dir>] [--dry-run] [--json] remove configured build outputs"},
+	{Name: "dev", Handler: dev, Usage: devUsage, ListSuffix: " [--addr <addr>] [--interval <duration>] [build flags...] build, serve, rebuild, and live reload"},
+	{Name: "preview", Handler: preview, Usage: previewUsage, ListSuffix: " [--addr <addr>] [--hot] [build flags...] build and serve a local deploy preview"},
+	{Name: "playground", Handler: playgroundCommand, Usage: staticCommandUsage(playgroundUsage), ListSuffix: " policy|export|run inspect sandbox policy, export projects, or run an opt-in sandbox build"},
+	{Name: "serve", Handler: serve, Usage: staticCommandUsage("usage: gowdk serve --dir <dir> [--addr <addr>]"), ListSuffix: " --dir <dir> [--addr <addr>] serve generated build output locally"},
+	{Name: "lsp", Handler: languageServer, Usage: staticCommandUsage(lspUsage), ListSuffix: " [--config <file>] [--ssr] start the language server over stdio"},
+}
+
+func topLevelCommand(name string) (topLevelCommandDescriptor, bool) {
+	for _, descriptor := range topLevelCommands {
+		if descriptor.Name == name {
+			return descriptor, true
+		}
+	}
+	return topLevelCommandDescriptor{}, false
 }
 
 func printVersion(args []string) error {
@@ -239,34 +178,9 @@ func usage() {
 	fmt.Println("compile-first Go web kit: build-time output, backend actions, SSR optional")
 	fmt.Println()
 	fmt.Println("Commands:")
-	fmt.Println("  version [--json]         print CLI version")
-	fmt.Println("  init [--force] [--tests] [--template <site|minimal>] [dir] scaffold a starter GOWDK project")
-	fmt.Println("  add <addon> [--config <file>] [--base-url <url>] | add --list [--registry] [--json]  wire or list addons")
-	fmt.Println("  tokens <file.gwdk>       print language tokens")
-	fmt.Println("  fmt [--write] [--check] <files>  format .gwdk files (--check reports files that need formatting)")
-	fmt.Println("  check [--config <file>] [--env-file <file>] [--module <name>] [--json] [--warnings-as-errors] [--ssr] [files...] parse and validate .gwdk files")
-	fmt.Println("  fix [--dry-run] [--code <diagnostic-code>] [--config <file>] [--env-file <file>] [--module <name>] [--ssr] [files...] apply registered safe diagnostic fixes")
-	fmt.Println("  manifest [--config <file>] [--env-file <file>] [--module <name>] [--ssr] [files...] print validated manifest JSON")
-	fmt.Println("  sitemap [--config <file>] [--env-file <file>] [--module <name>] [--ssr] [files...] print editor site-map JSON")
-	fmt.Println("  routes [--config <file>] [--env-file <file>] [--module <name>] [--ssr] [files...] print route and endpoint metadata JSON")
-	fmt.Println("  endpoints [--config <file>] [--env-file <file>] [--module <name>] [--ssr] [files...] print endpoint metadata JSON")
-	fmt.Println("  inspect ir|tree|endpoint-graph|asset-graph|go-bindings [--config <file>] [--env-file <file>] [--module <name>] [--json] [--ssr] [files...] print validated compiler inspection JSON")
-	fmt.Println("  generate stubs [--config <file>] [--env-file <file>] [--module <name>] [--ssr] [files...] write missing action/API Go handler stubs")
-	fmt.Println("  explain [--json] <diagnostic-code> explain a diagnostic code and next steps")
-	fmt.Println("  doctor [--config <file>] [--env-file <file>] [--module <name>] [--ssr] [--json] [files...] check local GOWDK environment and project health")
-	fmt.Println("  test [--config <file>] [--env-file <file>] [--module <name>] [--target <name>] [--stage <unit|app|binary|browser>] [--run <pattern>] [--timeout <duration>] [--count <n>] [--cover] [--json] [--keep-workdir] [--browser-command <command>] [--ssr] [files...] run Go tests against generated app artifacts")
-	fmt.Println("  audit [--config <file>] [--env-file <file>] [--module <name>] [--ssr] [--json] [--sarif[=<file>]] [--diff <previous-report>] [--schema[=report|security]] [--emit-tests[=<file>]] [--force] [--run] [files...] check security posture, emit SARIF/JSON-Schema, diff against a previous report, and run optional runtime tests")
-	fmt.Println("  contracts [--json] [dir]  print Go contract registration metadata")
-	fmt.Println("  graph [--json] [dir]      print command/event contract graph")
-	fmt.Println("  trace <contract> [--json] [dir] print one command/query/event/job contract trace")
-	fmt.Println("  list commands|queries|events|jobs [--json] [dir] print filtered contract metadata")
-	fmt.Println("  build [--config <file>] [--env-file <file>] [--debug] [--timings[=<file>]] [--ssr] [--allow-missing-backend] [--allow-insecure] [--obfuscate-assets] [--target <name>] [--module <name>] [--out <dir>] [--app <dir>] [--bin <file>] [--docker] [--docker-base <distroless|scratch>] [--deploy-recipe <caddy|nginx|split|static|systemd>] [--wasm <file>] [--backend-app <dir>] [--backend-bin <file>] [files...] compile .gwdk files into build output")
-	fmt.Println("  clean [--config <file>] [--target <name>] [--out <dir>] [--dry-run] [--json] remove configured build outputs")
-	fmt.Println("  dev [--addr <addr>] [--interval <duration>] [build flags...] build, serve, rebuild, and live reload")
-	fmt.Println("  preview [--addr <addr>] [--hot] [build flags...] build and serve a local deploy preview")
-	fmt.Println("  playground policy|export|run inspect sandbox policy, export projects, or run an opt-in sandbox build")
-	fmt.Println("  serve --dir <dir> [--addr <addr>] serve generated build output locally")
-	fmt.Println("  lsp [--config <file>] [--ssr] start the language server over stdio")
+	for _, descriptor := range topLevelCommands {
+		fmt.Println("  " + descriptor.Name + descriptor.ListSuffix)
+	}
 }
 
 type cliOptions struct {

--- a/cmd/gowdk/main_commands_test.go
+++ b/cmd/gowdk/main_commands_test.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestTopLevelCommandDescriptorsDriveHelp(t *testing.T) {
+	seen := map[string]bool{}
+	for _, command := range topLevelCommands {
+		if strings.TrimSpace(command.Name) == "" {
+			t.Fatal("top-level command has empty name")
+		}
+		if seen[command.Name] {
+			t.Fatalf("top-level command %q is registered more than once", command.Name)
+		}
+		seen[command.Name] = true
+		if command.Handler == nil {
+			t.Fatalf("top-level command %q has nil handler", command.Name)
+		}
+		if strings.TrimSpace(command.Usage()) == "" {
+			t.Fatalf("top-level command %q has empty usage", command.Name)
+		}
+		if help, ok := commandUsage(command.Name); !ok || help != command.Usage() {
+			t.Fatalf("commandUsage(%q) = %q, %v; want descriptor usage %q", command.Name, help, ok, command.Usage())
+		}
+	}
+	if help, ok := commandUsage("missing"); ok || help != "" {
+		t.Fatalf("commandUsage(missing) = %q, %v; want no help-only command", help, ok)
+	}
+}
+
+func TestUsageListsRegisteredTopLevelCommands(t *testing.T) {
+	stdout, stderr, err := captureCLIOutput(t, func() error {
+		usage()
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stderr != "" {
+		t.Fatalf("usage stderr = %q, want empty", stderr)
+	}
+	for _, command := range topLevelCommands {
+		line := "  " + command.Name + command.ListSuffix
+		if !strings.Contains(stdout, line) {
+			t.Fatalf("usage output missing %q\n%s", line, stdout)
+		}
+	}
+}

--- a/cmd/gowdk/playground.go
+++ b/cmd/gowdk/playground.go
@@ -308,35 +308,35 @@ func parsePlaygroundFileOptions(args []string) (playgroundFileOptions, error) {
 	options := playgroundFileOptions{Dir: "."}
 	for index := 0; index < len(args); index++ {
 		arg := args[index]
+		if value, next, ok, missing := consumeValueFlag(args, index, "--dir", true); ok {
+			if missing {
+				return playgroundFileOptions{}, fmt.Errorf(playgroundUsage)
+			}
+			options.Dir = value
+			index = next
+			continue
+		}
+		if value, next, ok, missing := consumeValueFlag(args, index, "--out", true); ok {
+			if missing {
+				return playgroundFileOptions{}, fmt.Errorf(playgroundUsage)
+			}
+			options.Output = value
+			index = next
+			continue
+		}
+		if value, next, ok, missing := consumeValueFlag(args, index, "--module-cache", true); ok {
+			if missing {
+				return playgroundFileOptions{}, fmt.Errorf(playgroundUsage)
+			}
+			options.ModuleCache = value
+			index = next
+			continue
+		}
 		switch {
-		case arg == "--dir":
-			index++
-			if index >= len(args) {
-				return playgroundFileOptions{}, fmt.Errorf(playgroundUsage)
-			}
-			options.Dir = args[index]
-		case strings.HasPrefix(arg, "--dir="):
-			options.Dir = strings.TrimPrefix(arg, "--dir=")
-		case arg == "--out":
-			index++
-			if index >= len(args) {
-				return playgroundFileOptions{}, fmt.Errorf(playgroundUsage)
-			}
-			options.Output = args[index]
-		case strings.HasPrefix(arg, "--out="):
-			options.Output = strings.TrimPrefix(arg, "--out=")
 		case arg == "--json":
 			options.JSON = true
 		case arg == "--allow-hosted-execution":
 			options.AllowExecution = true
-		case arg == "--module-cache":
-			index++
-			if index >= len(args) {
-				return playgroundFileOptions{}, fmt.Errorf(playgroundUsage)
-			}
-			options.ModuleCache = args[index]
-		case strings.HasPrefix(arg, "--module-cache="):
-			options.ModuleCache = strings.TrimPrefix(arg, "--module-cache=")
 		case arg == "--allow-shared-module-cache":
 			options.AllowSharedModuleCache = true
 		default:

--- a/cmd/gowdk/preview.go
+++ b/cmd/gowdk/preview.go
@@ -57,27 +57,26 @@ func parsePreviewOptions(args []string) (previewOptions, error) {
 	options := previewOptions{Addr: "127.0.0.1:8080"}
 	for i := 0; i < len(args); i++ {
 		arg := args[i]
-		switch {
-		case arg == "--addr":
-			i++
-			if i >= len(args) {
+		if value, next, ok, missing := consumeValueFlag(args, i, "--addr", true); ok {
+			if missing {
 				return previewOptions{}, errors.New(previewUsage())
 			}
-			options.Addr = args[i]
-		case strings.HasPrefix(arg, "--addr="):
-			options.Addr = strings.TrimPrefix(arg, "--addr=")
+			options.Addr = value
+			i = next
+			continue
+		}
+		if value, next, ok, missing := consumeValueFlag(args, i, "--out", true); ok {
+			if missing {
+				return previewOptions{}, errors.New(previewUsage())
+			}
+			options.OutputDir = value
+			options.BuildArgs = append(options.BuildArgs, "--out", value)
+			i = next
+			continue
+		}
+		switch {
 		case arg == "--hot":
 			options.Hot = true
-		case arg == "--out":
-			i++
-			if i >= len(args) {
-				return previewOptions{}, errors.New(previewUsage())
-			}
-			options.OutputDir = args[i]
-			options.BuildArgs = append(options.BuildArgs, "--out", args[i])
-		case strings.HasPrefix(arg, "--out="):
-			options.OutputDir = strings.TrimPrefix(arg, "--out=")
-			options.BuildArgs = append(options.BuildArgs, arg)
 		default:
 			options.BuildArgs = append(options.BuildArgs, arg)
 		}

--- a/cmd/gowdk/project_inputs.go
+++ b/cmd/gowdk/project_inputs.go
@@ -91,37 +91,38 @@ func discoverProjectFiles(config gowdk.Config, moduleNames []string, root string
 }
 
 func discoverConfiguredFiles(config gowdk.Config, outputDir string, moduleNames []string, root string) ([]string, error) {
-	if strings.TrimSpace(root) == "" {
-		var err error
-		root, err = os.Getwd()
-		if err != nil {
-			return nil, err
-		}
-	}
-	modules, err := buildModules(config.Modules, moduleNames)
+	inputs, err := configuredDiscoveryInputs(config, outputDir, moduleNames, root)
 	if err != nil {
 		return nil, err
 	}
-
-	includes := buildSourceIncludes(config, modules, len(moduleNames) > 0)
-	excludes := buildSourceExcludes(config, modules)
-	if pattern := outputExcludePattern(root, outputDir); pattern != "" {
-		excludes = append(excludes, pattern)
-	}
-	return discover.Files(root, includes, excludes)
+	return discover.Files(inputs.root, inputs.includes, inputs.excludes)
 }
 
 func discoverConfiguredFilesAndDirs(config gowdk.Config, outputDir string, moduleNames []string, root string) ([]string, []string, error) {
+	inputs, err := configuredDiscoveryInputs(config, outputDir, moduleNames, root)
+	if err != nil {
+		return nil, nil, err
+	}
+	return discover.FilesAndDirs(inputs.root, inputs.includes, inputs.excludes)
+}
+
+type discoveryInputs struct {
+	root     string
+	includes []string
+	excludes []string
+}
+
+func configuredDiscoveryInputs(config gowdk.Config, outputDir string, moduleNames []string, root string) (discoveryInputs, error) {
 	if strings.TrimSpace(root) == "" {
 		var err error
 		root, err = os.Getwd()
 		if err != nil {
-			return nil, nil, err
+			return discoveryInputs{}, err
 		}
 	}
 	modules, err := buildModules(config.Modules, moduleNames)
 	if err != nil {
-		return nil, nil, err
+		return discoveryInputs{}, err
 	}
 
 	includes := buildSourceIncludes(config, modules, len(moduleNames) > 0)
@@ -129,7 +130,7 @@ func discoverConfiguredFilesAndDirs(config gowdk.Config, outputDir string, modul
 	if pattern := outputExcludePattern(root, outputDir); pattern != "" {
 		excludes = append(excludes, pattern)
 	}
-	return discover.FilesAndDirs(root, includes, excludes)
+	return discoveryInputs{root: root, includes: includes, excludes: excludes}, nil
 }
 
 func loadCommandInputs(args []string, command string, allowJSON bool) (cliOptions, []string, error) {
@@ -262,6 +263,31 @@ func parseProjectOptions(args []string, command string, allowJSON bool) (cliOpti
 	usage := projectCommandUsage(command, allowJSON)
 	for i := 0; i < len(args); i++ {
 		arg := args[i]
+		if value, next, ok, missing := consumeValueFlag(args, i, "--config", true); ok {
+			if missing {
+				return options, "", nil, nil, errors.New(usage)
+			}
+			configPath = value
+			i = next
+			continue
+		}
+		if value, next, ok, missing := consumeValueFlag(args, i, "--env-file", true); ok {
+			if missing {
+				return options, "", nil, nil, errors.New(usage)
+			}
+			envFilePath = value
+			options.EnvFilePath = envFilePath
+			i = next
+			continue
+		}
+		if value, next, ok, missing := consumeValueFlag(args, i, "--module", true); ok {
+			if missing {
+				return options, "", nil, nil, errors.New(usage)
+			}
+			moduleNames = appendModuleNames(moduleNames, value)
+			i = next
+			continue
+		}
 		switch {
 		case arg == "-h" || arg == "--help":
 			return options, "", nil, nil, errors.New(usage)
@@ -276,32 +302,6 @@ func parseProjectOptions(args []string, command string, allowJSON bool) (cliOpti
 				return options, "", nil, nil, fmt.Errorf("unknown %s flag %q", command, arg)
 			}
 			options.WarningsAsErrors = true
-		case arg == "--config":
-			i++
-			if i >= len(args) {
-				return options, "", nil, nil, errors.New(usage)
-			}
-			configPath = args[i]
-		case strings.HasPrefix(arg, "--config="):
-			configPath = strings.TrimPrefix(arg, "--config=")
-		case arg == "--env-file":
-			i++
-			if i >= len(args) {
-				return options, "", nil, nil, errors.New(usage)
-			}
-			envFilePath = args[i]
-			options.EnvFilePath = envFilePath
-		case strings.HasPrefix(arg, "--env-file="):
-			envFilePath = strings.TrimPrefix(arg, "--env-file=")
-			options.EnvFilePath = envFilePath
-		case arg == "--module":
-			i++
-			if i >= len(args) {
-				return options, "", nil, nil, errors.New(usage)
-			}
-			moduleNames = appendModuleNames(moduleNames, args[i])
-		case strings.HasPrefix(arg, "--module="):
-			moduleNames = appendModuleNames(moduleNames, strings.TrimPrefix(arg, "--module="))
 		case strings.HasPrefix(arg, "-"):
 			return options, "", nil, nil, fmt.Errorf("unknown %s flag %q", command, arg)
 		default:

--- a/cmd/gowdk/project_inputs_test.go
+++ b/cmd/gowdk/project_inputs_test.go
@@ -1,0 +1,153 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/cssbruno/gowdk"
+)
+
+func TestConfiguredDiscoveryInputsResolveEmptyRoot(t *testing.T) {
+	root := t.TempDir()
+	previous, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(root); err != nil {
+		t.Fatal(err)
+	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(previous); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	inputs, err := configuredDiscoveryInputs(gowdk.Config{}, "", nil, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if inputs.root != cwd {
+		t.Fatalf("root = %q, want cwd %q", inputs.root, cwd)
+	}
+	if !reflect.DeepEqual(inputs.includes, defaultSourceIncludes) {
+		t.Fatalf("includes = %#v, want %#v", inputs.includes, defaultSourceIncludes)
+	}
+}
+
+func TestConfiguredDiscoveryInputsSelectedModulesAndExcludes(t *testing.T) {
+	root := t.TempDir()
+	config := gowdk.Config{
+		Source: gowdk.SourceConfig{
+			Include: []string{"pages/**/*.gwdk"},
+			Exclude: []string{"pages/draft/**"},
+		},
+		Modules: []gowdk.ModuleConfig{
+			{
+				Name: "admin",
+				Source: gowdk.SourceConfig{
+					Include: []string{"admin/**/*.gwdk"},
+					Exclude: []string{"admin/tmp/**"},
+				},
+			},
+			{Name: "public"},
+		},
+	}
+
+	inputs, err := configuredDiscoveryInputs(config, "dist", []string{"admin"}, root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(inputs.includes, []string{"admin/**/*.gwdk"}) {
+		t.Fatalf("includes = %#v, want selected module include only", inputs.includes)
+	}
+	for _, want := range append(defaultSourceExcludes, "pages/draft/**", "admin/tmp/**", "dist/**") {
+		if !hasString(inputs.excludes, want) {
+			t.Fatalf("excludes = %#v, missing %q", inputs.excludes, want)
+		}
+	}
+}
+
+func TestDiscoverConfiguredFilesAndDirsShareInputs(t *testing.T) {
+	root := t.TempDir()
+	writeProjectInputFile(t, root, "pages/home.page.gwdk")
+	writeProjectInputFile(t, root, "pages/draft/ignored.page.gwdk")
+	writeProjectInputFile(t, root, "admin/dashboard.page.gwdk")
+	writeProjectInputFile(t, root, "admin/tmp/ignored.page.gwdk")
+	writeProjectInputFile(t, root, "dist/generated.page.gwdk")
+	config := gowdk.Config{
+		Source: gowdk.SourceConfig{
+			Include: []string{"pages/**/*.gwdk"},
+			Exclude: []string{"pages/draft/**"},
+		},
+		Modules: []gowdk.ModuleConfig{
+			{
+				Name: "admin",
+				Source: gowdk.SourceConfig{
+					Include: []string{"admin/**/*.gwdk"},
+					Exclude: []string{"admin/tmp/**"},
+				},
+			},
+		},
+	}
+
+	files, err := discoverConfiguredFiles(config, "dist", nil, root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	filesWithDirs, dirs, err := discoverConfiguredFilesAndDirs(config, "dist", nil, root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantFiles := []string{"admin/dashboard.page.gwdk", "pages/home.page.gwdk"}
+	if got := projectInputRelPaths(t, root, files); !reflect.DeepEqual(got, wantFiles) {
+		t.Fatalf("files = %#v, want %#v", got, wantFiles)
+	}
+	if got := projectInputRelPaths(t, root, filesWithDirs); !reflect.DeepEqual(got, wantFiles) {
+		t.Fatalf("files from FilesAndDirs = %#v, want %#v", got, wantFiles)
+	}
+	for _, excluded := range []string{"pages/draft", "admin/tmp", "dist"} {
+		if hasString(projectInputRelPaths(t, root, dirs), excluded) {
+			t.Fatalf("dirs should exclude %q, got %#v", excluded, projectInputRelPaths(t, root, dirs))
+		}
+	}
+}
+
+func writeProjectInputFile(t *testing.T, root, name string) {
+	t.Helper()
+	path := filepath.Join(root, filepath.FromSlash(name))
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("package pages\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func projectInputRelPaths(t *testing.T, root string, paths []string) []string {
+	t.Helper()
+	out := make([]string, 0, len(paths))
+	for _, item := range paths {
+		rel, err := filepath.Rel(root, item)
+		if err != nil {
+			t.Fatal(err)
+		}
+		out = append(out, filepath.ToSlash(rel))
+	}
+	return out
+}
+
+func hasString(values []string, want string) bool {
+	for _, value := range values {
+		if strings.TrimSpace(value) == want {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/gowdk/route_report.go
+++ b/cmd/gowdk/route_report.go
@@ -113,30 +113,37 @@ type routeInfoJSON struct {
 	Message string `json:"message"`
 }
 
+type routeEndpointFieldsJSON struct {
+	EndpointSource string
+	Directive      string
+	Source         string
+	SourceSpan     *sourceSpanJSON
+	Package        string
+	PackagePath    string
+	PackageName    string
+	Symbol         string
+	Method         string
+	Route          string
+	Cache          string
+	DynamicParams  []string
+	RouteParams    []routeParamJSON
+	Guards         []string
+	CSRF           bool
+	PageID         string
+	Handler        string
+	BindingStatus  string
+}
+
 func routeMetadataJSON(metadata compiler.RouteMetadata) routeMetadataReport {
 	routes := make([]routeBindingJSON, 0, len(metadata.Routes)+len(metadata.Endpoints))
 	for _, binding := range metadata.Routes {
-		routes = append(routes, routeBindingJSON{
-			Kind:          binding.Kind,
-			Method:        binding.Method,
-			Route:         binding.Route,
-			PageID:        binding.PageID,
-			Package:       binding.Package,
-			Render:        string(binding.Render),
-			Cache:         binding.Cache,
-			DynamicParams: append([]string(nil), binding.DynamicParams...),
-			RouteParams:   routeParamsJSON(binding.RouteParams),
-			Layouts:       append([]string(nil), binding.Layouts...),
-			Guards:        append([]string(nil), binding.Guards...),
-			Source:        binding.Source,
-			SourceSpan:    endpointSourceSpanJSON(binding.SourceSpan),
-			Handler:       binding.Handler,
-		})
+		route := routeBindingFromFields(binding.Kind, routeFieldsJSON(binding))
+		route.Render = string(binding.Render)
+		route.Layouts = append([]string(nil), binding.Layouts...)
+		routes = append(routes, route)
 	}
-	endpoints := endpointsJSON(metadata.Endpoints)
-	for _, endpoint := range endpoints {
-		routes = append(routes, endpointRouteJSON(endpoint))
-	}
+	endpoints, endpointRoutes := endpointReportsJSON(metadata.Endpoints)
+	routes = append(routes, endpointRoutes...)
 	info := make([]routeInfoJSON, 0, len(metadata.Info))
 	for _, item := range metadata.Info {
 		info = append(info, routeInfoJSON{
@@ -155,38 +162,26 @@ func routeMetadataJSON(metadata compiler.RouteMetadata) routeMetadataReport {
 }
 
 func endpointMetadataJSON(metadata compiler.RouteMetadata) endpointMetadataReport {
+	endpoints, _ := endpointReportsJSON(metadata.Endpoints)
 	return endpointMetadataReport{
 		Version:   1,
-		Endpoints: endpointsJSON(metadata.Endpoints),
+		Endpoints: endpoints,
 	}
 }
 
 func endpointsJSON(bindings []compiler.EndpointBinding) []endpointBindingJSON {
+	endpoints, _ := endpointReportsJSON(bindings)
+	return endpoints
+}
+
+func endpointReportsJSON(bindings []compiler.EndpointBinding) ([]endpointBindingJSON, []routeBindingJSON) {
 	endpoints := make([]endpointBindingJSON, 0, len(bindings))
+	routes := make([]routeBindingJSON, 0, len(bindings))
 	for _, binding := range bindings {
-		item := endpointBindingJSON{
-			Kind:           binding.Kind,
-			EndpointSource: binding.EndpointSource,
-			Directive:      endpointDirective(binding.Kind),
-			Source:         binding.Source,
-			SourceSpan:     endpointSourceSpanJSON(binding.SourceSpan),
-			Package:        binding.Package,
-			PackagePath:    binding.PackagePath,
-			PackageName:    binding.PackageName,
-			Symbol:         binding.Symbol,
-			Method:         binding.Method,
-			Route:          binding.Route,
-			Cache:          binding.Cache,
-			DynamicParams:  append([]string(nil), binding.DynamicParams...),
-			RouteParams:    routeParamsJSON(binding.RouteParams),
-			Guards:         append([]string(nil), binding.Guards...),
-			CSRF:           binding.CSRF,
-			PageID:         binding.PageID,
-			Handler:        binding.Handler,
-			BindingStatus:  string(binding.BindingStatus),
-			Signature:      string(binding.BindingSignature),
-			InputType:      binding.BindingInputType,
-		}
+		fields := endpointFieldsJSON(binding)
+		item := endpointBindingFromFields(binding.Kind, fields)
+		item.Signature = string(binding.BindingSignature)
+		item.InputType = binding.BindingInputType
 		if binding.BindingStatus != "" {
 			item.BackendBinding = &backendBindingJSON{
 				Status:       string(binding.BindingStatus),
@@ -214,31 +209,95 @@ func endpointsJSON(bindings []compiler.EndpointBinding) []endpointBindingJSON {
 			}
 		}
 		endpoints = append(endpoints, item)
+		routes = append(routes, routeBindingFromFields(compiler.RouteKind(binding.Kind), fields))
 	}
-	return endpoints
+	return endpoints, routes
 }
 
-func endpointRouteJSON(endpoint endpointBindingJSON) routeBindingJSON {
+func routeFieldsJSON(binding compiler.RouteBinding) routeEndpointFieldsJSON {
+	return routeEndpointFieldsJSON{
+		Method:        binding.Method,
+		Route:         binding.Route,
+		PageID:        binding.PageID,
+		Package:       binding.Package,
+		Cache:         binding.Cache,
+		DynamicParams: append([]string(nil), binding.DynamicParams...),
+		RouteParams:   routeParamsJSON(binding.RouteParams),
+		Guards:        append([]string(nil), binding.Guards...),
+		Source:        binding.Source,
+		SourceSpan:    endpointSourceSpanJSON(binding.SourceSpan),
+		Handler:       binding.Handler,
+	}
+}
+
+func endpointFieldsJSON(binding compiler.EndpointBinding) routeEndpointFieldsJSON {
+	return routeEndpointFieldsJSON{
+		EndpointSource: binding.EndpointSource,
+		Directive:      endpointDirective(binding.Kind),
+		Source:         binding.Source,
+		SourceSpan:     endpointSourceSpanJSON(binding.SourceSpan),
+		Package:        binding.Package,
+		PackagePath:    binding.PackagePath,
+		PackageName:    binding.PackageName,
+		Symbol:         binding.Symbol,
+		Method:         binding.Method,
+		Route:          binding.Route,
+		Cache:          binding.Cache,
+		DynamicParams:  append([]string(nil), binding.DynamicParams...),
+		RouteParams:    routeParamsJSON(binding.RouteParams),
+		Guards:         append([]string(nil), binding.Guards...),
+		CSRF:           binding.CSRF,
+		PageID:         binding.PageID,
+		Handler:        binding.Handler,
+		BindingStatus:  string(binding.BindingStatus),
+	}
+}
+
+func routeBindingFromFields(kind compiler.RouteKind, fields routeEndpointFieldsJSON) routeBindingJSON {
 	return routeBindingJSON{
-		Kind:           compiler.RouteKind(endpoint.Kind),
-		EndpointSource: endpoint.EndpointSource,
-		Directive:      endpoint.Directive,
-		Method:         endpoint.Method,
-		Route:          endpoint.Route,
-		PageID:         endpoint.PageID,
-		Package:        endpoint.Package,
-		PackagePath:    endpoint.PackagePath,
-		PackageName:    endpoint.PackageName,
-		Symbol:         endpoint.Symbol,
-		Cache:          endpoint.Cache,
-		DynamicParams:  append([]string(nil), endpoint.DynamicParams...),
-		RouteParams:    append([]routeParamJSON(nil), endpoint.RouteParams...),
-		Guards:         append([]string(nil), endpoint.Guards...),
-		CSRF:           endpoint.CSRF,
-		Source:         endpoint.Source,
-		SourceSpan:     endpoint.SourceSpan,
-		Handler:        endpoint.Handler,
-		BindingStatus:  endpoint.BindingStatus,
+		Kind:           kind,
+		EndpointSource: fields.EndpointSource,
+		Directive:      fields.Directive,
+		Method:         fields.Method,
+		Route:          fields.Route,
+		PageID:         fields.PageID,
+		Package:        fields.Package,
+		PackagePath:    fields.PackagePath,
+		PackageName:    fields.PackageName,
+		Symbol:         fields.Symbol,
+		Cache:          fields.Cache,
+		DynamicParams:  append([]string(nil), fields.DynamicParams...),
+		RouteParams:    append([]routeParamJSON(nil), fields.RouteParams...),
+		Guards:         append([]string(nil), fields.Guards...),
+		CSRF:           fields.CSRF,
+		Source:         fields.Source,
+		SourceSpan:     fields.SourceSpan,
+		Handler:        fields.Handler,
+		BindingStatus:  fields.BindingStatus,
+	}
+}
+
+func endpointBindingFromFields(kind compiler.EndpointKind, fields routeEndpointFieldsJSON) endpointBindingJSON {
+	return endpointBindingJSON{
+		Kind:           kind,
+		EndpointSource: fields.EndpointSource,
+		Directive:      fields.Directive,
+		Source:         fields.Source,
+		SourceSpan:     fields.SourceSpan,
+		Package:        fields.Package,
+		PackagePath:    fields.PackagePath,
+		PackageName:    fields.PackageName,
+		Symbol:         fields.Symbol,
+		Method:         fields.Method,
+		Route:          fields.Route,
+		Cache:          fields.Cache,
+		DynamicParams:  append([]string(nil), fields.DynamicParams...),
+		RouteParams:    append([]routeParamJSON(nil), fields.RouteParams...),
+		Guards:         append([]string(nil), fields.Guards...),
+		CSRF:           fields.CSRF,
+		PageID:         fields.PageID,
+		Handler:        fields.Handler,
+		BindingStatus:  fields.BindingStatus,
 	}
 }
 

--- a/cmd/gowdk/route_report_test.go
+++ b/cmd/gowdk/route_report_test.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/cssbruno/gowdk/internal/compiler"
+	"github.com/cssbruno/gowdk/internal/source"
+)
+
+func TestEndpointSharedFieldsMatchRouteReport(t *testing.T) {
+	metadata := compiler.RouteMetadata{Endpoints: []compiler.EndpointBinding{{
+		Kind:           compiler.EndpointAction,
+		EndpointSource: "gwdk",
+		Source:         "pages/newsletter.page.gwdk",
+		SourceSpan: source.SourceSpan{
+			Start: source.SourcePosition{Line: 3, Column: 1},
+			End:   source.SourcePosition{Line: 3, Column: 32},
+		},
+		Package:       "pages",
+		PackagePath:   "github.com/acme/app/pages",
+		PackageName:   "pages",
+		Symbol:        "Subscribe",
+		Method:        "POST",
+		Route:         "/newsletter/{slug}",
+		Cache:         "no-store",
+		DynamicParams: []string{"slug"},
+		RouteParams:   []source.RouteParam{{Name: "slug", Type: "string"}},
+		Guards:        []string{"public"},
+		CSRF:          true,
+		PageID:        "newsletter",
+		Handler:       "Subscribe",
+		BindingStatus: source.BackendBindingBound,
+	}}}
+
+	routeReport := routeMetadataJSON(metadata)
+	endpointReport := endpointMetadataJSON(metadata)
+	if len(routeReport.Routes) != 1 || len(endpointReport.Endpoints) != 1 {
+		t.Fatalf("reports = %#v %#v, want one route endpoint and one endpoint", routeReport, endpointReport)
+	}
+	route := routeReport.Routes[0]
+	endpoint := endpointReport.Endpoints[0]
+	if route.EndpointSource != endpoint.EndpointSource ||
+		route.Directive != endpoint.Directive ||
+		route.Source != endpoint.Source ||
+		!reflect.DeepEqual(route.SourceSpan, endpoint.SourceSpan) ||
+		route.Package != endpoint.Package ||
+		route.PackagePath != endpoint.PackagePath ||
+		route.PackageName != endpoint.PackageName ||
+		route.Symbol != endpoint.Symbol ||
+		route.Method != endpoint.Method ||
+		route.Route != endpoint.Route ||
+		route.Cache != endpoint.Cache ||
+		!reflect.DeepEqual(route.DynamicParams, endpoint.DynamicParams) ||
+		!reflect.DeepEqual(route.RouteParams, endpoint.RouteParams) ||
+		!reflect.DeepEqual(route.Guards, endpoint.Guards) ||
+		route.CSRF != endpoint.CSRF ||
+		route.PageID != endpoint.PageID ||
+		route.Handler != endpoint.Handler ||
+		route.BindingStatus != endpoint.BindingStatus {
+		t.Fatalf("route endpoint fields = %#v, endpoint fields = %#v", route, endpoint)
+	}
+}

--- a/cmd/gowdk/serve.go
+++ b/cmd/gowdk/serve.go
@@ -53,23 +53,23 @@ func parseServeOptions(args []string) (string, string, error) {
 	var dir string
 	for i := 0; i < len(args); i++ {
 		arg := args[i]
+		if value, next, ok, missing := consumeValueFlag(args, i, "--dir", true); ok {
+			if missing {
+				return "", "", fmt.Errorf("usage: gowdk serve --dir <dir> [--addr <addr>]")
+			}
+			dir = value
+			i = next
+			continue
+		}
+		if value, next, ok, missing := consumeValueFlag(args, i, "--addr", true); ok {
+			if missing {
+				return "", "", fmt.Errorf("usage: gowdk serve --dir <dir> [--addr <addr>]")
+			}
+			addr = value
+			i = next
+			continue
+		}
 		switch {
-		case arg == "--dir":
-			i++
-			if i >= len(args) {
-				return "", "", fmt.Errorf("usage: gowdk serve --dir <dir> [--addr <addr>]")
-			}
-			dir = args[i]
-		case strings.HasPrefix(arg, "--dir="):
-			dir = strings.TrimPrefix(arg, "--dir=")
-		case arg == "--addr":
-			i++
-			if i >= len(args) {
-				return "", "", fmt.Errorf("usage: gowdk serve --dir <dir> [--addr <addr>]")
-			}
-			addr = args[i]
-		case strings.HasPrefix(arg, "--addr="):
-			addr = strings.TrimPrefix(arg, "--addr=")
 		case strings.HasPrefix(arg, "-"):
 			return "", "", fmt.Errorf("unknown serve flag %q", arg)
 		default:

--- a/cmd/gowdk/test.go
+++ b/cmd/gowdk/test.go
@@ -135,6 +135,86 @@ func parseTestOptions(args []string) (testOptions, error) {
 	var options testOptions
 	for index := 0; index < len(args); index++ {
 		arg := args[index]
+		if value, next, ok, missing := consumeValueFlag(args, index, "--config", true); ok {
+			if missing {
+				return testOptions{}, fmt.Errorf(testUsage)
+			}
+			options.ConfigPath = value
+			index = next
+			continue
+		}
+		if value, next, ok, missing := consumeValueFlag(args, index, "--env-file", true); ok {
+			if missing {
+				return testOptions{}, fmt.Errorf(testUsage)
+			}
+			options.EnvFilePath = value
+			index = next
+			continue
+		}
+		if value, next, ok, missing := consumeValueFlag(args, index, "--module", true); ok {
+			if missing {
+				return testOptions{}, fmt.Errorf(testUsage)
+			}
+			options.ModuleNames = appendModuleNames(options.ModuleNames, value)
+			index = next
+			continue
+		}
+		if value, next, ok, missing := consumeValueFlag(args, index, "--target", true); ok {
+			if missing {
+				return testOptions{}, fmt.Errorf(testUsage)
+			}
+			options.TargetNames = appendNames(options.TargetNames, value)
+			index = next
+			continue
+		}
+		if value, next, ok, missing := consumeValueFlag(args, index, "--stage", true); ok {
+			if missing {
+				return testOptions{}, fmt.Errorf(testUsage)
+			}
+			options.Stages = appendTestStages(options.Stages, value)
+			index = next
+			continue
+		}
+		if value, next, ok, missing := consumeValueFlag(args, index, "--run", true); ok {
+			if missing {
+				return testOptions{}, fmt.Errorf(testUsage)
+			}
+			options.RunPattern = value
+			index = next
+			continue
+		}
+		if value, next, ok, missing := consumeValueFlag(args, index, "--timeout", true); ok {
+			if missing {
+				return testOptions{}, fmt.Errorf(testUsage)
+			}
+			timeout, err := normalizeTestTimeout(value)
+			if err != nil {
+				return testOptions{}, err
+			}
+			options.Timeout = timeout
+			index = next
+			continue
+		}
+		if value, next, ok, missing := consumeValueFlag(args, index, "--count", true); ok {
+			if missing {
+				return testOptions{}, fmt.Errorf(testUsage)
+			}
+			count, err := normalizeTestCount(value)
+			if err != nil {
+				return testOptions{}, err
+			}
+			options.Count = count
+			index = next
+			continue
+		}
+		if value, next, ok, missing := consumeValueFlag(args, index, "--browser-command", true); ok {
+			if missing {
+				return testOptions{}, fmt.Errorf(testUsage)
+			}
+			options.BrowserCommand = value
+			index = next
+			continue
+		}
 		switch {
 		case arg == "-h" || arg == "--help":
 			return testOptions{}, fmt.Errorf(testUsage)
@@ -146,94 +226,6 @@ func parseTestOptions(args []string) (testOptions, error) {
 			options.JSON = true
 		case arg == "--keep-workdir":
 			options.KeepWorkdir = true
-		case arg == "--config":
-			index++
-			if index >= len(args) {
-				return testOptions{}, fmt.Errorf(testUsage)
-			}
-			options.ConfigPath = args[index]
-		case strings.HasPrefix(arg, "--config="):
-			options.ConfigPath = strings.TrimPrefix(arg, "--config=")
-		case arg == "--env-file":
-			index++
-			if index >= len(args) {
-				return testOptions{}, fmt.Errorf(testUsage)
-			}
-			options.EnvFilePath = args[index]
-		case strings.HasPrefix(arg, "--env-file="):
-			options.EnvFilePath = strings.TrimPrefix(arg, "--env-file=")
-		case arg == "--module":
-			index++
-			if index >= len(args) {
-				return testOptions{}, fmt.Errorf(testUsage)
-			}
-			options.ModuleNames = appendModuleNames(options.ModuleNames, args[index])
-		case strings.HasPrefix(arg, "--module="):
-			options.ModuleNames = appendModuleNames(options.ModuleNames, strings.TrimPrefix(arg, "--module="))
-		case arg == "--target":
-			index++
-			if index >= len(args) {
-				return testOptions{}, fmt.Errorf(testUsage)
-			}
-			options.TargetNames = appendNames(options.TargetNames, args[index])
-		case strings.HasPrefix(arg, "--target="):
-			options.TargetNames = appendNames(options.TargetNames, strings.TrimPrefix(arg, "--target="))
-		case arg == "--stage":
-			index++
-			if index >= len(args) {
-				return testOptions{}, fmt.Errorf(testUsage)
-			}
-			options.Stages = appendTestStages(options.Stages, args[index])
-		case strings.HasPrefix(arg, "--stage="):
-			options.Stages = appendTestStages(options.Stages, strings.TrimPrefix(arg, "--stage="))
-		case arg == "--run":
-			index++
-			if index >= len(args) {
-				return testOptions{}, fmt.Errorf(testUsage)
-			}
-			options.RunPattern = args[index]
-		case strings.HasPrefix(arg, "--run="):
-			options.RunPattern = strings.TrimPrefix(arg, "--run=")
-		case arg == "--timeout":
-			index++
-			if index >= len(args) {
-				return testOptions{}, fmt.Errorf(testUsage)
-			}
-			timeout, err := normalizeTestTimeout(args[index])
-			if err != nil {
-				return testOptions{}, err
-			}
-			options.Timeout = timeout
-		case strings.HasPrefix(arg, "--timeout="):
-			timeout, err := normalizeTestTimeout(strings.TrimPrefix(arg, "--timeout="))
-			if err != nil {
-				return testOptions{}, err
-			}
-			options.Timeout = timeout
-		case arg == "--count":
-			index++
-			if index >= len(args) {
-				return testOptions{}, fmt.Errorf(testUsage)
-			}
-			count, err := normalizeTestCount(args[index])
-			if err != nil {
-				return testOptions{}, err
-			}
-			options.Count = count
-		case strings.HasPrefix(arg, "--count="):
-			count, err := normalizeTestCount(strings.TrimPrefix(arg, "--count="))
-			if err != nil {
-				return testOptions{}, err
-			}
-			options.Count = count
-		case arg == "--browser-command":
-			index++
-			if index >= len(args) {
-				return testOptions{}, fmt.Errorf(testUsage)
-			}
-			options.BrowserCommand = args[index]
-		case strings.HasPrefix(arg, "--browser-command="):
-			options.BrowserCommand = strings.TrimPrefix(arg, "--browser-command=")
 		case strings.HasPrefix(arg, "-"):
 			return testOptions{}, fmt.Errorf("unknown test flag %q", arg)
 		default:

--- a/internal/source/source.go
+++ b/internal/source/source.go
@@ -214,32 +214,11 @@ func BackendRoutePath(value string) string {
 // ValidateBackendRoutePath rejects paths that would be unsafe or ambiguous when
 // registered as generated backend routes.
 func ValidateBackendRoutePath(value string) error {
-	if strings.TrimSpace(value) != value {
-		return fmt.Errorf("endpoint path %q must not contain surrounding whitespace", value)
+	if _, err := validateBackendRoutePreflight(value, "must be a concrete path without query, fragment, or params"); err != nil {
+		return err
 	}
-	if value == "" {
-		return fmt.Errorf("endpoint path must not be empty")
-	}
-	if value[0] != '/' {
-		return fmt.Errorf("endpoint path %q must be a local absolute path", value)
-	}
-	if len(value) > 1 && (value[1] == '/' || value[1] == '\\') {
-		return fmt.Errorf("endpoint path %q must not be protocol-relative", value)
-	}
-	if strings.Contains(value, "\\") {
-		return fmt.Errorf("endpoint path %q must not contain backslashes", value)
-	}
-	if strings.ContainsAny(value, "?#{}") {
+	if strings.ContainsAny(value, "{}") {
 		return fmt.Errorf("endpoint path %q must be a concrete path without query, fragment, or params", value)
-	}
-	for _, char := range value {
-		if char < 0x20 || char == 0x7f {
-			return fmt.Errorf("endpoint path %q must not contain control characters", value)
-		}
-	}
-	cleaned := BackendRoutePath(value)
-	if cleaned != value {
-		return fmt.Errorf("endpoint path %q must be a clean absolute path without dot segments, duplicate slashes, or trailing slash", value)
 	}
 	return nil
 }
@@ -247,32 +226,8 @@ func ValidateBackendRoutePath(value string) error {
 // ValidateBackendRoutePattern rejects unsafe generated route patterns while
 // allowing whole-segment route params such as /patients/{id:int}.
 func ValidateBackendRoutePattern(value string) error {
-	if strings.TrimSpace(value) != value {
-		return fmt.Errorf("endpoint path %q must not contain surrounding whitespace", value)
-	}
-	if value == "" {
-		return fmt.Errorf("endpoint path must not be empty")
-	}
-	if value[0] != '/' {
-		return fmt.Errorf("endpoint path %q must be a local absolute path", value)
-	}
-	if len(value) > 1 && (value[1] == '/' || value[1] == '\\') {
-		return fmt.Errorf("endpoint path %q must not be protocol-relative", value)
-	}
-	if strings.Contains(value, "\\") {
-		return fmt.Errorf("endpoint path %q must not contain backslashes", value)
-	}
-	if strings.ContainsAny(value, "?#") {
-		return fmt.Errorf("endpoint path %q must not contain query strings or fragments", value)
-	}
-	for _, char := range value {
-		if char < 0x20 || char == 0x7f {
-			return fmt.Errorf("endpoint path %q must not contain control characters", value)
-		}
-	}
-	cleaned := BackendRoutePath(value)
-	if cleaned != value {
-		return fmt.Errorf("endpoint path %q must be a clean absolute path without dot segments, duplicate slashes, or trailing slash", value)
+	if _, err := validateBackendRoutePreflight(value, "must not contain query strings or fragments"); err != nil {
+		return err
 	}
 	if value == "/" {
 		return nil
@@ -315,6 +270,37 @@ func ValidateBackendRoutePattern(value string) error {
 		seen[param.name] = true
 	}
 	return nil
+}
+
+func validateBackendRoutePreflight(value, queryFragmentRule string) (string, error) {
+	if strings.TrimSpace(value) != value {
+		return "", fmt.Errorf("endpoint path %q must not contain surrounding whitespace", value)
+	}
+	if value == "" {
+		return "", fmt.Errorf("endpoint path must not be empty")
+	}
+	if value[0] != '/' {
+		return "", fmt.Errorf("endpoint path %q must be a local absolute path", value)
+	}
+	if len(value) > 1 && (value[1] == '/' || value[1] == '\\') {
+		return "", fmt.Errorf("endpoint path %q must not be protocol-relative", value)
+	}
+	if strings.Contains(value, "\\") {
+		return "", fmt.Errorf("endpoint path %q must not contain backslashes", value)
+	}
+	if strings.ContainsAny(value, "?#") {
+		return "", fmt.Errorf("endpoint path %q %s", value, queryFragmentRule)
+	}
+	for _, char := range value {
+		if char < 0x20 || char == 0x7f {
+			return "", fmt.Errorf("endpoint path %q must not contain control characters", value)
+		}
+	}
+	cleaned := BackendRoutePath(value)
+	if cleaned != value {
+		return "", fmt.Errorf("endpoint path %q must be a clean absolute path without dot segments, duplicate slashes, or trailing slash", value)
+	}
+	return cleaned, nil
 }
 
 type backendRouteParam struct {
@@ -421,37 +407,6 @@ type BackendResultField struct {
 	Path     string
 	Selector string
 	Type     string
-}
-
-// BackendInputFieldTypeSupported reports whether goType is a form-decoder type
-// supported by compiler validation and generated action decoders.
-func BackendInputFieldTypeSupported(goType string) bool {
-	_, ok := LookupBackendInputFieldType(goType)
-	return ok
-}
-
-// BackendInputFieldSignedInteger reports whether goType uses the signed integer
-// form decoder.
-func BackendInputFieldSignedInteger(goType string) bool {
-	fieldType, ok := LookupBackendInputFieldType(goType)
-	return ok && fieldType.Kind == BackendInputFieldKindSignedInt
-}
-
-// BackendInputFieldUnsignedInteger reports whether goType uses the unsigned
-// integer form decoder.
-func BackendInputFieldUnsignedInteger(goType string) bool {
-	fieldType, ok := LookupBackendInputFieldType(goType)
-	return ok && fieldType.Kind == BackendInputFieldKindUnsignedInt
-}
-
-// BackendInputFieldIntegerBitSize returns the explicit bit size passed to form
-// integer decoders. Zero means the platform-sized int or uint type.
-func BackendInputFieldIntegerBitSize(goType string) int {
-	fieldType, ok := LookupBackendInputFieldType(goType)
-	if !ok {
-		return 0
-	}
-	return fieldType.BitSize
 }
 
 // BackendBinding describes the Go handler selected for a backend block (a page

--- a/internal/source/source_test.go
+++ b/internal/source/source_test.go
@@ -103,6 +103,35 @@ func TestValidateBackendRoutePattern(t *testing.T) {
 	}
 }
 
+func TestValidateBackendRouteSharedPreflight(t *testing.T) {
+	invalid := []string{
+		"",
+		"patients",
+		"//example.com/pay",
+		`/\example.com/pay`,
+		"/patients?filter=active",
+		"/patients#form",
+		"/patients\nadmin",
+		"/patients\\admin",
+		"/patients/../admin",
+		"/patients//active",
+		"/patients/./active",
+		"/patients/",
+		" /patients",
+	}
+	validators := map[string]func(string) error{
+		"path":    ValidateBackendRoutePath,
+		"pattern": ValidateBackendRoutePattern,
+	}
+	for _, path := range invalid {
+		for name, validate := range validators {
+			if err := validate(path); err == nil {
+				t.Fatalf("%s validator accepted shared-invalid path %q", name, path)
+			}
+		}
+	}
+}
+
 func TestPositionAtAndOffsetOf(t *testing.T) {
 	// Multi-line, multi-byte (the euro sign is 3 bytes) so rune columns and byte
 	// offsets diverge.

--- a/runtime/contracts/command.go
+++ b/runtime/contracts/command.go
@@ -31,12 +31,16 @@ func ExecuteCommandForRole[C, R any](ctx context.Context, registry *Registry, ro
 }
 
 func executeCommand[C, R any](ctx context.Context, registry *Registry, command C, role Role) (R, error) {
+	return executeCommandWithSink[C, R](ctx, registry, nil, command, role)
+}
+
+func executeCommandWithSink[C, R any](ctx context.Context, registry *Registry, sink CommandEventSink, command C, role Role) (R, error) {
 	result, recorder, dispatchCtx, err := runCommand[C, R](ctx, registry, command, role)
 	if err != nil {
 		var zero R
 		return zero, err
 	}
-	if err := recorder.dispatchForRole(dispatchCtx, registry, role); err != nil {
+	if err := DispatchCommandEvents(dispatchCtx, sink, registry, role, recorder.envelopes(dispatchCtx)); err != nil {
 		var zero R
 		return zero, err
 	}
@@ -81,16 +85,7 @@ func executeCommandToOutbox[C, R any](ctx context.Context, registry *Registry, o
 	if outbox == nil {
 		return zero, Error{Kind: ErrNilHandler, Contract: typeName[C](), Message: "command outbox cannot be nil"}
 	}
-	result, events, err := captureCommandEvents[C, R](ctx, registry, command, role)
-	if err != nil {
-		return zero, err
-	}
-	if len(events) > 0 {
-		if err := outbox.StoreEvents(ctx, events); err != nil {
-			return zero, err
-		}
-	}
-	return result, nil
+	return executeCommandWithSink[C, R](ctx, registry, OutboxCommandEventSink(outbox), command, role)
 }
 
 // ExecuteCommandToBroker runs a command and publishes emitted events to broker
@@ -110,14 +105,7 @@ func executeCommandToBroker[C, R any](ctx context.Context, registry *Registry, b
 	if broker == nil {
 		return zero, Error{Kind: ErrNilHandler, Contract: typeName[C](), Message: "command event broker cannot be nil"}
 	}
-	result, events, err := captureCommandEvents[C, R](ctx, registry, command, role)
-	if err != nil {
-		return zero, err
-	}
-	if err := PublishEventsToBroker(ctx, broker, events); err != nil {
-		return zero, err
-	}
-	return result, nil
+	return executeCommandWithSink[C, R](ctx, registry, BrokerCommandEventSink(broker), command, role)
 }
 
 // ExecuteCommandToPresentationFanout runs a command and sends presentation
@@ -138,14 +126,7 @@ func executeCommandToPresentationFanout[C, R any](ctx context.Context, registry 
 	if fanout == nil {
 		return zero, Error{Kind: ErrNilHandler, Contract: typeName[C](), Message: "command presentation fanout cannot be nil"}
 	}
-	result, events, err := captureCommandEvents[C, R](ctx, registry, command, role)
-	if err != nil {
-		return zero, err
-	}
-	if err := SendPresentationEventsToFanout(ctx, fanout, events); err != nil {
-		return zero, err
-	}
-	return result, nil
+	return executeCommandWithSink[C, R](ctx, registry, PresentationFanoutCommandEventSink(fanout), command, role)
 }
 
 func runCommand[C, R any](ctx context.Context, registry *Registry, command C, role Role) (R, *eventRecorder, context.Context, error) {

--- a/runtime/contracts/contracts_test.go
+++ b/runtime/contracts/contracts_test.go
@@ -457,6 +457,49 @@ func TestExecuteCommandToPresentationFanoutReturnsSendError(t *testing.T) {
 	}
 }
 
+func TestExecuteCommandSinkWrappersRejectNilDestinations(t *testing.T) {
+	registry := NewRegistry()
+	tests := []struct {
+		name    string
+		run     func() (createPatientResult, error)
+		message string
+	}{
+		{
+			name: "outbox",
+			run: func() (createPatientResult, error) {
+				return ExecuteCommandToOutbox[createPatient, createPatientResult](context.Background(), registry, nil, createPatient{Name: "Ada"})
+			},
+			message: "command outbox cannot be nil",
+		},
+		{
+			name: "broker",
+			run: func() (createPatientResult, error) {
+				return ExecuteCommandToBroker[createPatient, createPatientResult](context.Background(), registry, nil, createPatient{Name: "Ada"})
+			},
+			message: "command event broker cannot be nil",
+		},
+		{
+			name: "presentation",
+			run: func() (createPatientResult, error) {
+				return ExecuteCommandToPresentationFanout[createPatient, createPatientResult](context.Background(), registry, nil, createPatient{Name: "Ada"})
+			},
+			message: "command presentation fanout cannot be nil",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := tt.run()
+			var contractErr Error
+			if !errors.As(err, &contractErr) {
+				t.Fatalf("error = %v, want contracts.Error", err)
+			}
+			if contractErr.Kind != ErrNilHandler || contractErr.Contract != typeName[createPatient]() || contractErr.Message != tt.message {
+				t.Fatalf("error = %#v, want nil handler for createPatient with message %q", contractErr, tt.message)
+			}
+		})
+	}
+}
+
 func TestSendPresentationEventsToFanoutSkipsNonPresentationBatches(t *testing.T) {
 	fanout := &recordingFanout{}
 
@@ -470,6 +513,37 @@ func TestSendPresentationEventsToFanoutSkipsNonPresentationBatches(t *testing.T)
 	}
 	if fanout.calls != 0 {
 		t.Fatalf("fanout.calls = %d, want 0", fanout.calls)
+	}
+}
+
+func TestExecuteCommandWithSinkUsesCompositeSink(t *testing.T) {
+	registry := NewRegistry()
+	must(t, RegisterCommand[createPatient, createPatientResult](registry, func(ctx context.Context, command createPatient) (createPatientResult, error) {
+		return createPatientResult{ID: "patient-1"}, EmitDomain(ctx, patientCreated{ID: "patient-1"})
+	}, RoleWeb))
+	var calls []string
+	first := commandEventSinkFunc(func(ctx context.Context, registry *Registry, role Role, events []EventEnvelope) error {
+		calls = append(calls, "first:"+string(role)+":"+events[0].Type)
+		return nil
+	})
+	second := commandEventSinkFunc(func(ctx context.Context, registry *Registry, role Role, events []EventEnvelope) error {
+		calls = append(calls, "second:"+string(role)+":"+events[0].Type)
+		return nil
+	})
+
+	result, err := executeCommandWithSink[createPatient, createPatientResult](context.Background(), registry, CompositeCommandEventSink(first, second), createPatient{Name: "Ada"}, RoleWeb)
+	if err != nil {
+		t.Fatalf("execute command with composite sink: %v", err)
+	}
+	if result.ID != "patient-1" {
+		t.Fatalf("result.ID = %q, want patient-1", result.ID)
+	}
+	want := []string{
+		"first:web:" + typeName[patientCreated](),
+		"second:web:" + typeName[patientCreated](),
+	}
+	if !slices.Equal(calls, want) {
+		t.Fatalf("calls = %#v, want %#v", calls, want)
 	}
 }
 

--- a/runtime/contracts/events.go
+++ b/runtime/contracts/events.go
@@ -279,7 +279,6 @@ func registerEvent[E any](registry *Registry, category EventCategory, handler Ev
 	registry.ensureMapsLocked()
 	key := eventKey{category: category, event: typeName[E]()}
 	registry.events[key] = append(registry.events[key], eventEntry{
-		event:    key.event,
 		dispatch: eventDispatcher(handler),
 		roles:    copyRoles(roles),
 	})

--- a/runtime/contracts/recorder.go
+++ b/runtime/contracts/recorder.go
@@ -9,12 +9,10 @@ type eventRecorder struct {
 }
 
 type recordedEvent struct {
-	category        EventCategory
-	eventType       string
-	audience        []string
-	value           any
-	dispatch        func(context.Context, *Registry) error
-	dispatchForRole func(context.Context, *Registry, Role) error
+	category  EventCategory
+	eventType string
+	audience  []string
+	value     any
 }
 
 func withRecorder(ctx context.Context) (context.Context, *eventRecorder) {
@@ -40,22 +38,7 @@ func emitWithAudience[E any](ctx context.Context, category EventCategory, event 
 		eventType: typeName[E](),
 		audience:  normalizeAudience(audience),
 		value:     event,
-		dispatch: func(dispatchCtx context.Context, registry *Registry) error {
-			return dispatchEvent(dispatchCtx, registry, category, event)
-		},
-		dispatchForRole: func(dispatchCtx context.Context, registry *Registry, role Role) error {
-			return dispatchEventForRole(dispatchCtx, registry, category, event, role)
-		},
 	})
-	return nil
-}
-
-func (recorder *eventRecorder) dispatch(ctx context.Context, registry *Registry) error {
-	for _, event := range recorder.events {
-		if err := event.dispatch(ctx, registry); err != nil {
-			return err
-		}
-	}
 	return nil
 }
 
@@ -75,13 +58,4 @@ func (recorder *eventRecorder) envelopes(ctx context.Context) []EventEnvelope {
 		}))
 	}
 	return envelopes
-}
-
-func (recorder *eventRecorder) dispatchForRole(ctx context.Context, registry *Registry, role Role) error {
-	for _, event := range recorder.events {
-		if err := event.dispatchForRole(ctx, registry, role); err != nil {
-			return err
-		}
-	}
-	return nil
 }

--- a/runtime/contracts/registry.go
+++ b/runtime/contracts/registry.go
@@ -137,7 +137,6 @@ type eventKey struct {
 }
 
 type eventEntry struct {
-	event    string
 	dispatch func(context.Context, any) error
 	roles    []Role
 }


### PR DESCRIPTION
## Summary

Completes the open refactor issue set by consolidating repeated command, discovery, route-report, route-validation, and command-event-delivery paths without changing public behavior.

Closes #649
Closes #650
Closes #652
Closes #653
Closes #654
Closes #655
Closes #656
Closes #657
Closes #660

## Changes

- Adds a top-level command descriptor table for dispatch, help, and command listing.
- Centralizes CLI value-flag token consumption across command parsers.
- Makes `buildRequest` the canonical ad-hoc build predicate and shares configured target resolution with clean.
- Shares configured discovery input preparation between files-only and files-plus-directories discovery.
- Reuses the validated-program command path for route and endpoint metadata.
- Projects shared route/endpoint JSON fields through one private projection.
- Deduplicates backend route path/pattern preflight validation.
- Routes command event convenience helpers through `CommandEventSink` while preserving compatibility wrappers.

## Validation

- `go test ./cmd/gowdk ./internal/source ./runtime/contracts`
- `go build ./cmd/gowdk`
- Earlier before rebasing onto this stack: `go test ./...`, `scripts/test-go-modules.sh`, and `go run ./cmd/gowdk check --ssr examples/pages/*.gwdk examples/marketing/*.gwdk examples/ssr/*.gwdk`

## Notes

This is a stacked PR based on `codex/complete-646-648` because the current checkout already contains the preceding `gowdk test` branch work.
