### PR TITLE
fix(examples): align SSR smoke fixture with interop contract

### DIFF
--- a/examples/ssr/dashboard.page.gwdk
+++ b/examples/ssr/dashboard.page.gwdk
@@ -5,9 +5,7 @@ route "/dashboard"
 layout root, dashboard
 guard auth.required
 
-server {
-  user := auth.User(ctx)?
-  => {user}
+go server {
 }
 
 view {

--- a/gowdk.config.go
+++ b/gowdk.config.go
@@ -4,6 +4,7 @@ package gowdkconfig
 
 import (
 	"github.com/cssbruno/gowdk"
+	authaddon "github.com/cssbruno/gowdk/addons/auth"
 	contractsaddon "github.com/cssbruno/gowdk/addons/contracts"
 	"github.com/cssbruno/gowdk/addons/realtime"
 )
@@ -25,6 +26,7 @@ var Config = gowdk.Config{
 		Output: "gowdk_cache",
 	},
 	Addons: []gowdk.Addon{
+		authaddon.Addon(),
 		contractsaddon.Addon(),
 		realtime.Addon(),
 	},


### PR DESCRIPTION
## Summary

- enable the built-in auth addon for the root smoke project so `auth.required` remains valid
- make the data-free SSR dashboard use `go server {}` instead of declaring an external `server {}` load lane
- restore the broad example-report CI gate after the typed interop migration in #807

## Issue Closure

Follow-up to #807.

## Verification

- [x] `GOCACHE=/tmp/gowdk-ci-debug-cache go run ./cmd/gowdk check --ssr examples/ssr/*.gwdk`
- [x] `GOCACHE=/tmp/gowdk-ci-debug-cache sh scripts/check-example-reports.sh`
- [x] `git diff --check`

## LLM Assistance

- LLM session summary: Traced the failed GitHub Actions job to the root SSR smoke fixture, reproduced it locally, and aligned the fixture with the typed interop contract.
- Human-reviewed assumptions: Keep the dashboard protected while removing an unused external load lane.
- Follow-up work: None.
