### PR TITLE
fix(build): harden artifact output topology

### DIFF
--- a/docs/compiler/generated-output.md
+++ b/docs/compiler/generated-output.md
@@ -7,7 +7,7 @@ surfaces. Generated directories are outputs, not authoring locations.
 
 | Output | Purpose |
 | --- | --- |
-| `<out>/` | Static/SPA HTML, assets, route metadata, asset metadata, build report, and optional SEO files |
+| `<out>/` | Static/SPA HTML, assets, runtime-private manifests, build-private reports, and optional SEO files |
 | `<app>/` | Generated Go application source for embedded assets and request-time handlers |
 | `<bin>` | Optional compiled generated application binary |
 | `<wasm>` | Optional Go `js/wasm` deploy artifact |
@@ -19,8 +19,17 @@ The default scaffold writes `.gowdk/output/<target>`, `.gowdk/<target>`, and
 ## Static Output
 
 Build-time pages can emit route-derived `index.html` files, content-hashed CSS
-and asset files, generated browser runtime assets, `gowdk-routes.json`,
-`gowdk-assets.json`, and `gowdk-build-report.json`.
+and asset files, generated browser runtime assets, runtime-private manifests
+such as `gowdk-routes.json` and `gowdk-assets.json`, and build-private reports
+such as `gowdk-build-report.json`.
+
+Only browser-facing artifacts are served by `gowdk serve` and generated app
+static handlers. HTML, generated assets under `assets/`, `sitemap.xml`,
+`robots.txt`, `openapi.json`, and `asyncapi.json` are public by default.
+`gowdk-routes.json` and `gowdk-assets.json` are embedded for generated runtime
+use but are not public URLs. Build reports, timings, security/audit data,
+source maps, source files, and unknown files under the output directory are not
+served by default.
 
 Dynamic SPA routes emit concrete files only for supported `paths {}` entries.
 Request-time SSR or hybrid pages are listed in metadata but are served by the
@@ -50,11 +59,12 @@ storage, process supervision, and backups remain deployment responsibilities.
 
 | File | Source |
 | --- | --- |
-| `gowdk-build-report.json` | Build planning, writes, cache policy, security posture, contracts, OpenAPI/AsyncAPI metadata, and diagnostics |
-| `gowdk-routes.json` | Emitted page routes and generated output paths |
-| `gowdk-assets.json` | Generated assets, cache policy, CSS, JS, WASM, and component assets |
+| `gowdk-build-report.json` | Build-private planning, writes, cache policy, security posture, contracts, OpenAPI/AsyncAPI metadata, and diagnostics |
+| `gowdk-routes.json` | Runtime-private emitted page routes and generated output paths |
+| `gowdk-assets.json` | Runtime-private generated assets, cache policy, CSS, JS, WASM, and component assets |
 | `gowdk-security.json` | Non-served posture report for generated-app security checks |
-| `sitemap.xml` / `robots.txt` | Optional SEO addon output |
+| `sitemap.xml` / `robots.txt` | Optional public SEO addon output |
+| `openapi.json` / `asyncapi.json` | Public API documentation artifacts when generated |
 
 The public `gowdk manifest` command is documented in
 [Reference Manifest](../reference/manifest.md). Build-report details live in
@@ -69,6 +79,13 @@ The public `gowdk manifest` command is documented in
   assets or explicit page code.
 - Document new generated files in this page, the build report page, or the
   reference page that owns the public contract.
+- New generated artifact kinds must declare whether they are public,
+  runtime-private, or build-private before they are embedded, served, or
+  packaged.
+- Build destination topology is validated before filesystem writes. Selected
+  targets must not share output/app/binary/WASM/report/recipe destinations, put
+  binaries or WASM under served static output, put generated apps under static
+  output, or nest one selected target output inside another.
 - Generated output ownership and license policy are documented in
   [LICENSE](../../LICENSE) and
   [Generated Code Policy](../engineering/generated-code-policy.md).

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -162,6 +162,12 @@ gowdk lsp [--ssr]
   timing report. Without an explicit file, the report is written to
   `gowdk-build-timings.json` in the output root. Generated paths remain the
   only stdout payload.
+- `gowdk build` validates the complete selected artifact topology before source
+  discovery or writes. Static output, generated app directories, frontend and
+  backend binaries, WASM artifacts, timing/report sidecars, Docker files, and
+  deployment recipes must have disjoint ownership unless a containment is
+  documented as compiler-owned. Binaries, WASM artifacts, and generated app
+  source trees must not be placed under served static output.
 - `gowdk build` writes `contract_reference` build-report events for
   `g:command` forms and `g:query` elements with `unknown`, `bound`, `missing`,
   or `invalid` status.
@@ -181,7 +187,7 @@ gowdk lsp [--ssr]
   `endpoints`, `inspect`, `generate stubs`, and `build`; may be repeated or
   comma-separated, and limits discovery to selected configured modules when no
   explicit file list is passed.
-- `--out`: supported by `build` and `clean`; for `build` it selects the output directory and overrides `Build.Output`, and for `clean` it adds an extra output directory to remove alongside the configured outputs. `playground export` uses `--out` as the archive path. `playground run` uses `--out` as the generated output directory and never writes build output into the source project.
+- `--out`: supported by `build` and `clean`; for `build` it selects the output directory and overrides `Build.Output`, and for `clean` it adds an extra output directory to remove alongside the configured outputs. `clean --target` refuses to remove a selected target root that contains artifacts owned by an unselected configured target. `playground export` uses `--out` as the archive path. `playground run` uses `--out` as the generated output directory and never writes build output into the source project.
 - `--app`: supported by `build`; writes generated Go app source that embeds the selected output directory.
 - `--bin`: supported by `build`; requires `--app` and compiles the generated app with `go build -o <file>`.
 - `--docker`: supported by `build`; requires `--bin` and emits `Dockerfile`
@@ -201,7 +207,7 @@ gowdk lsp [--ssr]
 - `--worker-bin`: supported by `build`; requires `--worker-app` and compiles the generated worker app with `go build -o <file>`.
 - `--cron-app`: supported by `build`; writes generated contract cron app source using configured `Build.Cron` or target cron settings.
 - `--cron-bin`: supported by `build`; requires `--cron-app` and compiles the generated cron app with `go build -o <file>`.
