### PR TITLE
[codex] fix build output diagnostic source

### DIFF
--- a/docs/reference/diagnostics.md
+++ b/docs/reference/diagnostics.md
@@ -95,6 +95,9 @@ Current v0.1-supported language surfaces report source locations as follows:
   reports the offending line; build execution errors that come from external Go
   execution keep their command/error context rather than a precise `.gwdk`
   expression range.
+- Build-output planning diagnostics report the owning `.gwdk` source file and
+  route when the compiler IR knows them, instead of asking authors to debug a
+  generated file name.
 
 Remaining known exact-range gaps:
 

--- a/internal/buildgen/build.go
+++ b/internal/buildgen/build.go
@@ -717,13 +717,12 @@ func buildIncrementalFromIR(config gowdk.Config, ir gwdkir.Program, backendBindi
 			continue
 		}
 		for _, artifact := range routeArtifacts {
-			rel, err := relativeOutputPath(outputDir, artifact.Path)
-			if err != nil {
+			if _, err := relativeOutputPath(outputDir, artifact.Path); err != nil {
 				failures = append(failures, fmt.Sprintf("%s: %v", page.ID, err))
 				continue
 			}
 			if previousPage, ok := seenOutputPaths[artifact.Path]; ok {
-				failures = append(failures, fmt.Sprintf("%s: generated output path %q duplicates page %s", page.ID, rel, previousPage))
+				failures = append(failures, pageOutputCollisionError(page, artifact.Route, previousPage))
 				continue
 			}
 			seenOutputPaths[artifact.Path] = page.ID
@@ -1010,13 +1009,12 @@ func planFromIR(config gowdk.Config, ir gwdkir.Program, outputDir string) (build
 			continue
 		}
 		for _, artifact := range pageArtifacts {
-			rel, err := relativeOutputPath(outputDir, artifact.Path)
-			if err != nil {
+			if _, err := relativeOutputPath(outputDir, artifact.Path); err != nil {
 				failures = append(failures, fmt.Sprintf("%s: %v", page.ID, err))
 				continue
 			}
 			if previousPage, ok := seenOutputPaths[artifact.Path]; ok {
-				failures = append(failures, fmt.Sprintf("%s: generated output path %q duplicates page %s", page.ID, rel, previousPage))
+				failures = append(failures, pageOutputCollisionError(page, artifact.Route, previousPage))
 				continue
 			}
 			seenOutputPaths[artifact.Path] = page.ID
@@ -1037,4 +1035,22 @@ func planFromIR(config gowdk.Config, ir gwdkir.Program, outputDir string) (build
 		return buildPlan{}, err
 	}
 	return buildPlan{pages: planned, css: css.assets, assets: assets, obfuscations: obfuscations}, nil
+}
+
+func pageBuildErrorPrefix(page gwdkir.Page) string {
+	if sourcePath := strings.TrimSpace(page.Source); sourcePath != "" {
+		return fmt.Sprintf("%s (%s)", page.ID, sourcePath)
+	}
+	return page.ID
+}
+
+func pageOutputCollisionError(page gwdkir.Page, route string, previousPage string) string {
+	route = strings.TrimSpace(route)
+	if route == "" {
+		route = strings.TrimSpace(page.Route)
+	}
+	if route != "" {
+		return fmt.Sprintf("%s: page route %q duplicates page %s", pageBuildErrorPrefix(page), route, previousPage)
+	}
+	return fmt.Sprintf("%s: generated page output duplicates page %s", pageBuildErrorPrefix(page), previousPage)
 }

--- a/internal/buildgen/build_data_routes_test.go
+++ b/internal/buildgen/build_data_routes_test.go
@@ -1119,16 +1119,21 @@ func TestBuildRejectsInvalidDynamicPathsBeforeWriting(t *testing.T) {
 			name: "duplicate output",
 			body: `=> { slug: "hello-gowdk" }
 => { slug: "hello-gowdk" }`,
-			wantError: `generated output path "blog/hello-gowdk/index.html" duplicates page blog.post`,
+			wantError: `blog.post (src/pages/blog.post.page.gwdk): page route "/blog/hello-gowdk" duplicates page blog.post`,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			outputDir := t.TempDir()
+			sourcePath := ""
+			if tt.name == "duplicate output" {
+				sourcePath = "src/pages/blog.post.page.gwdk"
+			}
 			app := gwdkanalysis.Sources{Pages: []gwdkir.Page{{
-				ID:    "blog.post",
-				Route: "/blog/{slug}",
+				ID:     "blog.post",
+				Route:  "/blog/{slug}",
+				Source: sourcePath,
 				Blocks: gwdkir.Blocks{
 					Paths:     true,
 					PathsBody: tt.body,


### PR DESCRIPTION
## What changed

- Include the owning `.gwdk` source file in duplicate page-output collision errors when the page source is known.
- Report the duplicated page route, not the generated HTML file path, in source-facing diagnostics.
- Apply the same attribution in incremental and full build-output planning paths.
- Add regression coverage for duplicate dynamic-path output errors.
- Document that build-output planning diagnostics should point authors to the owning source file and route instead of generated file names.

## Why

Duplicate page-output failures were reported in terms of generated file paths. That explained the generated collision, but it made the source error feel like an output-file problem instead of a `.gwdk` route/source problem.

## Verification

- `go test ./internal/buildgen`
- `scripts/check-docs-links.sh`
- `scripts/check-docs-style.sh` (passes with existing long-paragraph warnings)
- `scripts/check-removed-syntax.sh`
- `scripts/check-doc-versions.sh`