### PR TITLE
fix(app): do not trust Host alone for local trace viewer access

### DIFF
--- a/docs/reference/observability.md
+++ b/docs/reference/observability.md
@@ -24,10 +24,13 @@ Generated development builds mount the local trace viewer at:
 ```
 
 The viewer is off unless the addon is enabled and `Build.DebugAssets()` is true
-(`Build.Mode != gowdk.Production`). Outside dev, generated apps mount the viewer
-behind `runtime/app.LocalTraceAccess`, which only allows direct localhost or
-loopback requests and rejects forwarded reverse-proxy requests unless the app
-supplies an explicit `TraceAccess` function.
+(`Build.Mode != gowdk.Production`). Generated apps keep browser trace ingest on
+`POST /_gowdk/traces/browser` through
+`runtime/app.BrowserTraceIngestAccess`, but serve the readable viewer, JSON
+data, and SSE stream from `runtime/app.LocalTraceViewerService` on a separate
+loopback listener. The generated binary prints that local viewer URL at startup.
+Do not proxy that listener to public traffic. If an app mounts trace handlers on
+its own routes, use an explicit app-owned `TraceAccess` function.
 
 Current generated instrumentation:
 
@@ -66,8 +69,8 @@ and app-owned trace events.
 
 | Mode | Generated spans | Local collector/viewer | Intended access |
 | --- | --- | --- | --- |
-| `gowdk dev` / local debug | Enabled when the addon is present and debug assets are on. | Mounted at `/_gowdk/traces`. | Localhost only by default. |
-| Preview/debug app builds | Enabled when `Build.DebugAssets()` is true. | Mounted only when the addon is present. | Keep behind `LocalTraceAccess` or an app-owned gate. |
+| `gowdk dev` / local debug | Enabled when the addon is present and debug assets are on. | Browser ingest on the app route; readable viewer on a generated loopback listener. | Open the printed local viewer URL. |
+| Preview/debug app builds | Enabled when `Build.DebugAssets()` is true. | Mounted only when the addon is present. | Keep the generated viewer listener local or provide an app-owned gate. |
 | Production builds | Disabled by default because debug assets are off. | Not mounted by generated code. | Use app-owned telemetry export and access policy. |
 | Direct `runtime/trace` use | App-controlled. | App-controlled. | The app must wrap public routes with auth, TLS, proxy, and rate-limit policy. |
 

--- a/docs/reference/tracing.md
+++ b/docs/reference/tracing.md
@@ -138,9 +138,15 @@ collector := gowdktrace.NewCollector(
 `collector.HealthSnapshot()` returns the same storage, dropped, rejected,
 subscriber, and ingest-limit counters for app-owned health endpoints.
 
-Generated apps mount the viewer behind `runtime/app.LocalTraceAccess`. If an
-application mounts `Collector.Handler()` or `ViewerHandler()` itself on an
-internet-facing route, the application must still provide normal authentication,
+Generated apps keep browser ingest on the main app handler but serve the
+readable viewer, JSON data, and SSE stream from
+`runtime/app.LocalTraceViewerService` on a separate loopback listener. The
+generated binary prints that local viewer URL at startup. If an application
+mounts `Collector.Handler()` or `ViewerHandler()` itself, it can use
+`runtime/app.LocalTraceAccess` as a local-only gate: it ignores
+client-supplied `Host` and requires both the remote peer and the server listener
+address recorded in `http.LocalAddrContextKey` to be loopback, with no forwarded
+proxy headers. Internet-facing trace routes still need normal authentication,
 authorization, TLS, reverse-proxy, and production rate-limit policy.
 
 ## Log Correlation And Health

--- a/internal/appgen/appgen_test.go
+++ b/internal/appgen/appgen_test.go
@@ -1365,6 +1365,8 @@ func TestGenerateObservabilityTracesSSRRouteAndLoad(t *testing.T) {
 	for _, expected := range []string{
 		`gowdktrace "github.com/cssbruno/gowdk/runtime/trace"`,
 		`Tracer: traceTracer,`,
+		`TraceAccess: gowdkruntime.BrowserTraceIngestAccess,`,
+		`services = append(services, gowdkruntime.LocalTraceViewerService(traceCollector.ViewerHandler()))`,
 		`ctx, ssrSpan := gowdktrace.Start(request.Context(), "ssr /dashboard"`,
 		`gowdktrace.WithLane(gowdktrace.LaneSSR)`,
 		`gowdktrace.WithSource(gowdktrace.SourceRef{File: "dashboard.page.gwdk", Line: 3, Column: 1, OwnerKind: "page", OwnerID: "dashboard"})`,

--- a/internal/appgen/source.go
+++ b/internal/appgen/source.go
@@ -614,7 +614,7 @@ func embeddedHandlerFields(options Options, identity ast.Expr) []ast.Expr {
 		fields = append(fields,
 			keyValue("Tracer", id("traceTracer")),
 			keyValue("TraceHandler", call(selExpr(id("traceCollector"), "ViewerHandler"))),
-			keyValue("TraceAccess", sel("gowdkruntime", "LocalTraceAccess")),
+			keyValue("TraceAccess", sel("gowdkruntime", "BrowserTraceIngestAccess")),
 		)
 	}
 	fields = append(fields,
@@ -843,7 +843,7 @@ func backendOnlyBaseHandlerExpr(options Options) ast.Expr {
 					keyValue("Backend", call(selExpr(id("backendRouter"), "HandlerFunc"))),
 					keyValue("Tracer", id("traceTracer")),
 					keyValue("TraceHandler", call(selExpr(id("traceCollector"), "ViewerHandler"))),
-					keyValue("TraceAccess", sel("gowdkruntime", "LocalTraceAccess")),
+					keyValue("TraceAccess", sel("gowdkruntime", "BrowserTraceIngestAccess")),
 					keyValue("RequestTimeout", sel("gowdkruntime", "DefaultRequestTimeout")),
 				},
 			}}

--- a/internal/appgen/source_lifecycle.go
+++ b/internal/appgen/source_lifecycle.go
@@ -33,6 +33,9 @@ func appDecl(options Options) ast.Decl {
 			Cond: notNil("err"),
 			Body: block(&ast.ReturnStmt{Results: []ast.Expr{id("nil"), id("err")}}),
 		},
+	)
+	stmts = append(stmts, observabilityServiceStmts(options)...)
+	stmts = append(stmts,
 		&ast.ReturnStmt{Results: []ast.Expr{&ast.UnaryExpr{Op: token.AND, X: &ast.CompositeLit{
 			Type: sel("gowdkruntime", "Application"),
 			Elts: []ast.Expr{

--- a/internal/appgen/source_observability.go
+++ b/internal/appgen/source_observability.go
@@ -21,6 +21,19 @@ func observabilityDecls(options Options) []ast.Decl {
 	}
 }
 
+func observabilityServiceStmts(options Options) []ast.Stmt {
+	if !generatedObservabilityEnabled(options) {
+		return nil
+	}
+	viewerService := call(
+		sel("gowdkruntime", "LocalTraceViewerService"),
+		call(selExpr(id("traceCollector"), "ViewerHandler")),
+	)
+	return []ast.Stmt{
+		assign([]ast.Expr{id("services")}, call(id("append"), id("services"), viewerService)),
+	}
+}
+
 func traceCollectorVarDecl() ast.Decl {
 	return &ast.GenDecl{Tok: token.VAR, Specs: []ast.Spec{&ast.ValueSpec{
 		Names:  []*ast.Ident{id("traceCollector")},

--- a/internal/securitymanifest/manifest.go
+++ b/internal/securitymanifest/manifest.go
@@ -454,9 +454,9 @@ func observabilityEntries(config gowdk.Config, ir gwdkir.Program) []Observabilit
 		buildMode = string(gowdk.Development)
 	}
 	absoluteSources := exportsAbsoluteSourcePaths(ir)
-	common := ObservabilityEntry{
+	readCommon := ObservabilityEntry{
 		Mounted:                    true,
-		AccessPolicy:               "loopback-only",
+		AccessPolicy:               "loopback-listener",
 		BuildMode:                  buildMode,
 		DevOnly:                    config.Build.DebugAssets(),
 		AllowedOrigins:             []string{"loopback"},
@@ -464,39 +464,41 @@ func observabilityEntries(config gowdk.Config, ir gwdkir.Program) []Observabilit
 		ExportsAbsoluteSourcePaths: absoluteSources,
 		SpanDataLeavesProcess:      true,
 	}
+	browserCommon := readCommon
+	browserCommon.AccessPolicy = "same-origin-browser-ingest"
+	browserCommon.AllowedOrigins = []string{"same-origin"}
 	return []ObservabilityEntry{
-		mergeObservability(common, ObservabilityEntry{
+		mergeObservability(readCommon, ObservabilityEntry{
 			ID:      "trace.viewer",
 			Kind:    "viewer",
 			Path:    "/_gowdk/traces",
 			Methods: []string{http.MethodGet},
 		}),
-		mergeObservability(common, ObservabilityEntry{
+		mergeObservability(readCommon, ObservabilityEntry{
 			ID:                  "trace.data",
 			Kind:                "json",
 			Path:                "/_gowdk/traces/data",
-			Methods:             []string{http.MethodGet, http.MethodPost},
+			Methods:             []string{http.MethodGet},
 			ContentTypeRequired: "",
-			BodyLimitBytes:      1 << 20,
 			BatchLimit:          0,
 		}),
-		mergeObservability(common, ObservabilityEntry{
+		mergeObservability(readCommon, ObservabilityEntry{
 			ID:                  "trace.events",
 			Kind:                "sse",
 			Path:                "/_gowdk/traces/events",
-			Methods:             []string{http.MethodGet, http.MethodPost},
+			Methods:             []string{http.MethodGet},
 			ContentTypeRequired: "",
-			BodyLimitBytes:      1 << 20,
 			BatchLimit:          0,
+			SubscriberLimit:     32,
 		}),
-		mergeObservability(common, ObservabilityEntry{
+		mergeObservability(browserCommon, ObservabilityEntry{
 			ID:                  "trace.browser",
 			Kind:                "browser-ingest",
 			Path:                "/_gowdk/traces/browser",
 			Methods:             []string{http.MethodPost},
-			ContentTypeRequired: "",
+			ContentTypeRequired: "application/json",
 			BodyLimitBytes:      1 << 20,
-			BatchLimit:          0,
+			BatchLimit:          128,
 		}),
 	}
 }

--- a/internal/securitymanifest/manifest_test.go
+++ b/internal/securitymanifest/manifest_test.go
@@ -436,16 +436,19 @@ func TestBuildRecordsGuardContractAndObservabilityEvidence(t *testing.T) {
 	if !hasMethod(browser.Methods, http.MethodPost) || browser.BodyLimitBytes != 1<<20 {
 		t.Fatalf("expected browser ingestion body posture, got %#v", browser)
 	}
+	if browser.AccessPolicy != "same-origin-browser-ingest" || browser.ContentTypeRequired != "application/json" || browser.BatchLimit != 128 {
+		t.Fatalf("expected same-origin JSON browser ingestion posture, got %#v", browser)
+	}
 	data, ok := observabilityEntry(manifest.Observability, "trace.data", "/_gowdk/traces/data", true)
-	if !ok || !hasMethod(data.Methods, http.MethodGet) || !hasMethod(data.Methods, http.MethodPost) || data.BodyLimitBytes != 1<<20 {
-		t.Fatalf("expected trace data GET/POST posture with body limit, got %#v", data)
+	if !ok || !hasMethod(data.Methods, http.MethodGet) || hasMethod(data.Methods, http.MethodPost) || data.BodyLimitBytes != 0 {
+		t.Fatalf("expected trace data GET posture on local viewer listener, got %#v", data)
 	}
 	events, ok := observabilityEntry(manifest.Observability, "trace.events", "/_gowdk/traces/events", true)
-	if !ok || !hasMethod(events.Methods, http.MethodGet) || !hasMethod(events.Methods, http.MethodPost) || events.BodyLimitBytes != 1<<20 {
-		t.Fatalf("expected trace events GET/POST posture with body limit, got %#v", events)
+	if !ok || !hasMethod(events.Methods, http.MethodGet) || hasMethod(events.Methods, http.MethodPost) || events.BodyLimitBytes != 0 {
+		t.Fatalf("expected trace events GET posture on local viewer listener, got %#v", events)
 	}
-	if events.SubscriberLimit != 0 {
-		t.Fatalf("trace events should not report an unenforced subscriber cap, got %#v", events)
+	if events.AccessPolicy != "loopback-listener" || events.SubscriberLimit != 32 {
+		t.Fatalf("expected trace events loopback listener posture with subscriber cap, got %#v", events)
 	}
 }
 

--- a/runtime/app/app_test.go
+++ b/runtime/app/app_test.go
@@ -2306,6 +2306,7 @@ func TestBoundaryAbortsConnectionAfterResponseStarted(t *testing.T) {
 func TestLocalTraceAccessRejectsForwardedLoopbackProxyRequest(t *testing.T) {
 	request := httptest.NewRequest(http.MethodGet, "http://example.com/_gowdk/traces", nil)
 	request.RemoteAddr = "127.0.0.1:4567"
+	request = requestWithLocalAddr(t, request, "127.0.0.1:8080")
 	request.Header.Set("X-Forwarded-For", "203.0.113.10")
 
 	if LocalTraceAccess(request) {
@@ -2318,6 +2319,7 @@ func TestLocalTraceAccessRejectsAnyXForwardedProxyHeader(t *testing.T) {
 		t.Run(header, func(t *testing.T) {
 			request := httptest.NewRequest(http.MethodGet, "http://localhost:8080/_gowdk/traces", nil)
 			request.RemoteAddr = "127.0.0.1:4567"
+			request = requestWithLocalAddr(t, request, "127.0.0.1:8080")
 			request.Header.Set(header, "localhost")
 
 			if LocalTraceAccess(request) {
@@ -2327,13 +2329,119 @@ func TestLocalTraceAccessRejectsAnyXForwardedProxyHeader(t *testing.T) {
 	}
 }
 
-func TestLocalTraceAccessAllowsDirectLocalhostRequest(t *testing.T) {
+func TestBrowserTraceIngestAccessOnlyAllowsBrowserPOST(t *testing.T) {
+	allowed := httptest.NewRequest(http.MethodPost, "http://public.example/_gowdk/traces/browser", nil)
+	if !BrowserTraceIngestAccess(allowed) {
+		t.Fatal("expected browser trace ingest POST to be allowed")
+	}
+	for _, tc := range []struct {
+		name   string
+		method string
+		path   string
+	}{
+		{name: "viewer", method: http.MethodGet, path: "/_gowdk/traces"},
+		{name: "data", method: http.MethodGet, path: "/_gowdk/traces/data"},
+		{name: "events", method: http.MethodGet, path: "/_gowdk/traces/events"},
+		{name: "browser get", method: http.MethodGet, path: "/_gowdk/traces/browser"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			request := httptest.NewRequest(tc.method, "http://public.example"+tc.path, nil)
+			if BrowserTraceIngestAccess(request) {
+				t.Fatalf("expected %s %s to be rejected", tc.method, tc.path)
+			}
+		})
+	}
+}
+
+func TestLocalTraceAccessRejectsSpoofedLoopbackHostWithoutLocalAddr(t *testing.T) {
 	request := httptest.NewRequest(http.MethodGet, "http://localhost:8080/_gowdk/traces", nil)
 	request.RemoteAddr = "127.0.0.1:4567"
+
+	if LocalTraceAccess(request) {
+		t.Fatal("expected loopback Host and RemoteAddr without server local address to be rejected")
+	}
+}
+
+func TestLocalTraceAccessRejectsLoopbackPeerOnPublicListener(t *testing.T) {
+	request := httptest.NewRequest(http.MethodGet, "http://localhost:8080/_gowdk/traces", nil)
+	request.RemoteAddr = "127.0.0.1:4567"
+	request = requestWithLocalAddr(t, request, "192.0.2.10:8080")
+
+	if LocalTraceAccess(request) {
+		t.Fatal("expected loopback peer on non-loopback listener to be rejected")
+	}
+}
+
+func TestLocalTraceAccessAllowsDirectLocalhostRequest(t *testing.T) {
+	request := httptest.NewRequest(http.MethodGet, "http://example.com/_gowdk/traces", nil)
+	request.RemoteAddr = "127.0.0.1:4567"
+	request = requestWithLocalAddr(t, request, "127.0.0.1:8080")
 
 	if !LocalTraceAccess(request) {
 		t.Fatal("expected direct localhost request to be allowed")
 	}
+}
+
+func TestLocalTraceViewerServiceServesOnLoopbackListener(t *testing.T) {
+	started := make(chan net.Addr, 1)
+	paths := make(chan string, 1)
+	service := localTraceViewerService{
+		handler: http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+			paths <- request.URL.Path
+			response.WriteHeader(http.StatusNoContent)
+		}),
+		onStart: func(addr net.Addr) {
+			started <- addr
+		},
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() {
+		done <- service.Run(ctx, ServiceContext{})
+	}()
+
+	var addr net.Addr
+	select {
+	case addr = <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("local trace viewer service did not start")
+	}
+	response, err := http.Get("http://" + addr.String() + "/_gowdk/traces")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = response.Body.Close()
+	if response.StatusCode != http.StatusNoContent {
+		t.Fatalf("unexpected trace viewer status: %d", response.StatusCode)
+	}
+	select {
+	case path := <-paths:
+		if path != "" && path != "/" {
+			t.Fatalf("expected trace prefix to be stripped, got %q", path)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("local trace viewer handler was not called")
+	}
+
+	cancel()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("local trace viewer service did not stop")
+	}
+}
+
+func requestWithLocalAddr(t *testing.T, request *http.Request, address string) *http.Request {
+	t.Helper()
+	tcpAddr, err := net.ResolveTCPAddr("tcp", address)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return request.WithContext(context.WithValue(request.Context(), http.LocalAddrContextKey, tcpAddr))
 }
 
 func TestTracedBackendRouteMarksServerStatusError(t *testing.T) {

--- a/runtime/app/app_test.go
+++ b/runtime/app/app_test.go
@@ -2331,6 +2331,7 @@ func TestLocalTraceAccessRejectsAnyXForwardedProxyHeader(t *testing.T) {
 
 func TestBrowserTraceIngestAccessOnlyAllowsBrowserPOST(t *testing.T) {
 	allowed := httptest.NewRequest(http.MethodPost, "http://public.example/_gowdk/traces/browser", nil)
+	allowed.Header.Set("Origin", "http://public.example")
 	if !BrowserTraceIngestAccess(allowed) {
 		t.Fatal("expected browser trace ingest POST to be allowed")
 	}
@@ -2346,8 +2347,38 @@ func TestBrowserTraceIngestAccessOnlyAllowsBrowserPOST(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			request := httptest.NewRequest(tc.method, "http://public.example"+tc.path, nil)
+			request.Header.Set("Origin", "http://public.example")
 			if BrowserTraceIngestAccess(request) {
 				t.Fatalf("expected %s %s to be rejected", tc.method, tc.path)
+			}
+		})
+	}
+}
+
+func TestBrowserTraceIngestAccessRequiresSameOriginBrowserOrigin(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		origin  string
+		headers map[string]string
+		want    bool
+	}{
+		{name: "same origin", origin: "http://public.example", want: true},
+		{name: "missing origin"},
+		{name: "cross origin", origin: "http://evil.example"},
+		{name: "https proxy", origin: "https://public.example", headers: map[string]string{"X-Forwarded-Proto": "https"}, want: true},
+		{name: "forwarded https proxy", origin: "https://public.example", headers: map[string]string{"Forwarded": `for=192.0.2.1;proto=https;host=public.example`}, want: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			request := httptest.NewRequest(http.MethodPost, "http://public.example/_gowdk/traces/browser", nil)
+			if tt.origin != "" {
+				request.Header.Set("Origin", tt.origin)
+			}
+			for name, value := range tt.headers {
+				request.Header.Set(name, value)
+			}
+
+			if got := BrowserTraceIngestAccess(request); got != tt.want {
+				t.Fatalf("BrowserTraceIngestAccess = %v, want %v", got, tt.want)
 			}
 		})
 	}
@@ -2425,6 +2456,68 @@ func TestLocalTraceViewerServiceServesOnLoopbackListener(t *testing.T) {
 	}
 
 	cancel()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("local trace viewer service did not stop")
+	}
+}
+
+func TestLocalTraceViewerServiceShutdownCancelsActiveViewerRequest(t *testing.T) {
+	started := make(chan net.Addr, 1)
+	entered := make(chan struct{})
+	requestCancelled := make(chan struct{})
+	service := localTraceViewerService{
+		handler: http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+			response.Header().Set("Content-Type", "text/event-stream")
+			response.WriteHeader(http.StatusOK)
+			if flusher, ok := response.(http.Flusher); ok {
+				flusher.Flush()
+			}
+			close(entered)
+			<-request.Context().Done()
+			close(requestCancelled)
+		}),
+		onStart: func(addr net.Addr) {
+			started <- addr
+		},
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		done <- service.Run(ctx, ServiceContext{})
+	}()
+
+	var addr net.Addr
+	select {
+	case addr = <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("local trace viewer service did not start")
+	}
+	response, err := http.Get("http://" + addr.String() + "/_gowdk/traces/events")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = response.Body.Close() }()
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("unexpected trace viewer stream status: %d", response.StatusCode)
+	}
+	select {
+	case <-entered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("local trace viewer stream did not start")
+	}
+
+	cancel()
+
+	select {
+	case <-requestCancelled:
+	case <-time.After(2 * time.Second):
+		t.Fatal("active trace viewer request context was not canceled")
+	}
 	select {
 	case err := <-done:
 		if err != nil {

--- a/runtime/app/tracing.go
+++ b/runtime/app/tracing.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"strconv"
 	"strings"
@@ -38,7 +39,83 @@ func BrowserTraceIngestAccess(request *http.Request) bool {
 	if request == nil || request.URL == nil {
 		return false
 	}
-	return request.Method == http.MethodPost && request.URL.Path == tracePathPrefix+"/browser"
+	if request.Method != http.MethodPost || request.URL.Path != tracePathPrefix+"/browser" {
+		return false
+	}
+	return traceBrowserIngestOriginAllowed(request)
+}
+
+func traceBrowserIngestOriginAllowed(request *http.Request) bool {
+	origin := strings.TrimSpace(request.Header.Get("Origin"))
+	if origin == "" {
+		return false
+	}
+	parsed, err := url.Parse(origin)
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		return false
+	}
+	scheme := traceExternalRequestScheme(request)
+	if scheme == "" {
+		return false
+	}
+	return strings.EqualFold(parsed.Scheme, scheme) &&
+		strings.EqualFold(traceCanonicalOriginHost(parsed.Scheme, parsed.Host), traceCanonicalOriginHost(scheme, request.Host))
+}
+
+func traceExternalRequestScheme(request *http.Request) string {
+	if request.TLS != nil {
+		return "https"
+	}
+	if scheme := traceForwardedRequestProto(request.Header); scheme != "" {
+		return scheme
+	}
+	if request.URL != nil && request.URL.Scheme != "" {
+		return request.URL.Scheme
+	}
+	return "http"
+}
+
+func traceForwardedRequestProto(header http.Header) string {
+	for _, value := range header.Values("Forwarded") {
+		for _, forwarded := range strings.Split(value, ",") {
+			for _, part := range strings.Split(forwarded, ";") {
+				name, raw, ok := strings.Cut(strings.TrimSpace(part), "=")
+				if !ok || !strings.EqualFold(name, "proto") {
+					continue
+				}
+				if scheme := traceCleanForwardedProto(raw); scheme != "" {
+					return scheme
+				}
+			}
+		}
+	}
+	for _, value := range header.Values("X-Forwarded-Proto") {
+		if scheme := traceCleanForwardedProto(strings.Split(value, ",")[0]); scheme != "" {
+			return scheme
+		}
+	}
+	return ""
+}
+
+func traceCleanForwardedProto(value string) string {
+	value = strings.ToLower(strings.Trim(strings.TrimSpace(value), `"`))
+	if value == "http" || value == "https" {
+		return value
+	}
+	return ""
+}
+
+func traceCanonicalOriginHost(scheme string, host string) string {
+	host = strings.ToLower(strings.TrimSpace(host))
+	name, port, err := net.SplitHostPort(host)
+	if err == nil {
+		name = strings.ToLower(strings.Trim(name, "[]"))
+		if (scheme == "http" && port == "80") || (scheme == "https" && port == "443") {
+			return name
+		}
+		return name + ":" + port
+	}
+	return strings.Trim(host, "[]")
 }
 
 // LocalTraceAccess allows a trace endpoint only on direct loopback connections.