-- `--addr`: supported by `dev`, `preview`, and `serve`; selects the listen address and defaults to `127.0.0.1:8080`.
+- `--addr`: supported by `dev`, `preview`, and `serve`; selects the listen address and defaults to `127.0.0.1:8080`. Disk-backed serving uses the generated-output public file allowlist and rejects symlinked path components by default.
 - `--interval`: supported by `dev`; sets the polling interval, such as `500ms`, `1s`, or `2s`.
 - `--hot`: supported by `preview`; runs the dev loop against the preview output instead of serving a one-shot build.
 - `--dir`: supported by `serve`; selects the generated build output directory. `playground export` and `playground run` use `--dir` as the source project directory and require a `gowdk.config.go` file there.

--- a/docs/reference/deployment.md
+++ b/docs/reference/deployment.md
@@ -60,18 +60,29 @@ gowdk build --out dist/site
 ```
 
 Deploy the contents of `dist/site` with any asset host that can serve
-directory indexes:
+directory indexes. Browser-public files are the generated HTML, assets under
+`assets/`, optional SEO files, and explicitly generated API documentation:
 
 ```text
 dist/site/
   index.html
   routes...
   assets...
-  gowdk-routes.json
-  gowdk-assets.json
+  sitemap.xml
+  robots.txt
   openapi.json
   asyncapi.json
+```
+
+The same output directory may also contain compiler/runtime metadata that is
+not part of the browser-facing static surface:
+
+```text
+dist/site/
+  gowdk-routes.json
+  gowdk-assets.json
   gowdk-build-report.json
+  gowdk-build-timings.json
 ```
 
 Local smoke test:
@@ -80,8 +91,13 @@ Local smoke test:
 gowdk serve --dir dist/site --addr 127.0.0.1:8080
 ```
 
-`gowdk serve` serves generated build output from disk. It does not run generated
-request-time features.
+`gowdk serve` serves only the public generated-output allowlist from disk. It
+does not expose `gowdk-routes.json`, `gowdk-assets.json`, build reports,
+timings, security/audit data, source maps, source files, or manually added
+unknown files. It rejects symlinked path components by default and returns a
+generic 404 for unsafe paths. It does not run generated request-time features.
+
+Keep local preview listeners on loopback unless you intentionally expose them.
 
 ## Single Binary
 

