### PR TITLE
[codex] chore(ci): add focused dead-code gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,23 @@ jobs:
       - name: Build CLI
         run: go build ./cmd/gowdk
 
+  dead-code:
+    name: Dead code
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: '1.26.4'
+          cache: true
+
+      - name: Check focused dead code
+        run: scripts/check-dead-code.sh
+
   vscode-extension:
     name: VS Code extension
     runs-on: ubuntu-latest

--- a/cmd/gowdk/init.go
+++ b/cmd/gowdk/init.go
@@ -378,30 +378,6 @@ func initStringLit(value string) *ast.BasicLit {
 	return &ast.BasicLit{Kind: token.STRING, Value: strconv.Quote(value)}
 }
 
-func initBlock(stmts ...ast.Stmt) *ast.BlockStmt {
-	return &ast.BlockStmt{List: stmts}
-}
-
-func initExprStmt(expr ast.Expr) ast.Stmt {
-	return &ast.ExprStmt{X: expr}
-}
-
-func initCall(fun ast.Expr, args ...ast.Expr) *ast.CallExpr {
-	return &ast.CallExpr{Fun: fun, Args: args}
-}
-
-func initDefine(names []ast.Expr, values ...ast.Expr) ast.Stmt {
-	return &ast.AssignStmt{Lhs: names, Tok: token.DEFINE, Rhs: values}
-}
-
-func initAssign(names []ast.Expr, values ...ast.Expr) ast.Stmt {
-	return &ast.AssignStmt{Lhs: names, Tok: token.ASSIGN, Rhs: values}
-}
-
-func initNotNil(name string) ast.Expr {
-	return &ast.BinaryExpr{X: ast.NewIdent(name), Op: token.NEQ, Y: ast.NewIdent("nil")}
-}
-
 func parseInitOptions(args []string) (initOptions, error) {
 	options := initOptions{Dir: ".", Template: "site"}
 	for index := 0; index < len(args); index++ {

--- a/cmd/gowdk/route_report.go
+++ b/cmd/gowdk/route_report.go
@@ -169,11 +169,6 @@ func endpointMetadataJSON(metadata compiler.RouteMetadata) endpointMetadataRepor
 	}
 }
 
