### PR TITLE
fix(release): require conventional PR titles

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,6 +2,10 @@
 
 - 
 
+Title format: use Conventional Commits, for example
+`feat(compiler): add route graph output` or
+`fix(runtime): preserve clicked submit button`.
+
 ## Issue Closure
 
 <!-- Use Closes/Fixes/Resolves only when this PR fully resolves the issue.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,12 @@ on:
     branches:
       - main
   pull_request:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+      - ready_for_review
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,29 @@
+name: PR title
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+      - ready_for_review
+
+permissions:
+  contents: read
+
+jobs:
+  conventional-title:
+    name: Conventional Commit title
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out base repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+
+      - name: Check pull request title
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: scripts/check-pr-title.sh "$PR_TITLE"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -130,6 +130,11 @@ If a future package adds a more specific validation command, document it in
 
 - Treat `AGENTS.md` as the always-on project instruction file for every coding
   agent.
+- When committing or opening pull requests, use the repository Conventional
+  Commit format for commit messages and PR titles, such as
+  `ci: require conventional PR titles` or
+  `fix(compiler): preserve route diagnostics`. Do not add generic agent
+  prefixes such as `[codex]`; release-please parses the final PR/squash title.
 - Keep this file small by moving long process details into `.agents/skills/` and
   `.agents/templates/`.
 - If more specific rules are needed for a future subdirectory, add a nested

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,12 +28,16 @@ reverse.
 ## Workflow
 
 1. Make the smallest vertical slice that exercises the behavior.
-2. Preserve unrelated user changes.
-3. Update tests, examples, docs, and status in the same change.
-4. Keep generated Go as adapter glue rather than application logic.
-5. Avoid new production dependencies unless the change documents the reason.
-6. Run focused checks first, then the relevant repository gates.
-7. Record commands that fail and the next action needed.
+2. Title pull requests with Conventional Commits, such as
+   `feat(compiler): add route graph output` or
+   `fix(runtime): preserve clicked submit button`; release-please uses the
+   squash title for changelog and release-note generation.
+3. Preserve unrelated user changes.
+4. Update tests, examples, docs, and status in the same change.
+5. Keep generated Go as adapter glue rather than application logic.
+6. Avoid new production dependencies unless the change documents the reason.
+7. Run focused checks first, then the relevant repository gates.
+8. Record commands that fail and the next action needed.
 
 ## Verification
 


### PR DESCRIPTION
## Summary

- Add a lightweight PR-title workflow that validates Conventional Commit titles from the base branch.
- Rerun the existing CI PR-title job when PR titles are edited.
- Document the required title format in the PR template and contributing guide.

## Issue Closure

Related: release-please PR title/changelog enforcement.

## Verification

- [x] `bash -n scripts/check-pr-title.sh`
- [x] `scripts/check-pr-title.sh 'feat(compiler): add route graph output'`
- [x] `scripts/check-pr-title.sh 'fix(runtime): preserve clicked submit button'`
- [x] `scripts/check-pr-title.sh 'docs: update release workflow'`
- [x] `scripts/check-pr-title.sh 'introduce phase typed program boundaries'` rejects the invalid title
- [x] `scripts/check-supply-chain-pins.sh`
- [x] `scripts/check-docs-style.sh`

## LLM Assistance

- LLM session summary: Diagnosed release-please skips from non-Conventional PR titles, added PR-title validation wiring, documented the requirement, committed the focused change, and opened this draft PR.
- Human-reviewed assumptions: The required merge check should be `PR title`; the existing title script remains the source of truth.
- Follow-up work: Keep the repository `main` ruleset requiring the `PR title` check so invalid titles block merges.