--- a/internal/appgen/appgen_test.go
+++ b/internal/appgen/appgen_test.go
@@ -858,6 +858,11 @@ func TestGenerateSkipsUnsafeEmbeddedOutputFiles(t *testing.T) {
 	writeTestFile(t, filepath.Join(outputDir, "keys", "ID_RSA"), "private key")
 	writeTestFile(t, filepath.Join(outputDir, ".npmrc"), "//registry.example/:_authToken=secret")
 	writeTestFile(t, filepath.Join(outputDir, "gowdk-security.json"), `{"endpoints":[{"path":"/admin"}]}`)
+	writeTestFile(t, filepath.Join(outputDir, "gowdk-build-report.json"), `{"events":[{"path":"src/pages/admin.page.gwdk"}]}`)
+	writeTestFile(t, filepath.Join(outputDir, "gowdk-build-timings.json"), `{"phases":[{"name":"build"}]}`)
+	writeTestFile(t, filepath.Join(outputDir, "gowdk-routes.json"), `{"routes":[{"route":"/admin"}]}`)
+	writeTestFile(t, filepath.Join(outputDir, "gowdk-assets.json"), `{"files":{"app.css":"assets/app.css"}}`)
+	writeTestFile(t, filepath.Join(outputDir, "notes.txt"), "operator notes")
 	writeTestFile(t, filepath.Join(outputDir, "assets", "scratch.tmp"), "temporary")
 	writeTestFile(t, filepath.Join(outputDir, "assets", "app.css"), "body{}")
 
@@ -866,7 +871,7 @@ func TestGenerateSkipsUnsafeEmbeddedOutputFiles(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if strings.Join(result.Files, ",") != "assets/app.css,index.html" {
+	if strings.Join(result.Files, ",") != "assets/app.css,gowdk-assets.json,gowdk-routes.json,index.html" {
 		t.Fatalf("unexpected embedded files: %#v", result.Files)
 	}
 	for _, path := range []string{
@@ -889,6 +894,9 @@ func TestGenerateSkipsUnsafeEmbeddedOutputFiles(t *testing.T) {
 		filepath.Join(result.OutputDir, "keys", "ID_RSA"),
 		filepath.Join(result.OutputDir, ".npmrc"),
 		filepath.Join(result.OutputDir, "assets", "scratch.tmp"),
+		filepath.Join(result.OutputDir, "gowdk-build-report.json"),
+		filepath.Join(result.OutputDir, "gowdk-build-timings.json"),
+		filepath.Join(result.OutputDir, "notes.txt"),
 	} {
 		if _, err := os.Stat(path); !os.IsNotExist(err) {
 			t.Fatalf("expected unsafe file %s to be skipped, stat err: %v", path, err)

--- a/internal/appgen/files.go
+++ b/internal/appgen/files.go
@@ -65,7 +65,7 @@ func copyOutputFiles(sourceRoot, targetRoot string) ([]string, error) {
 		if !info.Mode().IsRegular() {
 			return nil
 		}
-		if unsafeEmbeddedFile(rel) {
+		if !safeasset.EmbeddableGeneratedOutputFile(rel) {
 			return nil
 		}
 		if err := copyFile(sourcePath, targetPath); err != nil {
@@ -80,10 +80,6 @@ func copyOutputFiles(sourceRoot, targetRoot string) ([]string, error) {
 
 func unsafeEmbeddedDirectory(rel string) bool {
 	return safeasset.UnsafeEmbeddedDirectory(rel)
-}
-
-func unsafeEmbeddedFile(rel string) bool {
-	return safeasset.UnsafeEmbeddedFile(rel)
 }
 
 func copyFile(sourcePath, targetPath string) error {

--- a/internal/gowdkcmd/artifact_topology.go
+++ b/internal/gowdkcmd/artifact_topology.go
@@ -1,0 +1,353 @@
+package gowdkcmd
+
+import (
+	"errors"
+	"fmt"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+
+	"github.com/cssbruno/gowdk"
+)
+
+const appOutputDirName = "gowdkapp/app"
+
+type artifactDestination struct {
+	Target    string
+	Role      string
+	Kind      string
+	RawPath   string
+	AbsPath   string
+	Canonical string
+	PathType  string
+}
+
+func validateAdHocBuildTopology(root string, request buildRequest, timings bool) error {
+	return validateArtifactTopology(root, destinationsForBuildRequest("adhoc", request, timings))
+}
+
+func validateConfiguredBuildTopology(root string, targets []gowdk.BuildTargetConfig, timings bool, timingsPath string) error {
+	var destinations []artifactDestination
+	for _, target := range targets {
+		destinations = append(destinations, destinationsForBuildRequest(target.Name, buildRequest{
+			OutputDir:         target.Output,
+			AppDir:            target.App,
+			BinaryPath:        target.Binary,
+			WASMPath:          target.WASM,
+			BackendAppDir:     target.BackendApp,
+			BackendBinaryPath: target.BackendBinary,
+			WorkerAppDir:      target.WorkerApp,
+			WorkerBinaryPath:  target.WorkerBinary,
+			CronAppDir:        target.CronApp,
+			CronBinaryPath:    target.CronBinary,
+			DeployRecipes:     target.DeployRecipes,
+			TimingsPath:       timingsPath,
+		}, timings)...)
+	}
+	return validateArtifactTopology(root, destinations)
+}
+
+func validateCleanArtifactOwnership(root string, config gowdk.Config, selectedNames []string, candidates []string) error {
+	if len(config.Build.Targets) == 0 || len(candidates) == 0 {
+		return nil
+	}
+	allTargets, err := selectBuildTargets(config.Build.Targets, nil)
+	if err != nil {
+		return err
+	}
+	selectedTargets, err := selectBuildTargets(config.Build.Targets, selectedNames)
+	if err != nil {
+		return err
+	}
+	selected := map[string]bool{}
+	for _, target := range selectedTargets {
+		selected[target.Name] = true
+	}
+	if len(selectedNames) == 0 {
+		for _, target := range allTargets {
+			selected[target.Name] = true
+		}
+	}
+	cleanRoots, err := normalizeArtifactDestinations(root, cleanCandidateDestinations(candidates))
+	if err != nil {
+		return err
+	}
+	var unselected []artifactDestination
+	for _, target := range allTargets {
+		if selected[target.Name] {
+			continue
+		}
+		unselected = append(unselected, destinationsForBuildRequest(target.Name, buildRequest{
+			OutputDir:         target.Output,
+			AppDir:            target.App,
+			BinaryPath:        target.Binary,
+			WASMPath:          target.WASM,
+			BackendAppDir:     target.BackendApp,
+			BackendBinaryPath: target.BackendBinary,
+			WorkerAppDir:      target.WorkerApp,
+			WorkerBinaryPath:  target.WorkerBinary,
+			CronAppDir:        target.CronApp,
+			CronBinaryPath:    target.CronBinary,
+			DeployRecipes:     target.DeployRecipes,
+		}, false)...)
+	}
+	owned, err := normalizeArtifactDestinations(root, unselected)
+	if err != nil {
+		return err
+	}
+	for _, cleanRoot := range cleanRoots {
+		for _, destination := range owned {
+			if cleanRoot.Canonical == destination.Canonical || (cleanRoot.PathType == "dir" && pathContains(cleanRoot.Canonical, destination.Canonical)) {
+				return fmt.Errorf("clean_output_overlap: clean target %q contains target %q %s %q; select both targets or clean a narrower path", cleanRoot.RawPath, destination.Target, destination.Kind, destination.RawPath)
+			}
+		}
+	}
+	return nil
+}
+
+func cleanCandidateDestinations(candidates []string) []artifactDestination {
+	destinations := make([]artifactDestination, 0, len(candidates))
+	for _, candidate := range candidates {
+		if strings.TrimSpace(candidate) == "" {
+			continue
+		}
+		destinations = append(destinations, artifactDestination{
+			Target:   "clean",
+			Role:     "clean",
+			Kind:     "clean-root",
+			RawPath:  candidate,
+			PathType: "dir",
+		})
+	}
+	return destinations
+}
+
+func destinationsForBuildRequest(target string, request buildRequest, timings bool) []artifactDestination {
+	var destinations []artifactDestination
+	add := func(role, kind, pathType, raw string) {
+		if strings.TrimSpace(raw) == "" {
+			return
+		}
+		destinations = append(destinations, artifactDestination{
+			Target:   target,
+			Role:     role,
+			Kind:     kind,
+			RawPath:  strings.TrimSpace(raw),
+			PathType: pathType,
+		})
+	}
+
+	add("frontend", "static-output", "dir", request.OutputDir)
+	add("frontend", "frontend-app", "dir", request.AppDir)
+	if strings.TrimSpace(request.AppDir) != "" {
+		add("frontend", "frontend-embedded-output", "dir", filepath.Join(request.AppDir, appOutputDirName))
+	}
+	add("frontend", "frontend-binary", "file", request.BinaryPath)
+	add("frontend", "frontend-wasm", "file", request.WASMPath)
+	add("backend", "backend-app", "dir", request.BackendAppDir)
+	add("backend", "backend-binary", "file", request.BackendBinaryPath)
+	add("worker", "worker-app", "dir", request.WorkerAppDir)
+	add("worker", "worker-binary", "file", request.WorkerBinaryPath)
+	add("cron", "cron-app", "dir", request.CronAppDir)
+	add("cron", "cron-binary", "file", request.CronBinaryPath)
+
+	if strings.TrimSpace(request.OutputDir) != "" {
+		add("compiler", "build-report", "file", filepath.Join(request.OutputDir, "gowdk-build-report.json"))
+		add("compiler", "route-manifest", "file", filepath.Join(request.OutputDir, "gowdk-routes.json"))
+		add("compiler", "asset-manifest", "file", filepath.Join(request.OutputDir, "gowdk-assets.json"))
+		if timings && strings.TrimSpace(request.TimingsPath) == "" {
+			add("compiler", "timings-report", "file", filepath.Join(request.OutputDir, buildTimingsFile))
+		}
+	}
+	if timings && strings.TrimSpace(request.TimingsPath) != "" {
+		add("compiler", "timings-report", "file", request.TimingsPath)
+	}
+	if request.Docker && strings.TrimSpace(request.BinaryPath) != "" {
+		dir := filepath.Dir(request.BinaryPath)
+		add("deploy", "dockerfile", "file", filepath.Join(dir, "Dockerfile"))
+		add("deploy", "dockerignore", "file", filepath.Join(dir, ".dockerignore"))
+	}
+	for _, recipe := range request.DeployRecipes {
+		switch recipe {
+		case deployRecipeStatic:
+			add("deploy", "deployment-recipe", "file", filepath.Join(request.OutputDir, "deploy", "static-host.md"))
+		case deployRecipeSplit:
+			add("deploy", "deployment-recipe", "file", filepath.Join(request.OutputDir, "deploy", "split-frontend-backend.md"))
+		case deployRecipeSystem:
+			if binary := deploymentRecipeBinaryPath(deploymentRecipeRequest{
+				BinaryPath:        request.BinaryPath,
+				BackendBinaryPath: request.BackendBinaryPath,
+				WorkerBinaryPath:  request.WorkerBinaryPath,
+				CronBinaryPath:    request.CronBinaryPath,
+			}); strings.TrimSpace(binary) != "" {
+				add("deploy", "deployment-recipe", "file", filepath.Join(filepath.Dir(binary), deploymentServiceName(binary)+".service"))
+			}
+		case deployRecipeCaddy:
+			if binary := deploymentRecipeBinaryPath(deploymentRecipeRequest{BinaryPath: request.BinaryPath, BackendBinaryPath: request.BackendBinaryPath}); strings.TrimSpace(binary) != "" {
+				add("deploy", "deployment-recipe", "file", filepath.Join(filepath.Dir(binary), "Caddyfile"))
+			}
+		case deployRecipeNginx:
+			if binary := deploymentRecipeBinaryPath(deploymentRecipeRequest{BinaryPath: request.BinaryPath, BackendBinaryPath: request.BackendBinaryPath}); strings.TrimSpace(binary) != "" {
+				add("deploy", "deployment-recipe", "file", filepath.Join(filepath.Dir(binary), "nginx.gowdk.conf"))
+			}
+		}
+	}
+	return destinations
+}
+
+func validateArtifactTopology(root string, destinations []artifactDestination) error {
+	normalized, err := normalizeArtifactDestinations(root, destinations)
+	if err != nil {
+		return err
+	}
+	var conflicts []string
+	byPath := map[string]artifactDestination{}
+	for _, destination := range normalized {
+		if previous, exists := byPath[destination.Canonical]; exists {
+			if !sameDestinationOwner(previous, destination) {
+				conflicts = append(conflicts, artifactCollision("build_output_collision", previous, destination, "share the same destination"))
+			}
+			continue
+		}
+		byPath[destination.Canonical] = destination
+	}
+	for i := range normalized {
+		for j := i + 1; j < len(normalized); j++ {
+			left, right := normalized[i], normalized[j]
+			if left.Canonical == right.Canonical {
+				continue
+			}
+			if conflict := containmentConflict(left, right); conflict != "" {
+				conflicts = append(conflicts, conflict)
+			}
+		}
+	}
+	if len(conflicts) > 0 {
+		sort.Strings(conflicts)
+		return errors.New(strings.Join(conflicts, "\n"))
+	}
+	return nil
+}
+
+func normalizeArtifactDestinations(root string, destinations []artifactDestination) ([]artifactDestination, error) {
+	if strings.TrimSpace(root) == "" {
+		root = "."
+	}
+	rootAbs, err := filepath.Abs(root)
+	if err != nil {
+		return nil, err
+	}
+	normalized := make([]artifactDestination, 0, len(destinations))
+	for _, destination := range destinations {
+		raw := strings.TrimSpace(destination.RawPath)
+		if raw == "" {
+			continue
+		}
+		abs := raw
+		if !filepath.IsAbs(abs) {
+			abs = filepath.Join(rootAbs, raw)
+		}
+		abs = filepath.Clean(abs)
+		destination.AbsPath = abs
+		destination.Canonical = canonicalArtifactPath(abs)
+		normalized = append(normalized, destination)
+	}
+	return normalized, nil
+}
+
+func canonicalArtifactPath(abs string) string {
+	probe := abs
+	var suffix []string
+	for {
+		if resolved, err := filepath.EvalSymlinks(probe); err == nil {
+			parts := append([]string{resolved}, reverseStrings(suffix)...)
+			path := filepath.Join(parts...)
+			if caseFoldArtifactPaths() {
+				return strings.ToLower(path)
+			}
+			return path
+		}
+		next := filepath.Dir(probe)
+		if next == probe {
+			break
+		}
+		suffix = append(suffix, filepath.Base(probe))
+		probe = next
+	}
+	clean := filepath.Clean(abs)
+	if caseFoldArtifactPaths() {
+		return strings.ToLower(clean)
+	}
+	return clean
+}
+
+func reverseStrings(values []string) []string {
+	out := make([]string, len(values))
+	for i := range values {
+		out[len(values)-1-i] = values[i]
+	}
+	return out
+}
+
+func caseFoldArtifactPaths() bool {
+	return runtime.GOOS == "windows" || runtime.GOOS == "darwin"
+}
+
+func containmentConflict(left, right artifactDestination) string {
+	if left.PathType == "dir" && pathContains(left.Canonical, right.Canonical) && !allowedContainment(left, right) {
+		return artifactCollision("build_output_overlap", left, right, "contains an unsupported generated artifact destination")
+	}
+	if right.PathType == "dir" && pathContains(right.Canonical, left.Canonical) && !allowedContainment(right, left) {
+		return artifactCollision("build_output_overlap", right, left, "contains an unsupported generated artifact destination")
+	}
+	return ""
+}
+
+func allowedContainment(parent, child artifactDestination) bool {
+	if parent.Target == child.Target && parent.Kind == "frontend-app" && child.Kind == "frontend-embedded-output" {
+		return true
+	}
+	if parent.Target == child.Target && parent.Kind == "static-output" && (child.Kind == "build-report" || child.Kind == "route-manifest" || child.Kind == "asset-manifest" || child.Kind == "timings-report" || child.Kind == "deployment-recipe") {
+		return true
+	}
+	if parent.Kind == "static-output" && (strings.HasSuffix(child.Kind, "-binary") || child.Kind == "frontend-wasm" || strings.HasSuffix(child.Kind, "-app") || child.Kind == "frontend-embedded-output") {
+		return false
+	}
+	if strings.HasSuffix(parent.Kind, "-app") && (strings.HasSuffix(child.Kind, "-binary") || child.Kind == "frontend-wasm" || strings.HasSuffix(child.Kind, "-app") || child.Kind == "static-output") {
+		return false
+	}
+	if parent.Kind == "static-output" && child.Kind == "static-output" {
+		return false
+	}
+	if strings.HasSuffix(parent.Kind, "-app") && strings.HasSuffix(child.Kind, "-app") {
+		return false
+	}
+	return false
+}
+
+func sameDestinationOwner(left, right artifactDestination) bool {
+	return left.Target == right.Target && left.Role == right.Role && left.Kind == right.Kind
+}
+
+func pathContains(parent, child string) bool {
+	rel, err := filepath.Rel(parent, child)
+	if err != nil {
+		return false
+	}
+	return rel != "." && rel != ".." && !strings.HasPrefix(filepath.ToSlash(rel), "../")
+}
+
+func artifactCollision(code string, left, right artifactDestination, reason string) string {
+	return fmt.Sprintf("%s: target %q %s %q and target %q %s %q resolve to %q: %s",
+		code,
+		left.Target,
+		left.Kind,
+		left.RawPath,
+		right.Target,
+		right.Kind,
+		right.RawPath,
+		left.AbsPath,
+		reason,
+	)
+}

--- a/internal/gowdkcmd/build.go
+++ b/internal/gowdkcmd/build.go
@@ -223,6 +223,10 @@ func buildOnce(options cliOptions, request buildRequest, timings *buildTimingRec
 			return fmt.Errorf(buildUsage)
 		}
 	}
+	request.OutputDir = outputDir
+	if err := validateAdHocBuildTopology(options.ProjectRoot, request, timings != nil && timings.enabled); err != nil {
+		return err
+	}
 	options.Config.Build.Output = outputDir
 	paths := append([]string(nil), request.Paths...)
 	if len(paths) == 0 {
@@ -595,6 +599,9 @@ func buildConfiguredTargets(plan buildOptions, timings *buildTimingRecorder) err
 	}
 	if plan.Timings && strings.TrimSpace(plan.TimingsPath) != "" && len(targets) > 1 {
 		return fmt.Errorf("--timings=<file> cannot be used when building multiple configured targets")
+	}
+	if err := validateConfiguredBuildTopology(plan.Options.ProjectRoot, targets, timings != nil && timings.enabled, plan.TimingsPath); err != nil {
+		return err
 	}
 	for _, target := range targets {
 		targetOptions := plan.Options

--- a/internal/gowdkcmd/build_options_test.go
+++ b/internal/gowdkcmd/build_options_test.go
@@ -1,6 +1,8 @@
 package gowdkcmd
 
 import (
+	"os"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
@@ -160,6 +162,92 @@ func TestSelectBuildTargetsAppliesBuildOnlyDefaultsAndValidation(t *testing.T) {
 	}
 	if _, err := selectBuildTargets([]gowdk.BuildTargetConfig{{Name: "site", CronBinary: "bin/cron"}}, nil); err == nil || !strings.Contains(err.Error(), "cron binary requires cron app") {
 		t.Fatalf("cron binary without app error = %v", err)
+	}
+}
+
+func TestValidateConfiguredBuildTopologyRejectsUnsafeLayouts(t *testing.T) {
+	tests := []struct {
+		name    string
+		targets []gowdk.BuildTargetConfig
+		want    string
+	}{
+		{
+			name: "duplicate output",
+			targets: []gowdk.BuildTargetConfig{
+				{Name: "admin", Output: "dist/site"},
+				{Name: "public", Output: "dist/site"},
+			},
+			want: "build_output_collision",
+		},
+		{
+			name: "nested outputs",
+			targets: []gowdk.BuildTargetConfig{
+				{Name: "one", Output: "dist"},
+				{Name: "two", Output: "dist/two"},
+			},
+			want: "build_output_overlap",
+		},
+		{
+			name: "binary under static output",
+			targets: []gowdk.BuildTargetConfig{
+				{Name: "site", Output: "dist/site", App: ".gowdk/app", Binary: "dist/site/server"},
+			},
+			want: "build_output_overlap",
+		},
+		{
+			name: "frontend and backend apps share directory",
+			targets: []gowdk.BuildTargetConfig{
+				{Name: "site", Output: "dist/site", App: ".gowdk/app", BackendApp: ".gowdk/app"},
+			},
+			want: "build_output_collision",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			targets, err := selectBuildTargets(tt.targets, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			err = validateConfiguredBuildTopology(t.TempDir(), targets, false, "")
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("topology error = %v, want %q", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidateConfiguredBuildTopologyAcceptsDisjointTargets(t *testing.T) {
+	targets, err := selectBuildTargets([]gowdk.BuildTargetConfig{
+		{Name: "site", Output: "dist/site", App: ".gowdk/site", Binary: "bin/site", WASM: "bin/site.wasm"},
+		{Name: "admin", Output: "dist/admin", BackendApp: ".gowdk/admin-backend", BackendBinary: "bin/admin-backend"},
+	}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := validateConfiguredBuildTopology(t.TempDir(), targets, true, ""); err != nil {
+		t.Fatalf("expected valid topology: %v", err)
+	}
+}
+
+func TestValidateConfiguredBuildTopologyRejectsExistingSymlinkAliases(t *testing.T) {
+	root := t.TempDir()
+	realOutput := filepath.Join(root, "real-output")
+	if err := os.MkdirAll(realOutput, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(realOutput, filepath.Join(root, "linked-output")); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	targets, err := selectBuildTargets([]gowdk.BuildTargetConfig{
+		{Name: "one", Output: "real-output"},
+		{Name: "two", Output: "linked-output"},
+	}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = validateConfiguredBuildTopology(root, targets, false, "")
+	if err == nil || !strings.Contains(err.Error(), "build_output_collision") {
+		t.Fatalf("topology error = %v, want symlink alias collision", err)
 	}
 }
 

--- a/internal/gowdkcmd/clean.go
+++ b/internal/gowdkcmd/clean.go
@@ -79,6 +79,9 @@ func clean(args []string) error {
 	if err != nil {
 		return err
 	}
+	if err := validateCleanArtifactOwnership(options.ProjectRoot, options.Config, cleanNames(targetNames), candidates); err != nil {
+		return err
+	}
 
 	result, err := runClean(options.ProjectRoot, candidates, dryRun)
 	if err != nil {

--- a/internal/gowdkcmd/clean_test.go
+++ b/internal/gowdkcmd/clean_test.go
@@ -159,6 +159,20 @@ func TestRunCleanDoesNotFollowSymlinkOutsideRoot(t *testing.T) {
 	}
 }
 
+func TestValidateCleanArtifactOwnershipRejectsUnselectedNestedTarget(t *testing.T) {
+	config := gowdk.Config{Build: gowdk.BuildConfig{Targets: []gowdk.BuildTargetConfig{
+		{Name: "one", Output: "dist"},
+		{Name: "two", Output: "dist/two"},
+	}}}
+	candidates, err := cleanTargets(config, []string{"one"}, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := validateCleanArtifactOwnership(t.TempDir(), config, []string{"one"}, candidates); err == nil {
+		t.Fatal("expected clean ownership validation to reject nested unselected target")
+	}
+}
+
 func TestCleanCommandRejectsUnknownFlag(t *testing.T) {
 	if err := clean([]string{"--nope"}); err == nil {
 		t.Fatal("expected an error for an unknown flag")

--- a/internal/gowdkcmd/main_test.go
+++ b/internal/gowdkcmd/main_test.go
@@ -7676,9 +7676,43 @@ func TestOutputFileHandlerDoesNotListDirectories(t *testing.T) {
 func TestOutputFileHandlerDoesNotServeSecurityManifest(t *testing.T) {
 	root := t.TempDir()
 	writeCLIFile(t, filepath.Join(root, "gowdk-security.json"), `{"endpoints":[{"path":"/admin"}]}`)
+	writeCLIFile(t, filepath.Join(root, "gowdk-build-report.json"), `{"events":[{"path":"src/pages/admin.page.gwdk"}]}`)
+	writeCLIFile(t, filepath.Join(root, "gowdk-build-timings.json"), `{"phases":[{"name":"build"}]}`)
+	writeCLIFile(t, filepath.Join(root, "gowdk-routes.json"), `{"routes":[{"route":"/admin"}]}`)
+	writeCLIFile(t, filepath.Join(root, "gowdk-assets.json"), `{"files":{"app.css":"assets/app.css"}}`)
+
+	for _, name := range []string{"gowdk-security.json", "gowdk-build-report.json", "gowdk-build-timings.json", "gowdk-routes.json", "gowdk-assets.json"} {
+		response := httptest.NewRecorder()
+		outputFileHandler(root).ServeHTTP(response, httptest.NewRequest(http.MethodGet, "/"+name, nil))
+
+		if response.Code != http.StatusNotFound {
+			t.Fatalf("%s: expected 404, got %d with body %s", name, response.Code, response.Body.String())
+		}
+	}
+}
+
+func TestOutputFileHandlerRejectsUnplannedRegularFiles(t *testing.T) {
+	root := t.TempDir()
+	writeCLIFile(t, filepath.Join(root, "notes.txt"), "private notes")
 
 	response := httptest.NewRecorder()
-	outputFileHandler(root).ServeHTTP(response, httptest.NewRequest(http.MethodGet, "/gowdk-security.json", nil))
+	outputFileHandler(root).ServeHTTP(response, httptest.NewRequest(http.MethodGet, "/notes.txt", nil))
+
+	if response.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d with body %s", response.Code, response.Body.String())
+	}
+}
+
+func TestOutputFileHandlerRejectsSymlinkEscape(t *testing.T) {
+	root := t.TempDir()
+	outside := t.TempDir()
+	writeCLIFile(t, filepath.Join(outside, "secret.html"), "<main>secret</main>")
+	if err := os.Symlink(filepath.Join(outside, "secret.html"), filepath.Join(root, "linked.html")); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+
+	response := httptest.NewRecorder()
+	outputFileHandler(root).ServeHTTP(response, httptest.NewRequest(http.MethodGet, "/linked.html", nil))
 
 	if response.Code != http.StatusNotFound {
 		t.Fatalf("expected 404, got %d with body %s", response.Code, response.Body.String())

--- a/internal/gowdkcmd/serve.go
+++ b/internal/gowdkcmd/serve.go
@@ -14,6 +14,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/cssbruno/gowdk/internal/safeasset"
 	gowdkroute "github.com/cssbruno/gowdk/runtime/route"
 )
 
@@ -85,19 +86,25 @@ func parseServeOptions(args []string) (string, string, error) {
 }
 
 func outputFileHandler(root string) http.Handler {
+	files, err := newRootedOutputFiles(root)
 	return http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		if err != nil {
+			http.Error(w, "static output unavailable", http.StatusInternalServerError)
+			return
+		}
 		if request.Method != http.MethodGet && request.Method != http.MethodHead {
 			w.Header().Set("Allow", "GET, HEAD")
 			http.Error(w, staticMethodNotAllowedMessage(root, request), http.StatusMethodNotAllowed)
 			return
 		}
 
-		filePath, ok := outputFilePath(root, request.URL.Path)
+		file, info, _, ok := files.Open(request.URL.Path)
 		if !ok {
 			http.NotFound(w, request)
 			return
 		}
-		http.ServeFile(w, request, filePath)
+		defer file.Close()
+		http.ServeContent(w, request, info.Name(), info.ModTime(), file)
 	})
 }
 
@@ -174,6 +181,7 @@ func readStaticRouteManifest(root string) (staticRouteManifest, bool) {
 }
 
 func liveReloadFileHandler(root string, reload *liveReloadBroker) http.Handler {
+	rooted, rootedErr := newRootedOutputFiles(root)
 	files := outputFileHandler(root)
 	return http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
 		if request.URL.Path == "/__gowdk/reload" {
@@ -184,12 +192,17 @@ func liveReloadFileHandler(root string, reload *liveReloadBroker) http.Handler {
 			files.ServeHTTP(w, request)
 			return
 		}
-		filePath, ok := outputFilePath(root, request.URL.Path)
-		if !ok || filepath.Ext(filePath) != ".html" {
+		if rootedErr != nil {
 			files.ServeHTTP(w, request)
 			return
 		}
-		payload, err := os.ReadFile(filePath)
+		file, _, rel, ok := rooted.Open(request.URL.Path)
+		if !ok || path.Ext(rel) != ".html" {
+			files.ServeHTTP(w, request)
+			return
+		}
+		defer file.Close()
+		payload, err := io.ReadAll(file)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
@@ -541,7 +554,19 @@ func writeLiveReloadEvent(w io.Writer, event liveReloadEvent) {
 	_, _ = fmt.Fprintln(w)
 }
 
-func outputFilePath(root, requestPath string) (string, bool) {
+type rootedOutputFiles struct {
+	root *os.Root
+}
+
+func newRootedOutputFiles(root string) (*rootedOutputFiles, error) {
+	opened, err := os.OpenRoot(root)
+	if err != nil {
+		return nil, err
+	}
+	return &rootedOutputFiles{root: opened}, nil
+}
+
+func (files *rootedOutputFiles) Open(requestPath string) (*os.File, os.FileInfo, string, bool) {
 	clean := path.Clean("/" + requestPath)
 	candidates := []string{clean}
 	if strings.HasSuffix(requestPath, "/") {
@@ -551,38 +576,66 @@ func outputFilePath(root, requestPath string) (string, bool) {
 	}
 
 	for _, candidate := range candidates {
-		filePath, ok := outputCandidatePath(root, candidate)
+		file, info, rel, ok := files.openCandidate(candidate)
 		if ok {
-			return filePath, true
+			return file, info, rel, true
 		}
 	}
-	return "", false
+	return nil, nil, "", false
 }
 
-func outputCandidatePath(root, candidate string) (string, bool) {
+func (files *rootedOutputFiles) openCandidate(candidate string) (*os.File, os.FileInfo, string, bool) {
 	rel := strings.TrimPrefix(path.Clean("/"+candidate), "/")
-	if unsafeServedOutputFile(rel) {
-		return "", false
+	if rel == "" {
+		rel = "index.html"
 	}
-	filePath := filepath.Join(root, filepath.FromSlash(rel))
-	relative, err := filepath.Rel(root, filePath)
-	if err != nil || relative == ".." || strings.HasPrefix(relative, ".."+string(filepath.Separator)) {
-		return "", false
+	file, info, ok := files.openPublicRegularFile(rel)
+	if ok {
+		return file, info, rel, true
 	}
-	info, err := os.Stat(filePath)
-	if err != nil {
-		return "", false
+	indexRel := path.Join(rel, "index.html")
+	file, info, ok = files.openPublicRegularFile(indexRel)
+	if ok {
+		return file, info, indexRel, true
 	}
-	if info.IsDir() {
-		indexPath := filepath.Join(filePath, "index.html")
-		if indexInfo, err := os.Stat(indexPath); err == nil && !indexInfo.IsDir() {
-			return indexPath, true
-		}
-		return "", false
-	}
-	return filePath, true
+	return nil, nil, "", false
 }
 
-func unsafeServedOutputFile(rel string) bool {
-	return strings.EqualFold(path.Base(filepath.ToSlash(rel)), "gowdk-security.json")
+func (files *rootedOutputFiles) openPublicRegularFile(rel string) (*os.File, os.FileInfo, bool) {
+	rel = strings.TrimPrefix(path.Clean("/"+rel), "/")
+	if !safeasset.PublicGeneratedOutputFile(rel) || files.pathContainsLink(rel) {
+		return nil, nil, false
+	}
+	file, err := files.root.Open(rel)
+	if err != nil {
+		return nil, nil, false
+	}
+	info, err := file.Stat()
+	if err != nil || !info.Mode().IsRegular() {
+		file.Close()
+		return nil, nil, false
+	}
+	return file, info, true
+}
+
+func (files *rootedOutputFiles) pathContainsLink(rel string) bool {
+	rel = strings.Trim(path.Clean("/"+rel), "/")
+	if rel == "" {
+		return false
+	}
+	var current string
+	for _, segment := range strings.Split(rel, "/") {
+		if segment == "" || segment == "." || segment == ".." {
+			return true
+		}
+		current = path.Join(current, segment)
+		info, err := files.root.Lstat(current)
+		if err != nil {
+			return false
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/safeasset/safeasset.go
+++ b/internal/safeasset/safeasset.go
@@ -11,7 +11,7 @@ import (
 // UnsafeEmbeddedDirectory reports whether a directory should be skipped when
 // copying generated output into a generated app.
 func UnsafeEmbeddedDirectory(rel string) bool {
-	base := path.Base(filepath.ToSlash(rel))
+	base := strings.ToLower(path.Base(filepath.ToSlash(rel)))
 	switch base {
 	case ".git", ".hg", ".svn", "node_modules", "tmp", "temp", ".tmp", "private", ".private", "secrets", ".secrets":
 		return true
@@ -23,6 +23,45 @@ func UnsafeEmbeddedDirectory(rel string) bool {
 // UnsafeEmbeddedFile reports whether a file must not be embedded or served as
 // generated static output.
 func UnsafeEmbeddedFile(rel string) bool {
+	return unsafeEmbeddedFile(rel, true)
+}
+
+// PublicGeneratedOutputFile reports whether rel is part of the browser-facing
+// generated-output surface. Unknown files fail closed so compiler-private
+// metadata and user-added files under an output directory are not served or
+// embedded by default.
+func PublicGeneratedOutputFile(rel string) bool {
+	rel = cleanRelativeSlashPath(rel)
+	if rel == "" || unsafeEmbeddedFile(rel, false) || privateGeneratedMetadata(rel) {
+		return false
+	}
+	if strings.HasPrefix(rel, "assets/") {
+		return true
+	}
+	switch path.Base(rel) {
+	case "sitemap.xml", "robots.txt", "openapi.json", "asyncapi.json":
+		return true
+	}
+	switch strings.ToLower(path.Ext(rel)) {
+	case ".html", ".css", ".js", ".wasm", ".png", ".jpg", ".jpeg", ".gif", ".webp", ".svg", ".ico", ".avif", ".woff", ".woff2", ".ttf", ".otf":
+		return true
+	default:
+		return false
+	}
+}
+
+// EmbeddableGeneratedOutputFile reports whether rel should be copied into a
+// generated app's embedded filesystem. Runtime-private manifests are embedded
+// for generated code but remain non-public in the runtime handler.
+func EmbeddableGeneratedOutputFile(rel string) bool {
+	rel = cleanRelativeSlashPath(rel)
+	if rel == "" || unsafeEmbeddedFile(rel, false) {
+		return false
+	}
+	return PublicGeneratedOutputFile(rel) || runtimePrivateGeneratedMetadata(rel)
+}
+
+func unsafeEmbeddedFile(rel string, blockMetadata bool) bool {
 	rel = filepath.ToSlash(rel)
 	base := path.Base(rel)
 	normalizedBase := strings.ToLower(base)
@@ -30,7 +69,7 @@ func UnsafeEmbeddedFile(rel string) bool {
 	switch {
 	case normalizedBase == ".env" || strings.HasPrefix(normalizedBase, ".env."):
 		return true
-	case normalizedBase == "gowdk-security.json":
+	case blockMetadata && privateGeneratedMetadata(rel):
 		return true
 	case normalizedBase == ".npmrc" || normalizedBase == ".netrc":
 		return true
@@ -47,6 +86,36 @@ func UnsafeEmbeddedFile(rel string) bool {
 	default:
 		return false
 	}
+}
+
+func privateGeneratedMetadata(rel string) bool {
+	switch strings.ToLower(path.Base(filepath.ToSlash(rel))) {
+	case "gowdk-security.json", "gowdk-build-report.json", "gowdk-build-timings.json", "gowdk-routes.json", "gowdk-assets.json":
+		return true
+	default:
+		return false
+	}
+}
+
+func runtimePrivateGeneratedMetadata(rel string) bool {
+	switch strings.ToLower(path.Base(filepath.ToSlash(rel))) {
+	case "gowdk-routes.json", "gowdk-assets.json":
+		return true
+	default:
+		return false
+	}
+}
+
+func cleanRelativeSlashPath(rel string) string {
+	rel = strings.TrimPrefix(filepath.ToSlash(strings.TrimSpace(rel)), "/")
+	if rel == "" {
+		return ""
+	}
+	clean := path.Clean(rel)
+	if clean == "." || clean == ".." || strings.HasPrefix(clean, "../") {
+		return ""
+	}
+	return clean
 }
 
 // PrivateKeyFile reports common private key filenames without extension.

--- a/runtime/app/app.go
+++ b/runtime/app/app.go
@@ -826,7 +826,7 @@ func readSPAFile(root fs.FS, name string) ([]byte, fs.FileInfo, bool) {
 	if name == "" {
 		name = "index.html"
 	}
-	if unsafeSPAFile(name) {
+	if !publicSPAFile(name) {
 		return nil, nil, false
 	}
 	info, err := fs.Stat(root, name)
@@ -835,6 +835,9 @@ func readSPAFile(root fs.FS, name string) ([]byte, fs.FileInfo, bool) {
 	}
 	if info.IsDir() {
 		name = path.Join(name, "index.html")
+		if !publicSPAFile(name) {
+			return nil, nil, false
+		}
 		info, err = fs.Stat(root, name)
 		if err != nil || info.IsDir() {
 			return nil, nil, false
@@ -847,8 +850,42 @@ func readSPAFile(root fs.FS, name string) ([]byte, fs.FileInfo, bool) {
 	return payload, info, true
 }
 
-func unsafeSPAFile(name string) bool {
-	return strings.EqualFold(path.Base(name), "gowdk-security.json")
+func publicSPAFile(name string) bool {
+	name = strings.TrimPrefix(path.Clean("/"+name), "/")
+	if name == "" || privateSPAMetadata(name) {
+		return false
+	}
+	if strings.HasPrefix(name, "assets/") {
+		return !unsafeSPAExtension(name)
+	}
+	switch path.Base(name) {
+	case "sitemap.xml", "robots.txt", "openapi.json", "asyncapi.json":
+		return true
+	}
+	switch strings.ToLower(path.Ext(name)) {
+	case ".html", ".css", ".js", ".wasm", ".png", ".jpg", ".jpeg", ".gif", ".webp", ".svg", ".ico", ".avif", ".woff", ".woff2", ".ttf", ".otf":
+		return true
+	default:
+		return false
+	}
+}
+
+func privateSPAMetadata(name string) bool {
+	switch strings.ToLower(path.Base(name)) {
+	case "gowdk-security.json", "gowdk-build-report.json", "gowdk-build-timings.json", "gowdk-routes.json", "gowdk-assets.json":
+		return true
+	default:
+		return false
+	}
+}
+
+func unsafeSPAExtension(name string) bool {
+	switch strings.ToLower(path.Ext(name)) {
+	case ".map", ".gwdk", ".go", ".tmp", ".temp", ".key", ".pem", ".p12", ".pfx":
+		return true
+	default:
+		return strings.HasSuffix(strings.ToLower(path.Base(name)), "~")
+	}
 }
 
 func unsafeRequestPath(requestPath string) bool {

--- a/runtime/app/app_test.go
+++ b/runtime/app/app_test.go
@@ -613,18 +613,24 @@ func TestHandlerAppliesAssetManifestCachePolicy(t *testing.T) {
 func TestHandlerDoesNotServeSecurityManifest(t *testing.T) {
 	handler := Handler{
 		Root: fstest.MapFS{
-			"gowdk-security.json": {Data: []byte(`{"endpoints":[{"path":"/admin"}]}`)},
+			"gowdk-security.json":      {Data: []byte(`{"endpoints":[{"path":"/admin"}]}`)},
+			"gowdk-build-report.json":  {Data: []byte(`{"events":[{"path":"src/pages/admin.page.gwdk"}]}`)},
+			"gowdk-build-timings.json": {Data: []byte(`{"phases":[{"name":"build"}]}`)},
+			"gowdk-routes.json":        {Data: []byte(`{"routes":[{"route":"/admin"}]}`)},
+			"gowdk-assets.json":        {Data: []byte(`{"files":{"app.css":"assets/app.css"}}`)},
 		},
 		Identity: Identity{AppID: "clinic", ModuleName: "frontend", InstanceID: "frontend-1"},
 		Assets:   asset.Manifest{Version: 1, Files: map[string]string{}},
 	}
-	recorder := httptest.NewRecorder()
-	request := httptest.NewRequest(http.MethodGet, "/gowdk-security.json", nil)
+	for _, name := range []string{"gowdk-security.json", "gowdk-build-report.json", "gowdk-build-timings.json", "gowdk-routes.json", "gowdk-assets.json"} {
+		recorder := httptest.NewRecorder()
+		request := httptest.NewRequest(http.MethodGet, "/"+name, nil)
 
-	handler.ServeHTTP(recorder, request)
+		handler.ServeHTTP(recorder, request)
 
-	if recorder.Code != http.StatusNotFound {
-		t.Fatalf("expected 404, got %d with body %s", recorder.Code, recorder.Body.String())
+		if recorder.Code != http.StatusNotFound {
+			t.Fatalf("%s: expected 404, got %d with body %s", name, recorder.Code, recorder.Body.String())
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

- add pre-write artifact destination topology validation for ad hoc and configured builds
- make generated-output serving fail closed through a public artifact allowlist and rooted disk opener
- keep runtime-private route/asset manifests embeddable for generated apps without serving them as public URLs
- document public, runtime-private, and build-private generated artifact behavior

## Context

Refs #692, #693, #694.

This hardens the current artifact surface without introducing shared mutable target outputs. Disk-backed serving now rejects symlinked path components and unknown files, and build topology checks reject common collisions, nesting, and alias cases before generation starts.

## Validation

- `go test ./internal/safeasset ./internal/appgen ./internal/gowdkcmd ./runtime/app`
- `scripts/check-docs-links.sh`
- `scripts/check-docs-style.sh` (passes with existing long-paragraph warnings)
- `scripts/check-removed-syntax.sh`
- `scripts/check-doc-versions.sh`
- `go build ./cmd/gowdk`
- `go run ./cmd/gowdk build --out <tmp> examples/pages/home.page.gwdk examples/pages/hero.cmp.gwdk`
