### PR TITLE
fix(app): skip csrf injection for off-origin post forms

### DIFF
--- a/runtime/app/app.go
+++ b/runtime/app/app.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"html"
 	"io/fs"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -499,6 +500,9 @@ func CSRFInjectHTML(response http.ResponseWriter, request *http.Request, payload
 		if !formStartTagHasPostMethod(tag) {
 			continue
 		}
+		if !formStartTagHasSameOriginAction(request, tag) {
+			continue
+		}
 		if token == "" {
 			generated, err := source.Token(response, request)
 			if err != nil {
@@ -543,13 +547,75 @@ func formStartTagRanges(payload []byte) [][2]int {
 }
 
 func formStartTagHasPostMethod(tag []byte) bool {
+	value, ok := formStartTagAttrValue(tag, "method")
+	return ok && strings.EqualFold(html.UnescapeString(string(value)), http.MethodPost)
+}
+
+func formStartTagHasSameOriginAction(request *http.Request, tag []byte) bool {
+	value, ok := formStartTagAttrValue(tag, "action")
+	if !ok {
+		return true
+	}
+	action := strings.TrimSpace(html.UnescapeString(string(value)))
+	if action == "" {
+		return true
+	}
+	if request == nil {
+		return false
+	}
+	scheme, host := requestOrigin(request)
+	if scheme == "" || host == "" {
+		return false
+	}
+	actionURL, err := url.Parse(action)
+	if err != nil {
+		return false
+	}
+	resolved := (&url.URL{Scheme: scheme, Host: host, Path: "/"}).ResolveReference(actionURL)
+	return strings.EqualFold(resolved.Scheme, scheme) &&
+		strings.EqualFold(canonicalOriginHost(resolved.Scheme, resolved.Host), canonicalOriginHost(scheme, host))
+}
+
+func requestOrigin(request *http.Request) (string, string) {
+	scheme := ""
+	if request.URL != nil {
+		scheme = request.URL.Scheme
+	}
+	if scheme == "" {
+		if request.TLS != nil {
+			scheme = "https"
+		} else {
+			scheme = "http"
+		}
+	}
+	host := request.Host
+	if host == "" && request.URL != nil {
+		host = request.URL.Host
+	}
+	return scheme, host
+}
+
+func canonicalOriginHost(scheme string, host string) string {
+	host = strings.ToLower(strings.TrimSpace(host))
+	name, port, err := net.SplitHostPort(host)
+	if err == nil {
+		defaultPort := (scheme == "http" && port == "80") || (scheme == "https" && port == "443")
+		if defaultPort {
+			return strings.ToLower(strings.Trim(name, "[]"))
+		}
+		return strings.ToLower(strings.Trim(name, "[]") + ":" + port)
+	}
+	return strings.Trim(host, "[]")
+}
+
+func formStartTagAttrValue(tag []byte, attrName string) ([]byte, bool) {
 	cursor := len("<form")
 	for cursor < len(tag) {
 		for cursor < len(tag) && isHTMLSpace(tag[cursor]) {
 			cursor++
 		}
 		if cursor >= len(tag) || tag[cursor] == '>' || tag[cursor] == '/' {
-			return false
+			return nil, false
 		}
 		nameStart := cursor
 		for cursor < len(tag) && !isHTMLSpace(tag[cursor]) && tag[cursor] != '=' && tag[cursor] != '/' && tag[cursor] != '>' {
@@ -568,11 +634,11 @@ func formStartTagHasPostMethod(tag []byte) bool {
 		}
 		value, next := htmlAttrValue(tag, cursor)
 		cursor = next
-		if bytes.EqualFold(name, []byte("method")) && strings.EqualFold(string(value), http.MethodPost) {
-			return true
+		if bytes.EqualFold(name, []byte(attrName)) {
+			return value, true
 		}
 	}
-	return false
+	return nil, false
 }
 
 func htmlTagEnd(payload []byte, cursor int) int {

--- a/runtime/app/app.go
+++ b/runtime/app/app.go
@@ -560,6 +560,9 @@ func formStartTagHasSameOriginAction(request *http.Request, tag []byte) bool {
 	if action == "" {
 		return true
 	}
+	if formActionHasBrowserNetworkPath(action) {
+		return false
+	}
 	if request == nil {
 		return false
 	}
@@ -578,21 +581,28 @@ func formStartTagHasSameOriginAction(request *http.Request, tag []byte) bool {
 
 func requestOrigin(request *http.Request) (string, string) {
 	scheme := ""
-	if request.URL != nil {
+	if requestIsHTTPS(request) {
+		scheme = "https"
+	} else if request.URL != nil {
 		scheme = request.URL.Scheme
 	}
 	if scheme == "" {
-		if request.TLS != nil {
-			scheme = "https"
-		} else {
-			scheme = "http"
-		}
+		scheme = "http"
 	}
 	host := request.Host
 	if host == "" && request.URL != nil {
 		host = request.URL.Host
 	}
 	return scheme, host
+}
+
+func formActionHasBrowserNetworkPath(action string) bool {
+	if len(action) < 2 {
+		return false
+	}
+	first := action[0]
+	second := action[1]
+	return (first == '/' || first == '\\') && (second == '/' || second == '\\')
 }
 
 func canonicalOriginHost(scheme string, host string) string {

--- a/runtime/app/app_test.go
+++ b/runtime/app/app_test.go
@@ -1398,6 +1398,10 @@ func TestCSRFInjectHTMLSkipsOffOriginPOSTFormActions(t *testing.T) {
 	payload := []byte(`<main>` +
 		`<form method="post" action="https://payments.example/checkout"></form>` +
 		`<form method="post" action="//evil.example/collect"></form>` +
+		`<form method="post" action="///evil.example/collect"></form>` +
+		`<form method="post" action="/\evil.example/collect"></form>` +
+		`<form method="post" action="\/evil.example/collect"></form>` +
+		`<form method="post" action="\\evil.example/collect"></form>` +
 		`<form method="post" action="http://example.com/signup"></form>` +
 		`<form method="post" action="/local"></form>` +
 		`</main>`)
@@ -1413,6 +1417,10 @@ func TestCSRFInjectHTMLSkipsOffOriginPOSTFormActions(t *testing.T) {
 	for _, external := range []string{
 		`<form method="post" action="https://payments.example/checkout"></form>`,
 		`<form method="post" action="//evil.example/collect"></form>`,
+		`<form method="post" action="///evil.example/collect"></form>`,
+		`<form method="post" action="/\evil.example/collect"></form>`,
+		`<form method="post" action="\/evil.example/collect"></form>`,
+		`<form method="post" action="\\evil.example/collect"></form>`,
 	} {
 		if !strings.Contains(body, external) {
 			t.Fatalf("expected off-origin form to remain without csrf input: %s", body)
@@ -1434,6 +1442,28 @@ func TestCSRFInjectHTMLSkipsOffOriginPOSTFormActions(t *testing.T) {
 	}
 	if cache := recorder.Header().Get("Cache-Control"); cache != "no-store" {
 		t.Fatalf("expected no-store for csrf-personalized HTML, got %q", cache)
+	}
+}
+
+func TestCSRFInjectHTMLUsesForwardedHTTPSForSameOriginActions(t *testing.T) {
+	csrf := &fakeCSRFTokenSource{field: "_csrf", token: "signed-token"}
+	payload := []byte(`<main><form method="post" action="https://example.com/signup"></form></main>`)
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "http://example.com/page", nil)
+	request.Header.Set("X-Forwarded-Proto", "https")
+
+	updated, ok := CSRFInjectHTML(recorder, request, payload, csrf)
+
+	if !ok {
+		t.Fatal("expected csrf injection to succeed")
+	}
+	body := string(updated)
+	expected := `<form method="post" action="https://example.com/signup"><input type="hidden" name="_csrf" value="signed-token">`
+	if !strings.Contains(body, expected) {
+		t.Fatalf("expected forwarded HTTPS same-origin form to receive csrf input, got %s", body)
+	}
+	if csrf.calls != 1 {
+		t.Fatalf("expected one token generation call, got %d", csrf.calls)
 	}
 }
 

--- a/runtime/app/app_test.go
+++ b/runtime/app/app_test.go
@@ -1393,6 +1393,72 @@ func TestHandlerInjectsCSRFHiddenInputsIntoPOSTForms(t *testing.T) {
 	}
 }
 
+func TestCSRFInjectHTMLSkipsOffOriginPOSTFormActions(t *testing.T) {
+	csrf := &fakeCSRFTokenSource{field: "_csrf", token: "signed-token"}
+	payload := []byte(`<main>` +
+		`<form method="post" action="https://payments.example/checkout"></form>` +
+		`<form method="post" action="//evil.example/collect"></form>` +
+		`<form method="post" action="http://example.com/signup"></form>` +
+		`<form method="post" action="/local"></form>` +
+		`</main>`)
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "http://example.com/page", nil)
+
+	updated, ok := CSRFInjectHTML(recorder, request, payload, csrf)
+
+	if !ok {
+		t.Fatal("expected csrf injection to succeed")
+	}
+	body := string(updated)
+	for _, external := range []string{
+		`<form method="post" action="https://payments.example/checkout"></form>`,
+		`<form method="post" action="//evil.example/collect"></form>`,
+	} {
+		if !strings.Contains(body, external) {
+			t.Fatalf("expected off-origin form to remain without csrf input: %s", body)
+		}
+	}
+	for _, local := range []string{
+		`<form method="post" action="http://example.com/signup"><input type="hidden" name="_csrf" value="signed-token">`,
+		`<form method="post" action="/local"><input type="hidden" name="_csrf" value="signed-token">`,
+	} {
+		if !strings.Contains(body, local) {
+			t.Fatalf("expected same-origin form to receive csrf input %q in %s", local, body)
+		}
+	}
+	if count := strings.Count(body, `name="_csrf"`); count != 2 {
+		t.Fatalf("expected csrf input only for same-origin forms, got %d: %s", count, body)
+	}
+	if csrf.calls != 1 {
+		t.Fatalf("expected one token generation call, got %d", csrf.calls)
+	}
+	if cache := recorder.Header().Get("Cache-Control"); cache != "no-store" {
+		t.Fatalf("expected no-store for csrf-personalized HTML, got %q", cache)
+	}
+}
+
+func TestCSRFInjectHTMLDoesNotGenerateTokenForOnlyOffOriginPOSTForms(t *testing.T) {
+	csrf := &fakeCSRFTokenSource{field: "_csrf", token: "signed-token"}
+	payload := []byte(`<main><form method="post" action="https://payments.example/checkout"></form></main>`)
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "http://example.com/page", nil)
+
+	updated, ok := CSRFInjectHTML(recorder, request, payload, csrf)
+
+	if !ok {
+		t.Fatal("expected csrf injection to succeed")
+	}
+	if string(updated) != string(payload) {
+		t.Fatalf("expected off-origin form payload to remain unchanged, got %s", updated)
+	}
+	if csrf.calls != 0 {
+		t.Fatalf("expected no token generation for off-origin form, got %d", csrf.calls)
+	}
+	if cache := recorder.Header().Get("Cache-Control"); cache != "" {
+		t.Fatalf("expected no cache-control mutation without injected token, got %q", cache)
+	}
+}
+
 func TestHandlerReturnsNoStoreErrorWhenCSRFTokenGenerationFails(t *testing.T) {
 	handler := Handler{
 		Root: fstest.MapFS{


### PR DESCRIPTION
## Summary

- Fixes CSRF HTML personalization so hidden tokens are only injected into POST forms whose `action` resolves to the current request origin.
- Leaves off-origin and protocol-relative external POST forms untouched, and avoids token generation/cache mutation when no same-origin POST form needs a token.
- Keeps same-origin absolute actions and local/root-relative actions working.

## Issue Closure

Fixes #779

## Verification

- [x] I ran the relevant tests, lint, and build commands.
- [ ] I ran `scripts/test-go-modules.sh` when Go code or compiler behavior changed.
- [x] I ran `go build ./cmd/gowdk` when CLI, compiler, runtime, addon, or release behavior changed.
- [ ] I ran `node --check editors/vscode/extension.js` when editor files changed.
- [ ] I updated docs for behavior, setup, or architecture changes.
- [x] I added or updated tests for changed behavior.
- [x] I considered security-sensitive surfaces such as auth, CSRF, redirects, request-time handlers, logs, diagnostics, embedded assets, editor commands, WASM, contracts, and realtime behavior.

Commands run:

- `go test ./runtime/app -count=1`
- `go test ./internal/appgen -run 'TestGenerate.*CSRF|TestSSR.*CSRF|TestGenerateSSR.*CSRF' -count=1`
- `go build ./cmd/gowdk`
- `git diff --check`

## LLM Assistance

- LLM session summary: AI assistance narrowed CSRF token injection to same-origin POST forms and added regression coverage for off-origin actions.
- Human-reviewed assumptions: Same-origin absolute, root-relative, relative, and empty form actions remain eligible for injection; malformed or off-origin actions skip injection.
- Follow-up work: None for #779.