### PR TITLE
refactor(compiler): split semantic IR source maps and target plans

### DIFF
--- a/docs/compiler/pipeline.md
+++ b/docs/compiler/pipeline.md
@@ -61,6 +61,12 @@ The IR models packages, source files, page routes, backend endpoints from
 source-selected assets, asset scope/hash metadata, parsed view nodes, typed
 literal records, and imported build-data call metadata.
 
+Standalone Go endpoint comments lower into normalized `Program.Endpoints`
+records with stable `EndpointID` values. Exact source spelling and route-param
+spans for those comments live in `Program.SourceMap`; validators can use that
+source map for diagnostics, but generated-output planners consume the normalized
+endpoint record and carry the semantic ID into target-specific plans.
+
 `gwdkir.Blocks` retains source bodies for spans, formatting, inspection, and
 compatibility only. Parser/analyzer lowering must populate parsed `view {}`
 nodes, ordered literal `paths {}`/`build {}` records, and imported build-data

--- a/docs/compiler/pipeline.md
+++ b/docs/compiler/pipeline.md
@@ -49,7 +49,10 @@ into `internal/gwdkir.Program`. The IR models packages, source
 files, page routes, backend endpoints from `.gwdk` declarations or explicit Go
 comments, templates, client behavior, source-selected assets, asset scope/hash
 metadata, parsed view nodes, typed literal records, and imported build-data call
-metadata. `gwdkir.Blocks` retains source bodies for spans and
+metadata. Semantic records expose typed identities such as `PageID`, `RouteID`,
+and `EndpointID`; target plans should carry those IDs instead of rebuilding
+ad hoc string keys from route or endpoint fields. `gwdkir.Blocks` retains source
+bodies for spans and
 compatibility, but the parser-lowered handoff also carries parsed `view {}`
 nodes, ordered literal `paths {}`/`build {}` records, and imported build-data
 call metadata; downstream passes should consume those typed fields before

--- a/docs/engineering/architecture.md
+++ b/docs/engineering/architecture.md
@@ -35,6 +35,13 @@ request-time lane selected with `server {}` or `go server {}`.
 `internal/gwdkir.Program` is the compiler handoff. New generated-output work
 should consume that IR or add fields there first.
 
