### PR TITLE
fix(cli): preserve delegated helper source paths

### DIFF
--- a/internal/gowdkcmd/config_helper.go
+++ b/internal/gowdkcmd/config_helper.go
@@ -49,7 +49,11 @@ func runProjectHelperIfNeeded(args []string) (bool, error) {
 		}
 		return true, err
 	}
-	cmd := exec.Command(helperPath, args...)
+	helperArgs, err := normalizeProjectHelperArgs(args)
+	if err != nil {
+		return true, err
+	}
+	cmd := exec.Command(helperPath, helperArgs...)
 	cmd.Dir = projectRoot
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
@@ -67,6 +71,139 @@ func runProjectHelperIfNeeded(args []string) (bool, error) {
 		return true, err
 	}
 	return true, nil
+}
+
+func normalizeProjectHelperArgs(args []string) ([]string, error) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return nil, err
+	}
+	out := append([]string(nil), args...)
+	switch out[0] {
+	case "build", "check":
+		return normalizeProjectCommandPathArgs(out, cwd, 1), nil
+	case "dev":
+		return normalizeDevHelperArgs(out, cwd), nil
+	default:
+		return out, nil
+	}
+}
+
+func normalizeDevHelperArgs(args []string, cwd string) []string {
+	out := append([]string(nil), args...)
+	for index := 1; index < len(out); index++ {
+		if _, next, ok, _ := consumeValueFlag(out, index, "--addr", true); ok {
+			index = next
+			continue
+		}
+		if _, next, ok, _ := consumeValueFlag(out, index, "--interval", true); ok {
+			index = next
+			continue
+		}
+		buildArgs := append([]string{"build"}, out[index:]...)
+		buildArgs = normalizeProjectCommandPathArgs(buildArgs, cwd, 1)
+		copy(out[index:], buildArgs[1:])
+		return out
+	}
+	return out
+}
+
+func normalizeProjectCommandPathArgs(args []string, cwd string, start int) []string {
+	out := append([]string(nil), args...)
+	for index := start; index < len(out); index++ {
+		if next, ok := normalizeHelperValueFlag(out, index, cwd, "--config"); ok {
+			index = next
+			continue
+		}
+		if next, ok := normalizeHelperValueFlag(out, index, cwd, "--env-file"); ok {
+			index = next
+			continue
+		}
+		if next, ok := skipProjectHelperValueFlag(out, index); ok {
+			index = next
+			continue
+		}
+		if skipProjectHelperBooleanFlag(out[index]) {
+			continue
+		}
+		arg := out[index]
+		if strings.HasPrefix(arg, "-") {
+			continue
+		}
+		out[index] = absoluteExistingPath(cwd, arg)
+	}
+	return out
+}
+
+func normalizeHelperValueFlag(args []string, index int, cwd string, name string) (int, bool) {
+	value, next, ok, missing := consumeValueFlag(args, index, name, true)
+	if !ok || missing {
+		return next, ok
+	}
+	normalized := absoluteExistingPath(cwd, value)
+	if strings.HasPrefix(args[index], name+"=") {
+		args[index] = name + "=" + normalized
+	} else if next < len(args) {
+		args[next] = normalized
+	}
+	return next, true
+}
+
+func skipProjectHelperValueFlag(args []string, index int) (int, bool) {
+	for _, name := range []string{
+		"--out",
+		"--app",
+		"--bin",
+		"--docker-base",
+		"--deploy-recipe",
+		"--wasm",
+		"--backend-app",
+		"--backend-bin",
+		"--worker-app",
+		"--worker-bin",
+		"--cron-app",
+		"--cron-bin",
+		"--target",
+		"--module",
+	} {
+		if _, next, ok, _ := consumeValueFlag(args, index, name, name == "--deploy-recipe" || name == "--docker-base"); ok {
+			return next, true
+		}
+	}
+	return index, false
+}
+
+func skipProjectHelperBooleanFlag(arg string) bool {
+	switch arg {
+	case "--ssr",
+		"--debug",
+		"--timings",
+		"--allow-missing-backend",
+		"--allow-insecure",
+		"--obfuscate-assets",
+		"--docker",
+		"--json",
+		"--warnings-as-errors",
+		"--standalone":
+		return true
+	}
+	return strings.HasPrefix(arg, "--timings=") ||
+		strings.HasPrefix(arg, "--allow-insecure=")
+}
+
+func absoluteExistingPath(cwd string, value string) string {
+	if strings.TrimSpace(value) == "" || filepath.IsAbs(value) {
+		return value
+	}
+	candidate := filepath.Join(cwd, value)
+	if _, err := os.Stat(candidate); err != nil {
+		return value
+	}
+	absolute, err := filepath.Abs(candidate)
+	if err != nil {
+		return value
+	}
+	return absolute
 }
 
 func projectHelperCommand(command string) bool {

--- a/internal/gowdkcmd/config_helper_test.go
+++ b/internal/gowdkcmd/config_helper_test.go
@@ -1,0 +1,86 @@
+package gowdkcmd
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestNormalizeProjectCommandPathArgsAbsolutizesExistingInputs(t *testing.T) {
+	root := t.TempDir()
+	configRel := filepath.Join("examples", "css", "gowdk.config.go")
+	pageRel := filepath.Join("examples", "css", "styled.page.gwdk")
+	configPath := writeHelperArgTestFile(t, root, configRel)
+	pagePath := writeHelperArgTestFile(t, root, pageRel)
+	args := []string{"build", "--config", configRel, "--out", "dist", pageRel}
+
+	got := normalizeProjectCommandPathArgs(args, root, 1)
+	want := []string{"build", "--config", configPath, "--out", "dist", pagePath}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("normalizeProjectCommandPathArgs() = %#v, want %#v", got, want)
+	}
+	if !reflect.DeepEqual(args, []string{"build", "--config", configRel, "--out", "dist", pageRel}) {
+		t.Fatalf("normalizeProjectCommandPathArgs mutated input args: %#v", args)
+	}
+}
+
+func TestNormalizeProjectCommandPathArgsHandlesEqualsAndBooleanFlags(t *testing.T) {
+	root := t.TempDir()
+	configRel := filepath.Join("examples", "css", "gowdk.config.go")
+	pageRel := filepath.Join("examples", "css", "styled.page.gwdk")
+	configPath := writeHelperArgTestFile(t, root, configRel)
+	pagePath := writeHelperArgTestFile(t, root, pageRel)
+	args := []string{"build", "--config=" + configRel, "--timings", pageRel}
+
+	got := normalizeProjectCommandPathArgs(args, root, 1)
+	want := []string{"build", "--config=" + configPath, "--timings", pagePath}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("normalizeProjectCommandPathArgs() = %#v, want %#v", got, want)
+	}
+}
+
+func TestNormalizeDevHelperArgsNormalizesForwardedBuildInputs(t *testing.T) {
+	root := t.TempDir()
+	configRel := filepath.Join("examples", "css", "gowdk.config.go")
+	pageRel := filepath.Join("examples", "css", "styled.page.gwdk")
+	configPath := writeHelperArgTestFile(t, root, configRel)
+	pagePath := writeHelperArgTestFile(t, root, pageRel)
+	args := []string{
+		"dev",
+		"--addr", "127.0.0.1:8081",
+		"--interval=250ms",
+		"--config", configRel,
+		"--out", "dist",
+		pageRel,
+	}
+
+	got := normalizeDevHelperArgs(args, root)
+	want := []string{
+		"dev",
+		"--addr", "127.0.0.1:8081",
+		"--interval=250ms",
+		"--config", configPath,
+		"--out", "dist",
+		pagePath,
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("normalizeDevHelperArgs() = %#v, want %#v", got, want)
+	}
+}
+
+func writeHelperArgTestFile(t *testing.T, root string, rel string) string {
+	t.Helper()
+	path := filepath.Join(root, rel)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("test"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return abs
+}


### PR DESCRIPTION
## Summary

- Normalize existing `--config`, `--env-file`, and explicit source file paths before delegating `build`, `check`, or `dev` into the native project helper.
- Preserve project-root-relative output and target flags while preventing repo-relative source paths from being resolved under the helper working directory.
- Add regression coverage for split flags, equals flags, boolean flags, and forwarded `dev` build args.

## Issue Closure

Related: #746

## Verification

- [x] I ran the relevant tests, lint, and build commands.
- [ ] I ran `scripts/test-go-modules.sh` when Go code or compiler behavior changed.
- [ ] I ran `go build ./cmd/gowdk` when CLI, compiler, runtime, addon, or release behavior changed.
- [ ] I ran `node --check editors/vscode/extension.js` when editor files changed.
- [ ] I updated docs for behavior, setup, or architecture changes.
- [x] I added or updated tests for changed behavior.
- [x] I considered security-sensitive surfaces such as auth, CSRF, redirects, request-time handlers, logs, diagnostics, embedded assets, editor commands, WASM, contracts, and realtime behavior.

Commands run:

- `go test ./internal/gowdkcmd -run 'TestNormalize(ProjectCommandPathArgs|DevHelperArgs)'`
- `go run ./cmd/gowdk build --config examples/css/gowdk.config.go --out <temp-output> examples/css/styled.page.gwdk` plus stylesheet-link check
- `node editors/vscode/scripts/sync-version.js --check`
- `scripts/check-pr-title.sh 'fix: support config helper source checkout builds'`
- `go run ../../cmd/gowdk build` from `examples/login`

Note: `go test ./internal/gowdkcmd` was started from the original worktree and printed `ok` after a long run, but I had already sent an interrupt while it was silent, so the wrapper returned nonzero; I am not counting it as a clean verification gate.

## LLM Assistance

- LLM session summary: Codex diagnosed the post-merge helper delegation smoke failure, added path normalization and tests, and opened this follow-up PR after PR 746 was already squash-merged.
- Human-reviewed assumptions: Existing input paths should be made absolute before helper delegation; output and target flags should remain project-root-relative.
- Follow-up work: None known.