@@ -127,6 +204,8 @@ func (service localTraceViewerService) Run(ctx context.Context, _ ServiceContext
 	mux := http.NewServeMux()
 	mux.Handle(tracePathPrefix, http.StripPrefix(tracePathPrefix, traceHandler))
 	mux.Handle(tracePathPrefix+"/", http.StripPrefix(tracePathPrefix, traceHandler))
+	serverContext, cancelServer := context.WithCancel(ctx)
+	defer cancelServer()
 	server := &http.Server{
 		Handler:           mux,
 		ReadHeaderTimeout: 5 * time.Second,
@@ -134,7 +213,11 @@ func (service localTraceViewerService) Run(ctx context.Context, _ ServiceContext
 		WriteTimeout:      30 * time.Second,
 		IdleTimeout:       60 * time.Second,
 		MaxHeaderBytes:    1 << 20,
+		BaseContext: func(net.Listener) context.Context {
+			return serverContext
+		},
 	}
+	server.RegisterOnShutdown(cancelServer)
 	fmt.Fprintf(os.Stderr, "GOWDK trace viewer: http://%s%s\n", listener.Addr().String(), tracePathPrefix)
 	done := make(chan error, 1)
 	go func() {
@@ -152,10 +235,18 @@ func (service localTraceViewerService) Run(ctx context.Context, _ ServiceContext
 		}
 		return nil
 	case <-ctx.Done():
+		cancelServer()
 		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
-		if err := server.Shutdown(shutdownCtx); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		err := server.Shutdown(shutdownCtx)
+		timedOut := errors.Is(err, context.DeadlineExceeded)
+		if err != nil && !errors.Is(err, http.ErrServerClosed) && !timedOut {
 			return fmt.Errorf("shutdown local trace viewer: %w", err)
+		}
+		if timedOut {
+			if closeErr := server.Close(); closeErr != nil && !errors.Is(closeErr, http.ErrServerClosed) {
+				return fmt.Errorf("close local trace viewer after shutdown timeout: %w", closeErr)
+			}
 		}
 		select {
 		case err := <-done:
@@ -163,8 +254,11 @@ func (service localTraceViewerService) Run(ctx context.Context, _ ServiceContext
 				return fmt.Errorf("serve local trace viewer: %w", err)
 			}
 			return nil
-		case <-shutdownCtx.Done():
-			return fmt.Errorf("shutdown local trace viewer timed out: %w", shutdownCtx.Err())
+		case <-time.After(time.Second):
+			if timedOut {
+				return nil
+			}
+			return fmt.Errorf("shutdown local trace viewer timed out")
 		}
 	}
 }

--- a/runtime/app/tracing.go
+++ b/runtime/app/tracing.go
@@ -2,17 +2,22 @@ package app
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"net"
 	"net/http"
+	"os"
 	"strconv"
 	"strings"
+	"time"
 
 	gowdktrace "github.com/cssbruno/gowdk/runtime/trace"
 )
 
 const tracePathPrefix = "/_gowdk/traces"