+Semantic records carry stable typed IDs for pages, routes, components, layouts,
+and endpoints. Exact source spelling and spans that are only needed for
+diagnostics or inspection belong in source-map records instead of duplicate raw
+semantic entities. Build output and generated app code use explicit target plans
+(`buildgen.BuildPlan`, `appgen.ApplicationPlan`) so target-only decisions do not
+expand the shared semantic program.
+
 Current handoff path:
 
 ```text

--- a/internal/appgen/adapter_ir.go
+++ b/internal/appgen/adapter_ir.go
@@ -32,6 +32,7 @@ const (
 )
 
 type BackendEndpointRegistration struct {
+	ID      gwdkir.EndpointID
 	Kind    BackendEndpointKind
 	Method  string
 	Path    string
@@ -149,6 +150,7 @@ func backendAdapterIR(options Options) BackendAdapterIR {
 	var ir BackendAdapterIR
 	for _, action := range sortedActionEndpoints(options.Actions) {
 		endpoint := BackendEndpointRegistration{
+			ID:      action.EndpointID,
 			Kind:    BackendEndpointAction,
 			Method:  actionMethod(action),
 			Path:    action.Route,
@@ -223,6 +225,7 @@ func backendAdapterIR(options Options) BackendAdapterIR {
 	}
 	for _, api := range sortedAPIEndpoints(options.APIs) {
 		endpoint := BackendEndpointRegistration{
+			ID:      api.EndpointID,
 			Kind:    BackendEndpointAPI,
 			Method:  api.Method,
 			Path:    api.Route,
@@ -268,6 +271,7 @@ func backendAdapterIR(options Options) BackendAdapterIR {
 	}
 	for _, fragment := range sortedFragmentEndpoints(options.Fragments) {
 		endpoint := BackendEndpointRegistration{
+			ID:      fragment.EndpointID,
 			Kind:    BackendEndpointFragment,
 			Method:  fragment.Method,
 			Path:    fragment.Route,

--- a/internal/appgen/adapter_ir_test.go
+++ b/internal/appgen/adapter_ir_test.go
@@ -11,6 +11,7 @@ import (
 func TestBackendAdapterIRCapturesRouteAndHandlerMetadata(t *testing.T) {
 	ir := backendAdapterIR(Options{
 		Actions: []ActionEndpoint{{
+			EndpointID:  gwdkir.EndpointID("action-id"),
 			PageID:      "newsletter",
 			ActionName:  "Subscribe",
 			Method:      "POST",
@@ -32,11 +33,12 @@ func TestBackendAdapterIRCapturesRouteAndHandlerMetadata(t *testing.T) {
 			BackendAlias: "newsletter",
 		}},
 		APIs: []APIEndpoint{{
-			PageID:  "status",
-			APIName: "Health",
-			Method:  "GET",
-			Route:   "/api/health",
-			Guards:  []string{"public"},
+			EndpointID: gwdkir.EndpointID("api-id"),
+			PageID:     "status",
+			APIName:    "Health",
+			Method:     "GET",
+			Route:      "/api/health",
+			Guards:     []string{"public"},
 			Binding: source.BackendBinding{
 				Status:       source.BackendBindingBound,
 				ImportPath:   "example.com/app/status",
@@ -46,6 +48,7 @@ func TestBackendAdapterIRCapturesRouteAndHandlerMetadata(t *testing.T) {
 			BackendAlias: "status",
 		}},
 		Fragments: []FragmentEndpoint{{
+			EndpointID:   gwdkir.EndpointID("fragment-id"),
 			PageID:       "patients",
 			FragmentName: "List",
 			Method:       "GET",
@@ -77,6 +80,9 @@ func TestBackendAdapterIRCapturesRouteAndHandlerMetadata(t *testing.T) {
 	}
 	if ir.Registrations[0].Kind != BackendEndpointAction || ir.Registrations[0].Path != "/newsletter" || ir.Registrations[0].Handler != "action" {
 		t.Fatalf("unexpected action registration: %#v", ir.Registrations[0])
+	}
+	if ir.Registrations[0].ID != gwdkir.EndpointID("action-id") || ir.Registrations[1].ID != gwdkir.EndpointID("api-id") || ir.Registrations[2].ID != gwdkir.EndpointID("fragment-id") {
+		t.Fatalf("expected semantic endpoint IDs in registrations, got %#v", ir.Registrations)
 	}
 	if ir.Registrations[1].Kind != BackendEndpointAPI || ir.Registrations[1].Path != "/api/health" || ir.Registrations[1].Handler != "api" {
 		t.Fatalf("unexpected API registration: %#v", ir.Registrations[1])

--- a/internal/appgen/ir.go
+++ b/internal/appgen/ir.go
@@ -28,13 +28,14 @@ func actionEndpointsFromIR(config gowdk.Config, ir gwdkir.Program) ([]ActionEndp
 			if route == "" {
 				route = page.Route
 			}
-			bindingRoute := route
 			fragments, err := actionFragmentsFromIR(action)
 			if err != nil {
 				return nil, fmt.Errorf("%s.%s: %w", page.ID, action.Name, err)
 			}
+			semanticEndpoint := irEndpointForBlock(ir.Endpoints, gwdkir.EndpointAction, page.ID, action.Name, method, route)
 			for _, localized := range actionEndpointRoutes(config.I18N, page.Route, route, action.Route == "") {
 				endpoints = append(endpoints, ActionEndpoint{
+					EndpointID:       semanticEndpoint.SemanticID(),
 					PageID:           page.ID,
 					ActionName:       action.Name,
 					Method:           method,
@@ -51,7 +52,7 @@ func actionEndpointsFromIR(config gowdk.Config, ir gwdkir.Program) ([]ActionEndp
 					Redirect:         action.Redirect,
 					Fragments:        fragments,
 					ErrorPage:        action.ErrorPage,
-					Binding:          bindings[irEndpointKey(gwdkir.EndpointAction, page.ID, action.Name, method, bindingRoute)],
+					Binding:          bindings[semanticEndpoint.SemanticID()],
 					Source:           page.Source,
 					SourceSpan:       action.Span,
 				})
@@ -62,8 +63,9 @@ func actionEndpointsFromIR(config gowdk.Config, ir gwdkir.Program) ([]ActionEndp
 		if endpoint.Kind != gwdkir.EndpointAction || endpoint.Source != gwdkir.EndpointSourceGo {
 			continue
 		}
-		binding := bindings[irEndpointKey(endpoint.Kind, endpoint.PageID, endpoint.Symbol, endpoint.Method, endpoint.Path)]
+		binding := bindings[endpoint.SemanticID()]
 		endpoints = append(endpoints, ActionEndpoint{
+			EndpointID:  endpoint.SemanticID(),
 			PageID:      endpoint.PageID,
 			ActionName:  endpoint.Symbol,
 			Method:      endpoint.Method,
@@ -113,7 +115,9 @@ func apiEndpointsFromIR(ir gwdkir.Program) ([]APIEndpoint, error) {
 			if route == "" {
 				route = page.Route
 			}
+			semanticEndpoint := irEndpointForBlock(ir.Endpoints, gwdkir.EndpointAPI, page.ID, api.Name, method, route)
 			endpoints = append(endpoints, APIEndpoint{
+				EndpointID: semanticEndpoint.SemanticID(),
 				PageID:     page.ID,
 				APIName:    api.Name,
 				Method:     method,
@@ -121,7 +125,7 @@ func apiEndpointsFromIR(ir gwdkir.Program) ([]APIEndpoint, error) {
 				Guards:     append([]string(nil), page.Guards...),
 				ErrorPage:  api.ErrorPage,
 				CORS:       cloneEndpointCORS(api.CORS),
-				Binding:    bindings[irEndpointKey(gwdkir.EndpointAPI, page.ID, api.Name, method, route)],
+				Binding:    bindings[semanticEndpoint.SemanticID()],
 				Source:     page.Source,
 				SourceSpan: api.Span,
 			})
@@ -132,13 +136,14 @@ func apiEndpointsFromIR(ir gwdkir.Program) ([]APIEndpoint, error) {
 			continue
 		}
 		endpoints = append(endpoints, APIEndpoint{
+			EndpointID: endpoint.SemanticID(),
 			PageID:     endpoint.PageID,
 			APIName:    endpoint.Symbol,
 			Method:     endpoint.Method,
 			Route:      endpoint.Path,
 			ErrorPage:  endpoint.ErrorPage,
 			CORS:       cloneEndpointCORS(endpoint.CORS),
-			Binding:    bindings[irEndpointKey(endpoint.Kind, endpoint.PageID, endpoint.Symbol, endpoint.Method, endpoint.Path)],
+			Binding:    bindings[endpoint.SemanticID()],
 			Source:     endpoint.SourceFile,
 			SourceSpan: endpoint.Span,
 		})
@@ -172,18 +177,21 @@ func fragmentEndpointsFromIR(ir gwdkir.Program) ([]FragmentEndpoint, error) {
 			if method == "" {
 				method = "GET"
 			}
+			route := strings.TrimSpace(fragment.Route)
+			semanticEndpoint := irEndpointForBlock(ir.Endpoints, gwdkir.EndpointFragment, page.ID, fragment.Name, method, route)
 			endpoints = append(endpoints, FragmentEndpoint{
+				EndpointID:   semanticEndpoint.SemanticID(),
 				PageID:       page.ID,
 				FragmentName: fragment.Name,
 				Method:       method,
-				Route:        strings.TrimSpace(fragment.Route),
-				RouteParams:  gwdkir.RouteParamsFromPath(strings.TrimSpace(fragment.Route)),
+				Route:        route,
+				RouteParams:  gwdkir.RouteParamsFromPath(route),
 				Target:       fragment.Target,
 				HTML:         html,
 				Package:      page.Package,
 				Uses:         uses,
 				Guards:       append([]string(nil), page.Guards...),
-				Binding:      bindings[irEndpointKey(gwdkir.EndpointFragment, page.ID, fragment.Name, method, strings.TrimSpace(fragment.Route))],
+				Binding:      bindings[semanticEndpoint.SemanticID()],
 				Source:       page.Source,
 				SourceSpan:   fragment.Span,
 			})
@@ -313,8 +321,8 @@ func irExportTypes(exports []gwdkir.Export) map[string]clientlang.ValueType {
 	return out
 }
 
-func irBindingsByEndpoint(endpoints []gwdkir.Endpoint) map[string]source.BackendBinding {
-	out := map[string]source.BackendBinding{}
+func irBindingsByEndpoint(endpoints []gwdkir.Endpoint) map[gwdkir.EndpointID]source.BackendBinding {
+	out := map[gwdkir.EndpointID]source.BackendBinding{}
 	for _, endpoint := range endpoints {
 		if endpoint.Binding.Status == "" && endpoint.Binding.ImportPath == "" && endpoint.Binding.FunctionName == "" {
 			continue
@@ -323,7 +331,7 @@ func irBindingsByEndpoint(endpoints []gwdkir.Endpoint) map[string]source.Backend
 		if endpoint.Kind == gwdkir.EndpointAPI {
 			kind = "api"
 		}
-		out[irEndpointKey(endpoint.Kind, endpoint.PageID, endpoint.Symbol, endpoint.Method, endpoint.Path)] = source.BackendBinding{
+		out[endpoint.SemanticID()] = source.BackendBinding{
 			Kind:          kind,
 			PageID:        endpoint.PageID,
 			Source:        endpoint.SourceFile,
@@ -347,8 +355,23 @@ func irBindingsByEndpoint(endpoints []gwdkir.Endpoint) map[string]source.Backend
 	return out
 }
 
-func irEndpointKey(kind gwdkir.EndpointKind, pageID, symbol, method, route string) string {
-	return strings.Join([]string{string(kind), pageID, symbol, method, route}, "\x00")
+func irEndpointForBlock(endpoints []gwdkir.Endpoint, kind gwdkir.EndpointKind, pageID, symbol, method, route string) gwdkir.Endpoint {
+	for _, endpoint := range endpoints {
+		if endpoint.Kind == kind &&
+			endpoint.PageID == pageID &&
+			endpoint.Symbol == symbol &&
+			endpoint.Method == method &&
+			endpoint.Path == route {
+			return endpoint
+		}
+	}
+	return gwdkir.Endpoint{
+		Kind:   kind,
+		PageID: pageID,
+		Symbol: symbol,
+		Method: method,
+		Path:   route,
+	}
 }
 
 func actionFragmentsFromIR(action gwdkir.Action) ([]ActionFragment, error) {

--- a/internal/appgen/types.go
+++ b/internal/appgen/types.go
@@ -42,6 +42,7 @@ func OptionsFromIR(config gowdk.Config, ir *gwdkir.Program) Options {
 
 // ActionEndpoint describes a generated action handler.
 type ActionEndpoint struct {
+	EndpointID       gwdkir.EndpointID
 	PageID           string
 	ActionName       string
 	Method           string
@@ -85,6 +86,7 @@ type ActionValidationRule struct {
 
 // APIEndpoint describes a generated API handler.
 type APIEndpoint struct {
+	EndpointID   gwdkir.EndpointID
 	PageID       string
 	APIName      string
 	Method       string
@@ -100,6 +102,7 @@ type APIEndpoint struct {
 
 // FragmentEndpoint describes a generated server fragment handler.
 type FragmentEndpoint struct {
+	EndpointID   gwdkir.EndpointID
 	PageID       string
 	FragmentName string
 	Method       string

--- a/internal/compiler/backend_bindings.go
+++ b/internal/compiler/backend_bindings.go
@@ -74,17 +74,20 @@ func computeBackendBindings(ir gwdkir.Program) []source.BackendBinding {
 			}
 		}
 	}
-	for _, endpoint := range ir.GoEndpoints {
-		dir := sourceDir(endpoint.Source)
+	for _, endpoint := range ir.Endpoints {
+		if endpoint.Source != gwdkir.EndpointSourceGo {
+			continue
+		}
+		dir := sourceDir(endpoint.SourceFile)
 		pkg, ok := cache[dir]
 		if !ok {
 			pkg = inspectFeaturePackage(dir)
 			cache[dir] = pkg
 		}
 		switch endpoint.Kind {
-		case "act", "action":
+		case gwdkir.EndpointAction:
 			bindings = append(bindings, bindStandaloneAction(endpoint, pkg))
-		case "api":
+		case gwdkir.EndpointAPI:
 			bindings = append(bindings, bindStandaloneAPI(endpoint, pkg))
 		}
 	}
@@ -156,12 +159,8 @@ func bindLoadFromPackage(page gwdkir.Page, functionName string, pkg featurePacka
 	return binding
 }
 
-func bindStandaloneAction(endpoint gwdkir.GoEndpoint, pkg featurePackage) source.BackendBinding {
-	method := endpoint.Method
-	if method == "" {
-		method = "POST"
-	}
-	return bindActionEndpoint(baseStandaloneBackendBinding(endpoint, actionHandlerKind, method, pkg), pkg)
+func bindStandaloneAction(endpoint gwdkir.Endpoint, pkg featurePackage) source.BackendBinding {
+	return bindActionEndpoint(baseStandaloneBackendBinding(endpoint, actionHandlerKind, endpoint.Method, pkg), pkg)
 }
 
 func bindActionEndpoint(binding source.BackendBinding, pkg featurePackage) source.BackendBinding {
@@ -193,12 +192,8 @@ func bindActionEndpoint(binding source.BackendBinding, pkg featurePackage) sourc
 	return binding
 }
 
-func bindStandaloneAPI(endpoint gwdkir.GoEndpoint, pkg featurePackage) source.BackendBinding {
-	method := endpoint.Method
-	if method == "" {
-		method = "GET"
-	}
-	return bindAPIEndpoint(baseStandaloneBackendBinding(endpoint, apiHandlerKind, method, pkg), pkg)
+func bindStandaloneAPI(endpoint gwdkir.Endpoint, pkg featurePackage) source.BackendBinding {
+	return bindAPIEndpoint(baseStandaloneBackendBinding(endpoint, apiHandlerKind, endpoint.Method, pkg), pkg)
 }
 
 func bindAPIEndpoint(binding source.BackendBinding, pkg featurePackage) source.BackendBinding {
@@ -315,18 +310,18 @@ func baseBackendBinding(page gwdkir.Page, kind, blockName, method, route string,
 	}
 }
 
-func baseStandaloneBackendBinding(endpoint gwdkir.GoEndpoint, kind, method string, pkg featurePackage) source.BackendBinding {
+func baseStandaloneBackendBinding(endpoint gwdkir.Endpoint, kind, method string, pkg featurePackage) source.BackendBinding {
 	return source.BackendBinding{
 		Kind:         kind,
-		PageID:       standaloneEndpointPageID(endpoint.Package, endpoint.Name),
-		Source:       endpoint.Source,
+		PageID:       endpoint.PageID,
+		Source:       endpoint.SourceFile,
 		Span:         endpoint.Span,
-		BlockName:    endpoint.Name,
+		BlockName:    endpoint.Symbol,
 		Method:       method,
-		Route:        endpoint.Route,
+		Route:        endpoint.Path,
 		ImportPath:   pkg.ImportPath,
 		PackageName:  bindingPackageName(pkg.Name, endpoint.Package),
-		FunctionName: endpoint.Name,
+		FunctionName: endpoint.Symbol,
 		Status:       source.BackendBindingMissing,
 	}
 }

--- a/internal/compiler/backend_bindings_test.go
+++ b/internal/compiler/backend_bindings_test.go
@@ -603,8 +603,8 @@ func Refresh(context.Context, *http.Request) (response.Response, error) {
 	if err := DiscoverGoEndpoints(gowdk.Config{}, &ir); err != nil {
 		t.Fatal(err)
 	}
-	if len(ir.GoEndpoints) != 3 {
-		t.Fatalf("expected three Go comment endpoints, got %#v", ir.GoEndpoints)
+	if len(ir.SourceMap.Endpoints) != 3 {
+		t.Fatalf("expected three Go comment endpoint source-map entries, got %#v", ir.SourceMap.Endpoints)
 	}
 	for _, endpoint := range ir.Endpoints {
 		switch endpoint.Symbol {
@@ -733,8 +733,8 @@ func Session(context.Context, *http.Request) (response.Response, error) {
 	if err := DiscoverGoEndpoints(gowdk.Config{}, &ir); err != nil {
 		t.Fatal(err)
 	}
-	if len(ir.GoEndpoints) != 1 || ir.GoEndpoints[0].Route != "/api/session" {
-		t.Fatalf("expected only the valid GOWDK endpoint, got %#v", ir.GoEndpoints)
+	if len(ir.SourceMap.Endpoints) != 1 || ir.SourceMap.Endpoints[0].Route != "/api/session" {
+		t.Fatalf("expected only the valid GOWDK endpoint source-map entry, got %#v", ir.SourceMap.Endpoints)
 	}
 }
 
@@ -788,7 +788,7 @@ func TestValidateManifestRejectsGoEndpointConflictWithGOWDKEndpoint(t *testing.T
 				APIs:     []gwdkir.API{{Name: "Session", Method: "GET", Route: "/api/session"}},
 			},
 		}},
-		Endpoints: []gwdkir.GoEndpoint{{
+		Endpoints: []gwdkir.StandaloneEndpointDeclaration{{
 			Kind:       "api",
 			SourceKind: gwdkir.EndpointSourceGo,
 			Package:    "api",

--- a/internal/compiler/backend_bindings_test.go
+++ b/internal/compiler/backend_bindings_test.go
@@ -808,6 +808,49 @@ func TestValidateManifestRejectsGoEndpointConflictWithGOWDKEndpoint(t *testing.T
 	}
 }
 
+func TestValidateManifestReportsDuplicateStandaloneEndpointsAsAuthorDiagnostic(t *testing.T) {
+	root := t.TempDir()
+	app := appFixture{
+		Pages: []gwdkir.Page{{
+			ID:     "home",
+			Source: filepath.Join(root, "home.page.gwdk"),
+			Route:  "/",
+			Blocks: gwdkir.Blocks{View: true, ViewBody: "<main>Home</main>"},
+		}},
+		Endpoints: []gwdkir.StandaloneEndpointDeclaration{
+			{
+				Kind:       "act",
+				SourceKind: gwdkir.EndpointSourceGo,
+				Package:    "actions",
+				Source:     filepath.Join(root, "handlers.go"),
+				Name:       "Save",
+				Method:     "POST",
+				Route:      "/profile",
+			},
+			{
+				Kind:       "act",
+				SourceKind: gwdkir.EndpointSourceGo,
+				Package:    "actions",
+				Source:     filepath.Join(root, "handlers.go"),
+				Name:       "Save",
+				Method:     "POST",
+				Route:      "/profile",
+			},
+		},
+	}
+
+	err := validateManifest(gowdk.Config{}, app)
+	if err == nil {
+		t.Fatal("expected route conflict diagnostic")
+	}
+	if strings.Contains(err.Error(), "internal compiler error") {
+		t.Fatalf("duplicate standalone endpoints should not produce internal compiler error: %v", err)
+	}
+	if !hasDiagnosticCode(err.(ValidationErrors), "route_method_conflict") {
+		t.Fatalf("missing route_method_conflict diagnostic: %#v", err)
+	}
+}
+
 func TestValidateBackendBindingPolicyFailsProductionMissingHandler(t *testing.T) {
 	app := appFixture{Pages: []gwdkir.Page{{
 		ID:     "login",

--- a/internal/compiler/go_endpoints.go
+++ b/internal/compiler/go_endpoints.go
@@ -25,7 +25,7 @@ func DiscoverGoEndpoints(config gowdk.Config, ir *gwdkir.Program) error {
 	if len(dirs) == 0 {
 		return nil
 	}
-	var endpoints []gwdkir.GoEndpoint
+	var endpoints []gwdkir.StandaloneEndpointDeclaration
 	var diagnostics []ValidationError
 	for _, dir := range dirs {
 		discovered, found := discoverGoEndpointsInDir(dir)
@@ -76,7 +76,7 @@ func endpointSourceDirs(ir gwdkir.Program) []string {
 	return dirs
 }
 
-func discoverGoEndpointsInDir(dir string) ([]gwdkir.GoEndpoint, []ValidationError) {
+func discoverGoEndpointsInDir(dir string) ([]gwdkir.StandaloneEndpointDeclaration, []ValidationError) {
 	entries, err := os.ReadDir(dir)
 	if err != nil {
 		// A source directory that simply does not exist is not an error - the
@@ -89,7 +89,7 @@ func discoverGoEndpointsInDir(dir string) ([]gwdkir.GoEndpoint, []ValidationErro
 		return nil, []ValidationError{goEndpointDiagnostic(token.NewFileSet(), dir, nil, "go_endpoint_read_error", fmt.Sprintf("read Go endpoint directory: %v", err))}
 	}
 	fileSet := token.NewFileSet()
-	var endpoints []gwdkir.GoEndpoint
+	var endpoints []gwdkir.StandaloneEndpointDeclaration
 	var diagnostics []ValidationError
 	for _, entry := range entries {
 		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".go") || strings.HasSuffix(entry.Name(), "_test.go") {
@@ -131,8 +131,8 @@ func discoverGoEndpointsInDir(dir string) ([]gwdkir.GoEndpoint, []ValidationErro
 	return endpoints, diagnostics
 }
 
-func endpointCommentsForFunction(fileSet *token.FileSet, path string, packageName string, function *ast.FuncDecl) ([]gwdkir.GoEndpoint, []ValidationError) {
-	var endpoints []gwdkir.GoEndpoint
+func endpointCommentsForFunction(fileSet *token.FileSet, path string, packageName string, function *ast.FuncDecl) ([]gwdkir.StandaloneEndpointDeclaration, []ValidationError) {
+	var endpoints []gwdkir.StandaloneEndpointDeclaration
 	var diagnostics []ValidationError
 	for _, comment := range function.Doc.List {
 		text := strings.TrimSpace(strings.TrimPrefix(comment.Text, "//"))
@@ -154,7 +154,7 @@ func endpointCommentsForFunction(fileSet *token.FileSet, path string, packageNam
 		}
 		method := strings.ToUpper(methodText)
 		route := strings.Trim(routeText, `"`)
