### PR TITLE
fix(config): harden CORS, addons, CSS, and artifact scans

### DIFF
--- a/addons/tailwind/tailwind.go
+++ b/addons/tailwind/tailwind.go
@@ -75,9 +75,10 @@ func (p processor) ProcessCSS(context gowdk.CSSContext) (gowdk.CSSResult, error)
 	defer os.RemoveAll(tempDir)
 
 	tempOutput := filepath.Join(tempDir, "app.css")
-	input := options.Input
+	workingDir := cssWorkingDir(context)
+	input := resolveCSSPath(workingDir, options.Input)
 	if len(context.Sources) > 0 {
-		generatedInput, err := writeInputWithSources(tempDir, options.Input, context.Sources)
+		generatedInput, err := writeInputWithSources(tempDir, workingDir, input, context.Sources)
 		if err != nil {
 			return gowdk.CSSResult{}, err
 		}
@@ -91,6 +92,7 @@ func (p processor) ProcessCSS(context gowdk.CSSContext) (gowdk.CSSResult, error)
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
 	command := exec.Command(commandPath, args...)
+	command.Dir = workingDir
 	command.Stdout = &stdout
 	command.Stderr = &stderr
 	if err := command.Run(); err != nil {
@@ -111,11 +113,8 @@ func (p processor) ProcessCSS(context gowdk.CSSContext) (gowdk.CSSResult, error)
 	}, nil
 }
 