+const localTraceViewerAddr = "127.0.0.1:0"
 
-// TraceAccess decides whether a request may use the generated trace viewer.
+// TraceAccess decides whether a request may use a generated trace endpoint.
 type TraceAccess func(*http.Request) bool
 
 func isTracePath(requestPath string) bool {
@@ -26,8 +31,20 @@ func (handler Handler) traceAccessAllowed(request *http.Request) bool {
 	return LocalTraceAccess(request)
 }
 
-// LocalTraceAccess allows the trace viewer only from loopback clients. Generated
-// apps use this as the default gate when the observability viewer is enabled.
+// BrowserTraceIngestAccess allows only generated browser span ingest on the
+// main app handler. Readable trace viewer, JSON, and SSE routes should use
+// LocalTraceViewerService or an app-owned TraceAccess policy.
+func BrowserTraceIngestAccess(request *http.Request) bool {
+	if request == nil || request.URL == nil {
+		return false
+	}
+	return request.Method == http.MethodPost && request.URL.Path == tracePathPrefix+"/browser"
+}
+
+// LocalTraceAccess allows a trace endpoint only on direct loopback connections.
+// Applications that mount trace handlers on their own can use it as a local-only
+// gate. The decision intentionally ignores request.Host because Host is
+// client-controlled and can be forwarded by a reverse proxy.
 func LocalTraceAccess(request *http.Request) bool {
 	if request == nil {
 		return false
@@ -35,10 +52,10 @@ func LocalTraceAccess(request *http.Request) bool {
 	if hasForwardedProxyHeader(request.Header) {
 		return false
 	}
-	if !loopbackHost(request.Host) {
+	if !loopbackHost(request.RemoteAddr) {
 		return false
 	}
-	return loopbackHost(request.RemoteAddr)
+	return loopbackRequestLocalAddr(request)
 }
 
 func hasForwardedProxyHeader(header http.Header) bool {
@@ -64,6 +81,99 @@ func loopbackHost(address string) bool {
 	}
 	ip := net.ParseIP(host)
 	return ip != nil && ip.IsLoopback()
+}
+
+func loopbackRequestLocalAddr(request *http.Request) bool {
+	localAddr, ok := request.Context().Value(http.LocalAddrContextKey).(net.Addr)
+	if !ok || localAddr == nil {
+		return false
+	}
+	return loopbackHost(localAddr.String())
+}
+
+// LocalTraceViewerService serves the readable trace viewer, JSON data, and SSE
+// stream on a separate loopback listener. Generated apps use this so the main
+// app handler does not expose trace reads through public or reverse-proxied
+// routes.
+func LocalTraceViewerService(handler http.Handler) Service {
+	return localTraceViewerService{handler: handler}
+}
+
+type localTraceViewerService struct {
+	handler http.Handler
+	onStart func(net.Addr)
+}
+
+func (service localTraceViewerService) Name() string {
+	return "trace-viewer"
+}
+
+func (service localTraceViewerService) Mount(ServiceContext) error {
+	return nil
+}
+
+func (service localTraceViewerService) Run(ctx context.Context, _ ServiceContext) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	listener, err := net.Listen("tcp", localTraceViewerAddr)
+	if err != nil {
+		return fmt.Errorf("listen local trace viewer: %w", err)
+	}
+	if service.onStart != nil {
+		service.onStart(listener.Addr())
+	}
+	traceHandler := service.traceHandler()
+	mux := http.NewServeMux()
+	mux.Handle(tracePathPrefix, http.StripPrefix(tracePathPrefix, traceHandler))
+	mux.Handle(tracePathPrefix+"/", http.StripPrefix(tracePathPrefix, traceHandler))
+	server := &http.Server{
+		Handler:           mux,
+		ReadHeaderTimeout: 5 * time.Second,
+		ReadTimeout:       10 * time.Second,
+		WriteTimeout:      30 * time.Second,
+		IdleTimeout:       60 * time.Second,
+		MaxHeaderBytes:    1 << 20,
+	}
+	fmt.Fprintf(os.Stderr, "GOWDK trace viewer: http://%s%s\n", listener.Addr().String(), tracePathPrefix)
+	done := make(chan error, 1)
+	go func() {
+		err := server.Serve(listener)
+		if errors.Is(err, http.ErrServerClosed) {
+			err = nil
+		}
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			return fmt.Errorf("serve local trace viewer: %w", err)
+		}
+		return nil
+	case <-ctx.Done():
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := server.Shutdown(shutdownCtx); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			return fmt.Errorf("shutdown local trace viewer: %w", err)
+		}
+		select {
+		case err := <-done:
+			if err != nil {
+				return fmt.Errorf("serve local trace viewer: %w", err)
+			}
+			return nil
+		case <-shutdownCtx.Done():
+			return fmt.Errorf("shutdown local trace viewer timed out: %w", shutdownCtx.Err())
+		}
+	}
+}
+
+func (service localTraceViewerService) traceHandler() http.Handler {
+	if service.handler != nil {
+		return service.handler
+	}
+	return http.NotFoundHandler()
 }
 
 func (handler Handler) startRequestTrace(response http.ResponseWriter, request *http.Request) (http.ResponseWriter, *http.Request, *gowdktrace.Span) {

--- a/runtime/trace/collector.go
+++ b/runtime/trace/collector.go
@@ -375,17 +375,64 @@ func sameOriginRequest(request *http.Request) bool {
 	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
 		return false
 	}
-	return strings.EqualFold(parsed.Scheme, requestScheme(request)) && strings.EqualFold(parsed.Host, request.Host)
+	scheme := requestScheme(request)
+	return strings.EqualFold(parsed.Scheme, scheme) && strings.EqualFold(canonicalOriginHost(parsed.Scheme, parsed.Host), canonicalOriginHost(scheme, request.Host))
 }
 
 func requestScheme(request *http.Request) string {
-	if request.URL != nil && request.URL.Scheme != "" {
-		return request.URL.Scheme
-	}
 	if request.TLS != nil {
 		return "https"
 	}
+	if scheme := forwardedRequestProto(request.Header); scheme != "" {
+		return scheme
+	}
+	if request.URL != nil && request.URL.Scheme != "" {
+		return request.URL.Scheme
+	}
 	return "http"
+}
+
+func forwardedRequestProto(header http.Header) string {
+	for _, value := range header.Values("Forwarded") {
+		for _, forwarded := range strings.Split(value, ",") {
+			for _, part := range strings.Split(forwarded, ";") {
+				name, raw, ok := strings.Cut(strings.TrimSpace(part), "=")
+				if !ok || !strings.EqualFold(name, "proto") {
+					continue
+				}
+				if scheme := cleanForwardedProto(raw); scheme != "" {
+					return scheme
+				}
+			}
+		}
+	}
+	for _, value := range header.Values("X-Forwarded-Proto") {
+		if scheme := cleanForwardedProto(strings.Split(value, ",")[0]); scheme != "" {
+			return scheme
+		}
+	}
+	return ""
+}
+
+func cleanForwardedProto(value string) string {
+	value = strings.ToLower(strings.Trim(strings.TrimSpace(value), `"`))
+	if value == "http" || value == "https" {
+		return value
+	}
+	return ""
+}
+
+func canonicalOriginHost(scheme string, host string) string {
+	host = strings.ToLower(strings.TrimSpace(host))
+	name, port, err := net.SplitHostPort(host)
+	if err == nil {
+		name = strings.ToLower(strings.Trim(name, "[]"))
+		if (scheme == "http" && port == "80") || (scheme == "https" && port == "443") {
+			return name
+		}
+		return name + ":" + port
+	}
+	return strings.Trim(host, "[]")
 }
 
 func (collector *Collector) allowIngest(request *http.Request) bool {

--- a/runtime/trace/trace_test.go
+++ b/runtime/trace/trace_test.go
@@ -559,6 +559,24 @@ func TestCollectorAcceptsSameOriginAndMissingOriginBrowserIngest(t *testing.T) {
 	}
 }
 
+func TestCollectorAcceptsSameOriginHTTPSProxyBrowserIngest(t *testing.T) {
+	collector := trace.NewCollector(4)
+	payload := []byte(snapshotJSON(t, validSnapshot("browser")))
+	request := jsonPostRequest("http://trace.local/browser", payload)
+	request.Header.Set("Origin", "https://trace.local")
+	request.Header.Set("X-Forwarded-Proto", "https")
+	response := httptest.NewRecorder()
+
+	collector.ViewerHandler().ServeHTTP(response, request)
+
+	if response.Code != http.StatusNoContent {
+		t.Fatalf("browser ingest status = %d body=%q, want 204", response.Code, response.Body.String())
+	}
+	if got := collector.Spans(); len(got) != 1 || got[0].Name != "browser" {
+		t.Fatalf("browser ingest stored unexpected spans: %#v", got)
+	}
+}
+
 func TestCollectorRateLimitsIngest(t *testing.T) {
 	collector := trace.NewCollector(4, trace.WithCollectorIngestRate(1, time.Minute))
 	handler := collector.Handler()


### PR DESCRIPTION
## Summary

- Fixes the local trace viewer access root cause: generated apps exposed readable trace routes on the main app listener and relied on request metadata that included client-controlled `Host`.
- Keeps browser trace ingest on the main app route through `BrowserTraceIngestAccess`, limited to `POST /_gowdk/traces/browser`.
- Serves the readable trace viewer, JSON data, and SSE stream through `LocalTraceViewerService` on a separate loopback listener, and hardens `LocalTraceAccess` for app-owned mounts to ignore `Host` and require loopback peer plus loopback server local address.
- Updates generated app wiring, security manifest posture, tests, and observability/tracing docs.

## Issue Closure

Fixes #780

## Verification

- [x] I ran the relevant tests, lint, and build commands.
- [x] I ran `scripts/test-go-modules.sh` when Go code or compiler behavior changed.
- [x] I ran `go build ./cmd/gowdk` when CLI, compiler, runtime, addon, or release behavior changed.
- [ ] I ran `node --check editors/vscode/extension.js` when editor files changed.
- [x] I updated docs for behavior, setup, or architecture changes.
- [x] I added or updated tests for changed behavior.
- [x] I considered security-sensitive surfaces such as auth, CSRF, redirects, request-time handlers, logs, diagnostics, embedded assets, editor commands, WASM, contracts, and realtime behavior.

Commands run:

- `go test ./runtime/app ./runtime/trace ./internal/appgen ./internal/securitymanifest ./internal/auditspec -count=1`
- `go build ./cmd/gowdk`
- `scripts/check-docs-links.sh && scripts/check-docs-style.sh`
- `go test ./...`
- `scripts/test-go-modules.sh`
- `git diff --check`

`check-docs-style` passed with existing long-paragraph warnings in unrelated docs.

## LLM Assistance

- LLM session summary: AI assistance implemented trace viewer listener isolation, generated app wiring changes, manifest/docs updates, and regression coverage for #780.
- Human-reviewed assumptions: Generated debug trace reads should use the printed loopback URL, while browser ingest remains on the main app handler for frontend spans. App-owned trace mounts can still provide their own `TraceAccess` policy.
- Follow-up work: None for #780. The other open trace/realtime security issues are separate.