-		endpoints = append(endpoints, gwdkir.GoEndpoint{
+		endpoints = append(endpoints, gwdkir.StandaloneEndpointDeclaration{
 			Kind:        kind,
 			SourceKind:  gwdkir.EndpointSourceGo,
 			Package:     packageName,

--- a/internal/compiler/routes.go
+++ b/internal/compiler/routes.go
@@ -67,10 +67,10 @@ func duplicateRouteMessage(route, firstID, firstSource, duplicateID, duplicateSo
 	return message
 }
 
-func validateAmbiguousDynamicPageRoutes(config gowdk.Config, pages []gwdkir.Page, endpoints []gwdkir.GoEndpoint, refs []gwdkir.ContractReference) []ValidationError {
+func validateAmbiguousDynamicPageRoutes(config gowdk.Config, pages []gwdkir.Page, endpoints []gwdkir.Endpoint, sourceMap gwdkir.SourceMap, refs []gwdkir.ContractReference) []ValidationError {
 	var registered []routeRegistration
 	var diagnostics []ValidationError
-	for _, current := range routeRegistrations(config, pages, endpoints, refs) {
+	for _, current := range routeRegistrations(config, pages, endpoints, sourceMap, refs) {
 		for _, previous := range registered {
 			if current.Pattern == previous.Pattern {
 				// Exact duplicates are reported by the duplicate-route and
@@ -188,10 +188,10 @@ func routePatternSegments(pattern string) []string {
 	return strings.Split(trimmed, "/")
 }
 
-func validateRouteMethodConflicts(config gowdk.Config, pages []gwdkir.Page, endpoints []gwdkir.GoEndpoint, refs []gwdkir.ContractReference) []ValidationError {
+func validateRouteMethodConflicts(config gowdk.Config, pages []gwdkir.Page, endpoints []gwdkir.Endpoint, sourceMap gwdkir.SourceMap, refs []gwdkir.ContractReference) []ValidationError {
 	seen := map[string][]routeRegistration{}
 	var diagnostics []ValidationError
-	for _, registration := range routeRegistrations(config, pages, endpoints, refs) {
+	for _, registration := range routeRegistrations(config, pages, endpoints, sourceMap, refs) {
 		key := registration.Method + " " + registration.Pattern
 		for _, previous := range seen[key] {
 			if previous.Kind == "page" && registration.Kind == "page" {
@@ -239,7 +239,7 @@ type routeRegistration struct {
 	Span     source.SourceSpan
 }
 
-func routeRegistrations(config gowdk.Config, pages []gwdkir.Page, endpoints []gwdkir.GoEndpoint, refs []gwdkir.ContractReference) []routeRegistration {
+func routeRegistrations(config gowdk.Config, pages []gwdkir.Page, endpoints []gwdkir.Endpoint, sourceMap gwdkir.SourceMap, refs []gwdkir.ContractReference) []routeRegistration {
 	var registrations []routeRegistration
 	for _, page := range pages {
 		for _, route := range localizedPageRoutes(config.I18N, page) {
@@ -338,24 +338,28 @@ func routeRegistrations(config gowdk.Config, pages []gwdkir.Page, endpoints []gw
 		}
 	}
 	for _, endpoint := range endpoints {
-		info, issues := parseRoute(endpoint.Route)
+		if endpoint.Source != gwdkir.EndpointSourceGo {
+			continue
+		}
+		endpointSource, _ := sourceMap.Endpoint(endpoint.SemanticID())
+		info, issues := parseRoute(endpoint.Path)
 		if len(issues) > 0 {
 			continue
 		}
-		kind := strings.TrimSpace(endpoint.Kind)
+		kind := strings.TrimSpace(standaloneEndpointKindLabel(endpoint, endpointSource))
 		if kind == "" {
 			kind = "endpoint"
 		}
 		method := strings.ToUpper(strings.TrimSpace(endpoint.Method))
 		registrations = append(registrations, routeRegistration{
 			Kind:    kind,
-			Owner:   fmt.Sprintf("%s %s.%s", kind, endpoint.Package, endpoint.Name),
+			Owner:   fmt.Sprintf("%s %s.%s", kind, endpoint.Package, endpoint.Symbol),
 			Method:  method,
-			Route:   endpoint.Route,
+			Route:   endpoint.Path,
 			Pattern: info.Pattern,
-			PageID:  standaloneEndpointPageID(endpoint.Package, endpoint.Name),
-			Source:  endpoint.Source,
-			Span:    firstSpan(endpoint.RouteSpan, endpoint.Span),
+			PageID:  endpoint.PageID,
+			Source:  endpoint.SourceFile,
+			Span:    firstSpan(endpointSource.RouteSpan, endpoint.Span),
 		})
 	}
 	for _, ref := range refs {
@@ -435,59 +439,59 @@ func pageOwnedQueryRouteConflict(page routeRegistration, query routeRegistration
 		query.Route == page.Route
 }
 
-func validateStandaloneEndpoints(endpoints []gwdkir.GoEndpoint) []ValidationError {
+func validateStandaloneEndpoints(program gwdkir.Program) []ValidationError {
 	var diagnostics []ValidationError
-	for _, endpoint := range endpoints {
-		page := gwdkir.Page{ID: standaloneEndpointPageID(endpoint.Package, endpoint.Name), Source: endpoint.Source}
-		if !isExportedHandlerName(endpoint.Name) {
+	for _, endpoint := range program.Endpoints {
+		if endpoint.Source != gwdkir.EndpointSourceGo {
+			continue
+		}
+		endpointSource, _ := program.EndpointSource(endpoint.SemanticID())
+		page := gwdkir.Page{ID: endpoint.PageID, Source: endpoint.SourceFile}
+		if !isExportedHandlerName(endpoint.Symbol) {
 			diagnostics = append(diagnostics, ValidationError{
 				Code:    "invalid_backend_handler_name",
 				PageID:  page.ID,
-				Source:  endpoint.Source,
+				Source:  endpoint.SourceFile,
 				Span:    endpoint.Span,
-				Message: fmt.Sprintf("%s endpoint handler %q must be an exported Go identifier", endpoint.Kind, endpoint.Name),
+				Message: fmt.Sprintf("%s endpoint handler %q must be an exported Go identifier", standaloneEndpointKindLabel(endpoint, endpointSource), endpoint.Symbol),
 			})
 		}
 		method := strings.ToUpper(strings.TrimSpace(endpoint.Method))
-		if method == "" {
-			if endpoint.Kind == "act" || endpoint.Kind == "action" {
-				method = "POST"
-			} else {
-				method = "GET"
-			}
-		}
-		if endpoint.Kind == "act" || endpoint.Kind == "action" {
+		if endpoint.Kind == gwdkir.EndpointAction {
 			if method != "POST" {
 				diagnostics = append(diagnostics, ValidationError{
 					Code:    "unsupported_action_method",
 					PageID:  page.ID,
-					Source:  endpoint.Source,
+					Source:  endpoint.SourceFile,
 					Span:    endpoint.Span,
-					Message: fmt.Sprintf("Go action endpoint %s uses unsupported method %s; actions currently require POST", endpoint.Name, method),
+					Message: fmt.Sprintf("Go action endpoint %s uses unsupported method %s; actions currently require POST", endpoint.Symbol, method),
 				})
 			}
 		}
-		info, issues := parseRoute(endpoint.Route)
-		label := fmt.Sprintf("Go %s endpoint path", endpoint.Kind)
-		diagnostics = append(diagnostics, routeDiagnostics(page, label, issues, firstSpan(endpoint.RouteSpan, endpoint.Span), endpoint.RouteParams)...)
+		info, issues := parseRoute(endpoint.Path)
+		label := fmt.Sprintf("Go %s endpoint path", standaloneEndpointKindLabel(endpoint, endpointSource))
+		diagnostics = append(diagnostics, routeDiagnostics(page, label, issues, firstSpan(endpointSource.RouteSpan, endpoint.Span), endpointSource.RouteParams)...)
 		if len(issues) == 0 && info.RestParam != "" {
 			diagnostics = append(diagnostics, ValidationError{
 				Code:    "malformed_route",
 				PageID:  page.ID,
-				Source:  endpoint.Source,
-				Span:    firstSpan(endpoint.RouteSpan, endpoint.Span),
-				Message: fmt.Sprintf("%s declares invalid %s: route %q uses rest route parameter {%s...}; rest parameters are only supported on page routes", page.ID, label, endpoint.Route, info.RestParam),
+				Source:  endpoint.SourceFile,
+				Span:    firstSpan(endpointSource.RouteSpan, endpoint.Span),
+				Message: fmt.Sprintf("%s declares invalid %s: route %q uses rest route parameter {%s...}; rest parameters are only supported on page routes", page.ID, label, endpoint.Path, info.RestParam),
 			})
 		}
 	}
 	return diagnostics
 }
 
-func standaloneEndpointPageID(packageName, name string) string {
-	if packageName == "" {
-		return name
+func standaloneEndpointKindLabel(endpoint gwdkir.Endpoint, endpointSource gwdkir.EndpointSourceMap) string {
+	if endpointSource.Kind != "" {
+		return endpointSource.Kind
 	}
-	return packageName + "." + name
+	if endpoint.Kind == gwdkir.EndpointAction {
+		return "act"
+	}
+	return string(endpoint.Kind)
 }
 
 func routeDiagnostics(page gwdkir.Page, label string, issues []routeIssue, routeSpan source.SourceSpan, paramSpans []source.NamedSpan) []ValidationError {

--- a/internal/compiler/routes_related_test.go
+++ b/internal/compiler/routes_related_test.go
@@ -93,7 +93,7 @@ func TestContractRouteConflictCarriesRelatedFirstDeclaration(t *testing.T) {
 		{Kind: gwdkir.ContractQuery, Name: "Summary", Method: "GET", Path: "/reports", Source: "summary.gwdk", Span: span(7, 1, 12)},
 	}
 
-	diagnostic, ok := findByCode(validateRouteMethodConflicts(gowdk.Config{}, nil, nil, refs), "route_method_conflict")
+	diagnostic, ok := findByCode(validateRouteMethodConflicts(gowdk.Config{}, nil, nil, gwdkir.SourceMap{}, refs), "route_method_conflict")
 	if !ok {
 		t.Fatal("expected a route_method_conflict diagnostic")
 	}

--- a/internal/compiler/validate.go
+++ b/internal/compiler/validate.go
@@ -102,9 +102,9 @@ func validateProgram(config gowdk.Config, ir gwdkir.Program, crossFile bool) Val
 	diagnostics = append(diagnostics, validatePageLayoutReferences(ir.Pages, ir.Layouts)...)
 	diagnostics = append(diagnostics, validateGoBlocks(config, ir)...)
 	diagnostics = append(diagnostics, validateUniquePageRoutes(config, ir.Pages)...)
-	diagnostics = append(diagnostics, validateAmbiguousDynamicPageRoutes(config, ir.Pages, ir.GoEndpoints, ir.ContractRefs)...)
-	diagnostics = append(diagnostics, validateRouteMethodConflicts(config, ir.Pages, ir.GoEndpoints, ir.ContractRefs)...)
-	diagnostics = append(diagnostics, validateStandaloneEndpoints(ir.GoEndpoints)...)
+	diagnostics = append(diagnostics, validateAmbiguousDynamicPageRoutes(config, ir.Pages, ir.Endpoints, ir.SourceMap, ir.ContractRefs)...)
+	diagnostics = append(diagnostics, validateRouteMethodConflicts(config, ir.Pages, ir.Endpoints, ir.SourceMap, ir.ContractRefs)...)
+	diagnostics = append(diagnostics, validateStandaloneEndpoints(ir)...)
 	diagnostics = append(diagnostics, validateContractReferenceRoutes(ir.ContractRefs)...)
 	diagnostics = append(diagnostics, validateRealtimeSubscriptions(config, ir.RealtimeSubscriptions)...)
 	for _, page := range ir.Pages {

--- a/internal/compiler/validate_test.go
+++ b/internal/compiler/validate_test.go
@@ -5581,7 +5581,7 @@ type appFixture struct {
 	Pages           []gwdkir.Page
 	Components      []gwdkir.Component
 	Layouts         []gwdkir.Layout
-	Endpoints       []gwdkir.GoEndpoint
+	Endpoints       []gwdkir.StandaloneEndpointDeclaration
 	BackendBindings []source.BackendBinding
 }
 

--- a/internal/gwdkanalysis/ir_bindings.go
+++ b/internal/gwdkanalysis/ir_bindings.go
@@ -1,8 +1,6 @@
 package gwdkanalysis
 
 import (
-	"strings"
-
 	"github.com/cssbruno/gowdk/internal/gwdkir"
 	"github.com/cssbruno/gowdk/internal/source"
 )
@@ -12,7 +10,7 @@ import (
 // matched by (kind, page, block, method, route); endpoints and pages without a
 // matching record get a zero binding.
 func AttachBackendBindings(program *gwdkir.Program, bindings []source.BackendBinding) {
-	byEndpoint := map[string]source.BackendBinding{}
+	byEndpoint := map[gwdkir.EndpointID]source.BackendBinding{}
 	byLoadPage := map[string]source.BackendBinding{}
 	for _, binding := range bindings {
 		if binding.Kind == "load" {
@@ -25,11 +23,11 @@ func AttachBackendBindings(program *gwdkir.Program, bindings []source.BackendBin
 		} else if binding.Kind == "fragment" {
 			kind = gwdkir.EndpointFragment
 		}
-		byEndpoint[endpointKey(kind, binding.PageID, binding.BlockName, binding.Method, binding.Route)] = binding
+		byEndpoint[gwdkir.EndpointIdentity(kind, binding.PageID, binding.BlockName, binding.Method, binding.Route)] = binding
 	}
 	for index := range program.Endpoints {
 		endpoint := &program.Endpoints[index]
-		binding := byEndpoint[endpointKey(endpoint.Kind, endpoint.PageID, endpoint.Symbol, endpoint.Method, endpoint.Path)]
+		binding := byEndpoint[endpoint.SemanticID()]
 		endpoint.Binding = gwdkir.Binding{
 			Status:        binding.Status,
 			Message:       binding.Message,
@@ -60,8 +58,4 @@ func AttachBackendBindings(program *gwdkir.Program, bindings []source.BackendBin
 			ResultFields:  append([]source.BackendResultField(nil), binding.ResultFields...),
 		}
 	}
-}
-
-func endpointKey(kind gwdkir.EndpointKind, pageID, symbol, method, route string) string {
-	return strings.Join([]string{string(kind), pageID, symbol, method, route}, "\x00")
 }

--- a/internal/gwdkanalysis/ir_builder.go
+++ b/internal/gwdkanalysis/ir_builder.go
@@ -89,7 +89,7 @@ func (builder *irBuilder) addPage(page gwdkir.Page) {
 	appendPackageStores(pkg, page.Stores)
 
 	mode := page.RenderMode(builder.config.Render.DefaultMode())
-	builder.program.Routes = append(builder.program.Routes, gwdkir.Route{
+	route := gwdkir.Route{
 		Kind:          routeKind(mode),
 		Method:        "GET",
 		Path:          page.Route,
@@ -103,7 +103,9 @@ func (builder *irBuilder) addPage(page gwdkir.Page) {
 		Guards:        append([]string(nil), page.Guards...),
 		Source:        page.Source,
 		Span:          page.Spans.Route,
-	})
+	}
+	route.ID = route.ExpectedID()
+	builder.program.Routes = append(builder.program.Routes, route)
 	builder.addPageTemplate(page)
 	builder.addPageAssets(page)
 	builder.addPageEndpoints(page)
@@ -176,7 +178,7 @@ func (builder *irBuilder) addPageAssets(page gwdkir.Page) {
 func (builder *irBuilder) addPageEndpoints(page gwdkir.Page) {
 	for _, action := range page.Blocks.Actions {
 		path := endpointPath(action.Route, page.Route)
-		builder.program.Endpoints = append(builder.program.Endpoints, gwdkir.Endpoint{
+		endpoint := gwdkir.Endpoint{
 			Kind:          gwdkir.EndpointAction,
 			Source:        gwdkir.EndpointSourceGOWDK,
 			Package:       page.Package,
@@ -192,12 +194,14 @@ func (builder *irBuilder) addPageEndpoints(page gwdkir.Page) {
 			RouteParams:   copyRouteParams(gwdkir.RouteParamsFromPath(path)),
 			SourceFile:    page.Source,
 			Span:          action.Span,
-		})
+		}
+		endpoint.ID = endpoint.ExpectedID()
+		builder.program.Endpoints = append(builder.program.Endpoints, endpoint)
 	}
 	for _, api := range page.Blocks.APIs {
 		path := endpointPath(api.Route, page.Route)
 		method := endpointMethod(api.Method, "GET")
-		builder.program.Endpoints = append(builder.program.Endpoints, gwdkir.Endpoint{
+		endpoint := gwdkir.Endpoint{
 			Kind:          gwdkir.EndpointAPI,
 			Source:        gwdkir.EndpointSourceGOWDK,
 			Package:       page.Package,
@@ -214,10 +218,12 @@ func (builder *irBuilder) addPageEndpoints(page gwdkir.Page) {
 			RouteParams:   copyRouteParams(gwdkir.RouteParamsFromPath(path)),
 			SourceFile:    page.Source,
 			Span:          api.Span,
-		})
+		}
+		endpoint.ID = endpoint.ExpectedID()
+		builder.program.Endpoints = append(builder.program.Endpoints, endpoint)
 	}
 	for _, fragment := range page.Blocks.Fragments {
-		builder.program.Endpoints = append(builder.program.Endpoints, gwdkir.Endpoint{
+		endpoint := gwdkir.Endpoint{
 			Kind:          gwdkir.EndpointFragment,
 			Source:        gwdkir.EndpointSourceGOWDK,
 			Package:       page.Package,
@@ -231,7 +237,9 @@ func (builder *irBuilder) addPageEndpoints(page gwdkir.Page) {
 			RouteParams:   copyRouteParams(gwdkir.RouteParamsFromPath(fragment.Route)),
 			SourceFile:    page.Source,
 			Span:          fragment.Span,
-		})
+		}
+		endpoint.ID = endpoint.ExpectedID()
+		builder.program.Endpoints = append(builder.program.Endpoints, endpoint)
 	}
 }
 
@@ -372,7 +380,7 @@ func (builder *irBuilder) addStandaloneEndpoint(endpoint gwdkir.GoEndpoint) {
 		defaultMethod = "POST"
 	}
 	method := endpointMethod(endpoint.Method, defaultMethod)
-	builder.program.Endpoints = append(builder.program.Endpoints, gwdkir.Endpoint{
+	normalized := gwdkir.Endpoint{
 		Kind:          kind,
 		Source:        endpoint.SourceKind,
 		Package:       endpoint.Package,
@@ -386,9 +394,12 @@ func (builder *irBuilder) addStandaloneEndpoint(endpoint gwdkir.GoEndpoint) {
 		RouteParams:   copyRouteParams(gwdkir.RouteParamsFromPath(endpoint.Route)),
 		SourceFile:    endpoint.Source,
 		Span:          endpoint.Span,
-	})
+	}
+	normalized.ID = normalized.ExpectedID()
+	builder.program.Endpoints = append(builder.program.Endpoints, normalized)
 	// Preserve the raw declaration losslessly for validation, which needs the
 	// exact kind, method, and spans before normalization.
+	endpoint.ID = normalized.ID
 	builder.program.GoEndpoints = append(builder.program.GoEndpoints, endpoint)
 }
 

--- a/internal/gwdkanalysis/ir_builder.go
+++ b/internal/gwdkanalysis/ir_builder.go
@@ -386,7 +386,7 @@ func cloneEndpointCORS(cors gwdkir.EndpointCORS) gwdkir.EndpointCORS {
 	return cors
 }
 
-func (builder *irBuilder) addStandaloneEndpoint(endpoint gwdkir.GoEndpoint) {
+func (builder *irBuilder) addStandaloneEndpoint(endpoint gwdkir.StandaloneEndpointDeclaration) {
 	kind := gwdkir.EndpointAPI
 	if endpoint.Kind == "act" || endpoint.Kind == "action" {
 		kind = gwdkir.EndpointAction
@@ -413,18 +413,16 @@ func (builder *irBuilder) addStandaloneEndpoint(endpoint gwdkir.GoEndpoint) {
 	}
 	normalized.ID = normalized.ExpectedID()
 	builder.program.Endpoints = append(builder.program.Endpoints, normalized)
-	// Preserve the raw declaration losslessly for validation, which needs the
-	// exact kind, method, and spans before normalization.
 	endpoint.ID = normalized.ID
-	builder.program.GoEndpoints = append(builder.program.GoEndpoints, endpoint)
+	builder.program.SourceMap.Endpoints = append(builder.program.SourceMap.Endpoints, endpoint)
 }
 
 // AddStandaloneEndpoints appends discovered standalone Go endpoint declarations
-// to an already-built program: each declaration is preserved losslessly in
-// Program.GoEndpoints and normalized into Program.Endpoints, which is then
+// to an already-built program: each declaration is normalized into
+// Program.Endpoints and preserved losslessly in Program.SourceMap, which is then
 // re-sorted with the same ordering BuildIR produces so post-build discovery
 // yields the same program as build-time discovery.
-func AddStandaloneEndpoints(config gowdk.Config, program *gwdkir.Program, endpoints []gwdkir.GoEndpoint) {
+func AddStandaloneEndpoints(config gowdk.Config, program *gwdkir.Program, endpoints []gwdkir.StandaloneEndpointDeclaration) {
 	if len(endpoints) == 0 {
 		return
 	}
@@ -463,6 +461,9 @@ func (builder *irBuilder) sortOutput() {
 			return builder.program.Endpoints[i].Method < builder.program.Endpoints[j].Method
 		}
 		return builder.program.Endpoints[i].Path < builder.program.Endpoints[j].Path
+	})
+	sort.Slice(builder.program.SourceMap.Endpoints, func(i, j int) bool {
+		return builder.program.SourceMap.Endpoints[i].ID < builder.program.SourceMap.Endpoints[j].ID
 	})
 }
 

--- a/internal/gwdkanalysis/ir_builder_test.go
+++ b/internal/gwdkanalysis/ir_builder_test.go
@@ -43,3 +43,28 @@ func TestBuildProgramMarksStateChangingAPIsCSRFProtected(t *testing.T) {
 		}
 	}
 }
+
+func TestBuildProgramAssignsStableSemanticIdentities(t *testing.T) {
+	program := BuildProgram(gowdk.Config{}, Sources{Pages: []gwdkir.Page{{
+		ID:      "newsletter",
+		Package: "pages",
+		Source:  "newsletter.page.gwdk",
+		Route:   "/newsletter",
+		Blocks: gwdkir.Blocks{Actions: []gwdkir.Action{
+			{Name: "Subscribe", Method: "POST", Route: "/newsletter"},
+		}},
+	}}})
+
+	if len(program.Routes) != 1 {
+		t.Fatalf("expected one route, got %#v", program.Routes)
+	}
+	if got, want := program.Routes[0].ID, program.Routes[0].ExpectedID(); got != want {
+		t.Fatalf("route ID = %q, want %q", got, want)
+	}
+	if len(program.Endpoints) != 1 {
+		t.Fatalf("expected one endpoint, got %#v", program.Endpoints)
+	}
+	if got, want := program.Endpoints[0].ID, program.Endpoints[0].ExpectedID(); got != want {
+		t.Fatalf("endpoint ID = %q, want %q", got, want)
+	}
+}

--- a/internal/gwdkanalysis/util.go
+++ b/internal/gwdkanalysis/util.go
@@ -8,7 +8,7 @@ import (
 	"github.com/cssbruno/gowdk/internal/source"
 )
 
-func standaloneEndpointPageID(endpoint gwdkir.GoEndpoint) string {
+func standaloneEndpointPageID(endpoint gwdkir.StandaloneEndpointDeclaration) string {
 	if endpoint.Package == "" {
 		return endpoint.Name
 	}

--- a/internal/gwdkir/identity.go
+++ b/internal/gwdkir/identity.go
@@ -1,0 +1,74 @@
+package gwdkir
+
+import (
+	"net/url"
+	"strings"
+)
+
+// PageID, ComponentID, LayoutID, RouteID, and EndpointID are stable semantic
+// identities used across compiler stages. Legacy string fields remain for now
+// while consumers migrate toward typed stage boundaries.
+type PageID string
+type ComponentID string
+type LayoutID string
+type RouteID string
+type EndpointID string
+
+func (id PageID) String() string      { return string(id) }
+func (id ComponentID) String() string { return string(id) }
+func (id LayoutID) String() string    { return string(id) }
+func (id RouteID) String() string     { return string(id) }
+func (id EndpointID) String() string  { return string(id) }
+
+func NewPageID(id string) PageID             { return PageID(id) }
+func NewComponentID(name string) ComponentID { return ComponentID(name) }
+func NewLayoutID(id string) LayoutID         { return LayoutID(id) }
+func RouteIdentity(method, path, pageID string) RouteID {
+	return RouteID(joinIdentityParts(method, path, pageID))
+}
+
+func EndpointIdentity(kind EndpointKind, pageID, symbol, method, path string) EndpointID {
+	return EndpointID(joinIdentityParts(string(kind), pageID, symbol, method, path))
+}
+
+func (page Page) SemanticID() PageID {
+	return NewPageID(page.ID)
+}
+
+func (component Component) SemanticID() ComponentID {
+	return NewComponentID(component.Name)
+}
+
+func (layout Layout) SemanticID() LayoutID {
+	return NewLayoutID(layout.ID)
+}
+
+func (route Route) ExpectedID() RouteID {
+	return RouteIdentity(route.Method, route.Path, route.PageID)
+}
+
+func (route Route) SemanticID() RouteID {
+	if route.ID != "" {
+		return route.ID
+	}
+	return route.ExpectedID()
+}
+
+func (endpoint Endpoint) ExpectedID() EndpointID {
+	return EndpointIdentity(endpoint.Kind, endpoint.PageID, endpoint.Symbol, endpoint.Method, endpoint.Path)
+}
+
+func (endpoint Endpoint) SemanticID() EndpointID {
+	if endpoint.ID != "" {
+		return endpoint.ID
+	}
+	return endpoint.ExpectedID()
+}
+
+func joinIdentityParts(parts ...string) string {
+	escaped := make([]string, 0, len(parts))
+	for _, part := range parts {
+		escaped = append(escaped, url.PathEscape(part))
+	}
+	return strings.Join(escaped, ":")
+}

--- a/internal/gwdkir/identity.go
+++ b/internal/gwdkir/identity.go
@@ -68,7 +68,7 @@ func (endpoint Endpoint) SemanticID() EndpointID {
 func joinIdentityParts(parts ...string) string {
 	escaped := make([]string, 0, len(parts))
 	for _, part := range parts {
-		escaped = append(escaped, url.PathEscape(part))
+		escaped = append(escaped, strings.ReplaceAll(url.PathEscape(part), ":", "%3A"))
 	}
 	return strings.Join(escaped, ":")
 }

--- a/internal/gwdkir/identity_test.go
+++ b/internal/gwdkir/identity_test.go
@@ -1,0 +1,20 @@
+package gwdkir
+
+import "testing"
+
+func TestSemanticIdentitiesEscapeTupleSeparator(t *testing.T) {
+	left := RouteIdentity("GET", "/foo:bar", "baz")
+	right := RouteIdentity("GET", "/foo", "bar:baz")
+	if left == right {
+		t.Fatalf("RouteIdentity collapsed distinct tuples: %q", left)
+	}
+	if got, want := string(left), "GET:%2Ffoo%3Abar:baz"; got != want {
+		t.Fatalf("RouteIdentity() = %q, want %q", got, want)
+	}
+
+	endpointLeft := EndpointIdentity(EndpointAPI, "page:one", "List", "GET", "/api/items")
+	endpointRight := EndpointIdentity(EndpointAPI, "page", "one:List", "GET", "/api/items")
+	if endpointLeft == endpointRight {
+		t.Fatalf("EndpointIdentity collapsed distinct tuples: %q", endpointLeft)
+	}
+}

--- a/internal/gwdkir/invariants.go
+++ b/internal/gwdkir/invariants.go
@@ -43,6 +43,7 @@ func CheckInvariants(program Program) error {
 		}
 	}
 
+	routeIDs := map[RouteID]Route{}
 	for index, route := range program.Routes {
 		switch route.Kind {
 		case RouteStatic, RouteSPA, RouteSSR, RouteHybrid:
@@ -52,11 +53,21 @@ func CheckInvariants(program Program) error {
 		if !pages[route.PageID] {
 			report("route %q references unknown page %q", route.Path, route.PageID)
 		}
+		if route.ID != "" && route.ID != route.ExpectedID() {
+			report("route %q has semantic id %q, want %q", route.Path, route.ID, route.ExpectedID())
+		}
+		routeID := route.SemanticID()
+		if previous, exists := routeIDs[routeID]; exists {
+			report("route %q duplicates semantic id %q from route %q", route.Path, routeID, previous.Path)
+		} else if routeID != "" {
+			routeIDs[routeID] = route
+		}
 		if index > 0 && route.Path < program.Routes[index-1].Path {
 			report("routes are not sorted: %q after %q", route.Path, program.Routes[index-1].Path)
 		}
 	}
 
+	endpointIDs := map[EndpointID]Endpoint{}
 	for index, endpoint := range program.Endpoints {
 		switch endpoint.Kind {
 		case EndpointAction, EndpointAPI, EndpointFragment:
@@ -70,6 +81,15 @@ func CheckInvariants(program Program) error {
 		}
 		if endpoint.Method == "" {
 			report("endpoint %q has no method", endpoint.Path)
+		}
+		if endpoint.ID != "" && endpoint.ID != endpoint.ExpectedID() {
+			report("endpoint %q has semantic id %q, want %q", endpoint.Path, endpoint.ID, endpoint.ExpectedID())
+		}
+		endpointID := endpoint.SemanticID()
+		if previous, exists := endpointIDs[endpointID]; exists {
+			report("endpoint %q duplicates semantic id %q from endpoint %q", endpoint.Path, endpointID, previous.Path)
+		} else if endpointID != "" {
+			endpointIDs[endpointID] = endpoint
 		}
 		if index > 0 {
 			previous := program.Endpoints[index-1]

--- a/internal/gwdkir/invariants.go
+++ b/internal/gwdkir/invariants.go
@@ -111,7 +111,10 @@ func CheckInvariants(program Program) error {
 		reportViewBlockNodes("layout", layout.ID, layout.Blocks, report)
 	}
 
-	for _, endpoint := range program.GoEndpoints {
+	for _, endpoint := range program.SourceMap.Endpoints {
+		if _, exists := endpointIDs[endpoint.ID]; !exists {
+			report("source map endpoint %q references unknown endpoint", endpoint.ID)
+		}
 		switch endpoint.SourceKind {
 		case EndpointSourceGOWDK, EndpointSourceGo:
 		default:

--- a/internal/gwdkir/invariants.go
+++ b/internal/gwdkir/invariants.go
@@ -86,9 +86,7 @@ func CheckInvariants(program Program) error {
 			report("endpoint %q has semantic id %q, want %q", endpoint.Path, endpoint.ID, endpoint.ExpectedID())
 		}
 		endpointID := endpoint.SemanticID()
-		if previous, exists := endpointIDs[endpointID]; exists {
-			report("endpoint %q duplicates semantic id %q from endpoint %q", endpoint.Path, endpointID, previous.Path)
-		} else if endpointID != "" {
+		if _, exists := endpointIDs[endpointID]; !exists && endpointID != "" {
 			endpointIDs[endpointID] = endpoint
 		}
 		if index > 0 {

--- a/internal/gwdkir/invariants_test.go
+++ b/internal/gwdkir/invariants_test.go
@@ -21,9 +21,9 @@ func validProgram() Program {
 			{Kind: EndpointAction, Source: EndpointSourceGOWDK, PageID: "home", Method: "POST", Path: "/actions/save"},
 			{Kind: EndpointAPI, Source: EndpointSourceGo, Method: "GET", Path: "/api/items"},
 		},
-		GoEndpoints: []GoEndpoint{
-			{Kind: "api", SourceKind: EndpointSourceGo, Name: "ListItems", Route: "/api/items"},
-		},
+		SourceMap: SourceMap{Endpoints: []EndpointSourceMap{
+			{ID: EndpointIdentity(EndpointAPI, "", "", "GET", "/api/items"), Kind: "api", SourceKind: EndpointSourceGo, Name: "ListItems", Route: "/api/items"},
+		}},
 		Templates: []Template{
 			{OwnerKind: SourcePage, OwnerID: "home"},
 			{OwnerKind: SourceComponent, OwnerID: "ProductCard"},
@@ -136,9 +136,14 @@ func TestCheckInvariantsReportsViolations(t *testing.T) {
 			want: "endpoints are not sorted",
 		},
 		{
-			name:    "unknown go endpoint source",
-			corrupt: func(p *Program) { p.GoEndpoints[0].SourceKind = "yaml" },
+			name:    "unknown source map endpoint source",
+			corrupt: func(p *Program) { p.SourceMap.Endpoints[0].SourceKind = "yaml" },
 			want:    `go endpoint "ListItems" has unknown source "yaml"`,
+		},
+		{
+			name:    "source map endpoint to missing endpoint",
+			corrupt: func(p *Program) { p.SourceMap.Endpoints[0].ID = EndpointID("missing") },
+			want:    `source map endpoint "missing" references unknown endpoint`,
 		},
 		{
 			name:    "template with unknown owner kind",

--- a/internal/gwdkir/invariants_test.go
+++ b/internal/gwdkir/invariants_test.go
@@ -84,6 +84,11 @@ func TestCheckInvariantsReportsViolations(t *testing.T) {
 			want:    `route "/" references unknown page "ghost"`,
 		},
 		{
+			name:    "mismatched route semantic id",
+			corrupt: func(p *Program) { p.Routes[0].ID = RouteID("wrong") },
+			want:    `has semantic id "wrong"`,
+		},
+		{
 			name: "unsorted routes",
 			corrupt: func(p *Program) {
 				p.Pages = append(p.Pages, Page{ID: "about", Route: "/about"})
@@ -108,6 +113,18 @@ func TestCheckInvariantsReportsViolations(t *testing.T) {
 			name:    "endpoint without method",
 			corrupt: func(p *Program) { p.Endpoints[0].Method = "" },
 			want:    "has no method",
+		},
+		{
+			name:    "mismatched endpoint semantic id",
+			corrupt: func(p *Program) { p.Endpoints[0].ID = EndpointID("wrong") },
+			want:    `has semantic id "wrong"`,
+		},
+		{
+			name: "duplicate endpoint semantic id",
+			corrupt: func(p *Program) {
+				p.Endpoints[1].ID = p.Endpoints[0].SemanticID()
+			},
+			want: "duplicates semantic id",
 		},
 		{
 			name: "unsorted endpoints",

--- a/internal/gwdkir/invariants_test.go
+++ b/internal/gwdkir/invariants_test.go
@@ -122,13 +122,6 @@ func TestCheckInvariantsReportsViolations(t *testing.T) {
 			want:    `has semantic id "wrong"`,
 		},
 		{
-			name: "duplicate endpoint semantic id",
-			corrupt: func(p *Program) {
-				p.Endpoints[1].ID = p.Endpoints[0].SemanticID()
-			},
-			want: "duplicates semantic id",
-		},
-		{
 			name: "unsorted endpoints",
 			corrupt: func(p *Program) {
 				p.Endpoints[0], p.Endpoints[1] = p.Endpoints[1], p.Endpoints[0]
@@ -283,6 +276,22 @@ func TestCheckInvariantsReportsViolations(t *testing.T) {
 				t.Fatalf("CheckInvariants() = %q, want error containing %q", err, test.want)
 			}
 		})
+	}
+}
+
+func TestCheckInvariantsAllowsDuplicateEndpointSemanticIDs(t *testing.T) {
+	program := validProgram()
+	program.SourceMap.Endpoints = nil
+	program.Endpoints = []Endpoint{
+		{Kind: EndpointAction, Source: EndpointSourceGOWDK, PageID: "home", Symbol: "Save", Method: "POST", Path: "/profile"},
+		{Kind: EndpointAction, Source: EndpointSourceGOWDK, PageID: "home", Symbol: "Save", Method: "POST", Path: "/profile"},
+	}
+	for index := range program.Endpoints {
+		program.Endpoints[index].ID = program.Endpoints[index].ExpectedID()
+	}
+
+	if err := CheckInvariants(program); err != nil {
+		t.Fatalf("CheckInvariants() = %v, want nil", err)
 	}
 }
 

--- a/internal/gwdkir/ir.go
+++ b/internal/gwdkir/ir.go
@@ -398,6 +398,7 @@ func GoRefFromLiteral(literal string) GoRef {
 // Route is page/file route metadata. Endpoint behavior is represented by
 // Endpoint, not by route kinds.
 type Route struct {
+	ID            RouteID
 	Kind          RouteKind
 	Method        string
 	Path          string
@@ -424,6 +425,7 @@ const (
 
 // Endpoint is framework-neutral backend endpoint metadata.
 type Endpoint struct {
+	ID            EndpointID
 	Kind          EndpointKind
 	Source        EndpointSource
 	Package       string
@@ -451,6 +453,7 @@ type Endpoint struct {
 // the exact kind, method, and spans the author wrote with no information loss.
 // Fields mirror the parser/discovery output one-to-one.
 type GoEndpoint struct {
+	ID            EndpointID
 	Kind          string
 	SourceKind    EndpointSource
 	Package       string

--- a/internal/gwdkir/ir.go
+++ b/internal/gwdkir/ir.go
@@ -18,7 +18,6 @@ type Program struct {
 	Layouts               []Layout
 	Routes                []Route
 	Endpoints             []Endpoint
-	GoEndpoints           []GoEndpoint
 	Templates             []Template
 	ContractRefs          []ContractReference
 	RealtimeSubscriptions []RealtimeSubscription
@@ -26,6 +25,7 @@ type Program struct {
 	AuditSpecs            []AuditSpec
 	ClientBehaviors       []ClientBehavior
 	Assets                []Asset
+	SourceMap             SourceMap
 	Diagnostics           []Diagnostic
 }
 
@@ -445,14 +445,16 @@ type Endpoint struct {
 	Binding       Binding
 }
 
-// GoEndpoint preserves a standalone Go endpoint declaration (discovered from
-// `//gowdk:` comments) in its raw source-level form. Program.Endpoints holds the
-// normalized, codegen-ready endpoints with bindings attached, which is lossy for
-// validation (it collapses the raw kind, normalizes the method, and drops the
-// route/error-page spans). Keeping the raw declaration here lets validation read
-// the exact kind, method, and spans the author wrote with no information loss.
-// Fields mirror the parser/discovery output one-to-one.
-type GoEndpoint struct {
+// SourceMap keeps exact source spelling and spans outside semantic IR records.
+// Generators consume normalized semantic fields and use source-map entries only
+// for diagnostics, inspection, formatting, and trace metadata.
+type SourceMap struct {
+	Endpoints []EndpointSourceMap
+}
+
+// EndpointSourceMap records the exact standalone endpoint declaration that
+// lowered into a normalized Program.Endpoints entry.
+type EndpointSourceMap struct {
 	ID            EndpointID
 	Kind          string
 	SourceKind    EndpointSource
@@ -466,6 +468,26 @@ type GoEndpoint struct {
 	RouteSpan     source.SourceSpan
 	RouteParams   []source.NamedSpan
 	ErrorPageSpan source.SourceSpan
+}
+
+// StandaloneEndpointDeclaration is the lossless discovery input for
+// `//gowdk:` Go endpoint comments. Program assembly lowers it into a normalized
+// Endpoint plus an EndpointSourceMap entry.
+type StandaloneEndpointDeclaration = EndpointSourceMap
+
+// EndpointSource returns the source-map entry for a normalized endpoint ID.
+func (program Program) EndpointSource(id EndpointID) (EndpointSourceMap, bool) {
+	return program.SourceMap.Endpoint(id)
+}
+
+// Endpoint returns the source-map entry for a normalized endpoint ID.
+func (sourceMap SourceMap) Endpoint(id EndpointID) (EndpointSourceMap, bool) {
+	for _, endpoint := range sourceMap.Endpoints {
+		if endpoint.ID == id {
+			return endpoint, true
+		}
+	}
+	return EndpointSourceMap{}, false
 }
 
 type EndpointKind string


### PR DESCRIPTION
## Summary

- Split standalone Go endpoint source fidelity out of the semantic IR by replacing `Program.GoEndpoints` with `Program.SourceMap` entries keyed by stable `EndpointID`.
- Keep normalized standalone Go endpoints in `Program.Endpoints` so validation, binding lookup, route checks, and generated-output planners consume semantic records instead of raw declaration records.
- Carry stable typed IDs for pages, components, layouts, routes, and endpoints through IR assembly, invariant checks, backend binding lookup, and appgen endpoint planning.
- Document the semantic IR/source-map boundary and the target-plan boundary for buildgen/appgen consumers.

## Issue Closure

Closes #668
Related: #664
Related: #667

## Verification

- [x] I ran the relevant tests, lint, and build commands.
- [x] I ran `scripts/test-go-modules.sh` when Go code or compiler behavior changed.
- [x] I ran `go build ./cmd/gowdk` when CLI, compiler, runtime, addon, or release behavior changed.
- [ ] I ran `node --check editors/vscode/extension.js` when editor files changed.
- [x] I updated docs for behavior, setup, or architecture changes.
- [x] I added or updated tests for changed behavior.
- [x] I considered security-sensitive surfaces such as auth, CSRF, redirects, request-time handlers, logs, diagnostics, embedded assets, editor commands, WASM, contracts, and realtime behavior.

Commands run:

- `go test ./internal/gwdkir ./internal/gwdkanalysis`
- `go test ./internal/compiler`
- `go test ./internal/appgen`
- `go test ./internal/buildgen ./internal/lsp`
- `go test ./internal/diagnostics ./internal/diagnosticfix`
- `go build ./cmd/gowdk`
- `go run ./cmd/gowdk inspect ir examples/pages/home.page.gwdk`
- `scripts/check-docs-links.sh`
- `scripts/check-docs-style.sh`
- `scripts/test-go-modules.sh`

## LLM Assistance

- LLM session summary: Codex implemented the semantic IR/source-map split for standalone Go endpoints, carried typed semantic IDs through IR and generated-output planning boundaries, updated invariants/tests/docs, and verified the full Go module gate.
- Human-reviewed assumptions: #668 is fully resolved by this PR because `gwdkir.Program` now separates normalized semantic endpoint records from diagnostic source-map records and generated-output consumers carry semantic IDs into target-specific plans. #664 and #667 remain related follow-up issues because their broader typed-only and phase-boundary acceptance criteria are not fully closed here.
- Follow-up work: Continue #664 and #667 in separate PRs without reopening the `Program.GoEndpoints` semantic/raw declaration coupling.