-func endpointsJSON(bindings []compiler.EndpointBinding) []endpointBindingJSON {
-	endpoints, _ := endpointReportsJSON(bindings)
-	return endpoints
-}
-
 func endpointReportsJSON(bindings []compiler.EndpointBinding) ([]endpointBindingJSON, []routeBindingJSON) {
 	endpoints := make([]endpointBindingJSON, 0, len(bindings))
 	routes := make([]routeBindingJSON, 0, len(bindings))

--- a/docs/engineering/ci.md
+++ b/docs/engineering/ci.md
@@ -13,6 +13,9 @@ Required pull-request lanes:
 - `Runtime race detector`: `scripts/test-runtime-race.sh` on Linux for the
   explicit shared-state runtime package list.
 - `CLI build`: `go build ./cmd/gowdk`.
+- `Dead code`: `scripts/check-dead-code.sh` runs pinned Staticcheck `U1000`
+  and x/tools `deadcode` analyzers over the focused compiler, CLI, and
+  runtime-contract package sets documented below.
 - `VS Code extension`: extension version sync, Node syntax checks, and unit
   tests.
 - `Documentation links`: `scripts/check-docs-links.sh`.
@@ -53,6 +56,7 @@ Run the same local checks before handoff when relevant:
   scripts/test-go-modules.sh
   scripts/vulncheck-go-modules.sh
   go build ./cmd/gowdk
+  scripts/check-dead-code.sh
   ```
 
 - VS Code extension checks:
@@ -139,6 +143,35 @@ multiplied by generated-binary work:
 If one of these reveals nondeterministic output, either fix the generator in
 the same change or open a narrower issue naming the unstable file/report.
 
+## Dead Code
+
+`scripts/check-dead-code.sh` runs two pinned analyzers over reviewed starter
+package sets:
+
+```sh
+scripts/check-dead-code.sh
+```
+
+Staticcheck is pinned to `honnef.co/go/tools/cmd/staticcheck@v0.7.0` and runs
+`-checks=U1000` over `cmd/gowdk`, `internal/source`, `internal/gwdkir`,
+`internal/gwdkanalysis`, and `runtime/contracts`. This catches unused private
+declarations and unread private fields where a clean baseline is currently
+actionable.
+
+The x/tools dead-code analyzer is pinned to
+`golang.org/x/tools/cmd/deadcode@v0.45.0` and runs with `-test` over
+`cmd/gowdk`, `internal/source`, `internal/gwdkir`, and
+`internal/gwdkanalysis`. Its report is filtered to those packages so exported
+compiler-private wrapper functions are covered without turning public runtime
+APIs into false positives.
+
+Public runtime/addon APIs, optional nested modules, generated app fixtures,
+generated docs-site output, examples, and build-tag-specific platform
+implementations are intentionally outside the first gate. Add packages only
+after confirming a clean baseline without broad suppressions; if an intentional
+entry point needs a suppression, keep it local to the declaration and document
+why external reachability is expected.
+
 ## Release Smoke
 
 After publishing a tag, verify the current machine's release artifact locally:
@@ -166,6 +199,7 @@ Require these checks before merging to `main`:
 - `Reachable vulnerabilities`
 - `Runtime race detector`
 - `CLI build`
+- `Dead code`
 - `VS Code extension`
 - `Documentation links`
 - `Example reports`

--- a/runtime/contracts/contracts_test.go
+++ b/runtime/contracts/contracts_test.go
@@ -39,8 +39,6 @@ type syncPatientsJob struct {
 	Limit int
 }
 
-type commandDispatchContextKey struct{}
-
 type recordingOutbox struct {
 	events []EventEnvelope
 	err    error

--- a/scripts/check-dead-code.sh
+++ b/scripts/check-dead-code.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env sh
+set -eu
+
+repo_root=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+
+# Staticcheck U1000 catches unused private declarations and unread private
+# fields. The x/tools deadcode command catches unreachable exported helper
+# wrappers in the selected internal packages. Keep these package sets focused
+# and expand them only when the added package has a clean, reviewed baseline
+# without broad suppressions.
+staticcheck_version='v0.7.0'
+deadcode_version='v0.45.0'
+
+cd "${repo_root}"
+
+printf '%s\n' "==> staticcheck ${staticcheck_version} -checks=U1000"
+go run "honnef.co/go/tools/cmd/staticcheck@${staticcheck_version}" \
+	-checks=U1000 \
+	./cmd/gowdk \
+	./internal/source \
+	./internal/gwdkir \
+	./internal/gwdkanalysis \
+	./runtime/contracts
+
+printf '%s\n' "==> deadcode ${deadcode_version}"
+go run "golang.org/x/tools/cmd/deadcode@${deadcode_version}" \
+	-test \
+	-filter='^github.com/cssbruno/gowdk/(cmd/gowdk|internal/(source|gwdkir|gwdkanalysis))$' \
+	./cmd/gowdk \
+	./internal/source \
+	./internal/gwdkir \
+	./internal/gwdkanalysis


### PR DESCRIPTION
## Summary

- Add `scripts/check-dead-code.sh`, a focused dead-code gate that runs pinned Staticcheck `U1000` and x/tools `deadcode` analyzers.
- Wire the gate into CI and document the covered package sets, excluded surfaces, and expansion policy in `docs/engineering/ci.md`.
- Remove the initial gate findings from the focused baseline: unused CLI helper wrappers, an unused endpoint-report wrapper, and an unused runtime contracts test marker type.
- Confirm the previously tracked cleanup issues are clean on current `main`: docs sync no longer carries route-map wiring, backend input-type wrapper helpers are gone, and `eventEntry` no longer stores a duplicated event name.

## Issue Closure

Closes #661
Closes #659
Closes #658
Closes #651

## Verification

- [x] I ran the relevant tests, lint, and build commands.
- [x] I ran `scripts/test-go-modules.sh` when Go code or compiler behavior changed.
- [x] I ran `go build ./cmd/gowdk` when CLI, compiler, runtime, addon, or release behavior changed.
- [x] Editor files were not changed; Node checks were not applicable.
- [x] I updated docs for behavior, setup, or architecture changes.
- [x] I added or updated tests for changed behavior via the new CI gate.
- [x] I considered security-sensitive surfaces such as auth, CSRF, redirects, request-time handlers, logs, diagnostics, embedded assets, editor commands, WASM, contracts, and realtime behavior.

Commands run:

- `scripts/check-dead-code.sh`
- `go test ./cmd/gowdk ./internal/source ./internal/gwdkir ./internal/gwdkanalysis ./runtime/contracts`
- `go build ./cmd/gowdk`
- `scripts/test-go-modules.sh`
- `scripts/check-docs-style.sh` (passed with existing warning-only long-paragraph messages)
- `scripts/check-docs-links.sh`
- `scripts/check-root-deps.sh`
- `scripts/check-doc-versions.sh`
- `(cd docs-site && go run ./cmd/syncdocs)`

## LLM Assistance

- LLM session summary: Codex added a focused dead-code CI gate, removed the clean-baseline findings it exposed, documented the analyzer coverage, and verified the relevant local gates.
- Human-reviewed assumptions: The first gate should stay focused on clean, meaningful package sets and avoid broad suppressions for public runtime/addon APIs. The cleanup issues #651, #658, and #659 are already satisfied on current `main`; this PR adds the regression gate that keeps those classes from returning in covered surfaces.
- Follow-up work: Expand `scripts/check-dead-code.sh` package coverage only after each added package has a clean reviewed baseline.