-func writeInputWithSources(tempDir string, input string, sources []gowdk.CSSSource) (string, error) {
-	inputPath, err := filepath.Abs(input)
-	if err != nil {
-		return "", err
-	}
+func writeInputWithSources(tempDir string, workingDir string, input string, sources []gowdk.CSSSource) (string, error) {
+	inputPath := resolveCSSPath(workingDir, input)
 	relInput, err := filepath.Rel(tempDir, inputPath)
 	if err != nil {
 		return "", err
@@ -130,10 +129,7 @@ func writeInputWithSources(tempDir string, input string, sources []gowdk.CSSSour
 			continue
 		}
 		seen[sourcePath] = true
-		absoluteSource, err := filepath.Abs(sourcePath)
-		if err != nil {
-			return "", err
-		}
+		absoluteSource := resolveCSSPath(workingDir, sourcePath)
 		relativeSource, err := filepath.Rel(tempDir, absoluteSource)
 		if err != nil {
 			return "", err
@@ -146,6 +142,28 @@ func writeInputWithSources(tempDir string, input string, sources []gowdk.CSSSour
 		return "", err
 	}
 	return generatedInput, nil
+}
+
+func cssWorkingDir(context gowdk.CSSContext) string {
+	for _, candidate := range []string{context.WorkingDir, context.ConfigDir, context.ProjectRoot, context.SourceRoot} {
+		candidate = strings.TrimSpace(candidate)
+		if candidate != "" {
+			return candidate
+		}
+	}
+	return "."
+}
+
+func resolveCSSPath(workingDir string, path string) string {
+	path = strings.TrimSpace(path)
+	if filepath.IsAbs(path) {
+		return path
+	}
+	absolute, err := filepath.Abs(filepath.Join(workingDir, path))
+	if err != nil {
+		return filepath.Join(workingDir, path)
+	}
+	return absolute
 }
 
 func cssPath(path string) string {

--- a/addons/tailwind/tailwind_test.go
+++ b/addons/tailwind/tailwind_test.go
@@ -38,8 +38,10 @@ func TestProcessCSSRunsStandaloneCommand(t *testing.T) {
 		t.Fatal(err)
 	}
 	argsFile := filepath.Join(root, "args.txt")
+	cwdFile := filepath.Join(root, "cwd.txt")
 	inputCopy := filepath.Join(root, "generated-input.css")
 	t.Setenv("TAILWIND_ARGS_FILE", argsFile)
+	t.Setenv("TAILWIND_CWD_FILE", cwdFile)
 	t.Setenv("TAILWIND_INPUT_COPY", inputCopy)
 
 	result, err := Addon(Options{
@@ -66,6 +68,17 @@ func TestProcessCSSRunsStandaloneCommand(t *testing.T) {
 	if len(result.Stylesheets) != 1 || result.Stylesheets[0].Href != "/assets/site.css" {
 		t.Fatalf("unexpected stylesheets: %#v", result.Stylesheets)
 	}
+	wantCWD, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cwd, err := os.ReadFile(cwdFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.TrimSpace(string(cwd)) != wantCWD {
+		t.Fatalf("expected tailwind command to run in %q, got %q", wantCWD, cwd)
+	}
 
 	args, err := os.ReadFile(argsFile)
 	if err != nil {
@@ -86,6 +99,63 @@ func TestProcessCSSRunsStandaloneCommand(t *testing.T) {
 		if !strings.Contains(generated, expected) {
 			t.Fatalf("expected generated tailwind input to contain %q, got:\n%s", expected, generated)
 		}
+	}
+}
+
+func TestProcessCSSResolvesRelativePathsFromContextWorkingDir(t *testing.T) {
+	root := t.TempDir()
+	if err := os.Mkdir(filepath.Join(root, "styles"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	input := filepath.Join(root, "styles", "app.css")
+	if err := os.WriteFile(input, []byte(`@import "tailwindcss";`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	argsFile := filepath.Join(root, "args.txt")
+	cwdFile := filepath.Join(root, "cwd.txt")
+	inputCopy := filepath.Join(root, "generated-input.css")
+	t.Setenv("TAILWIND_ARGS_FILE", argsFile)
+	t.Setenv("TAILWIND_CWD_FILE", cwdFile)
+	t.Setenv("TAILWIND_INPUT_COPY", inputCopy)
+
+	other := t.TempDir()
+	previous, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(other); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(previous); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	_, err = Addon(Options{
+		Input:   "styles/app.css",
+		Command: fakeTailwindCommand(t),
+	}).ProcessCSS(gowdk.CSSContext{
+		WorkingDir: root,
+		Sources:    []gowdk.CSSSource{{Path: "site.page.gwdk"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	cwd, err := os.ReadFile(cwdFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.TrimSpace(string(cwd)) != root {
+		t.Fatalf("expected tailwind command to run in %q, got %q", root, cwd)
+	}
+	generatedInput, err := os.ReadFile(inputCopy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	generated := string(generatedInput)
+	if !strings.Contains(generated, `styles/app.css`) {
+		t.Fatalf("expected generated input to reference context-relative input, got:\n%s", generated)
 	}
 }
 
@@ -195,6 +265,9 @@ func fakeTailwindCommand(t *testing.T) string {
 
 const fakeTailwindScript = `#!/bin/sh
 set -eu
+if [ "${TAILWIND_CWD_FILE:-}" != "" ]; then
+	pwd > "$TAILWIND_CWD_FILE"
+fi
 printf '%s\n' "$@" > "$TAILWIND_ARGS_FILE"
 out=""
 in=""

--- a/docs/engineering/security.md
+++ b/docs/engineering/security.md
@@ -66,15 +66,21 @@ diagnostic code, a `file:line`, and remediation; run `gowdk explain <code>` for
 details.
 
 `gowdk build` evaluates the same static baseline before writing output and scans
-the final emitted artifact files for bundled secrets after generation.
+text-like final emitted artifact files for bundled secrets after generation. The
+final scan is bounded to 1 MiB per text file and 16 MiB total text input; known
+binary artifact types such as WASM, images, archives, and generated binaries are
+not scanned as text, and oversized text artifacts produce warnings.
+
 Production builds fail on error-severity findings unless they are explicitly
 waived or scoped-bypassed (see below); non-production builds print a prominent
-warning summary without blocking local iteration. `gowdk audit` remains the
-explicit report and CI surface: it prints the full human/JSON report, reads
-declared `*.audit.gwdk` policies, checks frontend risks such as bundle secrets
-and raw-HTML sinks, can emit readable standalone runtime tests with `gowdk audit
---emit-tests`, can verify committed tests are current with `gowdk audit
---check-tests`, and can run generated-app runtime tests with `gowdk audit --run`.
+warning summary without blocking local iteration.
+
+`gowdk audit` remains the explicit report and CI surface: it prints the full
+human/JSON report, reads declared `*.audit.gwdk` policies, checks frontend risks
+such as bundle secrets and raw-HTML sinks, can emit readable standalone runtime
+tests with `gowdk audit --emit-tests`, can verify committed tests are current
+with `gowdk audit --check-tests`, and can run generated-app runtime tests with
+`gowdk audit --run`.
 
 ## CI-Native Output: JSON Schema, SARIF, Fingerprints, And Diff
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -100,10 +100,12 @@ gowdk lsp [--config <file>] [--project-root <dir>] [--ssr]
   (`GOPROXY=off`, `GOTOOLCHAIN=local`). A failed expectation is reported as
   `audit_test_failed`; exceeding the deadline is reported distinctly as
   `audit_test_timeout`.
-  `gowdk build` runs the same baseline gate before writing output, scans the
-  final emitted artifact files for bundled secrets after generation, blocks
-  production builds on error-severity findings unless `--allow-insecure` is set,
-  and writes the
+  `gowdk build` runs the same baseline gate before writing output, scans
+  text-like final emitted artifact files for bundled secrets after generation
+  with a 1 MiB per-file limit and 16 MiB total text scan budget, skips known
+  binary artifact types such as WASM, images, archives, and binaries, reports
+  oversized text artifacts as warnings, blocks production builds on
+  error-severity findings unless `--allow-insecure` is set, and writes the
   posture alone to a non-served `.gowdk/reports/<output-name>/gowdk-security.json`
   path outside the selected output directory.
   `gowdk audit` exit codes form a stable CI contract; gate on the specific code

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -273,11 +273,18 @@ type CORSConfig struct {
 ```
 
 `AllowedOrigins` accepts literal `http` or `https` origins, or `"*"` only when
-`AllowCredentials` is false. Preflight requests must match a generated
-API/command/query route and must request a method and headers allowed by the
-policy. `AllowedMethods` is optional; when omitted, the matched route method is
-returned. `AllowedHeaders` must include non-simple request headers such as
-`Content-Type` for JSON APIs and any configured CSRF header.
+`AllowCredentials` is false. Origin validation canonicalizes host case, strips
+explicit default ports (`http:80`, `https:443`), strips a trailing DNS dot, and
+handles bracketed IPv6 hosts. Unicode hostnames are rejected; use ASCII
+punycode. Invalid ports, userinfo, paths, query strings, and fragments are
+rejected with the offending origin in the diagnostic. Runtime request matching
+uses the same canonical form as config validation.
+
+Preflight requests must match a generated API/command/query route and must
+request a method and headers allowed by the policy. `AllowedMethods` is
+optional; when omitted, the matched route method is returned. `AllowedHeaders`
+must include non-simple request headers such as `Content-Type` for JSON APIs and
+any configured CSRF header.
 
 `.gwdk` API declarations can attach endpoint-local CORS with a trailing `cors`
 clause:
@@ -731,6 +738,13 @@ embed, CSS, contracts, realtime, auth, DB helpers, rate limiting, and SEO
 output. Current validation uses feature registration for render-mode,
 realtime, and other compiler checks; SPA builds invoke addons that implement
 `gowdk.CSSProcessor` or `gowdk.SEOProvider`.
+
+Config loading rejects nil addons, empty addon names, duplicate addon names,
+empty feature IDs, addons with no features, and duplicate feature ownership
+except for the legacy `spa`/`static` `FeatureSPA` alias overlap. External addon
+feature names are allowed when they are non-empty. Behaviorful built-in features
+must provide their matching extension contract: `FeatureSEO` requires
+`gowdk.SEOProvider`, and `FeatureAuth` requires `gowdk.AuthSessionProvider`.
 
 DB helper usage is ordinary Go code around `database/sql`; see [db.md](db.md)
 for migrations, transactions, readiness, and sqlc usage.

--- a/docs/reference/css.md
+++ b/docs/reference/css.md
@@ -230,6 +230,9 @@ type CSSProcessor interface {
 
 `CSSContext` includes:
 
+- `ProjectRoot`, `ConfigDir`, `SourceRoot`, and `WorkingDir`: explicit root
+  paths for processors that need deterministic relative path handling. In CLI
+  builds these point at the loaded project/config root.
 - `Sources`: discovered page/component source metadata.
 - `Sources[*].CSSClasses`: extracted literal class names from the current view
   subset.
@@ -296,7 +299,9 @@ Defaults:
 At build time the addon creates a temporary Tailwind input file that imports the
 configured `Input` CSS and adds `@source` declarations for discovered GOWDK
 source files. This follows Tailwind v4's CSS/source directive model. It then
-runs the standalone executable with `-i <temp-input> -o <temp-output>`.
+runs the standalone executable with `-i <temp-input> -o <temp-output>` from the
+CSS context working directory. Relative `Input` and source paths resolve from
+that directory instead of the caller's process working directory.
 
 The addon does not use npm, run `npx`, or run through a shell. If `Command` is
 omitted and `tailwindcss` is not available on `PATH`, `gowdk build` fails with

--- a/gowdk.go
+++ b/gowdk.go
@@ -2,11 +2,12 @@ package gowdk
 
 import (
 	"fmt"
-	"net/url"
+	"reflect"
 	"strings"
 	"time"
 	"unicode"
 
+	"github.com/cssbruno/gowdk/runtime/corsorigin"
 	runtimeseo "github.com/cssbruno/gowdk/runtime/seo"
 )
 
@@ -554,22 +555,9 @@ func (config CORSConfig) Validate() error {
 }
 
 func validateCORSOrigin(origin string) error {
-	if strings.ContainsAny(origin, "\r\n") {
-		return fmt.Errorf("Build.CORS.AllowedOrigins contains invalid origin %q", origin)
-	}
-	parsed, err := url.Parse(origin)
+	_, err := corsorigin.Parse(origin)
 	if err != nil {
 		return fmt.Errorf("Build.CORS.AllowedOrigins contains invalid origin %q: %w", origin, err)
-	}
-	scheme := strings.ToLower(parsed.Scheme)
-	if scheme != "http" && scheme != "https" {
-		return fmt.Errorf("Build.CORS.AllowedOrigins origin %q must use http or https", origin)
-	}
-	if parsed.User != nil || parsed.Host == "" || parsed.RawQuery != "" || parsed.Fragment != "" {
-		return fmt.Errorf("Build.CORS.AllowedOrigins origin %q must not include userinfo, query, or fragment", origin)
-	}
-	if parsed.Path != "" && parsed.Path != "/" {
-		return fmt.Errorf("Build.CORS.AllowedOrigins origin %q must not include a path", origin)
 	}
 	return nil
 }
@@ -920,6 +908,79 @@ func (a addon) Features() []Feature {
 	return append([]Feature(nil), a.features...)
 }
 
+// ValidateAddons checks addon identity and feature ownership before compiler
+// planning so invalid declarations fail as config errors instead of panicking
+// during feature lookup or addon execution.
+func ValidateAddons(addons []Addon) error {
+	names := map[string]int{}
+	features := map[Feature]int{}
+	for index, addon := range addons {
+		if addonIsNil(addon) {
+			return fmt.Errorf("Addons[%d] is nil", index)
+		}
+		name := strings.TrimSpace(addon.Name())
+		if name == "" {
+			return fmt.Errorf("Addons[%d].Name is required", index)
+		}
+		if previous, ok := names[name]; ok {
+			return fmt.Errorf("Addons[%d] %q duplicates Addons[%d]", index, name, previous)
+		}
+		names[name] = index
+		addonFeatures := addon.Features()
+		if len(addonFeatures) == 0 {
+			return fmt.Errorf("Addons[%d] %q must declare at least one feature", index, name)
+		}
+		for featureIndex, feature := range addonFeatures {
+			if strings.TrimSpace(string(feature)) == "" {
+				return fmt.Errorf("Addons[%d] %q declares empty feature at index %d", index, name, featureIndex)
+			}
+			if previous, ok := features[feature]; ok && !duplicateFeatureAllowed(feature) {
+				return fmt.Errorf("Addons[%d] %q duplicates feature %q already owned by Addons[%d]", index, name, feature, previous)
+			}
+			if _, ok := features[feature]; !ok {
+				features[feature] = index
+			}
+		}
+		if err := validateAddonFeatureContracts(index, name, addon, addonFeatures); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateAddonFeatureContracts(index int, name string, addon Addon, features []Feature) error {
+	for _, feature := range features {
+		switch feature {
+		case FeatureSEO:
+			if _, ok := addon.(SEOProvider); !ok {
+				return fmt.Errorf("Addons[%d] %q declares feature %q but does not implement gowdk.SEOProvider", index, name, feature)
+			}
+		case FeatureAuth:
+			if _, ok := addon.(AuthSessionProvider); !ok {
+				return fmt.Errorf("Addons[%d] %q declares feature %q but does not implement gowdk.AuthSessionProvider", index, name, feature)
+			}
+		}
+	}
+	return nil
+}
+
+func addonIsNil(addon Addon) bool {
+	if addon == nil {
+		return true
+	}
+	value := reflect.ValueOf(addon)
+	switch value.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
+		return value.IsNil()
+	default:
+		return false
+	}
+}
+
+func duplicateFeatureAllowed(feature Feature) bool {
+	return feature == FeatureSPA
+}
+
 // FeatureSet is a lookup table of enabled compiler/generator capabilities.
 type FeatureSet map[Feature]bool
 
@@ -927,6 +988,9 @@ type FeatureSet map[Feature]bool
 func EnabledFeatures(config Config) FeatureSet {
 	features := FeatureSet{}
 	for _, addon := range config.Addons {
+		if addonIsNil(addon) {
+			continue
+		}
 		for _, feature := range addon.Features() {
 			features[feature] = true
 		}
@@ -966,10 +1030,14 @@ type CSSSource struct {
 
 // CSSContext is passed to compile-time CSS processors.
 type CSSContext struct {
-	Sources   []CSSSource
-	OutputDir string
-	Build     BuildConfig
-	CSS       CSSConfig
+	ProjectRoot string
+	ConfigDir   string
+	SourceRoot  string
+	WorkingDir  string
+	Sources     []CSSSource
+	OutputDir   string
+	Build       BuildConfig
+	CSS         CSSConfig
 }
 
 // CSSAsset is a CSS file emitted by a compile-time CSS processor.

--- a/internal/buildgen/css.go
+++ b/internal/buildgen/css.go
@@ -32,11 +32,20 @@ func planCSS(config gowdk.Config, ir gwdkir.Program, outputDir string, component
 	var failures []string
 	seen := map[string]bool{}
 	pageIDs := pageIDSet(ir.Pages)
+	root, rootErr := os.Getwd()
+	if rootErr != nil {
+		failures = append(failures, rootErr.Error())
+		root = "."
+	}
 	context := gowdk.CSSContext{
-		Sources:   cssSources(ir),
-		OutputDir: outputDir,
-		Build:     config.Build,
-		CSS:       config.CSS,
+		ProjectRoot: root,
+		ConfigDir:   root,
+		SourceRoot:  root,
+		WorkingDir:  root,
+		Sources:     cssSources(ir),
+		OutputDir:   outputDir,
+		Build:       config.Build,
+		CSS:         config.CSS,
 	}
 	for _, addon := range config.Addons {
 		processor, ok := addon.(gowdk.CSSProcessor)

--- a/internal/gowdkcmd/build_audit.go
+++ b/internal/gowdkcmd/build_audit.go
@@ -1,7 +1,9 @@
 package gowdkcmd
 
 import (
+	"bytes"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"sort"
@@ -14,6 +16,11 @@ import (
 	"github.com/cssbruno/gowdk/internal/diagnostics"
 	"github.com/cssbruno/gowdk/internal/securitymanifest"
 	"github.com/cssbruno/gowdk/internal/securitytext"
+)
+
+const (
+	finalArtifactMaxTextBytes  = 1 << 20
+	finalArtifactMaxTotalBytes = 16 << 20
 )
 
 // buildSecurityAuditError reports that gowdk build was blocked by error-severity
@@ -160,8 +167,9 @@ func recordBuildSecurityWaivers(findings []auditspec.Finding) {
 
 func finalBuildArtifactSecurityFindings(result buildgen.Result) []auditspec.Finding {
 	var findings []auditspec.Finding
+	var scannedBytes int64
 	for _, artifactPath := range finalBuildArtifactPaths(result) {
-		payload, err := os.ReadFile(artifactPath)
+		decision, err := classifyFinalArtifact(artifactPath)
 		if err != nil {
 			findings = append(findings, auditspec.Finding{
 				Code:        "audit_bundle_secret",
@@ -173,7 +181,45 @@ func finalBuildArtifactSecurityFindings(result buildgen.Result) []auditspec.Find
 			})
 			continue
 		}
-		if kind, ok := securitytext.FirstSecretKind(string(payload)); ok {
+		if !decision.scanText {
+			continue
+		}
+		if decision.size > finalArtifactMaxTextBytes {
+			findings = append(findings, auditspec.Finding{
+				Code:        "audit_bundle_secret",
+				Severity:    diagnostics.SeverityWarning,
+				Target:      "artifact:" + filepath.ToSlash(artifactPath),
+				Source:      filepath.ToSlash(artifactPath),
+				Message:     fmt.Sprintf("final emitted text artifact exceeds the bundled-secret scan limit (%d bytes > %d bytes)", decision.size, int64(finalArtifactMaxTextBytes)),
+				Remediation: "Reduce the generated artifact size or inspect it with an application-owned secret scanner before deployment.",
+			})
+			continue
+		}
+		if scannedBytes+decision.size > finalArtifactMaxTotalBytes {
+			findings = append(findings, auditspec.Finding{
+				Code:        "audit_bundle_secret",
+				Severity:    diagnostics.SeverityWarning,
+				Target:      "artifact:" + filepath.ToSlash(artifactPath),
+				Source:      filepath.ToSlash(artifactPath),
+				Message:     fmt.Sprintf("final artifact secret scanning skipped after reaching the total scan budget (%d bytes)", int64(finalArtifactMaxTotalBytes)),
+				Remediation: "Inspect skipped generated text artifacts with an application-owned secret scanner before deployment.",
+			})
+			continue
+		}
+		payload, err := readFinalArtifactText(artifactPath, decision.size)
+		if err != nil {
+			findings = append(findings, auditspec.Finding{
+				Code:        "audit_bundle_secret",
+				Severity:    auditDiagnosticSeverity("audit_bundle_secret"),
+				Target:      "artifact:" + filepath.ToSlash(artifactPath),
+				Source:      filepath.ToSlash(artifactPath),
+				Message:     fmt.Sprintf("final emitted artifact could not be scanned for bundled secrets: %v", err),
+				Remediation: "Regenerate the artifact or remove unreadable output so the final build security scan has complete coverage.",
+			})
+			continue
+		}
+		scannedBytes += decision.size
+		if kind, ok := securitytext.FirstSecretKind(payload); ok {
 			findings = append(findings, auditspec.Finding{
 				Code:        "audit_bundle_secret",
 				Severity:    auditDiagnosticSeverity("audit_bundle_secret"),
@@ -185,6 +231,79 @@ func finalBuildArtifactSecurityFindings(result buildgen.Result) []auditspec.Find
 		}
 	}
 	return auditspec.EnrichFindings(findings)
+}
+
+type finalArtifactScanDecision struct {
+	scanText bool
+	size     int64
+}
+
+func classifyFinalArtifact(path string) (finalArtifactScanDecision, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return finalArtifactScanDecision{}, err
+	}
+	if !info.Mode().IsRegular() {
+		return finalArtifactScanDecision{}, fmt.Errorf("not a regular file")
+	}
+	if finalArtifactExtensionIsBinary(filepath.Ext(path)) {
+		return finalArtifactScanDecision{size: info.Size()}, nil
+	}
+	file, err := os.Open(path)
+	if err != nil {
+		return finalArtifactScanDecision{}, err
+	}
+	defer file.Close()
+	header := make([]byte, 512)
+	n, err := file.Read(header)
+	if err != nil && err != io.EOF {
+		return finalArtifactScanDecision{}, err
+	}
+	return finalArtifactScanDecision{
+		scanText: finalArtifactHeaderIsText(header[:n]),
+		size:     info.Size(),
+	}, nil
+}
+
+func finalArtifactExtensionIsBinary(ext string) bool {
+	switch strings.ToLower(ext) {
+	case ".wasm", ".png", ".jpg", ".jpeg", ".gif", ".webp", ".ico", ".avif", ".zip", ".gz", ".br", ".tar", ".tgz", ".pdf", ".bin", ".exe", ".dylib", ".so", ".dll":
+		return true
+	default:
+		return false
+	}
+}
+
+func finalArtifactHeaderIsText(header []byte) bool {
+	if len(header) == 0 {
+		return true
+	}
+	if bytes.Contains(header, []byte{0}) {
+		return false
+	}
+	for _, b := range header {
+		if b < 0x20 && b != '\n' && b != '\r' && b != '\t' && b != '\f' {
+			return false
+		}
+	}
+	return true
+}
+
+func readFinalArtifactText(path string, size int64) (string, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer file.Close()
+	limit := size
+	if limit > finalArtifactMaxTextBytes {
+		limit = finalArtifactMaxTextBytes
+	}
+	payload, err := io.ReadAll(io.LimitReader(file, limit))
+	if err != nil {
+		return "", err
+	}
+	return string(payload), nil
 }
 
 func finalBuildArtifactPaths(result buildgen.Result) []string {

--- a/internal/gowdkcmd/build_audit_test.go
+++ b/internal/gowdkcmd/build_audit_test.go
@@ -1,0 +1,52 @@
+package gowdkcmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/cssbruno/gowdk/internal/buildgen"
+)
+
+func TestFinalBuildArtifactSecurityFindingsClassifiesBinaryAsNonText(t *testing.T) {
+	root := t.TempDir()
+	binary := filepath.Join(root, "app.wasm")
+	if err := os.WriteFile(binary, []byte("\x00token=live_secret_1234567890"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	findings := finalBuildArtifactSecurityFindings(buildgen.Result{
+		AssetArtifacts: []buildgen.AssetArtifact{{Path: binary}},
+	})
+	if len(findings) != 0 {
+		t.Fatalf("expected binary artifact to be skipped, got %#v", findings)
+	}
+}
+
+func TestFinalBuildArtifactSecurityFindingsScansTextAndWarnsOnLargeText(t *testing.T) {
+	root := t.TempDir()
+	secret := filepath.Join(root, "index.html")
+	if err := os.WriteFile(secret, []byte(`<main data-token="token=live_secret_1234567890"></main>`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	large := filepath.Join(root, "large.js")
+	payload := strings.Repeat("a", finalArtifactMaxTextBytes+1)
+	if err := os.WriteFile(large, []byte(payload), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	findings := finalBuildArtifactSecurityFindings(buildgen.Result{
+		Artifacts:      []buildgen.Artifact{{Path: secret}},
+		AssetArtifacts: []buildgen.AssetArtifact{{Path: large}},
+	})
+	if len(findings) != 2 {
+		t.Fatalf("expected secret and large-text findings, got %#v", findings)
+	}
+	if !strings.Contains(findings[0].Message, "secret-shaped") {
+		t.Fatalf("expected secret finding first, got %#v", findings)
+	}
+	if !strings.Contains(findings[1].Message, "exceeds the bundled-secret scan limit") {
+		t.Fatalf("expected large text warning, got %#v", findings)
+	}
+}

--- a/internal/gowdkcmd/project_inputs.go
+++ b/internal/gowdkcmd/project_inputs.go
@@ -131,6 +131,9 @@ func validateNativeProjectConfigStructure(path string, config gowdk.Config) erro
 	if err := config.Build.CORS.Validate(); err != nil {
 		return fmt.Errorf("%s CORS policy: %w", path, err)
 	}
+	if err := gowdk.ValidateAddons(config.Addons); err != nil {
+		return fmt.Errorf("%s addons: %w", path, err)
+	}
 	return nil
 }
 

--- a/internal/project/config.go
+++ b/internal/project/config.go
@@ -96,6 +96,9 @@ func validateLoadedConfig(path string, config gowdk.Config) error {
 	if err := config.Build.CORS.Validate(); err != nil {
 		return fmt.Errorf("%s CORS policy: %w", path, err)
 	}
+	if err := gowdk.ValidateAddons(config.Addons); err != nil {
+		return fmt.Errorf("%s addons: %w", path, err)
+	}
 	return nil
 }
 

--- a/internal/project/config_validation.go
+++ b/internal/project/config_validation.go
@@ -92,5 +92,8 @@ func validateLoadedConfigStructure(path string, config gowdk.Config) error {
 	if err := config.Build.CORS.Validate(); err != nil {
 		return fmt.Errorf("%s CORS policy: %w", path, err)
 	}
+	if err := gowdk.ValidateAddons(config.Addons); err != nil {
+		return fmt.Errorf("%s addons: %w", path, err)
+	}
 	return nil
 }

--- a/internal/publicapi/gowdk_test.go
+++ b/internal/publicapi/gowdk_test.go
@@ -36,6 +36,51 @@ func TestConfigHasFeature(t *testing.T) {
 	}
 }
 
+func TestValidateAddonsRejectsInvalidIdentityAndOwnership(t *testing.T) {
+	tests := []struct {
+		name   string
+		addons []gowdk.Addon
+		want   string
+	}{
+		{name: "nil", addons: []gowdk.Addon{nil}, want: "Addons[0] is nil"},
+		{name: "empty name", addons: []gowdk.Addon{gowdk.NewAddon("", gowdk.FeatureCSS)}, want: "Name is required"},
+		{name: "empty features", addons: []gowdk.Addon{gowdk.NewAddon("empty")}, want: "at least one feature"},
+		{name: "empty feature", addons: []gowdk.Addon{gowdk.NewAddon("empty-feature", gowdk.Feature(""))}, want: "empty feature"},
+		{name: "duplicate names", addons: []gowdk.Addon{
+			gowdk.NewAddon("css", gowdk.FeatureCSS),
+			gowdk.NewAddon("css", gowdk.FeatureSEO),
+		}, want: "duplicates Addons[0]"},
+		{name: "duplicate features", addons: []gowdk.Addon{
+			gowdk.NewAddon("css-a", gowdk.FeatureCSS),
+			gowdk.NewAddon("css-b", gowdk.FeatureCSS),
+		}, want: "duplicates feature"},
+		{name: "seo provider mismatch", addons: []gowdk.Addon{
+			gowdk.NewAddon("seo-marker", gowdk.FeatureSEO),
+		}, want: "does not implement gowdk.SEOProvider"},
+		{name: "auth provider mismatch", addons: []gowdk.Addon{
+			gowdk.NewAddon("auth-marker", gowdk.FeatureAuth),
+		}, want: "does not implement gowdk.AuthSessionProvider"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := gowdk.ValidateAddons(test.addons)
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("expected %q error, got %v", test.want, err)
+			}
+		})
+	}
+}
+
+func TestValidateAddonsAllowsExplicitSPAAliasFeatureOverlap(t *testing.T) {
+	err := gowdk.ValidateAddons([]gowdk.Addon{
+		gowdk.NewAddon("spa", gowdk.FeatureSPA),
+		gowdk.NewAddon("static", gowdk.FeatureSPA),
+	})
+	if err != nil {
+		t.Fatalf("expected legacy SPA/static feature overlap to be allowed, got %v", err)
+	}
+}
+
 func TestRenderConfigDefaultMode(t *testing.T) {
 	if got := (gowdk.RenderConfig{}).DefaultMode(); got != gowdk.SPA {
 		t.Fatalf("expected spa default, got %q", got)

--- a/runtime/app/app_test.go
+++ b/runtime/app/app_test.go
@@ -290,6 +290,39 @@ func TestBackendRouterHandlesCORSPreflightForAPI(t *testing.T) {
 	assertHeader(t, recorder, "Vary", "Origin")
 }
 
+func TestBackendRouterCanonicalizesCORSOrigins(t *testing.T) {
+	router, err := NewBackendRouter(BackendRoute{
+		Kind:    "api",
+		Method:  http.MethodGet,
+		Path:    "/api/health",
+		Handler: func(http.ResponseWriter, *http.Request) bool { return true },
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := router.SetCORSPolicy(CORSPolicy{
+		AllowedOrigins: []string{"https://APP.EXAMPLE:443", "https://[2001:db8::1]:8443"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/api/health", nil)
+	request.Header.Set("Origin", "https://app.example")
+	if !router.Dispatch(recorder, request) {
+		t.Fatal("expected API request to be handled")
+	}
+	assertHeader(t, recorder, "Access-Control-Allow-Origin", "https://app.example")
+
+	recorder = httptest.NewRecorder()
+	request = httptest.NewRequest(http.MethodGet, "/api/health", nil)
+	request.Header.Set("Origin", "https://[2001:db8::1]:8443")
+	if !router.Dispatch(recorder, request) {
+		t.Fatal("expected IPv6 API request to be handled")
+	}
+	assertHeader(t, recorder, "Access-Control-Allow-Origin", "https://[2001:db8::1]:8443")
+}
+
 func TestBackendRouterWritesCORSActualHeadersForAPI(t *testing.T) {
 	router, err := NewBackendRouter(BackendRoute{
 		Kind:   "api",

--- a/runtime/app/cors.go
+++ b/runtime/app/cors.go
@@ -4,9 +4,10 @@ import (
 	"fmt"
 	"net/http"
 	"net/textproto"
-	"net/url"
 	"strconv"
 	"strings"
+
+	"github.com/cssbruno/gowdk/runtime/corsorigin"
 )
 
 // CORSPolicy declares generated CORS behavior for API and web contract routes.
@@ -104,24 +105,11 @@ func normalizeCORSOrigin(origin string) (string, error) {
 	if origin == "*" {
 		return origin, nil
 	}
-	if strings.ContainsAny(origin, "\r\n") {
-		return "", fmt.Errorf("CORS origin %q contains a control character", origin)
-	}
-	parsed, err := url.Parse(origin)
+	parsed, err := corsorigin.Parse(origin)
 	if err != nil {
 		return "", fmt.Errorf("CORS origin %q is invalid: %w", origin, err)
 	}
-	scheme := strings.ToLower(parsed.Scheme)
-	if scheme != "http" && scheme != "https" {
-		return "", fmt.Errorf("CORS origin %q must use http or https", origin)
-	}
-	if parsed.User != nil || parsed.Host == "" || parsed.RawQuery != "" || parsed.Fragment != "" {
-		return "", fmt.Errorf("CORS origin %q must be an origin, not a URL with userinfo, query, or fragment", origin)
-	}
-	if parsed.Path != "" && parsed.Path != "/" {
-		return "", fmt.Errorf("CORS origin %q must not include a path", origin)
-	}
-	return scheme + "://" + strings.ToLower(parsed.Host), nil
+	return parsed.String(), nil
 }
 
 func normalizeCORSMethod(method string) (string, error) {

--- a/runtime/corsorigin/origin.go
+++ b/runtime/corsorigin/origin.go
@@ -1,0 +1,162 @@
+// Package corsorigin validates and canonicalizes CORS origin strings.
+package corsorigin
+
+import (
+	"fmt"
+	"net"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+// Origin is a canonical HTTP origin.
+type Origin struct {
+	Scheme string
+	Host   string
+	Port   string
+}
+
+// Parse validates a literal HTTP origin and returns its canonical form.
+func Parse(raw string) (Origin, error) {
+	value := strings.TrimSpace(raw)
+	if value == "" {
+		return Origin{}, fmt.Errorf("origin is required")
+	}
+	if strings.ContainsAny(value, "\r\n") {
+		return Origin{}, fmt.Errorf("origin %q contains a control character", raw)
+	}
+	parsed, err := url.Parse(value)
+	if err != nil {
+		return Origin{}, fmt.Errorf("origin %q is invalid: %w", raw, err)
+	}
+	scheme := strings.ToLower(parsed.Scheme)
+	if scheme != "http" && scheme != "https" {
+		return Origin{}, fmt.Errorf("origin %q must use http or https", raw)
+	}
+	if parsed.User != nil || parsed.Host == "" || parsed.Opaque != "" || parsed.RawQuery != "" || parsed.Fragment != "" {
+		return Origin{}, fmt.Errorf("origin %q must not include userinfo, query, or fragment", raw)
+	}
+	if parsed.Path != "" && parsed.Path != "/" {
+		return Origin{}, fmt.Errorf("origin %q must not include a path", raw)
+	}
+	host, port, err := splitHostPort(parsed.Host)
+	if err != nil {
+		return Origin{}, fmt.Errorf("origin %q has invalid host or port: %w", raw, err)
+	}
+	host, err = canonicalHost(host)
+	if err != nil {
+		return Origin{}, fmt.Errorf("origin %q has invalid host: %w", raw, err)
+	}
+	if port != "" {
+		if err := validatePort(port); err != nil {
+			return Origin{}, fmt.Errorf("origin %q has invalid port %q: %w", raw, port, err)
+		}
+		if defaultPort(scheme) == port {
+			port = ""
+		}
+	}
+	return Origin{Scheme: scheme, Host: host, Port: port}, nil
+}
+
+func (origin Origin) String() string {
+	host := origin.Host
+	if origin.Port != "" {
+		host = net.JoinHostPort(origin.Host, origin.Port)
+	} else if strings.Contains(host, ":") {
+		host = "[" + host + "]"
+	}
+	return origin.Scheme + "://" + host
+}
+
+func splitHostPort(value string) (host string, port string, err error) {
+	if strings.HasPrefix(value, "[") {
+		end := strings.LastIndex(value, "]")
+		if end < 0 {
+			return "", "", fmt.Errorf("missing closing IPv6 bracket")
+		}
+		host = value[1:end]
+		rest := value[end+1:]
+		if rest == "" {
+			return host, "", nil
+		}
+		if !strings.HasPrefix(rest, ":") {
+			return "", "", fmt.Errorf("unexpected data after IPv6 host")
+		}
+		port = rest[1:]
+		if port == "" {
+			return "", "", fmt.Errorf("port is required after colon")
+		}
+		return host, port, nil
+	}
+	if strings.Count(value, ":") == 0 {
+		return value, "", nil
+	}
+	if strings.Count(value, ":") > 1 {
+		return "", "", fmt.Errorf("IPv6 hosts must use brackets")
+	}
+	host, port, ok := strings.Cut(value, ":")
+	if !ok || host == "" || port == "" {
+		return "", "", fmt.Errorf("host and port are required")
+	}
+	return host, port, nil
+}
+
+func canonicalHost(value string) (string, error) {
+	host := strings.TrimSuffix(strings.ToLower(strings.TrimSpace(value)), ".")
+	if host == "" {
+		return "", fmt.Errorf("host is required")
+	}
+	for _, r := range host {
+		if r > 127 {
+			return "", fmt.Errorf("unicode hostnames are not accepted; use an ASCII punycode hostname")
+		}
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		return strings.ToLower(ip.String()), nil
+	}
+	if len(host) > 253 {
+		return "", fmt.Errorf("hostname is too long")
+	}
+	for _, label := range strings.Split(host, ".") {
+		if label == "" {
+			return "", fmt.Errorf("hostname contains an empty label")
+		}
+		if len(label) > 63 {
+			return "", fmt.Errorf("hostname label %q is too long", label)
+		}
+		if strings.HasPrefix(label, "-") || strings.HasSuffix(label, "-") {
+			return "", fmt.Errorf("hostname label %q must not start or end with hyphen", label)
+		}
+		for _, r := range label {
+			if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '-' {
+				continue
+			}
+			return "", fmt.Errorf("hostname label %q contains invalid character %q", label, r)
+		}
+	}
+	return host, nil
+}
+
+func validatePort(value string) error {
+	for _, r := range value {
+		if r < '0' || r > '9' {
+			return fmt.Errorf("port must be numeric")
+		}
+	}
+	number, err := strconv.Atoi(value)
+	if err != nil || number < 1 || number > 65535 {
+		return fmt.Errorf("port must be between 1 and 65535")
+	}
+	return nil
+}
+
+func defaultPort(scheme string) string {
+	switch scheme {
+	case "http":
+		return "80"
+	case "https":
+		return "443"
+	default:
+		return ""
+	}
+}

--- a/runtime/corsorigin/origin_test.go
+++ b/runtime/corsorigin/origin_test.go
@@ -1,0 +1,52 @@
+package corsorigin
+
+import "testing"
+
+func TestParseCanonicalizesOrigins(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{name: "lowercase host", raw: "https://APP.EXAMPLE", want: "https://app.example"},
+		{name: "default https port", raw: "https://app.example:443", want: "https://app.example"},
+		{name: "default http port", raw: "http://app.example:80", want: "http://app.example"},
+		{name: "non default port", raw: "https://app.example:8443", want: "https://app.example:8443"},
+		{name: "ipv6", raw: "https://[2001:db8::1]:8443", want: "https://[2001:db8::1]:8443"},
+		{name: "trailing dot", raw: "https://app.example.", want: "https://app.example"},
+		{name: "punycode", raw: "https://xn--bcher-kva.example", want: "https://xn--bcher-kva.example"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			origin, err := Parse(test.raw)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := origin.String(); got != test.want {
+				t.Fatalf("origin = %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
+func TestParseRejectsInvalidOrigins(t *testing.T) {
+	for _, raw := range []string{
+		"https://app.example:bad",
+		"https://app.example:",
+		"https://[2001:db8::1",
+		"https://2001:db8::1",
+		"https://bücher.example",
+		"https://app..example",
+		"https://-app.example",
+		"ftp://app.example",
+		"https://app.example/path",
+		"https://user@app.example",
+		"https://app.example?x=1",
+	} {
+		t.Run(raw, func(t *testing.T) {
+			if _, err := Parse(raw); err == nil {
+				t.Fatal("expected invalid origin")
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Adds shared CORS origin canonicalization for config validation and runtime matching, including default-port normalization, IPv6 handling, trailing-dot handling, and ASCII-only hostname policy.
- Validates addon identity and feature ownership during config loading, including nil addons, duplicate names/features, empty feature IDs, and SEO/Auth provider contract mismatches.
- Makes CSS processor path context explicit and runs Tailwind from a deterministic CSS working directory.
- Bounds final artifact secret scanning to text-like artifacts, skips binary artifacts, and reports oversized text artifacts without reading every emitted file as text.
- Updates reference/security docs for CORS, addons, CSS processor paths, Tailwind execution, and final artifact scan limits.

Root cause: these paths each had partial validation at the point of use, but lacked a shared canonical CORS parser, config-time addon contract checks, explicit CSS processor path context, and bounded artifact classification before final build secret scanning.

## Issue Closure

Closes #728
Closes #729
Closes #730
Closes #731

## Verification

- [x] I ran the relevant tests, lint, and build commands.
- [ ] I ran `scripts/test-go-modules.sh` when Go code or compiler behavior changed.
- [ ] I ran `go build ./cmd/gowdk` when CLI, compiler, runtime, addon, or release behavior changed.
- [ ] I ran `node --check editors/vscode/extension.js` when editor files changed.
- [x] I updated docs for behavior, setup, or architecture changes.
- [x] I added or updated tests for changed behavior.
- [x] I considered security-sensitive surfaces such as auth, CSRF, redirects, request-time handlers, logs, diagnostics, embedded assets, editor commands, WASM, contracts, and realtime behavior.

Commands run:

```sh
go test ./runtime ./runtime/app ./runtime/corsorigin ./internal/publicapi ./internal/project ./addons/tailwind ./internal/buildgen
go test ./internal/gowdkcmd -run 'TestFinalBuildArtifactSecurityFindings|TestBuildCommandProductionScansFinalArtifactsForSecrets'
scripts/check-docs-links.sh
scripts/check-docs-style.sh
scripts/check-removed-syntax.sh
scripts/check-doc-versions.sh
```

`check-docs-style` passed with existing long-paragraph warnings outside the new touched prose.

## LLM Assistance

- LLM session summary: Codex implemented the hardening changes, added focused regression tests, updated reference/security docs, and created this draft PR.
- Human-reviewed assumptions: Treat `FeatureSPA` duplicate ownership as an explicit legacy `spa`/`static` alias; keep non-empty external feature IDs allowed; reject SEO/Auth feature markers without their behaviorful provider interfaces.
- Follow-up work: None known for this PR.
