### PR TITLE
fix(trace): redact browser trace URL query data

### DIFF
--- a/internal/clientrt/assets/gowdk.js
+++ b/internal/clientrt/assets/gowdk.js
@@ -948,6 +948,24 @@
     return url;
   }
 
+  function traceURLPath(url) {
+    var value = traceInputURL(url);
+    try {
+      return new URL(value, window.location.href).pathname || '/';
+    } catch (error) {
+      var text = String(value || '');
+      var fragment = text.indexOf('#');
+      if (fragment >= 0) {
+        text = text.slice(0, fragment);
+      }
+      var query = text.indexOf('?');
+      if (query >= 0) {
+        text = text.slice(0, query);
+      }
+      return text;
+    }
+  }
+
   function traceInputHeaders(url, options) {
     if (options && options.headers) {
       return options.headers;
@@ -971,7 +989,7 @@
       return fetch(url, options);
     }
     var span = startTraceSpan(meta && meta.name || 'fetch', meta && meta.lane || 'api', [
-      { key: 'url.path', value: String(url || '') }
+      { key: 'url.path', value: traceURLPath(url) }
     ]);
     var traced = Object.assign({}, options || {});
     if (sameOriginURL(url)) {

--- a/internal/clientrt/runtime_test.go
+++ b/internal/clientrt/runtime_test.go
@@ -135,6 +135,9 @@ func TestSourceTraceFetchNormalizesRequestInputs(t *testing.T) {
 		`function traceInputURL(url)`,
 		`typeof Request !== 'undefined' && url instanceof Request`,
 		`return url.url || '';`,
+		`function traceURLPath(url)`,
+		`return new URL(value, window.location.href).pathname || '/';`,
+		`{ key: 'url.path', value: traceURLPath(url) }`,
 		`return new URL(traceInputURL(url), window.location.href).origin === window.location.origin;`,
 		`function traceInputHeaders(url, options)`,
 		`url && typeof url === 'object' && url.headers`,
@@ -143,6 +146,20 @@ func TestSourceTraceFetchNormalizesRequestInputs(t *testing.T) {
 		if !strings.Contains(source, expected) {
 			t.Fatalf("expected runtime source to contain %q:\n%s", expected, source)
 		}
+	}
+}
+
+func TestTraceFetchExportsPathOnlyURL(t *testing.T) {
+	node, err := exec.LookPath("node")
+	if err != nil {
+		t.Skip("node is not installed")
+	}
+	script := filepath.Join(t.TempDir(), "gowdk-trace-url-test.js")
+	if err := os.WriteFile(script, []byte(traceURLHarnessScript(string(Source()))), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if output, err := exec.Command(node, script).CombinedOutput(); err != nil {
+		t.Fatalf("trace URL harness failed: %v\n%s", err, output)
 	}
 }
 
@@ -182,6 +199,63 @@ func TestEmbeddedRuntimeSourceFilesParseWithNode(t *testing.T) {
 			}
 		})
 	}
+}
+
+func traceURLHarnessScript(runtime string) string {
+	return `
+'use strict';
+
+const assert = require('node:assert/strict');
+
+const requests = [];
+global.document = {
+  documentElement: { hasAttribute() { return false; } },
+  addEventListener() {},
+  querySelector() { return null; },
+  querySelectorAll() { return []; }
+};
+global.window = {
+  location: {
+    href: 'http://example.test/account?session=server-secret',
+    origin: 'http://example.test'
+  },
+  addEventListener() {},
+  __gowdkTraceEnabled: true
+};
+	global.fetch = async function(url, options) {
+  requests.push({ url: String(url), options: options || {} });
+  return {
+    ok: true,
+    status: 204,
+    headers: { get() { return ''; } },
+    text: async () => ''
+  };
+};
+
+` + runtime + `
+
+(async function() {
+  await window.__gowdkTrace.fetch('/api/patients?token=client-secret&code=123#frag', {}, {
+    name: 'fetch patients',
+    lane: 'api'
+  });
+  await new Promise(resolve => setImmediate(resolve));
+
+  assert.equal(requests[0].url, '/api/patients?token=client-secret&code=123#frag');
+  const traceRequest = requests.find(request => request.url === '/_gowdk/traces/browser');
+  assert.ok(traceRequest, 'trace span was not posted');
+  const payload = String(traceRequest.options.body || '');
+  assert.ok(!payload.includes('client-secret'), payload);
+  assert.ok(!payload.includes('code=123'), payload);
+  assert.ok(!payload.includes('#frag'), payload);
+  const span = JSON.parse(payload);
+  const urlPath = span.attributes.find(attr => attr.key === 'url.path');
+  assert.deepEqual(urlPath, { key: 'url.path', value: '/api/patients' });
+})().catch(error => {
+  console.error(error && error.stack || error);
+  process.exit(1);
+});
+`
 }
 
 func TestRuntimeTemplatesReplacePlaceholders(t *testing.T) {


### PR DESCRIPTION
## Summary

- Fixes browser trace export so the `url.path` span attribute is derived from parsed path-only URL data instead of `String(url)`.
- Drops query strings and fragments before a browser span is enqueued or posted, while leaving the actual fetch target unchanged.
- Adds a Node-backed runtime regression test that verifies a traced fetch with query secrets posts only `/api/patients` in the exported span payload.

## Issue Closure

Fixes #777

## Verification

- [x] I ran the relevant tests, lint, and build commands.
- [ ] I ran `scripts/test-go-modules.sh` when Go code or compiler behavior changed.
- [x] I ran `go build ./cmd/gowdk` when CLI, compiler, runtime, addon, or release behavior changed.
- [ ] I ran `node --check editors/vscode/extension.js` when editor files changed.
- [ ] I updated docs for behavior, setup, or architecture changes.
- [x] I added or updated tests for changed behavior.
- [x] I considered security-sensitive surfaces such as auth, CSRF, redirects, request-time handlers, logs, diagnostics, embedded assets, editor commands, WASM, contracts, and realtime behavior.

Commands run:

- `go test ./internal/clientrt -count=1`
- `go build ./cmd/gowdk`
- `git diff --check`

## LLM Assistance

- LLM session summary: AI assistance changed the browser trace runtime URL attribute normalization and added an executable regression harness.
- Human-reviewed assumptions: Browser trace spans should keep only path data in `url.path`; the request URL used by `fetch` remains unchanged.
- Follow-up work: None for #777.