### PR TITLE
feat(compiler): introduce phase typed program boundaries

### DIFF
--- a/docs/compiler/pipeline.md
+++ b/docs/compiler/pipeline.md
@@ -8,6 +8,7 @@ project config plus explicit file paths or configured discovery
   -> lower parsed records into internal/gwdkir.Program
   -> enrich IR with Go endpoint discovery and backend bindings
   -> validate IR invariants, render rules, routes, endpoints, packages, and assets
+     into a compiler-owned ValidatedProgram phase token
   -> emit diagnostics, public manifest JSON, site-map JSON, route/endpoint metadata, build-output artifacts, browser runtime assets, or generated app output
 ```
 
@@ -45,19 +46,34 @@ boundaries so one syntax error does not hide later declarations in the same
 file.
 
 `internal/gwdkanalysis` assembles parsed page, component, and layout records
-into `internal/gwdkir.Program`. The IR models packages, source
-files, page routes, backend endpoints from `.gwdk` declarations or explicit Go
-comments, templates, client behavior, source-selected assets, asset scope/hash
-metadata, parsed view nodes, typed literal records, and imported build-data call
-metadata. `gwdkir.Blocks` retains source bodies for spans and
-compatibility, but the parser-lowered handoff also carries parsed `view {}`
+into `internal/gwdkir.Program`. `internal/compiler.AnalyzedProgram` wraps that
+IR after enrichment, and `internal/compiler.ValidatedProgram` is the opaque
+phase token returned only by compiler validation. Build-output fast paths accept
+`ValidatedProgram`; raw `gwdkir.Program` entrypoints must run compiler
+validation before emission. Static build output resolves page artifacts, CSS,
+assets, manifests, and report metadata into `internal/buildgen.BuildPlan`
+before writing files. Generated app output resolves auto routes, endpoint
+projections, SSR artifacts, sitemap data, and generator-local validation into
+`internal/appgen.ApplicationPlan` before writing files.
+
+The IR models packages, source files, page routes, backend endpoints from
+`.gwdk` declarations or explicit Go comments, templates, client behavior,
+source-selected assets, asset scope/hash metadata, parsed view nodes, typed
+literal records, and imported build-data call metadata.
+
+`gwdkir.Blocks` retains source bodies for spans, formatting, inspection, and
+compatibility only. Parser/analyzer lowering must populate parsed `view {}`
 nodes, ordered literal `paths {}`/`build {}` records, and imported build-data
-call metadata; downstream passes should consume those typed fields before
-falling back to raw bodies. Build, memory build, incremental SPA build, SSR
-artifact, generated app planning, route reports, LSP metadata, and the public
-`gowdk manifest` report consume `internal/gwdkir.Program` and own their output
-planning separately. Route and asset manifests are generated output artifacts,
-not compiler handoff records.
+call metadata before validation. Downstream validation and generated-output
+planning consume those typed fields; raw block bodies are not a semantic fallback
+after lowering. `gwdkir.CheckInvariants` rejects non-empty supported `view {}`
+bodies that reach the IR without parsed view nodes.
+
+Build, memory build, incremental SPA build, SSR artifact, generated app
+planning, route reports, LSP metadata, and the public `gowdk manifest` report
+consume `internal/gwdkir.Program` and own their output planning separately.
+Route and asset manifests are generated output artifacts, not compiler handoff
+records.
 Generated app Go, backend adapter Go, build-data helper Go, and starter config
 Go are constructed as Go ASTs, printed, and formatted before use or write.
 

--- a/internal/appgen/appgen.go
+++ b/internal/appgen/appgen.go
@@ -21,13 +21,77 @@ const (
 	modFileName       = "go.mod"
 )
 
+var errInvalidApplicationPlan = fmt.Errorf("application plan was not constructed by appgen planning")
+
 // Generate writes a self-contained Go app that embeds outputDir.
 func Generate(outputDir, appDir string) (Result, error) {
 	return GenerateWithOptions(outputDir, appDir, Options{})
 }
 
+// PlanApplication resolves and validates generated app options before emission.
+func PlanApplication(outputDir string, options Options) (ApplicationPlan, error) {
+	if strings.TrimSpace(outputDir) == "" {
+		return ApplicationPlan{}, fmt.Errorf("build output directory is required")
+	}
+	absOutput, err := filepath.Abs(outputDir)
+	if err != nil {
+		return ApplicationPlan{}, err
+	}
+	planned, err := resolveOptions(absOutput, options)
+	if err != nil {
+		return ApplicationPlan{}, err
+	}
+	if err := validateAppPlanOptions(planned, true); err != nil {
+		return ApplicationPlan{}, err
+	}
+	return ApplicationPlan{options: planned, outputDir: absOutput, valid: true}, nil
+}
+
+// PlanBackendApplication resolves and validates backend-only generated app
+// options before emission.
+func PlanBackendApplication(options Options) (ApplicationPlan, error) {
+	planned, err := resolveBackendOptions(options)
+	if err != nil {
+		return ApplicationPlan{}, err
+	}
+	if err := validateAppPlanOptions(planned, false); err != nil {
+		return ApplicationPlan{}, err
+	}
+	return ApplicationPlan{options: planned, backendOnly: true, valid: true}, nil
+}
+
+func validateAppPlanOptions(options Options, includeSSR bool) error {
+	if err := validateActionEndpoints(options.Actions); err != nil {
+		return err
+	}
+	if err := validateAPIEndpoints(options.APIs); err != nil {
+		return err
+	}
+	if err := validateFragmentEndpoints(options.Fragments); err != nil {
+		return err
+	}
+	if err := validateContractRoutes(options.IR); err != nil {
+		return err
+	}
+	if includeSSR {
+		if err := validateSSRRoutes(options.SSR); err != nil {
+			return err
+		}
+	}
+	return validateCORSConfig(options)
+}
+
 // GenerateWithOptions writes a self-contained Go app that embeds outputDir.
 func GenerateWithOptions(outputDir, appDir string, options Options) (result Result, err error) {
+	plan, err := PlanApplication(outputDir, options)
+	if err != nil {
+		return Result{}, err
+	}
+	return GenerateWithPlan(outputDir, appDir, plan)
+}
+
+// GenerateWithPlan writes a self-contained Go app from an application plan.
+func GenerateWithPlan(outputDir, appDir string, plan ApplicationPlan) (result Result, err error) {
 	defer recoverGeneratedIdentifierError(&err)
 
 	if strings.TrimSpace(outputDir) == "" {
@@ -48,26 +112,14 @@ func GenerateWithOptions(outputDir, appDir string, options Options) (result Resu
 	if err := validateDirectories(absOutput, absApp); err != nil {
 		return Result{}, err
 	}
-	options, err = resolveOptions(absOutput, options)
+	if plan.backendOnly {
+		return Result{}, fmt.Errorf("backend application plan cannot be used for embedded app generation")
+	}
+	if plan.outputDir != "" && filepath.Clean(plan.outputDir) != filepath.Clean(absOutput) {
+		return Result{}, fmt.Errorf("application plan output directory %q does not match build output directory %q", plan.outputDir, absOutput)
+	}
+	options, err := plan.optionsForEmit()
 	if err != nil {
-		return Result{}, err
-	}
-	if err := validateActionEndpoints(options.Actions); err != nil {
-		return Result{}, err
-	}
-	if err := validateAPIEndpoints(options.APIs); err != nil {
-		return Result{}, err
-	}
-	if err := validateFragmentEndpoints(options.Fragments); err != nil {
-		return Result{}, err
-	}
-	if err := validateContractRoutes(options.IR); err != nil {
-		return Result{}, err
-	}
-	if err := validateSSRRoutes(options.SSR); err != nil {
-		return Result{}, err
-	}
-	if err := validateCORSConfig(options); err != nil {
 		return Result{}, err
 	}
 
@@ -153,6 +205,16 @@ func GenerateWithOptions(outputDir, appDir string, options Options) (result Resu
 // GenerateBackendWithOptions writes a generated Go app that serves only
 // request-time backend routes for feature-bound actions and APIs.
 func GenerateBackendWithOptions(appDir string, options Options) (result Result, err error) {
+	plan, err := PlanBackendApplication(options)
+	if err != nil {
+		return Result{}, err
+	}
+	return GenerateBackendWithPlan(appDir, plan)
+}
+
+// GenerateBackendWithPlan writes a generated Go app that serves only
+// request-time backend routes from an application plan.
+func GenerateBackendWithPlan(appDir string, plan ApplicationPlan) (result Result, err error) {
 	defer recoverGeneratedIdentifierError(&err)
 
 	if strings.TrimSpace(appDir) == "" {
@@ -162,24 +224,12 @@ func GenerateBackendWithOptions(appDir string, options Options) (result Result, 
 	if err != nil {
 		return Result{}, err
 	}
-	options, err = resolveBackendOptions(options)
+	options, err := plan.optionsForEmit()
 	if err != nil {
 		return Result{}, err
 	}
-	if err := validateActionEndpoints(options.Actions); err != nil {
-		return Result{}, err
-	}
-	if err := validateAPIEndpoints(options.APIs); err != nil {
-		return Result{}, err
-	}
-	if err := validateFragmentEndpoints(options.Fragments); err != nil {
-		return Result{}, err
-	}
-	if err := validateContractRoutes(options.IR); err != nil {
-		return Result{}, err
-	}
-	if err := validateCORSConfig(options); err != nil {
-		return Result{}, err
+	if !plan.backendOnly {
+		return Result{}, fmt.Errorf("embedded application plan cannot be used for backend app generation")
 	}
 	if err := os.MkdirAll(absApp, 0o755); err != nil {
 		return Result{}, err

--- a/internal/appgen/appgen_test.go
+++ b/internal/appgen/appgen_test.go
@@ -146,7 +146,7 @@ func TestGenerateWritesDynamicSitemapRoute(t *testing.T) {
 	writeTestFile(t, filepath.Join(outputDir, "sitemap.xml"), "<urlset></urlset>")
 	writeTestFile(t, filepath.Join(outputDir, "gowdk-assets.json"), `{"version":1}`)
 
-	ir := gwdkir.Program{Pages: []gwdkir.Page{{
+	ir := gwdkanalysis.BuildProgram(gowdk.Config{}, gwdkanalysis.Sources{Pages: []gwdkir.Page{{
 		ID:     "home",
 		Route:  "/",
 		Guards: []string{"public"},
@@ -154,7 +154,7 @@ func TestGenerateWritesDynamicSitemapRoute(t *testing.T) {
 			View:     true,
 			ViewBody: `<main>Home</main>`,
 		},
-	}}}
+	}}})
 	config := gowdk.Config{Addons: []gowdk.Addon{seo.Addon(seo.Options{
 		BaseURL: "https://example.com",
 		DynamicSitemap: gowdk.SEODynamicSitemap{
@@ -2019,6 +2019,59 @@ func TestGenerateRejectsInvalidCORSConfig(t *testing.T) {
 	})
 	if err == nil || !strings.Contains(err.Error(), "wildcard origin") {
 		t.Fatalf("expected invalid CORS config error, got %v", err)
+	}
+}
+
+func TestGenerateWithPlanRejectsZeroValue(t *testing.T) {
+	root := t.TempDir()
+	outputDir := filepath.Join(root, "dist")
+	appDir := filepath.Join(root, "generated-app")
+	writeTestFile(t, filepath.Join(outputDir, "index.html"), "<main>Home</main>")
+
+	_, err := GenerateWithPlan(outputDir, appDir, ApplicationPlan{})
+	if err == nil {
+		t.Fatal("expected zero-value application plan error")
+	}
+	if !strings.Contains(err.Error(), "application plan was not constructed") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestGenerateWithPlanRejectsBackendPlan(t *testing.T) {
+	root := t.TempDir()
+	outputDir := filepath.Join(root, "dist")
+	appDir := filepath.Join(root, "generated-app")
+	writeTestFile(t, filepath.Join(outputDir, "index.html"), "<main>Home</main>")
+	plan, err := PlanBackendApplication(Options{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = GenerateWithPlan(outputDir, appDir, plan)
+	if err == nil {
+		t.Fatal("expected backend plan lane error")
+	}
+	if !strings.Contains(err.Error(), "backend application plan cannot be used") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestGenerateBackendWithPlanRejectsEmbeddedPlan(t *testing.T) {
+	root := t.TempDir()
+	outputDir := filepath.Join(root, "dist")
+	appDir := filepath.Join(root, "generated-backend")
+	writeTestFile(t, filepath.Join(outputDir, "index.html"), "<main>Home</main>")
+	plan, err := PlanApplication(outputDir, Options{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = GenerateBackendWithPlan(appDir, plan)
+	if err == nil {
+		t.Fatal("expected embedded plan lane error")
+	}
+	if !strings.Contains(err.Error(), "embedded application plan cannot be used") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 
@@ -9394,15 +9447,37 @@ func waitForHTTPStatusWithHeaders(url, method, body string, headers map[string]s
 // through the production manifest->IR path, asserting against exactly what the
 // generated-app pipeline derives.
 func actionEndpointsFromManifestFixture(app gwdkanalysis.Sources) ([]ActionEndpoint, error) {
+	app = normalizeEndpointFixtureSources(app)
 	return actionEndpointsFromIR(gowdk.Config{}, gwdkanalysis.BuildProgram(gowdk.Config{}, app))
 }
 
 func apiEndpointsFromManifestFixture(app gwdkanalysis.Sources) ([]APIEndpoint, error) {
+	app = normalizeEndpointFixtureSources(app)
 	return apiEndpointsFromIR(gwdkanalysis.BuildProgram(gowdk.Config{}, app))
 }
 
 func fragmentEndpointsFromManifestFixture(app gwdkanalysis.Sources) ([]FragmentEndpoint, error) {
+	app = normalizeEndpointFixtureSources(app)
 	return fragmentEndpointsFromIR(gwdkanalysis.BuildProgram(gowdk.Config{}, app))
+}
+
+func normalizeEndpointFixtureSources(app gwdkanalysis.Sources) gwdkanalysis.Sources {
+	for index := range app.Pages {
+		if strings.TrimSpace(app.Pages[index].Blocks.ViewBody) != "" {
+			app.Pages[index].Blocks.View = true
+		}
+	}
+	for index := range app.Components {
+		if strings.TrimSpace(app.Components[index].Blocks.ViewBody) != "" {
+			app.Components[index].Blocks.View = true
+		}
+	}
+	for index := range app.Layouts {
+		if strings.TrimSpace(app.Layouts[index].Blocks.ViewBody) != "" {
+			app.Layouts[index].Blocks.View = true
+		}
+	}
+	return app
 }
 
 func TestDeniedPageRoutesSelectsGuardlessStaticPages(t *testing.T) {

--- a/internal/appgen/auto_routes.go
+++ b/internal/appgen/auto_routes.go
@@ -39,11 +39,21 @@ func resolveOptions(outputDir string, options Options) (Options, error) {
 	if err != nil {
 		return Options{}, err
 	}
-	ssrArtifacts, err := buildgen.SSRArtifactsFromIR(options.Config, ir, outputDir)
+	var ssrArtifacts []buildgen.SSRArtifact
+	if options.Program != nil {
+		ssrArtifacts, err = buildgen.SSRArtifactsFromValidatedProgram(options.Config, *options.Program, outputDir)
+	} else {
+		ssrArtifacts, err = buildgen.SSRArtifactsFromIR(options.Config, ir, outputDir)
+	}
 	if err != nil {
 		return Options{}, err
 	}
-	sitemap, err := buildgen.RuntimeSitemapPlanFromIR(options.Config, ir)
+	var sitemap buildgen.RuntimeSitemapPlan
+	if options.Program != nil {
+		sitemap, err = buildgen.RuntimeSitemapPlanFromValidatedProgram(options.Config, *options.Program)
+	} else {
+		sitemap, err = buildgen.RuntimeSitemapPlanFromIR(options.Config, ir)
+	}
 	if err != nil {
 		return Options{}, err
 	}
@@ -91,6 +101,12 @@ func resolveBackendOptions(options Options) (Options, error) {
 }
 
 func optionsIR(options Options) (gwdkir.Program, error) {
+	if options.Program != nil {
+		if !options.Program.Valid() {
+			return gwdkir.Program{}, fmt.Errorf("validated program was not constructed by compiler validation")
+		}
+		return options.Program.Program(), nil
+	}
 	if options.IR != nil {
 		if err := gwdkir.CheckInvariants(*options.IR); err != nil {
 			return gwdkir.Program{}, fmt.Errorf("invalid compiler IR: %w", err)

--- a/internal/appgen/ir.go
+++ b/internal/appgen/ir.go
@@ -94,10 +94,13 @@ func actionEndpointRoutes(config gowdk.I18NConfig, pageRoute string, route strin
 }
 
 func actionFormSchemaFromBlocks(blocks gwdkir.Blocks) (map[string][]view.ActionFormField, error) {
-	if len(blocks.ViewNodes) > 0 {
-		return view.ActionFormSchemaFromNodes(blocks.ViewNodes)
+	if len(blocks.ViewNodes) == 0 {
+		if strings.TrimSpace(blocks.ViewBody) == "" {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("view {} has source body but no parsed nodes")
 	}
-	return view.ActionFormSchema(blocks.ViewBody)
+	return view.ActionFormSchemaFromNodes(blocks.ViewNodes)
 }
 
 func apiEndpointsFromIR(ir gwdkir.Program) ([]APIEndpoint, error) {

--- a/internal/appgen/ir_test.go
+++ b/internal/appgen/ir_test.go
@@ -6,15 +6,22 @@ import (
 	"github.com/cssbruno/gowdk"
 	"github.com/cssbruno/gowdk/internal/gwdkir"
 	"github.com/cssbruno/gowdk/internal/source"
+	view "github.com/cssbruno/gowdk/internal/viewrender"
 )
 
 func TestActionEndpointsFromIR(t *testing.T) {
+	nodes, err := view.Parse(`<form g:post={Subscribe}><input name="email" required /></form>`)
+	if err != nil {
+		t.Fatal(err)
+	}
 	ir := gwdkir.Program{
 		Pages: []gwdkir.Page{{
 			ID:    "newsletter",
 			Route: "/newsletter",
 			Blocks: gwdkir.Blocks{
-				ViewBody: `<form g:post={Subscribe}><input name="email" required /></form>`,
+				View:      true,
+				ViewBody:  `<form g:post={Subscribe}><input name="email" required /></form>`,
+				ViewNodes: nodes,
 				Actions: []gwdkir.Action{{
 					Name:           "Subscribe",
 					InputName:      "input",
@@ -60,12 +67,18 @@ func TestActionEndpointsFromIR(t *testing.T) {
 }
 
 func TestActionEndpointsFromIRLocalizesInheritedRoutes(t *testing.T) {
+	nodes, err := view.Parse(`<form g:post={Submit}><input name="email" required /></form>`)
+	if err != nil {
+		t.Fatal(err)
+	}
 	ir := gwdkir.Program{
 		Pages: []gwdkir.Page{{
 			ID:    "contact",
 			Route: "/contact",
 			Blocks: gwdkir.Blocks{
-				ViewBody: `<form g:post={Submit}><input name="email" required /></form>`,
+				View:      true,
+				ViewBody:  `<form g:post={Submit}><input name="email" required /></form>`,
+				ViewNodes: nodes,
 				Actions: []gwdkir.Action{{
 					Name: "Submit",
 				}},

--- a/internal/appgen/types.go
+++ b/internal/appgen/types.go
@@ -3,6 +3,7 @@ package appgen
 import (
 	"github.com/cssbruno/gowdk"
 	"github.com/cssbruno/gowdk/internal/buildgen"
+	"github.com/cssbruno/gowdk/internal/compiler"
 	"github.com/cssbruno/gowdk/internal/gwdkir"
 	"github.com/cssbruno/gowdk/internal/source"
 )
@@ -30,8 +31,36 @@ type Options struct {
 	AutoRoutes   bool
 	ProxyBackend bool
 	Config       gowdk.Config
-	IR           *gwdkir.Program
-	Sitemap      buildgen.RuntimeSitemapPlan
+	Program      *compiler.ValidatedProgram
+	// IR is the legacy raw-IR option path. Production auto-routing should pass
+	// Program so generation receives a compiler-validated phase token.
+	IR      *gwdkir.Program
+	Sitemap buildgen.RuntimeSitemapPlan
+}
+
+// ApplicationPlan is the normalized generated-application plan consumed by
+// appgen emission. Construct it through PlanApplication or
+// PlanBackendApplication so route defaults, endpoint projections, SSR artifacts,
+// sitemap data, and generator-local validation are finalized before writes.
+type ApplicationPlan struct {
+	options     Options
+	outputDir   string
+	backendOnly bool
+	valid       bool
+}
+
+func (plan ApplicationPlan) optionsForEmit() (Options, error) {
+	if !plan.valid {
+		return Options{}, errInvalidApplicationPlan
+	}
+	return plan.options, nil
+}
+
+// OptionsFromValidatedProgram returns production generator options for
+// compiler-validated IR-driven route generation.
+func OptionsFromValidatedProgram(config gowdk.Config, program compiler.ValidatedProgram) Options {
+	ir := program.Program()
+	return Options{AutoRoutes: true, Config: config, Program: &program, IR: &ir}
 }
 
 // OptionsFromIR returns the production generator options for compiler IR-driven

--- a/internal/buildgen/actions_partials_test.go
+++ b/internal/buildgen/actions_partials_test.go
@@ -45,7 +45,7 @@ func TestBuildLowersGPostDirectiveForSPAPage(t *testing.T) {
 
 func TestBuildSynthesizesActionInputAttrsFromBindingFields(t *testing.T) {
 	outputDir := t.TempDir()
-	ir := gwdkir.Program{Pages: []gwdkir.Page{{
+	ir := analyzedIRFixture(t, gwdkir.Program{Pages: []gwdkir.Page{{
 		ID:     "signup",
 		Route:  "/signup",
 		Render: gowdk.SPA,
@@ -66,7 +66,7 @@ func TestBuildSynthesizesActionInputAttrsFromBindingFields(t *testing.T) {
 			{FieldName: "Age", FormName: "age", Type: "uint8"},
 			{FieldName: "Score", FormName: "score", Type: "int16"},
 		}},
-	}}}
+	}}})
 
 	_, err := BuildFromIR(gowdk.Config{}, ir, outputDir)
 	if err != nil {

--- a/internal/buildgen/bench_test.go
+++ b/internal/buildgen/bench_test.go
@@ -14,7 +14,11 @@ import (
 func BenchmarkGeneratedOutputFromValidatedIR(b *testing.B) {
 	config := gowdk.Config{}
 	sources := benchmarkBuildSources(`<main><h1>Home</h1></main>`)
-	ir, _, err := compiler.AssembleProgram(config, sources)
+	analyzed, err := compiler.AnalyzeProgram(config, sources)
+	if err != nil {
+		b.Fatal(err)
+	}
+	validated, err := compiler.ValidateAnalyzedProgram(config, analyzed)
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -22,7 +26,7 @@ func BenchmarkGeneratedOutputFromValidatedIR(b *testing.B) {
 
 	b.ResetTimer()
 	for b.Loop() {
-		if _, err := BuildFromValidatedIR(config, ir, outputDir); err != nil {
+		if _, err := BuildFromValidatedProgram(config, validated, outputDir); err != nil {
 			b.Fatal(err)
 		}
 	}

--- a/internal/buildgen/build.go
+++ b/internal/buildgen/build.go
@@ -15,33 +15,79 @@ import (
 	"github.com/cssbruno/gowdk/internal/source"
 )
 
+// BuildPlan is the normalized static output plan consumed by build emission.
+// Construct it through PlanBuildFromValidatedProgram so validation, route
+// defaults, localized page outputs, CSS/assets, fragments, schemas, and report
+// metadata are finalized before files are written.
+type BuildPlan struct {
+	reporter  *buildReporter
+	planned   buildPlan
+	config    gowdk.Config
+	ir        gwdkir.Program
+	outputDir string
+	valid     bool
+}
+
 func Build(config gowdk.Config, sources gwdkanalysis.Sources, outputDir string) (Result, error) {
-	ir, bindings, err := compiler.AssembleProgram(config, sources)
+	analyzed, err := compiler.AnalyzeProgram(config, sources)
 	if err != nil {
 		return Result{}, err
 	}
-	return buildFromIR(config, ir, bindings, outputDir, true)
+	return BuildFromAnalyzedProgram(config, analyzed, outputDir)
 }
 
 // BuildFromIR writes SPA build artifacts from normalized compiler IR.
 func BuildFromIR(config gowdk.Config, ir gwdkir.Program, outputDir string) (Result, error) {
-	return buildFromIR(config, ir, compiler.BackendBindingsFromIR(ir), outputDir, true)
+	return BuildFromAnalyzedProgram(config, compiler.AnalyzedProgramFromIR(ir), outputDir)
 }
 
-// BuildFromValidatedIR is BuildFromIR for orchestrators that already ran
-// compiler.ValidateProgram on the IR (the CLI build path). It skips the
-// defensive re-validation, which type-checks feature Go packages on disk and
-// is too expensive to run twice per build, but still runs cheap IR invariant
-// checks before planning generated output.
-func BuildFromValidatedIR(config gowdk.Config, ir gwdkir.Program, outputDir string) (Result, error) {
-	return buildFromIR(config, ir, compiler.BackendBindingsFromIR(ir), outputDir, false)
+// BuildFromAnalyzedProgram validates analyzed compiler IR before emission.
+func BuildFromAnalyzedProgram(config gowdk.Config, analyzed compiler.AnalyzedProgram, outputDir string) (Result, error) {
+	validated, err := compiler.ValidateAnalyzedProgram(config, analyzed)
+	if err != nil {
+		reporter := newBuildReporter("build", outputDir)
+		return Result{}, reporter.fail("validate", err)
+	}
+	return BuildFromValidatedProgram(config, validated, outputDir)
 }
 
-func buildFromIR(config gowdk.Config, ir gwdkir.Program, backendBindings []source.BackendBinding, outputDir string, validate bool) (Result, error) {
-	reporter, planned, err := prepareBuildPlan("build", "SPA build started", outputDir, config, ir, backendBindings, validate, true)
+// BuildFromValidatedProgram emits SPA build artifacts from compiler-validated
+// IR. The only way to obtain the phase token is through compiler validation.
+func BuildFromValidatedProgram(config gowdk.Config, validated compiler.ValidatedProgram, outputDir string) (Result, error) {
+	plan, err := PlanBuildFromValidatedProgram(config, validated, outputDir)
 	if err != nil {
 		return Result{}, err
 	}
+	return BuildFromPlan(plan)
+}
+
+// PlanBuildFromValidatedProgram plans SPA build artifacts from
+// compiler-validated IR without writing files.
+func PlanBuildFromValidatedProgram(config gowdk.Config, validated compiler.ValidatedProgram, outputDir string) (BuildPlan, error) {
+	reporter, planned, err := prepareBuildPlan("build", "SPA build started", outputDir, config, validated, true)
+	if err != nil {
+		return BuildPlan{}, err
+	}
+	return BuildPlan{
+		reporter:  reporter,
+		planned:   planned,
+		config:    config,
+		ir:        validated.Program(),
+		outputDir: outputDir,
+		valid:     true,
+	}, nil
+}
+
+// BuildFromPlan emits SPA build artifacts from a normalized build plan.
+func BuildFromPlan(plan BuildPlan) (Result, error) {
+	if !plan.valid || plan.reporter == nil {
+		return Result{}, fmt.Errorf("build plan was not constructed by buildgen planning")
+	}
+	reporter := plan.reporter
+	planned := plan.planned
+	config := plan.config
+	ir := plan.ir
+	outputDir := plan.outputDir
 
 	result := Result{
 		Artifacts:      make([]Artifact, 0, len(planned.pages)),
@@ -171,33 +217,61 @@ func finalizeAssetArtifact(artifact *plannedAssetArtifact) {
 }
 
 func BuildMemory(config gowdk.Config, sources gwdkanalysis.Sources, outputDir string) (MemoryResult, error) {
-	ir, bindings, err := compiler.AssembleProgram(config, sources)
+	analyzed, err := compiler.AnalyzeProgram(config, sources)
 	if err != nil {
 		return MemoryResult{}, err
 	}
-	return buildMemoryFromIR(config, ir, bindings, outputDir, true)
+	return BuildMemoryFromAnalyzedProgram(config, analyzed, outputDir)
 }
 
 // BuildMemoryWithOptions plans SPA build artifacts without requiring a real
 // output directory. Empty MemoryBuildOptions.OutputBase defaults to ".".
 func BuildMemoryWithOptions(config gowdk.Config, sources gwdkanalysis.Sources, options MemoryBuildOptions) (MemoryResult, error) {
-	ir, bindings, err := compiler.AssembleProgram(config, sources)
+	analyzed, err := compiler.AnalyzeProgram(config, sources)
 	if err != nil {
 		return MemoryResult{}, err
 	}
-	return buildMemoryFromIR(config, ir, bindings, memoryOutputBase(options), false)
+	return BuildMemoryFromAnalyzedProgramWithOptions(config, analyzed, options)
 }
 
 // BuildMemoryFromIR plans SPA build artifacts from normalized compiler IR
 // without writing them to disk.
 func BuildMemoryFromIR(config gowdk.Config, ir gwdkir.Program, outputDir string) (MemoryResult, error) {
-	return buildMemoryFromIR(config, ir, compiler.BackendBindingsFromIR(ir), outputDir, true)
+	return BuildMemoryFromAnalyzedProgram(config, compiler.AnalyzedProgramFromIR(ir), outputDir)
 }
 
 // BuildMemoryFromIRWithOptions is BuildMemoryWithOptions for orchestrators
 // that already have normalized compiler IR.
 func BuildMemoryFromIRWithOptions(config gowdk.Config, ir gwdkir.Program, options MemoryBuildOptions) (MemoryResult, error) {
-	return buildMemoryFromIR(config, ir, compiler.BackendBindingsFromIR(ir), memoryOutputBase(options), false)
+	return BuildMemoryFromAnalyzedProgramWithOptions(config, compiler.AnalyzedProgramFromIR(ir), options)
+}
+
+// BuildMemoryFromAnalyzedProgram validates analyzed compiler IR before planning
+// in-memory artifacts.
+func BuildMemoryFromAnalyzedProgram(config gowdk.Config, analyzed compiler.AnalyzedProgram, outputDir string) (MemoryResult, error) {
+	validated, err := compiler.ValidateAnalyzedProgram(config, analyzed)
+	if err != nil {
+		reporter := newBuildReporter("memory", outputDir)
+		return MemoryResult{}, reporter.fail("validate", err)
+	}
+	return BuildMemoryFromValidatedProgram(config, validated, outputDir)
+}
+
+// BuildMemoryFromAnalyzedProgramWithOptions is BuildMemoryWithOptions for
+// callers that already have analyzed compiler IR.
+func BuildMemoryFromAnalyzedProgramWithOptions(config gowdk.Config, analyzed compiler.AnalyzedProgram, options MemoryBuildOptions) (MemoryResult, error) {
+	validated, err := compiler.ValidateAnalyzedProgram(config, analyzed)
+	if err != nil {
+		reporter := newBuildReporter("memory", memoryOutputBase(options))
+		return MemoryResult{}, reporter.fail("validate", err)
+	}
+	return buildMemoryFromValidatedProgram(config, validated, memoryOutputBase(options), false)
+}
+
+// BuildMemoryFromValidatedProgram plans in-memory SPA artifacts from
+// compiler-validated IR.
+func BuildMemoryFromValidatedProgram(config gowdk.Config, validated compiler.ValidatedProgram, outputDir string) (MemoryResult, error) {
+	return buildMemoryFromValidatedProgram(config, validated, outputDir, true)
 }
 
 func memoryOutputBase(options MemoryBuildOptions) string {
@@ -207,8 +281,9 @@ func memoryOutputBase(options MemoryBuildOptions) string {
 	return options.OutputBase
 }
 
-func buildMemoryFromIR(config gowdk.Config, ir gwdkir.Program, backendBindings []source.BackendBinding, outputDir string, requireOutputDir bool) (MemoryResult, error) {
-	reporter, planned, err := prepareBuildPlan("memory", "in-memory SPA build started", outputDir, config, ir, backendBindings, true, requireOutputDir)
+func buildMemoryFromValidatedProgram(config gowdk.Config, validated compiler.ValidatedProgram, outputDir string, requireOutputDir bool) (MemoryResult, error) {
+	ir := validated.Program()
+	reporter, planned, err := prepareBuildPlan("memory", "in-memory SPA build started", outputDir, config, validated, requireOutputDir)
 	if err != nil {
 		return MemoryResult{}, err
 	}
@@ -319,7 +394,9 @@ func buildMemoryFromIR(config gowdk.Config, ir gwdkir.Program, backendBindings [
 	return result, nil
 }
 
-func prepareBuildPlan(kind string, startMessage string, outputDir string, config gowdk.Config, ir gwdkir.Program, backendBindings []source.BackendBinding, validate bool, requireOutputDir bool) (*buildReporter, buildPlan, error) {
+func prepareBuildPlan(kind string, startMessage string, outputDir string, config gowdk.Config, validated compiler.ValidatedProgram, requireOutputDir bool) (*buildReporter, buildPlan, error) {
+	ir := validated.Program()
+	backendBindings := validated.BackendBindings()
 	reporter := newBuildReporter(kind, outputDir)
 	reporter.info("start", "build_started", startMessage, BuildEvent{
 		Data: map[string]string{
@@ -331,12 +408,8 @@ func prepareBuildPlan(kind string, startMessage string, outputDir string, config
 	if requireOutputDir && strings.TrimSpace(outputDir) == "" {
 		return reporter, buildPlan{}, reporter.fail("validate", fmt.Errorf("build output directory is required"))
 	}
-	if validate {
-		if err := compiler.ValidateProgram(config, ir); err != nil {
-			return reporter, buildPlan{}, reporter.fail("validate", err)
-		}
-	} else if err := gwdkir.CheckInvariants(ir); err != nil {
-		return reporter, buildPlan{}, reporter.fail("validate", fmt.Errorf("internal compiler error: %w", err))
+	if !validated.Valid() {
+		return reporter, buildPlan{}, reporter.fail("validate", fmt.Errorf("validated program was not constructed by compiler validation"))
 	}
 	reporter.info("validate", "ir_valid", "compiler IR validation completed", BuildEvent{})
 	reportBackendBindings(reporter, backendBindings)
@@ -597,20 +670,35 @@ func reportStructuredData(reporter *buildReporter, ir gwdkir.Program) {
 }
 
 func BuildIncremental(config gowdk.Config, sources gwdkanalysis.Sources, outputDir string, changedPageSources []string) (Result, error) {
-	ir, bindings, err := compiler.AssembleProgram(config, sources)
+	analyzed, err := compiler.AnalyzeProgram(config, sources)
 	if err != nil {
 		return Result{}, err
 	}
-	return buildIncrementalFromIR(config, ir, bindings, outputDir, changedPageSources)
+	return BuildIncrementalFromAnalyzedProgram(config, analyzed, outputDir, changedPageSources)
 }
 
 // BuildIncrementalFromIR incrementally renders changed SPA page outputs from
 // normalized compiler IR.
 func BuildIncrementalFromIR(config gowdk.Config, ir gwdkir.Program, outputDir string, changedPageSources []string) (Result, error) {
-	return buildIncrementalFromIR(config, ir, compiler.BackendBindingsFromIR(ir), outputDir, changedPageSources)
+	return BuildIncrementalFromAnalyzedProgram(config, compiler.AnalyzedProgramFromIR(ir), outputDir, changedPageSources)
 }
 
-func buildIncrementalFromIR(config gowdk.Config, ir gwdkir.Program, backendBindings []source.BackendBinding, outputDir string, changedPageSources []string) (Result, error) {
+// BuildIncrementalFromAnalyzedProgram validates analyzed compiler IR before
+// incrementally rendering changed SPA pages.
+func BuildIncrementalFromAnalyzedProgram(config gowdk.Config, analyzed compiler.AnalyzedProgram, outputDir string, changedPageSources []string) (Result, error) {
+	validated, err := compiler.ValidateAnalyzedProgram(config, analyzed)
+	if err != nil {
+		reporter := newBuildReporter("incremental", outputDir)
+		return Result{}, reporter.fail("validate", err)
+	}
+	return BuildIncrementalFromValidatedProgram(config, validated, outputDir, changedPageSources)
+}
+
+// BuildIncrementalFromValidatedProgram incrementally renders changed SPA pages
+// from compiler-validated IR.
+func BuildIncrementalFromValidatedProgram(config gowdk.Config, validated compiler.ValidatedProgram, outputDir string, changedPageSources []string) (Result, error) {
+	ir := validated.Program()
+	backendBindings := validated.BackendBindings()
 	reporter := newBuildReporter("incremental", outputDir)
 	reporter.info("start", "build_started", "incremental SPA build started", BuildEvent{
 		Data: map[string]string{
@@ -621,8 +709,8 @@ func buildIncrementalFromIR(config gowdk.Config, ir gwdkir.Program, backendBindi
 	if strings.TrimSpace(outputDir) == "" {
 		return Result{}, reporter.fail("validate", fmt.Errorf("build output directory is required"))
 	}
-	if err := compiler.ValidateProgram(config, ir); err != nil {
-		return Result{}, reporter.fail("validate", err)
+	if !validated.Valid() {
+		return Result{}, reporter.fail("validate", fmt.Errorf("validated program was not constructed by compiler validation"))
 	}
 	reporter.info("validate", "ir_valid", "compiler IR validation completed", BuildEvent{})
 	reportBackendBindings(reporter, backendBindings)

--- a/internal/buildgen/build_report_test.go
+++ b/internal/buildgen/build_report_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/cssbruno/gowdk"
 	"github.com/cssbruno/gowdk/addons/ssr"
+	"github.com/cssbruno/gowdk/internal/compiler"
 	"github.com/cssbruno/gowdk/internal/gwdkanalysis"
 	"github.com/cssbruno/gowdk/internal/gwdkir"
 	"github.com/cssbruno/gowdk/internal/source"
@@ -133,7 +134,7 @@ func TestBuildWritesSPAHTMLForSimpleRoute(t *testing.T) {
 
 func TestRouteManifestIncludesTypedDynamicEndpointParams(t *testing.T) {
 	outputDir := t.TempDir()
-	ir := gwdkir.Program{
+	ir := analyzedIRFixture(t, gwdkir.Program{
 		Pages: []gwdkir.Page{{
 			ID:     "patients",
 			Route:  "/patients",
@@ -155,7 +156,7 @@ func TestRouteManifestIncludesTypedDynamicEndpointParams(t *testing.T) {
 			RouteParams:   []source.RouteParam{{Name: "id", Type: "int"}},
 			Guards:        []string{"public"},
 		}},
-	}
+	})
 
 	if _, err := BuildFromIR(gowdk.Config{}, ir, outputDir); err != nil {
 		t.Fatal(err)
@@ -657,7 +658,7 @@ func TestBuildReportIncludesQueryContractReferences(t *testing.T) {
 
 func TestBuildReportIncludesBoundContractReferenceRoles(t *testing.T) {
 	outputDir := t.TempDir()
-	result, err := BuildFromIR(gowdk.Config{}, gwdkir.Program{
+	result, err := BuildFromIR(gowdk.Config{}, analyzedIRFixture(t, gwdkir.Program{
 		Pages: []gwdkir.Page{{
 			Source: "pages/patients.page.gwdk",
 			ID:     "patients",
@@ -683,7 +684,7 @@ func TestBuildReportIncludesBoundContractReferenceRoles(t *testing.T) {
 			OwnerID:   "patients",
 			Source:    "pages/patients.page.gwdk",
 		}},
-	}, outputDir)
+	}), outputDir)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -698,7 +699,7 @@ func TestBuildReportIncludesBoundContractReferenceRoles(t *testing.T) {
 
 func TestBuildReportIncludesRealtimeSubscriptions(t *testing.T) {
 	outputDir := t.TempDir()
-	result, err := BuildFromIR(gowdk.Config{Addons: []gowdk.Addon{gowdk.NewAddon("realtime", gowdk.FeatureRealtime)}}, gwdkir.Program{
+	result, err := BuildFromIR(gowdk.Config{Addons: []gowdk.Addon{gowdk.NewAddon("realtime", gowdk.FeatureRealtime)}}, analyzedIRFixture(t, gwdkir.Program{
 		Pages: []gwdkir.Page{{
 			Source: "pages/patients.page.gwdk",
 			ID:     "patients",
@@ -725,7 +726,7 @@ func TestBuildReportIncludesRealtimeSubscriptions(t *testing.T) {
 			OwnerID:          "patients",
 			Source:           "pages/patients.page.gwdk",
 		}},
-	}, outputDir)
+	}), outputDir)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -743,7 +744,7 @@ func TestBuildReportIncludesRealtimeSubscriptions(t *testing.T) {
 
 func TestBuildReportIncludesQueryInvalidations(t *testing.T) {
 	outputDir := t.TempDir()
-	result, err := BuildFromIR(gowdk.Config{Addons: []gowdk.Addon{gowdk.NewAddon("realtime", gowdk.FeatureRealtime)}}, gwdkir.Program{
+	result, err := BuildFromIR(gowdk.Config{Addons: []gowdk.Addon{gowdk.NewAddon("realtime", gowdk.FeatureRealtime)}}, analyzedIRFixture(t, gwdkir.Program{
 		Pages: []gwdkir.Page{{
 			Source: "pages/patients.page.gwdk",
 			ID:     "patients",
@@ -765,7 +766,7 @@ func TestBuildReportIncludesQueryInvalidations(t *testing.T) {
 			OwnerID:       "patients",
 			Source:        "pages/patients.page.gwdk",
 		}},
-	}, outputDir)
+	}), outputDir)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -783,7 +784,8 @@ func TestBuildReportIncludesQueryInvalidations(t *testing.T) {
 
 func TestBuildEmitsRealtimeRuntimeForSubscribedRegions(t *testing.T) {
 	outputDir := t.TempDir()
-	result, err := BuildFromValidatedIR(gowdk.Config{Addons: []gowdk.Addon{gowdk.NewAddon("realtime", gowdk.FeatureRealtime)}}, gwdkir.Program{
+	config := gowdk.Config{Addons: []gowdk.Addon{gowdk.NewAddon("realtime", gowdk.FeatureRealtime)}}
+	validated, err := compiler.ValidateIR(config, analyzedIRFixture(t, gwdkir.Program{
 		Pages: []gwdkir.Page{{
 			Source: "pages/patients.page.gwdk",
 			ID:     "patients",
@@ -805,7 +807,11 @@ func TestBuildEmitsRealtimeRuntimeForSubscribedRegions(t *testing.T) {
 			OwnerID:         "patients",
 			Source:          "pages/patients.page.gwdk",
 		}},
-	}, outputDir)
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := BuildFromValidatedProgram(config, validated, outputDir)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -827,7 +833,8 @@ func TestBuildEmitsRealtimeRuntimeForSubscribedRegions(t *testing.T) {
 
 func TestBuildEmitsRealtimeRuntimeForInvalidatedQueryRegions(t *testing.T) {
 	outputDir := t.TempDir()
-	result, err := BuildFromValidatedIR(gowdk.Config{Addons: []gowdk.Addon{gowdk.NewAddon("realtime", gowdk.FeatureRealtime)}}, gwdkir.Program{
+	config := gowdk.Config{Addons: []gowdk.Addon{gowdk.NewAddon("realtime", gowdk.FeatureRealtime)}}
+	validated, err := compiler.ValidateIR(config, analyzedIRFixture(t, gwdkir.Program{
 		Pages: []gwdkir.Page{{
 			Source: "pages/patients.page.gwdk",
 			ID:     "patients",
@@ -849,7 +856,11 @@ func TestBuildEmitsRealtimeRuntimeForInvalidatedQueryRegions(t *testing.T) {
 			OwnerID:       "patients",
 			Source:        "pages/patients.page.gwdk",
 		}},
-	}, outputDir)
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := BuildFromValidatedProgram(config, validated, outputDir)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -955,7 +966,11 @@ func TestBuildReportIncludesHybridRequestTimeSkipMode(t *testing.T) {
 		},
 	}}})
 
-	result, err := buildFromIR(config, ir, nil, outputDir, true)
+	validated, err := compiler.ValidateIR(config, ir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := BuildFromValidatedProgram(config, validated, outputDir)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -993,11 +1008,11 @@ func TestBuildReportIncludesBackendBindingEndpointMetadata(t *testing.T) {
 		Route:        "/login",
 		PackageName:  "auth",
 		FunctionName: "Login",
-		Status:       source.BackendBindingMissing,
+		Status:       source.BackendBindingBound,
 		Message:      "GOWDK action handler auth.Login is not implemented",
 	}}
 
-	result, err := buildFromIR(gowdk.Config{}, ir, bindings, outputDir, true)
+	result, err := BuildFromAnalyzedProgram(gowdk.Config{}, compiler.AnalyzedProgramWithBindings(ir, bindings), outputDir)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1014,7 +1029,7 @@ func TestBuildReportIncludesBackendBindingEndpointMetadata(t *testing.T) {
 		"method":   "POST",
 		"package":  "auth",
 		"function": "Login",
-		"status":   "missing",
+		"status":   "bound",
 		"message":  "GOWDK action handler auth.Login is not implemented",
 	} {
 		if event.Data[key] != expected {

--- a/internal/buildgen/buildgen.go
+++ b/internal/buildgen/buildgen.go
@@ -93,29 +93,3 @@ func isCSSInputName(value string) bool {
 	}
 	return true
 }
-
-func layoutSlotIndexes(source string) [][2]int {
-	var matches [][2]int
-	for index := 0; index < len(source); index++ {
-		if source[index] != '<' || !strings.HasPrefix(source[index:], "<slot") {
-			continue
-		}
-		cursor := index + len("<slot")
-		for cursor < len(source) && (source[cursor] == ' ' || source[cursor] == '\t' || source[cursor] == '\n' || source[cursor] == '\r') {
-			cursor++
-		}
-		if cursor >= len(source) || source[cursor] != '/' {
-			continue
-		}
-		cursor++
-		for cursor < len(source) && (source[cursor] == ' ' || source[cursor] == '\t' || source[cursor] == '\n' || source[cursor] == '\r') {
-			cursor++
-		}
-		if cursor >= len(source) || source[cursor] != '>' {
-			continue
-		}
-		matches = append(matches, [2]int{index, cursor + 1})
-		index = cursor
-	}
-	return matches
-}

--- a/internal/buildgen/css.go
+++ b/internal/buildgen/css.go
@@ -325,13 +325,13 @@ func planComponentCSSStylesheetsByPage(pages []gwdkir.Page, components map[strin
 	}
 	var failures []string
 	for _, page := range pages {
-		viewSource, err := composePageViewSource(page, layouts)
+		viewNodes, err := composePageViewNodes(page, layouts)
 		if err != nil {
 			failures = append(failures, fmt.Sprintf("%s: %v", page.ID, err))
 			continue
 		}
 		pageComponents := componentRegistryForPage(page, components)
-		usages, err := recursiveViewComponentCallUsagesForView(viewSource, composedPageViewNodes(page), pageComponents, page.Package, componentUses(page.Uses))
+		usages, err := recursiveViewComponentCallUsagesForView("", viewNodes, pageComponents, page.Package, componentUses(page.Uses))
 		if err != nil {
 			failures = append(failures, fmt.Sprintf("%s: %v", page.ID, err))
 			continue
@@ -638,21 +638,7 @@ func cssSources(ir gwdkir.Program) []gowdk.CSSSource {
 }
 
 func cssClassesFromViewBlocks(blocks gwdkir.Blocks) []string {
-	if len(blocks.ViewNodes) > 0 {
-		return viewanalysis.ViewDependenciesFromNodes(blocks.ViewNodes).CSSClasses
-	}
-	return cssClassesFromViewBody(blocks.ViewBody)
-}
-
-func cssClassesFromViewBody(body string) []string {
-	if strings.TrimSpace(body) == "" {
-		return nil
-	}
-	dependencies, err := viewanalysis.ViewDependencies(body)
-	if err != nil {
-		return nil
-	}
-	return dependencies.CSSClasses
+	return viewanalysis.ViewDependenciesFromNodes(blocks.ViewNodes).CSSClasses
 }
 
 func nonEmptyStylesheets(stylesheets []gowdk.Stylesheet) []gowdk.Stylesheet {

--- a/internal/buildgen/ir_test.go
+++ b/internal/buildgen/ir_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/cssbruno/gowdk"
+	"github.com/cssbruno/gowdk/internal/compiler"
 	"github.com/cssbruno/gowdk/internal/gwdkanalysis"
 	"github.com/cssbruno/gowdk/internal/gwdkir"
 )
@@ -79,14 +80,14 @@ func TestBuildFromIRWritesArtifacts(t *testing.T) {
 	}
 }
 
-func TestBuildFromValidatedIRChecksInvariants(t *testing.T) {
+func TestBuildFromAnalyzedProgramChecksInvariants(t *testing.T) {
 	invalidIR := gwdkir.Program{Routes: []gwdkir.Route{{
 		Kind:   gwdkir.RouteSPA,
 		Method: "GET",
 		Path:   "/",
 		PageID: "missing",
 	}}}
-	_, err := BuildFromValidatedIR(gowdk.Config{}, invalidIR, t.TempDir())
+	_, err := BuildFromAnalyzedProgram(gowdk.Config{}, compiler.AnalyzedProgramFromIR(invalidIR), t.TempDir())
 	if err == nil {
 		t.Fatal("expected invalid IR error")
 	}
@@ -98,6 +99,26 @@ func TestBuildFromValidatedIRChecksInvariants(t *testing.T) {
 		t.Fatalf("expected invariant error, got %v", err)
 	}
 	requireBuildReportEvent(t, buildErr.Report, "validate", "failed")
+}
+
+func TestBuildFromValidatedProgramRejectsZeroValue(t *testing.T) {
+	_, err := BuildFromValidatedProgram(gowdk.Config{}, compiler.ValidatedProgram{}, t.TempDir())
+	if err == nil {
+		t.Fatal("expected zero-value validated program error")
+	}
+	if !strings.Contains(err.Error(), "not constructed by compiler validation") {
+		t.Fatalf("expected validated program construction error, got %v", err)
+	}
+}
+
+func TestBuildFromPlanRejectsZeroValue(t *testing.T) {
+	_, err := BuildFromPlan(BuildPlan{})
+	if err == nil {
+		t.Fatal("expected zero-value build plan error")
+	}
+	if !strings.Contains(err.Error(), "build plan was not constructed") {
+		t.Fatalf("expected build plan construction error, got %v", err)
+	}
 }
 
 func TestBuildMemoryFromIRCollectsArtifacts(t *testing.T) {

--- a/internal/buildgen/islands_test.go
+++ b/internal/buildgen/islands_test.go
@@ -130,12 +130,17 @@ func TestBuildEmitsJSIslandAssetsForStatefulComponent(t *testing.T) {
 }
 
 func TestPageScriptsReportsComponentTraversalErrors(t *testing.T) {
+	nodes, err := view.Parse(`<main><Broken /></main>`)
+	if err != nil {
+		t.Fatal(err)
+	}
 	page := gwdkir.Page{
 		ID:    "home",
 		Route: "/",
 		Blocks: gwdkir.Blocks{
-			View:     true,
-			ViewBody: `<main><Broken /></main>`,
+			View:      true,
+			ViewBody:  `<main><Broken /></main>`,
+			ViewNodes: nodes,
 		},
 	}
 	components := map[string]view.Component{
@@ -145,7 +150,7 @@ func TestPageScriptsReportsComponentTraversalErrors(t *testing.T) {
 		},
 	}
 
-	_, err := pageScripts(gowdk.Config{}, page, page.Blocks.ViewBody, nil, components, nil, renderModeSPA)
+	_, err = pageScripts(gowdk.Config{}, page, page.Blocks.ViewNodes, components, nil, renderModeSPA)
 	if err == nil {
 		t.Fatal("expected component traversal error")
 	}

--- a/internal/buildgen/render.go
+++ b/internal/buildgen/render.go
@@ -39,19 +39,18 @@ func renderPage(config gowdk.Config, page gwdkir.Page, route string, components 
 	if strings.TrimSpace(page.Blocks.ViewBody) == "" {
 		return "", ssrRegions{}, fmt.Errorf("%s: view {} is empty", page.ID)
 	}
-	viewSource, err := composePageViewSource(page, layouts)
+	viewNodes, err := composePageViewNodes(page, layouts)
 	if err != nil {
 		return "", ssrRegions{}, fmt.Errorf("%s: %w", page.ID, err)
 	}
-	viewNodes := composedPageViewNodes(page)
-	if err := validateViewParamReferences(page, viewSource, viewNodes); err != nil {
+	if err := validateViewParamReferences(page, viewNodes); err != nil {
 		return "", ssrRegions{}, fmt.Errorf("%s: %w", page.ID, err)
 	}
 
 	pageComponents := componentRegistryForPage(page, components)
 	var lists []view.SSRListReplacement
 	var conds []view.SSRCondReplacement
-	body, err := renderPageView(viewSource, viewNodes, pageComponents, data, view.Options{
+	body, err := renderPageView(viewNodes, pageComponents, data, view.Options{
 		Actions:                actionRoutes(page, route, data),
 		ActionInputFields:      actionFields,
 		Package:                page.Package,
@@ -68,7 +67,7 @@ func renderPage(config gowdk.Config, page gwdkir.Page, route string, components 
 	if err != nil {
 		return "", ssrRegions{}, fmt.Errorf("%s: %w", page.ID, err)
 	}
-	scripts, err := pageScripts(config, page, viewSource, viewNodes, pageComponents, queryTypeNames, policy)
+	scripts, err := pageScripts(config, page, viewNodes, pageComponents, queryTypeNames, policy)
 	if err != nil {
 		return "", ssrRegions{}, fmt.Errorf("%s: %w", page.ID, err)
 	}
@@ -145,18 +144,8 @@ func convertSSRListFields(fields []view.SSRListField) []source.SSRListField {
 	return out
 }
 
-func composedPageViewNodes(page gwdkir.Page) []view.Node {
-	if len(page.Layouts) > 0 || len(page.Blocks.ViewNodes) == 0 {
-		return nil
-	}
-	return page.Blocks.ViewNodes
-}
-
-func renderPageView(source string, nodes []view.Node, components map[string]view.Component, data map[string]string, options view.Options) (string, error) {
-	if len(nodes) > 0 {
-		return view.RenderNodesWithOptions(nodes, components, data, options)
-	}
-	return view.RenderWithOptions(source, components, data, options)
+func renderPageView(nodes []view.Node, components map[string]view.Component, data map[string]string, options view.Options) (string, error) {
+	return view.RenderNodesWithOptions(nodes, components, data, options)
 }
 
 // requestTimeTaintedFields returns the interpolation names that carry
@@ -181,52 +170,55 @@ func requestTimeTaintedFields(page gwdkir.Page, policy renderModePolicy) map[str
 	return tainted
 }
 
-func composePageViewSource(page gwdkir.Page, layouts map[string]gwdkir.Layout) (string, error) {
-	source := page.Blocks.ViewBody
+func composePageViewNodes(page gwdkir.Page, layouts map[string]gwdkir.Layout) ([]view.Node, error) {
+	nodes := cloneViewNodes(page.Blocks.ViewNodes)
+	if len(nodes) == 0 && strings.TrimSpace(page.Blocks.ViewBody) != "" {
+		return nil, fmt.Errorf("view {} has source body but no parsed nodes")
+	}
 	if len(layouts) == 0 {
-		return source, nil
+		return nodes, nil
 	}
 	for index := len(page.Layouts) - 1; index >= 0; index-- {
 		layoutRef := page.Layouts[index]
 		layout, ok := resolvePageLayout(page, layouts, layoutRef)
 		if !ok {
-			return "", fmt.Errorf("layout %q is not available for app-shell composition", layoutRef)
+			return nil, fmt.Errorf("layout %q is not available for app-shell composition", layoutRef)
 		}
-		next, err := composeLayoutWithParents(layout, source, layouts, map[string]bool{})
+		next, err := composeLayoutNodesWithParents(layout, nodes, layouts, map[string]bool{})
 		if err != nil {
-			return "", err
+			return nil, err
 		}
-		source = next
+		nodes = next
 	}
-	return source, nil
+	return nodes, nil
 }
 
 // composeLayoutWithParents wraps child in layout's slot, then wraps the result
 // in layout's own layout parent chain (outermost last). The visiting set
 // guards against cyclic inheritance, which validation also rejects.
-func composeLayoutWithParents(layout gwdkir.Layout, child string, layouts map[string]gwdkir.Layout, visiting map[string]bool) (string, error) {
+func composeLayoutNodesWithParents(layout gwdkir.Layout, child []view.Node, layouts map[string]gwdkir.Layout, visiting map[string]bool) ([]view.Node, error) {
 	key := layoutRegistryKey(layout.Package, layout.ID)
 	if visiting[key] {
-		return "", fmt.Errorf("cyclic layout reference at %q", layout.ID)
+		return nil, fmt.Errorf("cyclic layout reference at %q", layout.ID)
 	}
 	visiting[key] = true
 	defer delete(visiting, key)
 
-	source, err := composeLayoutSource(layout, child)
+	nodes, err := composeLayoutNodes(layout, child)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	for index := len(layout.Layouts) - 1; index >= 0; index-- {
 		parent, ok := resolveLayoutParent(layout, layouts, layout.Layouts[index])
 		if !ok {
-			return "", fmt.Errorf("parent layout %q is not available for app-shell composition", layout.Layouts[index])
+			return nil, fmt.Errorf("parent layout %q is not available for app-shell composition", layout.Layouts[index])
 		}
-		source, err = composeLayoutWithParents(parent, source, layouts, visiting)
+		nodes, err = composeLayoutNodesWithParents(parent, nodes, layouts, visiting)
 		if err != nil {
-			return "", err
+			return nil, err
 		}
 	}
-	return source, nil
+	return nodes, nil
 }
 
 func resolveLayoutParent(layout gwdkir.Layout, layouts map[string]gwdkir.Layout, ref string) (gwdkir.Layout, bool) {
@@ -261,26 +253,83 @@ func resolvePageLayout(page gwdkir.Page, layouts map[string]gwdkir.Layout, layou
 	return layout, ok
 }
 
-func composeLayoutSource(layout gwdkir.Layout, child string) (string, error) {
-	matches := layoutSlotIndexes(layout.Blocks.ViewBody)
-	if len(matches) != 1 {
-		return "", fmt.Errorf("layout %s must contain exactly one <slot /> placeholder", layout.ID)
+func composeLayoutNodes(layout gwdkir.Layout, child []view.Node) ([]view.Node, error) {
+	if len(layout.Blocks.ViewNodes) == 0 && strings.TrimSpace(layout.Blocks.ViewBody) != "" {
+		return nil, fmt.Errorf("layout %s has source body but no parsed nodes", layout.ID)
 	}
-	match := matches[0]
-	return layout.Blocks.ViewBody[:match[0]] + child + layout.Blocks.ViewBody[match[1]:], nil
+	nodes, slots := replaceLayoutSlotNodes(layout.Blocks.ViewNodes, child)
+	if slots != 1 {
+		return nil, fmt.Errorf("layout %s must contain exactly one <slot /> placeholder", layout.ID)
+	}
+	return nodes, nil
 }
 
-func validateViewParamReferences(page gwdkir.Page, source string, nodes []view.Node) error {
-	var refs []string
-	if len(nodes) > 0 {
-		refs = viewanalysis.ParamReferencesFromNodes(nodes)
-	} else {
-		var err error
-		refs, err = viewanalysis.ParamReferences(source)
-		if err != nil {
-			return err
+func replaceLayoutSlotNodes(nodes []view.Node, child []view.Node) ([]view.Node, int) {
+	var out []view.Node
+	slots := 0
+	for _, node := range nodes {
+		switch typed := node.(type) {
+		case view.Element:
+			if isDefaultLayoutSlot(typed) {
+				out = append(out, cloneViewNodes(child)...)
+				slots++
+				continue
+			}
+			typed.Children, slots = replaceLayoutSlotChildren(typed.Children, child, slots)
+			out = append(out, typed)
+		case view.ComponentCall:
+			typed.Children, slots = replaceLayoutSlotChildren(typed.Children, child, slots)
+			out = append(out, typed)
+		case view.AwaitBlock:
+			typed.Pending, slots = replaceLayoutSlotChildren(typed.Pending, child, slots)
+			typed.Then, slots = replaceLayoutSlotChildren(typed.Then, child, slots)
+			typed.Catch, slots = replaceLayoutSlotChildren(typed.Catch, child, slots)
+			out = append(out, typed)
+		default:
+			out = append(out, node)
 		}
 	}
+	return out, slots
+}
+
+func replaceLayoutSlotChildren(nodes []view.Node, child []view.Node, slots int) ([]view.Node, int) {
+	replaced, count := replaceLayoutSlotNodes(nodes, child)
+	return replaced, slots + count
+}
+
+func isDefaultLayoutSlot(node view.Element) bool {
+	return node.Name == "slot" && len(node.Attrs) == 0 && len(node.Children) == 0
+}
+
+func cloneViewNodes(nodes []view.Node) []view.Node {
+	if len(nodes) == 0 {
+		return nil
+	}
+	out := make([]view.Node, 0, len(nodes))
+	for _, node := range nodes {
+		switch typed := node.(type) {
+		case view.Element:
+			typed.Attrs = append([]view.Attr(nil), typed.Attrs...)
+			typed.Children = cloneViewNodes(typed.Children)
+			out = append(out, typed)
+		case view.ComponentCall:
+			typed.Attrs = append([]view.Attr(nil), typed.Attrs...)
+			typed.Children = cloneViewNodes(typed.Children)
+			out = append(out, typed)
+		case view.AwaitBlock:
+			typed.Pending = cloneViewNodes(typed.Pending)
+			typed.Then = cloneViewNodes(typed.Then)
+			typed.Catch = cloneViewNodes(typed.Catch)
+			out = append(out, typed)
+		default:
+			out = append(out, node)
+		}
+	}
+	return out
+}
+
+func validateViewParamReferences(page gwdkir.Page, nodes []view.Node) error {
+	refs := viewanalysis.ParamReferencesFromNodes(nodes)
 	if len(refs) == 0 {
 		return nil
 	}
@@ -309,21 +358,21 @@ func actionRoutes(page gwdkir.Page, pageRoute string, data map[string]string) ma
 	return routes
 }
 
-func pageScripts(config gowdk.Config, page gwdkir.Page, viewSource string, viewNodes []view.Node, components map[string]view.Component, queryTypeNames map[string]string, policy renderModePolicy) ([]gowdk.Script, error) {
+func pageScripts(config gowdk.Config, page gwdkir.Page, viewNodes []view.Node, components map[string]view.Component, queryTypeNames map[string]string, policy renderModePolicy) ([]gowdk.Script, error) {
 	scripts := append([]gowdk.Script{}, nonEmptyScripts(config.Build.Scripts)...)
-	hrefs, err := scopedScriptHrefs(page, viewSource, viewNodes, components)
+	hrefs, err := scopedScriptHrefs(page, "", viewNodes, components)
 	if err != nil {
 		return nil, err
 	}
 	for _, href := range hrefs {
 		scripts = append(scripts, gowdk.Script{Src: href, Type: "module"})
 	}
-	usesPartial := pageUsesPartialRuntime(page, viewSource)
-	usesRealtime, err := pageUsesRealtimeRuntime(page, viewSource, viewNodes, components, queryTypeNames)
+	usesPartial := pageUsesPartialRuntime(page, viewNodes)
+	usesRealtime, err := pageUsesRealtimeRuntime(page, viewNodes, components, queryTypeNames)
 	if err != nil {
 		return nil, err
 	}
-	usesCommand, err := pageUsesCommandRuntime(page, viewSource, viewNodes, components)
+	usesCommand, err := pageUsesCommandRuntime(page, viewNodes, components)
 	if err != nil {
 		return nil, err
 	}
@@ -341,7 +390,7 @@ func pageScripts(config gowdk.Config, page gwdkir.Page, viewSource string, viewN
 		}
 		return scripts, nil
 	}
-	usesSPANavigation, err := pageUsesSPANavigationRuntime(config, page, viewSource, viewNodes, components)
+	usesSPANavigation, err := pageUsesSPANavigationRuntime(config, page, viewNodes, components)
 	if err != nil {
 		return nil, err
 	}
@@ -351,7 +400,7 @@ func pageScripts(config gowdk.Config, page gwdkir.Page, viewSource string, viewN
 	if len(page.Stores) > 0 {
 		scripts = append(scripts, gowdk.Script{Src: storeRuntimeHref})
 	}
-	islandScripts, err := islandScriptHrefsForView(viewSource, viewNodes, components, page.Package, componentUses(page.Uses))
+	islandScripts, err := islandScriptHrefsForView("", viewNodes, components, page.Package, componentUses(page.Uses))
 	if err != nil {
 		return nil, err
 	}
@@ -364,29 +413,26 @@ func pageScripts(config gowdk.Config, page gwdkir.Page, viewSource string, viewN
 	return scripts, nil
 }
 
-func pageUsesPartialRuntime(page gwdkir.Page, viewSource string) bool {
-	if !strings.Contains(viewSource, "g:target") {
-		return false
-	}
-	return len(page.Blocks.Actions) > 0
+func pageUsesPartialRuntime(page gwdkir.Page, viewNodes []view.Node) bool {
+	return len(page.Blocks.Actions) > 0 && nodesHaveAttr(viewNodes, "g:target")
 }
 
-func pageUsesRealtimeRuntime(page gwdkir.Page, viewSource string, viewNodes []view.Node, components map[string]view.Component, queryTypeNames map[string]string) (bool, error) {
-	if viewHasRealtimeSubscription(viewSource, viewNodes) {
+func pageUsesRealtimeRuntime(page gwdkir.Page, viewNodes []view.Node, components map[string]view.Component, queryTypeNames map[string]string) (bool, error) {
+	if viewHasRealtimeSubscription(viewNodes) {
 		return true, nil
 	}
-	if viewHasInvalidatedQuery(viewSource, viewNodes, queryTypeNames) {
+	if viewHasInvalidatedQuery(viewNodes, queryTypeNames) {
 		return true, nil
 	}
-	usages, err := recursiveViewComponentCallUsagesForView(viewSource, viewNodes, components, page.Package, componentUses(page.Uses))
+	usages, err := recursiveViewComponentCallUsagesForView("", viewNodes, components, page.Package, componentUses(page.Uses))
 	if err != nil {
 		return false, err
 	}
 	for _, usage := range usages {
-		if viewHasRealtimeSubscription(usage.component.Body, usage.component.Nodes) {
+		if viewHasRealtimeSubscription(usage.component.Nodes) {
 			return true, nil
 		}
-		if viewHasInvalidatedQuery(usage.component.Body, usage.component.Nodes, queryTypeNames) {
+		if viewHasInvalidatedQuery(usage.component.Nodes, queryTypeNames) {
 			return true, nil
 		}
 	}
@@ -397,62 +443,37 @@ func pageUsesRealtimeRuntime(page gwdkir.Page, viewSource string, viewNodes []vi
 // declares a g:command write form. Such forms need the client interceptor so a
 // submit posts in the background and applies the server's region refresh,
 // instead of natively navigating to the adapter's raw JSON response.
-func pageUsesCommandRuntime(page gwdkir.Page, viewSource string, viewNodes []view.Node, components map[string]view.Component) (bool, error) {
-	if viewHasCommandForm(viewSource, viewNodes) {
+func pageUsesCommandRuntime(page gwdkir.Page, viewNodes []view.Node, components map[string]view.Component) (bool, error) {
+	if viewHasCommandForm(viewNodes) {
 		return true, nil
 	}
-	usages, err := recursiveViewComponentCallUsagesForView(viewSource, viewNodes, components, page.Package, componentUses(page.Uses))
+	usages, err := recursiveViewComponentCallUsagesForView("", viewNodes, components, page.Package, componentUses(page.Uses))
 	if err != nil {
 		return false, err
 	}
 	for _, usage := range usages {
-		if viewHasCommandForm(usage.component.Body, usage.component.Nodes) {
+		if viewHasCommandForm(usage.component.Nodes) {
 			return true, nil
 		}
 	}
 	return false, nil
 }
 
-func viewHasCommandForm(source string, nodes []view.Node) bool {
-	if !strings.Contains(source, "g:command") && len(nodes) == 0 {
-		return false
-	}
-	var refs []viewanalysis.CommandReference
-	var err error
-	if len(nodes) > 0 {
-		refs, err = viewanalysis.CommandReferencesFromNodes(nodes)
-	} else {
-		refs, err = viewanalysis.CommandReferences(source)
-	}
+func viewHasCommandForm(nodes []view.Node) bool {
+	refs, err := viewanalysis.CommandReferencesFromNodes(nodes)
 	return err == nil && len(refs) > 0
 }
 
-func viewHasRealtimeSubscription(source string, nodes []view.Node) bool {
-	if !strings.Contains(source, "g:subscribe") && len(nodes) == 0 {
-		return false
-	}
-	if len(nodes) > 0 {
-		refs, err := viewanalysis.SubscriptionReferencesFromNodes(nodes)
-		return err == nil && len(refs) > 0
-	}
-	refs, err := viewanalysis.SubscriptionReferences(source)
+func viewHasRealtimeSubscription(nodes []view.Node) bool {
+	refs, err := viewanalysis.SubscriptionReferencesFromNodes(nodes)
 	return err == nil && len(refs) > 0
 }
 
-func viewHasInvalidatedQuery(source string, nodes []view.Node, queryTypeNames map[string]string) bool {
+func viewHasInvalidatedQuery(nodes []view.Node, queryTypeNames map[string]string) bool {
 	if len(queryTypeNames) == 0 {
 		return false
 	}
-	if !strings.Contains(source, "g:query") && len(nodes) == 0 {
-		return false
-	}
-	var refs []viewanalysis.QueryReference
-	var err error
-	if len(nodes) > 0 {
-		refs, err = viewanalysis.QueryReferencesFromNodes(nodes)
-	} else {
-		refs, err = viewanalysis.QueryReferences(source)
-	}
+	refs, err := viewanalysis.QueryReferencesFromNodes(nodes)
 	if err != nil {
 		return false
 	}
@@ -464,35 +485,24 @@ func viewHasInvalidatedQuery(source string, nodes []view.Node, queryTypeNames ma
 	return false
 }
 
-func pageUsesSPANavigationRuntime(config gowdk.Config, page gwdkir.Page, viewSource string, viewNodes []view.Node, components map[string]view.Component) (bool, error) {
+func pageUsesSPANavigationRuntime(config gowdk.Config, page gwdkir.Page, viewNodes []view.Node, components map[string]view.Component) (bool, error) {
 	mode := page.RenderMode(config.Render.DefaultMode())
 	if mode != gowdk.SPA {
 		return false, nil
 	}
-	if viewHasInternalLink(viewSource, viewNodes) {
+	if nodesHaveInternalLink(viewNodes) {
 		return true, nil
 	}
-	usages, err := recursiveViewComponentCallUsagesForView(viewSource, viewNodes, components, page.Package, componentUses(page.Uses))
+	usages, err := recursiveViewComponentCallUsagesForView("", viewNodes, components, page.Package, componentUses(page.Uses))
 	if err != nil {
 		return false, err
 	}
 	for _, usage := range usages {
-		if viewHasInternalLink(usage.component.Body, usage.component.Nodes) {
+		if nodesHaveInternalLink(usage.component.Nodes) {
 			return true, nil
 		}
 	}
 	return false, nil
-}
-
-func viewHasInternalLink(source string, nodes []view.Node) bool {
-	if len(nodes) > 0 {
-		return nodesHaveInternalLink(nodes)
-	}
-	nodes, err := view.Parse(source)
-	if err != nil {
-		return false
-	}
-	return nodesHaveInternalLink(nodes)
 }
 
 func nodesHaveInternalLink(nodes []view.Node) bool {
@@ -511,6 +521,36 @@ func nodesHaveInternalLink(nodes []view.Node) bool {
 			}
 		case view.ComponentCall:
 			if nodesHaveInternalLink(typed.Children) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func nodesHaveAttr(nodes []view.Node, name string) bool {
+	for _, node := range nodes {
+		switch typed := node.(type) {
+		case view.Element:
+			for _, attr := range typed.Attrs {
+				if attr.Name == name {
+					return true
+				}
+			}
+			if nodesHaveAttr(typed.Children, name) {
+				return true
+			}
+		case view.ComponentCall:
+			for _, attr := range typed.Attrs {
+				if attr.Name == name {
+					return true
+				}
+			}
+			if nodesHaveAttr(typed.Children, name) {
+				return true
+			}
+		case view.AwaitBlock:
+			if nodesHaveAttr(typed.Pending, name) || nodesHaveAttr(typed.Then, name) || nodesHaveAttr(typed.Catch, name) {
 				return true
 			}
 		}

--- a/internal/buildgen/runtime_assets.go
+++ b/internal/buildgen/runtime_assets.go
@@ -12,24 +12,23 @@ import (
 func clientRuntimeArtifacts(config gowdk.Config, ir gwdkir.Program, outputDir string, layouts map[string]gwdkir.Layout, components map[string]view.Component) ([]plannedAssetArtifact, error) {
 	queryTypeNames := queryInvalidationTypeNames(ir.QueryInvalidations)
 	for _, page := range ir.Pages {
-		viewSource, err := composePageViewSource(page, layouts)
+		viewNodes, err := composePageViewNodes(page, layouts)
 		if err != nil {
 			return nil, err
 		}
-		viewNodes := composedPageViewNodes(page)
-		usesSPANavigation, err := pageUsesSPANavigationRuntime(config, page, viewSource, viewNodes, components)
+		usesSPANavigation, err := pageUsesSPANavigationRuntime(config, page, viewNodes, components)
 		if err != nil {
 			return nil, err
 		}
-		usesRealtime, err := pageUsesRealtimeRuntime(page, viewSource, viewNodes, components, queryTypeNames)
+		usesRealtime, err := pageUsesRealtimeRuntime(page, viewNodes, components, queryTypeNames)
 		if err != nil {
 			return nil, err
 		}
-		usesCommand, err := pageUsesCommandRuntime(page, viewSource, viewNodes, components)
+		usesCommand, err := pageUsesCommandRuntime(page, viewNodes, components)
 		if err != nil {
 			return nil, err
 		}
-		if pageUsesPartialRuntime(page, viewSource) || usesSPANavigation || usesRealtime || usesCommand {
+		if pageUsesPartialRuntime(page, viewNodes) || usesSPANavigation || usesRealtime || usesCommand {
 			return []plannedAssetArtifact{{
 				AssetArtifact:        AssetArtifact{Path: filepath.Join(outputDir, filepath.FromSlash(clientRuntimeAssetPath))},
 				contents:             clientrt.Source(),

--- a/internal/buildgen/runtime_islands.go
+++ b/internal/buildgen/runtime_islands.go
@@ -18,11 +18,11 @@ func islandRuntimeArtifacts(config gowdk.Config, pages []gwdkir.Page, allCompone
 	includeSourceMaps := config.Build.DebugAssets()
 	planned := map[string]plannedAssetArtifact{}
 	for _, page := range pages {
-		source, err := composePageViewSource(page, layouts)
+		nodes, err := composePageViewNodes(page, layouts)
 		if err != nil {
-			return nil, fmt.Errorf("compose island view source for page %q: %w", page.ID, err)
+			return nil, fmt.Errorf("compose island view nodes for page %q: %w", page.ID, err)
 		}
-		usages, err := recursiveComponentCallUsagesForView(source, composedPageViewNodes(page), components, page.Package, componentUses(page.Uses), manifestComponentResolver)
+		usages, err := recursiveComponentCallUsagesForView("", nodes, components, page.Package, componentUses(page.Uses), manifestComponentResolver)
 		if err != nil {
 			return nil, fmt.Errorf("resolve island components for page %q: %w", page.ID, err)
 		}

--- a/internal/buildgen/seo.go
+++ b/internal/buildgen/seo.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/cssbruno/gowdk"
+	"github.com/cssbruno/gowdk/internal/compiler"
 	"github.com/cssbruno/gowdk/internal/gwdkir"
 	gowdkauth "github.com/cssbruno/gowdk/runtime/auth"
 	runtimeseo "github.com/cssbruno/gowdk/runtime/seo"
@@ -82,6 +83,20 @@ func planSEOArtifacts(config gowdk.Config, ir gwdkir.Program, artifacts []Artifa
 }
 
 func RuntimeSitemapPlanFromIR(config gowdk.Config, ir gwdkir.Program) (RuntimeSitemapPlan, error) {
+	validated, err := compiler.ValidateIR(config, ir)
+	if err != nil {
+		return RuntimeSitemapPlan{}, err
+	}
+	return RuntimeSitemapPlanFromValidatedProgram(config, validated)
+}
+
+// RuntimeSitemapPlanFromValidatedProgram builds the generated app runtime
+// sitemap plan from compiler-validated IR.
+func RuntimeSitemapPlanFromValidatedProgram(config gowdk.Config, validated compiler.ValidatedProgram) (RuntimeSitemapPlan, error) {
+	if !validated.Valid() {
+		return RuntimeSitemapPlan{}, fmt.Errorf("validated program was not constructed by compiler validation")
+	}
+	ir := validated.Program()
 	options, enabled, err := seoOptionsFromConfig(config)
 	if err != nil || !enabled {
 		return RuntimeSitemapPlan{}, err

--- a/internal/buildgen/seo_test.go
+++ b/internal/buildgen/seo_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/cssbruno/gowdk"
 	"github.com/cssbruno/gowdk/addons/seo"
 	"github.com/cssbruno/gowdk/addons/ssr"
+	"github.com/cssbruno/gowdk/internal/compiler"
 	"github.com/cssbruno/gowdk/internal/gwdkanalysis"
 	"github.com/cssbruno/gowdk/internal/gwdkir"
 )
@@ -254,7 +255,7 @@ func TestRuntimeSitemapPlanIncludesStaticPublicURLsAndDynamicHook(t *testing.T) 
 		}),
 		ssr.Addon(),
 	}}
-	plan, err := RuntimeSitemapPlanFromIR(config, gwdkir.Program{Pages: []gwdkir.Page{
+	plan, err := RuntimeSitemapPlanFromIR(config, analyzedIRFixture(t, gwdkir.Program{Pages: []gwdkir.Page{
 		seoHomePage(),
 		{
 			ID:     "post",
@@ -289,7 +290,7 @@ func TestRuntimeSitemapPlanIncludesStaticPublicURLsAndDynamicHook(t *testing.T) 
 				ViewBody: `<main>Draft</main>`,
 			},
 		},
-	}})
+	}}))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -325,11 +326,21 @@ func TestRuntimeSitemapPlanRejectsPartialDynamicHook(t *testing.T) {
 			},
 		}),
 	}}
-	_, err := RuntimeSitemapPlanFromIR(config, gwdkir.Program{Pages: []gwdkir.Page{seoHomePage()}})
+	_, err := RuntimeSitemapPlanFromIR(config, analyzedIRFixture(t, gwdkir.Program{Pages: []gwdkir.Page{seoHomePage()}}))
 	if err == nil {
 		t.Fatal("expected partial dynamic sitemap hook to fail")
 	}
 	if !strings.Contains(err.Error(), "DynamicSitemap.ImportPath") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRuntimeSitemapPlanFromValidatedProgramRejectsZeroValue(t *testing.T) {
+	_, err := RuntimeSitemapPlanFromValidatedProgram(gowdk.Config{}, compiler.ValidatedProgram{})
+	if err == nil {
+		t.Fatal("expected zero-value validated program error")
+	}
+	if !strings.Contains(err.Error(), "not constructed by compiler validation") {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }

--- a/internal/buildgen/ssr.go
+++ b/internal/buildgen/ssr.go
@@ -51,19 +51,34 @@ type SSRListSpec = source.SSRListSpec
 type SSRCondSpec = source.SSRCondSpec
 
 func SSRArtifacts(config gowdk.Config, sources gwdkanalysis.Sources, outputDir string) ([]SSRArtifact, error) {
-	ir, _, err := compiler.AssembleProgram(config, sources)
+	analyzed, err := compiler.AnalyzeProgram(config, sources)
 	if err != nil {
 		return nil, err
 	}
-	return SSRArtifactsFromIR(config, ir, outputDir)
+	validated, err := compiler.ValidateAnalyzedProgram(config, analyzed)
+	if err != nil {
+		return nil, err
+	}
+	return SSRArtifactsFromValidatedProgram(config, validated, outputDir)
 }
 
 // SSRArtifactsFromIR renders request-time page artifacts from normalized
 // compiler IR.
 func SSRArtifactsFromIR(config gowdk.Config, ir gwdkir.Program, outputDir string) ([]SSRArtifact, error) {
-	if err := compiler.ValidateProgram(config, ir); err != nil {
+	validated, err := compiler.ValidateIR(config, ir)
+	if err != nil {
 		return nil, err
 	}
+	return SSRArtifactsFromValidatedProgram(config, validated, outputDir)
+}
+
+// SSRArtifactsFromValidatedProgram renders request-time page artifacts from
+// compiler-validated IR.
+func SSRArtifactsFromValidatedProgram(config gowdk.Config, validated compiler.ValidatedProgram, outputDir string) ([]SSRArtifact, error) {
+	if !validated.Valid() {
+		return nil, fmt.Errorf("validated program was not constructed by compiler validation")
+	}
+	ir := validated.Program()
 
 	components, componentFailures := buildComponents(ir.Components)
 	layouts, layoutFailures := buildLayouts(ir.Layouts)

--- a/internal/buildgen/ssr_test.go
+++ b/internal/buildgen/ssr_test.go
@@ -8,10 +8,21 @@ import (
 	"testing"
 
 	"github.com/cssbruno/gowdk"
+	"github.com/cssbruno/gowdk/internal/compiler"
 	"github.com/cssbruno/gowdk/internal/gwdkanalysis"
 	"github.com/cssbruno/gowdk/internal/gwdkir"
 	"github.com/cssbruno/gowdk/internal/source"
 )
+
+func TestSSRArtifactsFromValidatedProgramRejectsZeroValue(t *testing.T) {
+	_, err := SSRArtifactsFromValidatedProgram(gowdk.Config{}, compiler.ValidatedProgram{}, t.TempDir())
+	if err == nil {
+		t.Fatal("expected zero-value validated program error")
+	}
+	if !strings.Contains(err.Error(), "not constructed by compiler validation") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
 
 func TestBuildSkipsRequestTimePagesAndKeepsSPAArtifacts(t *testing.T) {
 	outputDir := t.TempDir()
@@ -149,7 +160,7 @@ func TestSSRArtifactsEmitClientRuntimeForInvalidatedQueryRegions(t *testing.T) {
 		gowdk.NewAddon("ssr", gowdk.FeatureSSR),
 		gowdk.NewAddon("realtime", gowdk.FeatureRealtime),
 	}}
-	program := gwdkir.Program{
+	program := analyzedIRFixture(t, gwdkir.Program{
 		Pages: []gwdkir.Page{{
 			Source: "pages/board.page.gwdk",
 			ID:     "board",
@@ -171,7 +182,7 @@ func TestSSRArtifactsEmitClientRuntimeForInvalidatedQueryRegions(t *testing.T) {
 			OwnerID:       "board",
 			Source:        "pages/board.page.gwdk",
 		}},
-	}
+	})
 
 	artifacts, err := SSRArtifactsFromIR(config, program, outputDir)
 	if err != nil {
@@ -195,7 +206,7 @@ func TestSSRArtifactsEmitClientRuntimeForInvalidatedQueryRegions(t *testing.T) {
 func TestSSRArtifactsEmitClientRuntimeForCommandWriteForm(t *testing.T) {
 	outputDir := t.TempDir()
 	config := gowdk.Config{Addons: []gowdk.Addon{gowdk.NewAddon("ssr", gowdk.FeatureSSR)}}
-	program := gwdkir.Program{
+	program := analyzedIRFixture(t, gwdkir.Program{
 		Pages: []gwdkir.Page{{
 			Source: "pages/board.page.gwdk",
 			ID:     "board",
@@ -206,7 +217,7 @@ func TestSSRArtifactsEmitClientRuntimeForCommandWriteForm(t *testing.T) {
 				ViewBody: `<main><form g:command="issues.CreateIssue"><input name="title" /></form></main>`,
 			},
 		}},
-	}
+	})
 
 	artifacts, err := SSRArtifactsFromIR(config, program, outputDir)
 	if err != nil {
@@ -225,7 +236,7 @@ func TestSSRArtifactsEmitClientRuntimeForCommandWriteForm(t *testing.T) {
 func TestSSRArtifactsOmitClientRuntimeWithoutRuntimeRegions(t *testing.T) {
 	outputDir := t.TempDir()
 	config := gowdk.Config{Addons: []gowdk.Addon{gowdk.NewAddon("ssr", gowdk.FeatureSSR)}}
-	program := gwdkir.Program{
+	program := analyzedIRFixture(t, gwdkir.Program{
 		Pages: []gwdkir.Page{{
 			Source: "pages/board.page.gwdk",
 			ID:     "board",
@@ -236,7 +247,7 @@ func TestSSRArtifactsOmitClientRuntimeWithoutRuntimeRegions(t *testing.T) {
 				ViewBody: `<main><h1>Board</h1></main>`,
 			},
 		}},
-	}
+	})
 
 	artifacts, err := SSRArtifactsFromIR(config, program, outputDir)
 	if err != nil {
@@ -471,7 +482,7 @@ func TestSSRArtifactsPreserveTypedLoadResultMetadata(t *testing.T) {
 		{Path: "user.name", Selector: "User.Name", Type: "string"},
 		{Path: "User.Name", Selector: "User.Name", Type: "string"},
 	}
-	program := gwdkir.Program{Pages: []gwdkir.Page{{
+	program := analyzedIRFixture(t, gwdkir.Program{Pages: []gwdkir.Page{{
 		ID:     "dashboard",
 		Route:  "/dashboard",
 		Render: gowdk.SSR,
@@ -491,7 +502,7 @@ func TestSSRArtifactsPreserveTypedLoadResultMetadata(t *testing.T) {
 			View:       true,
 			ViewBody:   `<main>{user.name}</main>`,
 		},
-	}}}
+	}}})
 
 	artifacts, err := SSRArtifactsFromIR(config, program, t.TempDir())
 	if err != nil {

--- a/internal/buildgen/test_helpers_test.go
+++ b/internal/buildgen/test_helpers_test.go
@@ -4,11 +4,13 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/cssbruno/gowdk"
 	"github.com/cssbruno/gowdk/internal/gwdkanalysis"
 	"github.com/cssbruno/gowdk/internal/gwdkir"
+	view "github.com/cssbruno/gowdk/internal/viewrender"
 )
 
 // irComponent converts a gwdkir.Component fixture into the IR component the
@@ -20,6 +22,42 @@ func irComponent(component gwdkir.Component) gwdkir.Component {
 		return gwdkir.Component{}
 	}
 	return ir.Components[0]
+}
+
+func analyzedIRFixture(t *testing.T, program gwdkir.Program) gwdkir.Program {
+	t.Helper()
+	parseBlocks := func(blocks *gwdkir.Blocks) {
+		t.Helper()
+		if strings.TrimSpace(blocks.ViewBody) == "" {
+			return
+		}
+		blocks.View = true
+		nodes, err := view.Parse(blocks.ViewBody)
+		if err != nil {
+			t.Fatal(err)
+		}
+		blocks.ViewNodes = nodes
+	}
+	for index := range program.Pages {
+		parseBlocks(&program.Pages[index].Blocks)
+	}
+	for index := range program.Components {
+		parseBlocks(&program.Components[index].Blocks)
+	}
+	for index := range program.Layouts {
+		parseBlocks(&program.Layouts[index].Blocks)
+	}
+	for index := range program.Templates {
+		if strings.TrimSpace(program.Templates[index].Body) == "" {
+			continue
+		}
+		nodes, err := view.Parse(program.Templates[index].Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		program.Templates[index].Nodes = nodes
+	}
+	return program
 }
 
 type testRouteManifest struct {

--- a/internal/compiler/phases.go
+++ b/internal/compiler/phases.go
@@ -1,0 +1,110 @@
+package compiler
+
+import (
+	"github.com/cssbruno/gowdk"
+	"github.com/cssbruno/gowdk/internal/gwdkanalysis"
+	"github.com/cssbruno/gowdk/internal/gwdkir"
+	"github.com/cssbruno/gowdk/internal/source"
+)
+
+// AnalyzedProgram is the output of source lowering plus compiler enrichment.
+// It is intentionally distinct from ValidatedProgram: analyzed IR may still
+// contain authoring errors and must not be used by emission fast paths.
+type AnalyzedProgram struct {
+	ir       gwdkir.Program
+	bindings []source.BackendBinding
+}
+
+// ValidatedProgram is the compiler-owned phase token for IR that passed
+// semantic validation and backend binding diagnostics.
+type ValidatedProgram struct {
+	ir       gwdkir.Program
+	bindings []source.BackendBinding
+	report   ValidationErrors
+	valid    bool
+}
+
+// AnalyzeProgram builds and enriches compiler IR from parsed sources.
+func AnalyzeProgram(config gowdk.Config, sources gwdkanalysis.Sources) (AnalyzedProgram, error) {
+	ir, bindings, err := AssembleProgram(config, sources)
+	if err != nil {
+		return AnalyzedProgram{}, err
+	}
+	return AnalyzedProgram{ir: ir, bindings: append([]source.BackendBinding(nil), bindings...)}, nil
+}
+
+// AnalyzedProgramFromIR wraps an existing IR value for callers that already own
+// the parse/analyze phase. It does not validate the program.
+func AnalyzedProgramFromIR(ir gwdkir.Program) AnalyzedProgram {
+	return AnalyzedProgram{ir: ir, bindings: BackendBindingsFromIR(ir)}
+}
+
+// AnalyzedProgramWithBindings wraps IR with a caller-owned backend binding
+// projection for tests and orchestrators that already performed binding.
+func AnalyzedProgramWithBindings(ir gwdkir.Program, bindings []source.BackendBinding) AnalyzedProgram {
+	return AnalyzedProgram{ir: ir, bindings: append([]source.BackendBinding(nil), bindings...)}
+}
+
+// Program returns the underlying compiler IR by value.
+func (program AnalyzedProgram) Program() gwdkir.Program {
+	return program.ir
+}
+
+// BackendBindings returns a copy of the backend binding projection.
+func (program AnalyzedProgram) BackendBindings() []source.BackendBinding {
+	return append([]source.BackendBinding(nil), program.bindings...)
+}
+
+// ValidateAnalyzedProgram validates analyzed IR and returns an opaque phase
+// token accepted by generated-output fast paths.
+func ValidateAnalyzedProgram(config gowdk.Config, program AnalyzedProgram) (ValidatedProgram, error) {
+	validated, report := ValidateAnalyzedProgramReport(config, program)
+	if report.HasErrors() {
+		return ValidatedProgram{}, report
+	}
+	return validated, nil
+}
+
+// ValidateAnalyzedProgramReport is the reporting form of
+// ValidateAnalyzedProgram. Warning-only reports still return a ValidatedProgram.
+func ValidateAnalyzedProgramReport(config gowdk.Config, program AnalyzedProgram) (ValidatedProgram, ValidationErrors) {
+	report := validateProgram(config, program.ir, true)
+	report = append(report, BackendBindingDiagnostics(program.bindings)...)
+	report = normalizeValidationErrors(report)
+	if report.HasErrors() {
+		return ValidatedProgram{}, report
+	}
+	return ValidatedProgram{
+		ir:       program.ir,
+		bindings: program.BackendBindings(),
+		report:   append(ValidationErrors(nil), report...),
+		valid:    true,
+	}, report
+}
+
+// Valid reports whether this value was returned by compiler validation.
+func (program ValidatedProgram) Valid() bool {
+	return program.valid
+}
+
+// ValidateIR validates an existing compiler IR value and returns the validated
+// phase token. New code should prefer AnalyzeProgram when starting from source.
+func ValidateIR(config gowdk.Config, ir gwdkir.Program) (ValidatedProgram, error) {
+	return ValidateAnalyzedProgram(config, AnalyzedProgramFromIR(ir))
+}
+
+// Program returns the validated compiler IR by value.
+func (program ValidatedProgram) Program() gwdkir.Program {
+	return program.ir
+}
+
+// BackendBindings returns a copy of the backend binding projection that was
+// validated with this program.
+func (program ValidatedProgram) BackendBindings() []source.BackendBinding {
+	return append([]source.BackendBinding(nil), program.bindings...)
+}
+
+// Report returns the warning-only validation report, if any.
+func (program ValidatedProgram) Report() ValidationErrors {
+	return append(ValidationErrors(nil), program.report...)
+}

--- a/internal/compiler/validate.go
+++ b/internal/compiler/validate.go
@@ -2,6 +2,7 @@ package compiler
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/cssbruno/gowdk"
 	"github.com/cssbruno/gowdk/internal/diagnostics"
@@ -78,8 +79,9 @@ func asError(report ValidationErrors) error {
 }
 
 func validateProgram(config gowdk.Config, ir gwdkir.Program, crossFile bool) ValidationErrors {
-	if err := gwdkir.CheckInvariants(ir); err != nil {
-		return normalizeValidationErrors([]ValidationError{{Message: fmt.Sprintf("internal compiler error: %v", err)}})
+	invariantErr := gwdkir.CheckInvariants(ir)
+	if invariantErr != nil && !onlyMissingViewNodesInvariant(invariantErr) {
+		return normalizeValidationErrors([]ValidationError{{Message: fmt.Sprintf("internal compiler error: %v", invariantErr)}})
 	}
 	var diagnostics ValidationErrors
 	diagnostics = append(diagnostics, validateIRDiagnostics(ir.Diagnostics)...)
@@ -109,7 +111,23 @@ func validateProgram(config gowdk.Config, ir gwdkir.Program, crossFile bool) Val
 		diagnostics = append(diagnostics, ValidatePage(config, page)...)
 		diagnostics = append(diagnostics, validatePageServerLists(page)...)
 	}
+	if invariantErr != nil && !diagnostics.HasErrors() {
+		diagnostics = append(diagnostics, ValidationError{Message: fmt.Sprintf("internal compiler error: %v", invariantErr)})
+	}
 	return normalizeValidationErrors(diagnostics)
+}
+
+func onlyMissingViewNodesInvariant(err error) bool {
+	message := strings.TrimPrefix(err.Error(), "invalid IR: ")
+	if message == "" {
+		return false
+	}
+	for _, part := range strings.Split(message, "; ") {
+		if !strings.Contains(part, "has view body but no parsed nodes") {
+			return false
+		}
+	}
+	return true
 }
 
 func validateIRDiagnostics(items []gwdkir.Diagnostic) []ValidationError {

--- a/internal/compiler/validate_page_contract_client.go
+++ b/internal/compiler/validate_page_contract_client.go
@@ -2,7 +2,6 @@ package compiler
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/cssbruno/gowdk"
 	"github.com/cssbruno/gowdk/internal/gwdkir"
@@ -55,21 +54,9 @@ func validatePageContractClient(page gwdkir.Page, mode gowdk.RenderMode) []Valid
 }
 
 func pageQueryReferences(page gwdkir.Page) ([]viewanalysis.QueryReference, error) {
-	if len(page.Blocks.ViewNodes) > 0 {
-		return viewanalysis.QueryReferencesFromNodes(page.Blocks.ViewNodes)
-	}
-	if strings.TrimSpace(page.Blocks.ViewBody) == "" {
-		return nil, nil
-	}
-	return viewanalysis.QueryReferences(page.Blocks.ViewBody)
+	return viewanalysis.QueryReferencesFromNodes(page.Blocks.ViewNodes)
 }
 
 func pageCommandReferences(page gwdkir.Page) ([]viewanalysis.CommandReference, error) {
-	if len(page.Blocks.ViewNodes) > 0 {
-		return viewanalysis.CommandReferencesFromNodes(page.Blocks.ViewNodes)
-	}
-	if strings.TrimSpace(page.Blocks.ViewBody) == "" {
-		return nil, nil
-	}
-	return viewanalysis.CommandReferences(page.Blocks.ViewBody)
+	return viewanalysis.CommandReferencesFromNodes(page.Blocks.ViewNodes)
 }

--- a/internal/compiler/validate_page_lists_test.go
+++ b/internal/compiler/validate_page_lists_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/cssbruno/gowdk"
+	"github.com/cssbruno/gowdk/internal/gwdkanalysis"
 	"github.com/cssbruno/gowdk/internal/gwdkir"
 	"github.com/cssbruno/gowdk/internal/source"
 )
@@ -22,7 +23,8 @@ func validatePageListsFor(t *testing.T, page gwdkir.Page) []ValidationError {
 		page.Render = gowdk.SSR
 	}
 	config := gowdk.Config{Addons: []gowdk.Addon{gowdk.NewAddon("ssr", gowdk.FeatureSSR)}}
-	report := ValidateProgramReport(config, gwdkir.Program{Pages: []gwdkir.Page{page}})
+	program := gwdkanalysis.BuildProgram(config, gwdkanalysis.Sources{Pages: []gwdkir.Page{page}})
+	report := ValidateProgramReport(config, program)
 	return report
 }
 

--- a/internal/gowdkcmd/audit.go
+++ b/internal/gowdkcmd/audit.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cssbruno/gowdk/internal/auditschema"
 	"github.com/cssbruno/gowdk/internal/auditspec"
 	"github.com/cssbruno/gowdk/internal/buildgen"
+	"github.com/cssbruno/gowdk/internal/compiler"
 	"github.com/cssbruno/gowdk/internal/diagnostics"
 	"github.com/cssbruno/gowdk/internal/gwdkir"
 	"github.com/cssbruno/gowdk/internal/lang"
@@ -191,11 +192,25 @@ func audit(args []string) error {
 	if err := linkIRContractReferences(&ir, options.ProjectRoot); err != nil {
 		return err
 	}
+	var manifest securitymanifest.SecurityManifest
+	if checked.Validated != nil {
+		validated, err := compiler.ValidateIR(options.Config, ir)
+		if err != nil {
+			return err
+		}
+		ir = validated.Program()
+		manifest, err = securitymanifest.BuildFromValidatedProgram(options.Config, validated)
+		if err != nil {
+			return err
+		}
+	} else {
+		manifest = securitymanifest.Build(options.Config, ir)
+	}
 
 	// Relativize source locations to the project root so the posture — and the
 	// digests, findings, and emitted tests derived from it — are identical
 	// regardless of where the project is checked out.
-	manifest := securitymanifest.Build(options.Config, ir).Relativize(options.ProjectRoot)
+	manifest = manifest.Relativize(options.ProjectRoot)
 	declared := auditspec.PoliciesFromIR(ir.AuditSpecs)
 	policies := relativizeAuditPolicies(auditspec.ComposeBaseline(declared), options.ProjectRoot)
 	waiverCtx := auditspec.WaiverContext{
@@ -495,7 +510,12 @@ func standaloneAuditPackageName(dir string) string {
 // infrastructure failure (build or generation); test execution outcomes,
 // including non-zero exit and timeout, are reported through auditRunResult.
 func runGeneratedAppAuditTests(options cliOptions, ir gwdkir.Program, runOptions auditRunOptions) (string, auditRunResult, error) {
-	source, err := appgen.GeneratedAuditTestSource(appgen.OptionsFromIR(options.Config, &ir))
+	validated, err := compiler.ValidateIR(options.Config, ir)
+	if err != nil {
+		return "", auditRunResult{}, err
+	}
+	appOptions := appgen.OptionsFromValidatedProgram(options.Config, validated)
+	source, err := appgen.GeneratedAuditTestSource(appOptions)
 	if err != nil || len(source) == 0 {
 		return "", auditRunResult{}, err
 	}
@@ -508,10 +528,14 @@ func runGeneratedAppAuditTests(options cliOptions, ir gwdkir.Program, runOptions
 
 	outputDir := filepath.Join(tempRoot, "output")
 	appDir := filepath.Join(tempRoot, "app")
-	if _, err := buildgen.BuildFromValidatedIR(options.Config, ir, outputDir); err != nil {
+	if _, err := buildgen.BuildFromValidatedProgram(options.Config, validated, outputDir); err != nil {
 		return "", auditRunResult{}, err
 	}
-	app, err := appgen.GenerateWithOptions(outputDir, appDir, appgen.OptionsFromIR(options.Config, &ir))
+	appPlan, err := appgen.PlanApplication(outputDir, appOptions)
+	if err != nil {
+		return "", auditRunResult{}, err
+	}
+	app, err := appgen.GenerateWithPlan(outputDir, appDir, appPlan)
 	if err != nil {
 		return "", auditRunResult{}, err
 	}

--- a/internal/gowdkcmd/build.go
+++ b/internal/gowdkcmd/build.go
@@ -266,18 +266,21 @@ func buildOnce(options cliOptions, request buildRequest, timings *buildTimingRec
 	timings.counter("components", len(ir.Components))
 	timings.counter("layouts", len(ir.Layouts))
 	timings.counter("endpoints", len(ir.Endpoints))
-	var bindings []source.BackendBinding
+	var analyzed compiler.AnalyzedProgram
 	if err := timings.measure("go_binding", func() error {
 		var bindErr error
+		var bindings []source.BackendBinding
 		bindings, bindErr = compiler.EnrichProgram(options.Config, &ir)
+		if bindErr == nil {
+			analyzed = compiler.AnalyzedProgramWithBindings(ir, bindings)
+		}
 		return bindErr
 	}); err != nil {
 		return operationErrorFromCause("build failed", err)
 	}
 	var report compiler.ValidationErrors
 	timings.measure("ir_validation", func() error {
-		report = compiler.ValidateProgramReport(options.Config, ir)
-		report = append(report, compiler.BackendBindingDiagnostics(bindings)...)
+		_, report = compiler.ValidateAnalyzedProgramReport(options.Config, analyzed)
 		return nil
 	})
 	if report.HasErrors() {
@@ -309,8 +312,17 @@ func buildOnce(options cliOptions, request buildRequest, timings *buildTimingRec
 		return operationErrorFromCause("build failed", err)
 	}
 
+	var validated compiler.ValidatedProgram
+	if err := timings.measure("validated_snapshot", func() error {
+		var validateErr error
+		validated, validateErr = compiler.ValidateIR(options.Config, ir)
+		return validateErr
+	}); err != nil {
+		return operationErrorFromCause("build failed", err)
+	}
+
 	if err := timings.measure("security_audit", func() error {
-		return enforceBuildSecurityAudit(options, ir)
+		return enforceBuildSecurityAudit(options, validated)
 	}); err != nil {
 		return err
 	}
@@ -318,7 +330,11 @@ func buildOnce(options cliOptions, request buildRequest, timings *buildTimingRec
 	var result buildgen.Result
 	if err := timings.measure("output_plan_writes", func() error {
 		var buildErr error
-		result, buildErr = buildgen.BuildFromValidatedIR(options.Config, ir, outputDir)
+		outputPlan, buildErr := buildgen.PlanBuildFromValidatedProgram(options.Config, validated, outputDir)
+		if buildErr != nil {
+			return buildErr
+		}
+		result, buildErr = buildgen.BuildFromPlan(outputPlan)
 		return buildErr
 	}); err != nil {
 		printBuildgenBuildErrorReport(err, options.Debug)
@@ -390,9 +406,13 @@ func buildOnce(options cliOptions, request buildRequest, timings *buildTimingRec
 		var app appgen.Result
 		if err := timings.measure("app_generation", func() error {
 			var appErr error
-			appOptions := appgen.OptionsFromIR(options.Config, &ir)
+			appOptions := appgen.OptionsFromValidatedProgram(options.Config, validated)
 			appOptions.ProxyBackend = strings.TrimSpace(backendAppDir) != ""
-			app, appErr = appgen.GenerateWithOptions(outputDir, appDir, appOptions)
+			appPlan, appErr := appgen.PlanApplication(outputDir, appOptions)
+			if appErr != nil {
+				return appErr
+			}
+			app, appErr = appgen.GenerateWithPlan(outputDir, appDir, appPlan)
 			return appErr
 		}); err != nil {
 			return operationErrorFromCause("build failed", err)
@@ -466,7 +486,11 @@ func buildOnce(options cliOptions, request buildRequest, timings *buildTimingRec
 		var app appgen.Result
 		if err := timings.measure("backend_app_generation", func() error {
 			var appErr error
-			app, appErr = appgen.GenerateBackendWithOptions(backendAppDir, appgen.OptionsFromIR(options.Config, &ir))
+			appPlan, appErr := appgen.PlanBackendApplication(appgen.OptionsFromValidatedProgram(options.Config, validated))
+			if appErr != nil {
+				return appErr
+			}
+			app, appErr = appgen.GenerateBackendWithPlan(backendAppDir, appPlan)
 			return appErr
 		}); err != nil {
 			return operationErrorFromCause("build failed", err)

--- a/internal/gowdkcmd/build_audit.go
+++ b/internal/gowdkcmd/build_audit.go
@@ -10,8 +10,8 @@ import (
 	"github.com/cssbruno/gowdk"
 	"github.com/cssbruno/gowdk/internal/auditspec"
 	"github.com/cssbruno/gowdk/internal/buildgen"
+	"github.com/cssbruno/gowdk/internal/compiler"
 	"github.com/cssbruno/gowdk/internal/diagnostics"
-	"github.com/cssbruno/gowdk/internal/gwdkir"
 	"github.com/cssbruno/gowdk/internal/securitymanifest"
 	"github.com/cssbruno/gowdk/internal/securitytext"
 )
@@ -68,11 +68,16 @@ func buildErrorIsBypassed(options cliOptions, code string) bool {
 // builds print a prominent summary so the exposure is visible without breaking
 // dev iteration. The --allow-insecure flag downgrades the production gate to a
 // warning for 0.x experimentation.
-func enforceBuildSecurityAudit(options cliOptions, ir gwdkir.Program) error {
+func enforceBuildSecurityAudit(options cliOptions, validated compiler.ValidatedProgram) error {
+	ir := validated.Program()
 	// Relativize source locations to the project root so the posture digest the
 	// build-time gate computes (and the digests a waiver pins) match what gowdk
 	// audit produces regardless of checkout location.
-	manifest := securitymanifest.Build(options.Config, ir).Relativize(options.ProjectRoot)
+	manifest, err := securitymanifest.BuildFromValidatedProgram(options.Config, validated)
+	if err != nil {
+		return err
+	}
+	manifest = manifest.Relativize(options.ProjectRoot)
 	declared := auditspec.PoliciesFromIR(ir.AuditSpecs)
 	policies := relativizeAuditPolicies(auditspec.ComposeBaseline(declared), options.ProjectRoot)
 	waiverCtx := auditspec.WaiverContext{
@@ -99,9 +104,8 @@ func enforceBuildSecurityFindings(options cliOptions, findings []auditspec.Findi
 		return nil
 	}
 
-	printBuildSecurityFindings(findings)
-
 	bypassedCodes, blocking := partitionBuildErrorBypass(options, findings)
+	printBuildSecurityFindings(findings)
 	if len(bypassedCodes) > 0 {
 		fmt.Fprintf(os.Stderr, "security bypass: %d error finding(s) downgraded by --allow-insecure (codes: %s); this is recorded provenance, not a fix\n",
 			summary.Errors-blocking, strings.Join(bypassedCodes, ", "))

--- a/internal/gowdkcmd/dev_loop.go
+++ b/internal/gowdkcmd/dev_loop.go
@@ -3,6 +3,7 @@ package gowdkcmd
 import (
 	"crypto/sha256"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -97,19 +98,35 @@ func buildIncrementalSPALoaded(plan buildOptions, change inputChange) (bool, err
 	timings.counter("incremental_component_changes", incrementalPlan.ComponentChanges)
 	timings.counter("incremental_layout_changes", incrementalPlan.LayoutChanges)
 	timings.counter("incremental_affected_pages", len(incrementalPlan.PageSources))
-	var ir gwdkir.Program
+	var analyzed compiler.AnalyzedProgram
 	if err := timings.measure("ir_assembly", func() error {
 		var assembleErr error
-		ir, _, assembleErr = compiler.AssembleProgram(options.Config, app)
+		analyzed, assembleErr = compiler.AnalyzeProgram(options.Config, app)
 		return assembleErr
 	}); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return true, fmt.Errorf("build failed")
+	}
+	var validated compiler.ValidatedProgram
+	if err := timings.measure("ir_validation", func() error {
+		var report compiler.ValidationErrors
+		validated, report = compiler.ValidateAnalyzedProgramReport(options.Config, analyzed)
+		if report.HasErrors() {
+			return report
+		}
+		return nil
+	}); err != nil {
+		var report compiler.ValidationErrors
+		if errors.As(err, &report) {
+			return true, newDevDiagnosticError("build failed", devOverlayDiagnosticsFromCompiler(report))
+		}
 		fmt.Fprintln(os.Stderr, err)
 		return true, fmt.Errorf("build failed")
 	}
 	var result buildgen.Result
 	if err := timings.measure("output_plan_writes", func() error {
 		var buildErr error
-		result, buildErr = buildgen.BuildIncrementalFromIR(options.Config, ir, outputDir, incrementalPlan.PageSources)
+		result, buildErr = buildgen.BuildIncrementalFromValidatedProgram(options.Config, validated, outputDir, incrementalPlan.PageSources)
 		return buildErr
 	}); err != nil {
 		printBuildgenBuildErrorReport(err, options.Debug)

--- a/internal/gowdkcmd/inspect.go
+++ b/internal/gowdkcmd/inspect.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/cssbruno/gowdk/internal/compiler"
 	"github.com/cssbruno/gowdk/internal/gwdkir"
 	"github.com/cssbruno/gowdk/internal/inspectreport"
 	"github.com/cssbruno/gowdk/internal/lang"
@@ -98,6 +99,13 @@ func commandProgram(args []string, command string, allowJSON bool) (cliOptions, 
 	ir := checked.IR
 	if err := linkIRContractReferences(&ir, options.ProjectRoot); err != nil {
 		return cliOptions{}, gwdkir.Program{}, err
+	}
+	if checked.Validated != nil {
+		validated, err := compiler.ValidateIR(options.Config, ir)
+		if err != nil {
+			return cliOptions{}, gwdkir.Program{}, err
+		}
+		ir = validated.Program()
 	}
 	return options, ir, nil
 }

--- a/internal/gwdkanalysis/ir_builder.go
+++ b/internal/gwdkanalysis/ir_builder.go
@@ -3,12 +3,14 @@ package gwdkanalysis
 import (
 	"path/filepath"
 	"sort"
+	"strings"
 
 	"github.com/cssbruno/gowdk"
 	"github.com/cssbruno/gowdk/internal/cssscope"
 	"github.com/cssbruno/gowdk/internal/gwdkir"
 	"github.com/cssbruno/gowdk/internal/source"
 	"github.com/cssbruno/gowdk/internal/viewmodel"
+	"github.com/cssbruno/gowdk/internal/viewparse"
 )
 
 // Sources are the parsed IR records one program is assembled from.
@@ -77,6 +79,7 @@ func (builder *irBuilder) addAuditSpec(audit gwdkir.AuditSpec) {
 }
 
 func (builder *irBuilder) addPage(page gwdkir.Page) {
+	ensureViewNodes(&page.Blocks)
 	// Normalize route params once at program assembly: explicit declarations
 	// win, otherwise they are derived from the route pattern, and untyped
 	// params default to string.
@@ -236,6 +239,7 @@ func (builder *irBuilder) addPageEndpoints(page gwdkir.Page) {
 }
 
 func (builder *irBuilder) addComponent(component gwdkir.Component) {
+	ensureViewNodes(&component.Blocks)
 	builder.program.Components = append(builder.program.Components, component)
 	pkg := builder.ensurePackage(component.Package, component.Source)
 	pkg.Files = append(pkg.Files, gwdkir.SourceFile{Path: component.Source, Kind: gwdkir.SourceComponent, Package: component.Package, Name: component.Name, Span: component.Span})
@@ -335,6 +339,7 @@ func (builder *irBuilder) addComponentTemplate(component gwdkir.Component) {
 }
 
 func (builder *irBuilder) addLayout(layout gwdkir.Layout) {
+	ensureViewNodes(&layout.Blocks)
 	builder.program.Layouts = append(builder.program.Layouts, layout)
 	pkg := builder.ensurePackage(layout.Package, layout.Source)
 	pkg.Files = append(pkg.Files, gwdkir.SourceFile{Path: layout.Source, Kind: gwdkir.SourceLayout, Package: layout.Package, Name: layout.ID, Span: layout.Span})
@@ -352,6 +357,17 @@ func (builder *irBuilder) addLayout(layout gwdkir.Layout) {
 		Span:      layout.Blocks.Spans.View,
 		BodyStart: layout.Blocks.Spans.ViewBodyStart,
 	})
+}
+
+func ensureViewNodes(blocks *gwdkir.Blocks) {
+	if !blocks.View || len(blocks.ViewNodes) > 0 || strings.TrimSpace(blocks.ViewBody) == "" {
+		return
+	}
+	nodes, err := viewparse.Parse(blocks.ViewBody)
+	if err != nil {
+		return
+	}
+	blocks.ViewNodes = nodes
 }
 
 func cloneEndpointCORS(cors gwdkir.EndpointCORS) gwdkir.EndpointCORS {

--- a/internal/gwdkir/invariants.go
+++ b/internal/gwdkir/invariants.go
@@ -79,6 +79,18 @@ func CheckInvariants(program Program) error {
 		}
 	}
 
+	for _, page := range program.Pages {
+		reportViewBlockNodes("page", page.ID, page.Blocks, report)
+	}
+
+	for _, component := range program.Components {
+		reportViewBlockNodes("component", component.Name, component.Blocks, report)
+	}
+
+	for _, layout := range program.Layouts {
+		reportViewBlockNodes("layout", layout.ID, layout.Blocks, report)
+	}
+
 	for _, endpoint := range program.GoEndpoints {
 		switch endpoint.SourceKind {
 		case EndpointSourceGOWDK, EndpointSourceGo:
@@ -89,6 +101,9 @@ func CheckInvariants(program Program) error {
 
 	for _, template := range program.Templates {
 		reportOwnerReference("template", template.OwnerKind, template.OwnerID, pages, components, layouts, report)
+		if strings.TrimSpace(template.Body) != "" && len(template.Nodes) == 0 {
+			report("template %s %q has view body but no parsed nodes", template.OwnerKind, template.OwnerID)
+		}
 		if len(template.Nodes) > 0 && strings.TrimSpace(template.Body) == "" {
 			report("template %s %q has parsed nodes but empty body", template.OwnerKind, template.OwnerID)
 		}
@@ -159,6 +174,13 @@ func CheckInvariants(program Program) error {
 		return nil
 	}
 	return fmt.Errorf("invalid IR: %s", strings.Join(violations, "; "))
+}
+
+func reportViewBlockNodes(kind, id string, blocks Blocks, report func(string, ...any)) {
+	if !blocks.View || strings.TrimSpace(blocks.ViewBody) == "" || len(blocks.ViewNodes) > 0 {
+		return
+	}
+	report("%s %q has view body but no parsed nodes", kind, id)
 }
 
 func reportOwnerReference(what string, kind SourceKind, ownerID string, pages, components, layouts map[string]bool, report func(string, ...any)) {

--- a/internal/gwdkir/invariants_test.go
+++ b/internal/gwdkir/invariants_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+
+	"github.com/cssbruno/gowdk/internal/viewmodel"
 )
 
 func validProgram() Program {
@@ -140,6 +142,41 @@ func TestCheckInvariantsReportsViolations(t *testing.T) {
 			name:    "template to missing layout",
 			corrupt: func(p *Program) { p.Templates[2].OwnerID = "ghost" },
 			want:    `template references unknown layout "ghost"`,
+		},
+		{
+			name: "page view without parsed nodes",
+			corrupt: func(p *Program) {
+				p.Pages[0].Blocks = Blocks{View: true, ViewBody: `<main>Home</main>`}
+			},
+			want: `page "home" has view body but no parsed nodes`,
+		},
+		{
+			name: "component view without parsed nodes",
+			corrupt: func(p *Program) {
+				p.Components[0].Blocks = Blocks{View: true, ViewBody: `<section>Product</section>`}
+			},
+			want: `component "ProductCard" has view body but no parsed nodes`,
+		},
+		{
+			name: "layout view without parsed nodes",
+			corrupt: func(p *Program) {
+				p.Layouts[0].Blocks = Blocks{View: true, ViewBody: `<slot />`}
+			},
+			want: `layout "base" has view body but no parsed nodes`,
+		},
+		{
+			name: "template view without parsed nodes",
+			corrupt: func(p *Program) {
+				p.Templates[0].Body = `<main>Home</main>`
+			},
+			want: `template page "home" has view body but no parsed nodes`,
+		},
+		{
+			name: "template nodes without body",
+			corrupt: func(p *Program) {
+				p.Templates[0].Nodes = []viewmodel.Node{viewmodel.Text{Value: "Home"}}
+			},
+			want: `template page "home" has parsed nodes but empty body`,
 		},
 		{
 			name:    "unknown asset kind",

--- a/internal/lang/tools.go
+++ b/internal/lang/tools.go
@@ -303,8 +303,10 @@ func isMetadataDeclaration(text, keyword string) bool {
 // discovered standalone Go endpoints and backend handler bindings attached,
 // plus the flat binding record list for the manifest JSON report.
 type CheckResult struct {
-	IR       gwdkir.Program
-	Bindings []source.BackendBinding
+	IR        gwdkir.Program
+	Bindings  []source.BackendBinding
+	Analyzed  compiler.AnalyzedProgram
+	Validated *compiler.ValidatedProgram
 }
 
 // CheckOptions controls validation behavior that depends on project context.
@@ -324,22 +326,29 @@ func CheckFilesWithOptions(config gowdk.Config, paths []string, options CheckOpt
 	if diagnostics.HasErrors() {
 		return CheckResult{}, diagnostics
 	}
-	ir, bindings, err := compiler.AssembleProgram(config, sources)
-	result := CheckResult{IR: ir}
+	analyzed, err := compiler.AnalyzeProgram(config, sources)
+	result := CheckResult{Analyzed: analyzed, IR: analyzed.Program()}
 	if err != nil {
-		diagnostics = append(diagnostics, compilerDiagnostics(err, ir)...)
+		diagnostics = append(diagnostics, compilerDiagnostics(err, result.IR)...)
 		return result, diagnostics
 	}
-	result.Bindings = bindings
-	validate := compiler.ValidateProgramReport
+	result.Bindings = analyzed.BackendBindings()
 	if len(paths) == 1 {
 		// A single file can never satisfy cross-file checks (use packages,
 		// component references), so validate it in source mode to avoid
 		// false project-level errors.
-		validate = compiler.ValidateSourceProgramReport
+		diagnostics = append(diagnostics, compilerDiagnostics(compiler.ValidateSourceProgramReport(config, result.IR), result.IR)...)
+	} else {
+		var validated compiler.ValidatedProgram
+		var report compiler.ValidationErrors
+		validated, report = compiler.ValidateAnalyzedProgramReport(config, analyzed)
+		diagnostics = append(diagnostics, compilerDiagnostics(report, result.IR)...)
+		if !report.HasErrors() {
+			result.Validated = &validated
+		}
 	}
-	diagnostics = append(diagnostics, compilerDiagnostics(validate(config, result.IR), result.IR)...)
-	if bindingDiagnostics := compiler.BackendBindingDiagnostics(result.Bindings); len(bindingDiagnostics) > 0 {
+	if len(paths) == 1 {
+		bindingDiagnostics := compiler.BackendBindingDiagnostics(result.Bindings)
 		diagnostics = append(diagnostics, compilerDiagnostics(compiler.ValidationErrors(bindingDiagnostics), result.IR)...)
 	}
 	diagnostics = append(diagnostics, accessibilityDiagnostics(result.IR)...)

--- a/internal/lsp/completion_hover.go
+++ b/internal/lsp/completion_hover.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/cssbruno/gowdk/internal/compiler"
 	"github.com/cssbruno/gowdk/internal/gwdkanalysis"
 	"github.com/cssbruno/gowdk/internal/gwdkir"
 	"github.com/cssbruno/gowdk/internal/lang"
@@ -135,6 +136,9 @@ func (server *Server) openProjectIR() (gwdkir.Program, map[string]document) {
 		}
 	}
 	ir := gwdkanalysis.BuildProgram(server.config, sources)
+	if analyzed, err := compiler.AnalyzeProgram(server.config, sources); err == nil {
+		ir = analyzed.Program()
+	}
 	server.projectCache = projectIRCache{
 		key:          key,
 		ir:           ir,

--- a/internal/securitymanifest/manifest.go
+++ b/internal/securitymanifest/manifest.go
@@ -322,6 +322,15 @@ func Build(config gowdk.Config, ir gwdkir.Program) SecurityManifest {
 	return manifest
 }
 
+// BuildFromValidatedProgram projects compiler-validated IR into a
+// SecurityManifest.
+func BuildFromValidatedProgram(config gowdk.Config, validated compiler.ValidatedProgram) (SecurityManifest, error) {
+	if !validated.Valid() {
+		return SecurityManifest{}, fmt.Errorf("validated program was not constructed by compiler validation")
+	}
+	return Build(config, validated.Program()), nil
+}
+
 // declaredWaivers projects the declared `waive` rules from the audit specs into
 // the manifest so gowdk-security.json records every suppression decision.
 func declaredWaivers(ir gwdkir.Program) []WaiverDeclaration {

--- a/internal/securitymanifest/manifest_test.go
+++ b/internal/securitymanifest/manifest_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/cssbruno/gowdk"
 	authaddon "github.com/cssbruno/gowdk/addons/auth"
+	"github.com/cssbruno/gowdk/internal/compiler"
 	"github.com/cssbruno/gowdk/internal/gwdkir"
 	"github.com/cssbruno/gowdk/internal/source"
 )
@@ -130,6 +131,16 @@ func TestBuildProjectsRoutesAndEndpoints(t *testing.T) {
 	}
 	if submit.Source != "signup.page.gwdk:8" {
 		t.Fatalf("Submit source should be file:line, got %q", submit.Source)
+	}
+}
+
+func TestBuildFromValidatedProgramRejectsZeroValue(t *testing.T) {
+	_, err := BuildFromValidatedProgram(gowdk.Config{}, compiler.ValidatedProgram{})
+	if err == nil {
+		t.Fatal("expected zero-value validated program error")
+	}
+	if err.Error() != "validated program was not constructed by compiler validation" {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

Introduces compiler-owned phase boundaries for analyzed and validated programs, and adds generated-output planning boundaries for static builds and generated apps.

This also moves supported `view {}` semantics further onto typed IR fields:

- adds `compiler.AnalyzedProgram` and `compiler.ValidatedProgram` phase tokens
- adds `buildgen.BuildPlan` and `appgen.ApplicationPlan` emission boundaries
- routes build/dev/audit/inspect, lang tooling, LSP fallback, security manifest, SSR, sitemap, buildgen, and appgen through validated/planned paths
- makes typed parsed view nodes the semantic source for selected buildgen/appgen/compiler paths instead of reparsing raw `ViewBody`
- adds IR invariant coverage for non-empty supported `view {}` bodies without parsed nodes
- preserves runtime-private metadata embedding for generated apps without exposing it through public output serving
- documents the phase and typed-field contracts in `docs/compiler/pipeline.md`

## Why

The compiler pipeline needs explicit phase tokens so emission code cannot accidentally treat raw or merely analyzed IR as validated input. Generated-output code also needs planning boundaries so validation, route projection, SSR artifacts, sitemap data, and generator-local checks happen before file writes.

For typed IR hardening, raw block bodies remain useful for spans, formatting, inspection, and compatibility, but downstream generated-output behavior should consume typed fields once lowering has completed.

## Validation

Ran on the clean PR worktree based on `origin/main`:

```sh
go test ./internal/gwdkanalysis ./internal/gwdkir ./internal/compiler ./internal/buildgen ./internal/appgen
go test ./internal/lang ./internal/lsp ./internal/gowdkcmd
go build ./cmd/gowdk
go run ./cmd/gowdk inspect ir examples/pages/home.page.gwdk
scripts/check-docs-links.sh
scripts/check-docs-style.sh
git diff --check HEAD~1..HEAD
```

`check-docs-style.sh` still reports existing long-paragraph warnings outside the touched pipeline doc, then exits successfully with `docs style ok`.
